### PR TITLE
fix: drop u128 ceiling in wide-tier FromStr

### DIFF
--- a/src/display.rs
+++ b/src/display.rs
@@ -5,6 +5,23 @@
 //! contains the hand-written D38 implementation and serves as the
 //! shape reference for the macro emissions.
 //!
+//! # Parser factoring
+//!
+//! [`parse_components`] is the shared string-parsing front-end (sign /
+//! dot / digit-character validation, plus the overlong-fractional and
+//! leading-zero checks). The arithmetic accumulator that turns the
+//! integer / fractional digit slices into a storage value is
+//! *per-storage*:
+//!
+//! - Narrow tier (D9 / D18 / D38) accumulates in `u128` inside
+//!   [`parse_decimal_bits`] — fast and the `10^SCALE` multiplier always
+//!   fits since SCALE ≤ 38.
+//! - Wide tier (D76 … D1231) accumulates in the storage type itself
+//!   via the per-width body emitted by
+//!   [`crate::macros::from_str::decl_decimal_from_str!`]'s `wide` arm.
+//!   The integer arithmetic happens at the storage width so the
+//!   `10^SCALE` multiplier never overflows even at SCALE = 1230.
+//!
 //! # Display format
 //!
 //! [`fmt::Display`] formats as a base-10 decimal literal: integer digits,
@@ -174,19 +191,32 @@ fn format_exp(raw: i128, scale: u32, upper: bool, f: &mut fmt::Formatter<'_>) ->
 // `ParseError`'s `Display` and `Error` impls live in `src/error.rs`.
 
 
-/// Core decimal string parser.
+/// Outcome of the string-parsing front-end: sign and the integer / fractional
+/// digit slices. Both byte slices contain only ASCII digits.
 ///
-/// Extracted from the trait impl to keep `from_str` small and to centralise
-/// the sign / dot / digit state machine in one place.
+/// Centralises the sign / dot / digit-character state machine so the
+/// per-storage accumulators (`i128` for the narrow tier; the wide signed
+/// integers emitted via the from-str macro for the wide tier) only need
+/// to do the base-10 arithmetic.
+pub(crate) struct ParseComponents<'a> {
+    pub negative: bool,
+    pub int_str: &'a [u8],
+    pub frac_str: &'a [u8],
+}
+
+/// String-parsing front-end shared by every width.
+///
+/// Validates and splits the input into sign / integer-digits / fractional-
+/// digits. The `SCALE` parameter is needed only to reject overlong fractional
+/// parts — no arithmetic happens here, so wide-tier callers can drive their
+/// own storage-typed accumulator without overflow risk.
 ///
 /// # Precision
 ///
-/// Strict: all arithmetic is integer-only; result is bit-exact.
-pub(crate) fn parse_decimal_bits<const SCALE: u32>(s: &str) -> Result<i128, ParseError> {
-    parse_decimal::<SCALE>(s).map(super::core_type::D38::to_bits)
-}
-
-fn parse_decimal<const SCALE: u32>(s: &str) -> Result<D38<SCALE>, ParseError> {
+/// Strict: integer-only string slicing; no arithmetic.
+pub(crate) fn parse_components<const SCALE: u32>(
+    s: &str,
+) -> Result<ParseComponents<'_>, ParseError> {
     if s.is_empty() {
         return Err(ParseError::Empty);
     }
@@ -260,6 +290,37 @@ fn parse_decimal<const SCALE: u32>(s: &str) -> Result<D38<SCALE>, ParseError> {
     if frac_str.len() > SCALE as usize {
         return Err(ParseError::OverlongFractional);
     }
+
+    Ok(ParseComponents {
+        negative,
+        int_str,
+        frac_str,
+    })
+}
+
+/// Core decimal string parser for `D38`-class native-`i128` storage.
+///
+/// Drives [`parse_components`] and accumulates the storage value in `u128`
+/// (which avoids the `i128::MIN` asymmetry), then applies the sign.
+///
+/// The wide tier (D76 … D1231) uses [`crate::macros::from_str`] to emit a
+/// per-storage accumulator with the same shape; the front-end is shared but
+/// the arithmetic happens at the storage width so `10^SCALE` cannot
+/// overflow.
+///
+/// # Precision
+///
+/// Strict: all arithmetic is integer-only; result is bit-exact.
+pub(crate) fn parse_decimal_bits<const SCALE: u32>(s: &str) -> Result<i128, ParseError> {
+    parse_decimal::<SCALE>(s).map(super::core_type::D38::to_bits)
+}
+
+fn parse_decimal<const SCALE: u32>(s: &str) -> Result<D38<SCALE>, ParseError> {
+    let ParseComponents {
+        negative,
+        int_str,
+        frac_str,
+    } = parse_components::<SCALE>(s)?;
 
     // Accumulate the storage value as u128 (avoids the i128::MIN asymmetry)
     // and apply the sign at the very end.

--- a/src/macros/from_str.rs
+++ b/src/macros/from_str.rs
@@ -1,28 +1,154 @@
 //! Macro-generated `FromStr` for the decimal widths.
 //!
-//! The full parser logic lives in `display.rs::parse_decimal_bits`,
-//! which returns the raw bits as `i128`.
+//! The string-parsing front-end ([`crate::display::parse_components`])
+//! is shared across every width — it does sign / dot / digit-character
+//! validation plus the overlong-fractional and leading-zero checks.
+//! The accumulator that turns the validated digit slices into a
+//! storage value is *per-storage*:
 //!
-//! - The *native* arm narrows that `i128` to the target storage and
-//! reports `ParseError::OutOfRange` when the narrowing would lose
-//! information.
-//! - The *wide* arm widens the `i128` into wide storage via
-//! the `WideInt` cast. Note: because the shared parser accumulates in
-//! `i128`, wide-width parsing is currently limited to values whose
-//! scaled magnitude fits in `i128`; literals beyond that report
-//! `ParseError::OutOfRange` from the parser itself. A full-range
-//! wide parser is future work.
+//! - The **native** arm calls [`crate::display::parse_decimal_bits`],
+//!   which accumulates in `u128` and narrows to the target storage,
+//!   reporting [`crate::core_type::ParseError::OutOfRange`] when the
+//!   narrowing would lose information. SCALE is bounded by 38 here
+//!   so `10^SCALE` always fits in `u128`.
+//! - The **wide** arm emits a per-storage accumulator that does the
+//!   base-10 arithmetic at the storage width using the inherent
+//!   `checked_mul` / `checked_add` / `checked_sub` / `checked_neg` /
+//!   `pow` / `from_i128` items the wide-int macro already emits. This
+//!   removes the historical `u128` ceiling — at the deepest tier
+//!   (D1231 with SCALE = 1230) the multiplier `10^SCALE` needs ~4087
+//!   bits, which fits in the 4096-bit storage.
+//!
+//! Negative values are accumulated directly into the signed storage
+//! (`acc * 10 - digit` rather than `acc * 10 + digit`) so the
+//! two's-complement `MIN` boundary is reached without going through a
+//! positive intermediate that would overflow `MAX`.
 
 /// Emits `core::str::FromStr` for a decimal type with the given
-/// storage. Reuses the central `parse_decimal_bits` helper.
+/// storage.
 macro_rules! decl_decimal_from_str {
-    // Wide storage.
+    // Wide storage. Accumulates the storage value at the storage
+    // width — see the module docs for the rationale.
     (wide $Type:ident, $Storage:ty) => {
         impl<const SCALE: u32> ::core::str::FromStr for $Type<SCALE> {
             type Err = $crate::core_type::ParseError;
             fn from_str(s: &str) -> ::core::result::Result<Self, Self::Err> {
-                let bits_i128 = $crate::display::parse_decimal_bits::<SCALE>(s)?;
-                ::core::result::Result::Ok(Self(<$Storage>::from_i128(bits_i128)))
+                let comps = $crate::display::parse_components::<SCALE>(s)?;
+                let negative = comps.negative;
+                let int_str = comps.int_str;
+                let frac_str = comps.frac_str;
+
+                // Storage-width constants. `from_i128(10).pow(SCALE)`
+                // is wrapping in the inherent impl, but SCALE is
+                // bounded by the type's MAX_SCALE and `10^MAX_SCALE`
+                // fits the storage by design (e.g. 10^307 fits the
+                // 1024-bit storage of D307; 10^1230 fits the 4096-bit
+                // storage of D1231).
+                let ten = <$Storage>::from_i128(10);
+                let multiplier = <$Storage>::pow(ten, SCALE);
+                let zero = <$Storage>::from_i128(0);
+
+                // Accumulate the integer part directly into the
+                // signed storage. The negative branch subtracts each
+                // digit so we approach `MIN` from above without ever
+                // forming the positive intermediate `MAX + 1`.
+                let mut int_value = zero;
+                for &b in int_str {
+                    let digit = <$Storage>::from_i128((b - b'0') as i128);
+                    let scaled = match <$Storage>::checked_mul(int_value, ten) {
+                        ::core::option::Option::Some(v) => v,
+                        ::core::option::Option::None => {
+                            return ::core::result::Result::Err(
+                                $crate::core_type::ParseError::OutOfRange,
+                            )
+                        }
+                    };
+                    int_value = if negative {
+                        match <$Storage>::checked_sub(scaled, digit) {
+                            ::core::option::Option::Some(v) => v,
+                            ::core::option::Option::None => {
+                                return ::core::result::Result::Err(
+                                    $crate::core_type::ParseError::OutOfRange,
+                                )
+                            }
+                        }
+                    } else {
+                        match <$Storage>::checked_add(scaled, digit) {
+                            ::core::option::Option::Some(v) => v,
+                            ::core::option::Option::None => {
+                                return ::core::result::Result::Err(
+                                    $crate::core_type::ParseError::OutOfRange,
+                                )
+                            }
+                        }
+                    };
+                }
+                let int_scaled = match <$Storage>::checked_mul(int_value, multiplier) {
+                    ::core::option::Option::Some(v) => v,
+                    ::core::option::Option::None => {
+                        return ::core::result::Result::Err(
+                            $crate::core_type::ParseError::OutOfRange,
+                        )
+                    }
+                };
+
+                // Accumulate the fractional part the same way.
+                let mut frac_value = zero;
+                let frac_len = frac_str.len();
+                for &b in frac_str {
+                    let digit = <$Storage>::from_i128((b - b'0') as i128);
+                    let scaled = match <$Storage>::checked_mul(frac_value, ten) {
+                        ::core::option::Option::Some(v) => v,
+                        ::core::option::Option::None => {
+                            return ::core::result::Result::Err(
+                                $crate::core_type::ParseError::OutOfRange,
+                            )
+                        }
+                    };
+                    frac_value = if negative {
+                        match <$Storage>::checked_sub(scaled, digit) {
+                            ::core::option::Option::Some(v) => v,
+                            ::core::option::Option::None => {
+                                return ::core::result::Result::Err(
+                                    $crate::core_type::ParseError::OutOfRange,
+                                )
+                            }
+                        }
+                    } else {
+                        match <$Storage>::checked_add(scaled, digit) {
+                            ::core::option::Option::Some(v) => v,
+                            ::core::option::Option::None => {
+                                return ::core::result::Result::Err(
+                                    $crate::core_type::ParseError::OutOfRange,
+                                )
+                            }
+                        }
+                    };
+                }
+                let pad = (SCALE as usize) - frac_len;
+                if pad > 0 {
+                    let pad_factor = <$Storage>::pow(ten, pad as u32);
+                    frac_value = match <$Storage>::checked_mul(frac_value, pad_factor) {
+                        ::core::option::Option::Some(v) => v,
+                        ::core::option::Option::None => {
+                            return ::core::result::Result::Err(
+                                $crate::core_type::ParseError::OutOfRange,
+                            )
+                        }
+                    };
+                }
+
+                // `int_scaled` and `frac_value` already share the
+                // value's sign, so a plain add combines them.
+                let combined = match <$Storage>::checked_add(int_scaled, frac_value) {
+                    ::core::option::Option::Some(v) => v,
+                    ::core::option::Option::None => {
+                        return ::core::result::Result::Err(
+                            $crate::core_type::ParseError::OutOfRange,
+                        )
+                    }
+                };
+                ::core::result::Result::Ok(Self(combined))
             }
         }
     };

--- a/tests/from_str_wide.rs
+++ b/tests/from_str_wide.rs
@@ -1,0 +1,114 @@
+//! Wide-tier `FromStr` coverage at deep scales.
+//!
+//! Regression guard for the historical `u128` ceiling on the shared
+//! parser. Before the fix, the parser materialised `10^SCALE` in
+//! `u128`, which overflows at `SCALE > 38` and made any wide-tier
+//! `from_str` call at deep scale fail with
+//! [`decimal_scaled::ParseError::OutOfRange`] (or worse — silently
+//! wrap to garbage). After the fix the wide-tier from-str macro
+//! arm does the arithmetic at the storage width, so deep-scale
+//! literals round-trip cleanly.
+
+#![cfg(all(feature = "wide", feature = "x-wide", feature = "xx-wide"))]
+
+use core::str::FromStr;
+use decimal_scaled::{D1231, D307, D38, D76};
+
+#[test]
+fn d76_deep_scale_parses_one_point_five() {
+    // SCALE = 60 was the first failure point: 10^60 overflows u128
+    // (u128::MAX ~ 3.4e38).
+    let v = D76::<60>::from_str("1.5").expect("D76<60>::from_str(\"1.5\")");
+    let round_trip = v.to_string();
+    // SCALE = 60 fractional digits, leading "1.5" then 59 zeros.
+    let expected = format!("1.5{}", "0".repeat(59));
+    assert_eq!(round_trip, expected);
+}
+
+#[test]
+fn d307_deep_scale_parses_one_point_five() {
+    let v = D307::<150>::from_str("1.5").expect("D307<150>::from_str(\"1.5\")");
+    let round_trip = v.to_string();
+    let expected = format!("1.5{}", "0".repeat(149));
+    assert_eq!(round_trip, expected);
+}
+
+#[test]
+fn d307_deep_scale_round_trip_back_to_value() {
+    let s_in = "1.5";
+    let v = D307::<150>::from_str(s_in).expect("parse");
+    let s_out = v.to_string();
+    let reparsed = D307::<150>::from_str(&s_out).expect("reparse");
+    assert_eq!(v, reparsed);
+}
+
+#[test]
+fn d1231_deepest_scale_parses_one_point_five() {
+    // Deepest supported tier × scale combination.
+    let v = D1231::<1230>::from_str("1.5").expect("D1231<1230>::from_str(\"1.5\")");
+    let round_trip = v.to_string();
+    let expected = format!("1.5{}", "0".repeat(1229));
+    assert_eq!(round_trip, expected);
+}
+
+#[test]
+fn d1231_deepest_scale_handles_negative() {
+    // Negative path: the per-storage accumulator subtracts each digit
+    // rather than negating after the fact, so the asymmetric two's-
+    // complement `MIN` boundary is reachable without overflowing on
+    // the positive side. Spot-check a non-boundary negative value.
+    let v = D1231::<1230>::from_str("-1.5").expect("negative parse");
+    let round_trip = v.to_string();
+    let expected = format!("-1.5{}", "0".repeat(1229));
+    assert_eq!(round_trip, expected);
+}
+
+#[test]
+fn d307_deep_scale_many_fractional_digits() {
+    // Exercise the per-digit `checked_mul(10) + checked_add(digit)`
+    // loop with a long fractional run.
+    let frac = "1234567890".repeat(10); // 100 digits
+    let input = format!("0.{frac}");
+    let v = D307::<150>::from_str(&input).expect("parse");
+    let s_out = v.to_string();
+    // Round-trip preserves the value bit-exactly; the displayed form
+    // has SCALE = 150 fractional digits, so 50 trailing zeros pad
+    // the 100-digit input.
+    let expected = format!("0.{frac}{}", "0".repeat(50));
+    assert_eq!(s_out, expected);
+}
+
+#[test]
+fn d307_deep_scale_zero() {
+    let v = D307::<150>::from_str("0").expect("parse 0");
+    assert_eq!(v.to_string(), format!("0.{}", "0".repeat(150)));
+    let v = D307::<150>::from_str("0.0").expect("parse 0.0");
+    assert_eq!(v.to_string(), format!("0.{}", "0".repeat(150)));
+}
+
+#[test]
+fn d307_deep_scale_overlong_fractional_is_err() {
+    // SCALE = 150, fractional length 151 → reject.
+    let frac = "0".repeat(151);
+    let input = format!("0.{frac}");
+    assert!(D307::<150>::from_str(&input).is_err());
+}
+
+#[test]
+fn d76_deep_scale_integer_only() {
+    // No decimal point: only the integer-scale path is exercised.
+    let v = D76::<60>::from_str("42").expect("parse 42");
+    let expected = format!("42.{}", "0".repeat(60));
+    assert_eq!(v.to_string(), expected);
+}
+
+#[test]
+fn d38_shallow_scale_unchanged_after_refactor() {
+    // Sanity: the narrow-tier parser still produces the same value
+    // after the front-end was extracted to `parse_components`.
+    let v: D38<12> = "1.5".parse().expect("D38<12> parses");
+    assert_eq!(v.to_string(), "1.500000000000");
+
+    let neg: D38<12> = "-1.5".parse().expect("D38<12> negative parses");
+    assert_eq!(neg.to_string(), "-1.500000000000");
+}


### PR DESCRIPTION
## The bug

`src/display.rs` materialised the per-parse `10^SCALE` multiplier in `u128`:

```rust
let multiplier: u128 = 10u128.pow(SCALE);
```

`10^39` overflows `u128`, so any wide-tier type at `SCALE > 38` either rejected valid input or silently wrapped to garbage. The function's `D38` return shape made it look D38-only, but the shared `parse_decimal_bits::<SCALE>` path is reached from every width's `FromStr` impl (via `decl_decimal_from_str!`).

Wide-tier values could still be constructed via `from_i64` / `from_bits`, just not parsed from a string at deep `SCALE` — a real hole in the deep-decimal use case the wide tier exists for.

## Reproducer (against this branch's parent)

```rust
use std::str::FromStr;
use decimal_scaled::{D76, D307, D1231};

D76::<60>::from_str("1.5")    // before: Err(OutOfRange) | after: Ok(1.5…)
D307::<150>::from_str("1.5")  // before: Ok(0.0…) silently wrapped | after: Ok(1.5…)
D1231::<1230>::from_str("1.5") // before: same silent wrap | after: Ok(1.5…)
```

## The fix

Split the parser into two pieces:

1. `parse_components` — the shared string-parsing front-end (sign / dot / digit-character validation, leading-zero and overlong-fractional checks). No arithmetic, returns `(negative, int_str, frac_str)`. Used by every width.
2. Per-storage accumulators — narrow tier keeps `parse_decimal_bits`'s `u128` accumulator (SCALE always <= 38 so `u128` always fits). The `wide` arm of `decl_decimal_from_str!` now emits a per-storage body that does the base-10 arithmetic at the storage width using the inherent `checked_mul` / `checked_add` / `checked_sub` / `pow` items the wide-int macro already provides. At the deepest tier (D1231 with SCALE=1230) the multiplier needs ~4087 bits, which fits in the 4096-bit storage.

Negative values accumulate directly into the signed storage (`acc * 10 - digit` instead of `acc * 10 + digit`) so the asymmetric two's-complement `MIN` boundary is reachable without forming a positive intermediate that would overflow `MAX`.

### Approach choice

The task spec listed two options:
- **(1) Generic over `WideStorage`** — rejected: `WideStorage` doesn't expose `checked_mul` / `checked_add` / `checked_sub` / `MAX` / `MIN`, only the wrapping `Mul` / `Add` / `Sub` ops plus `pow`. Adding those to the trait just for parsing would pollute a kernel-only surface.
- **(2) Per-storage parse emitted by the macro** — chosen. The macro already has `$Storage` in scope and the wide-int's inherent surface already has all the checked ops we need. Tradeoff: each wide width gets its own monomorphised parse body, but they're all dead-code-eliminated when unused.

The choice is documented in the `decl_decimal_from_str!` module docstring.

## Test plan

- [x] New `tests/from_str_wide.rs` — 10 tests covering D76<60>, D307<150>, D1231<1230> (the deepest case), round-trip through `Display`, long fractional runs, negative path, overlong-fractional rejection, integer-only input.
- [x] `cargo test --features wide,x-wide,xx-wide,macros --lib --tests` — all 1330+ tests pass (4 `should_panic` debug-overflow tests in `arithmetic_mode_aware.rs` and 1 in `wide_strict_transcendentals.rs` only fail in `--release` because `debug_assertions` is off; same behaviour on `origin/main`, unrelated to this change).
- [x] `cargo test --release --features wide,x-wide,xx-wide,macros --test from_str_wide` — 10/10 pass.
- [x] Narrow tier (D9 / D18 / D38) behaviour unchanged — verified by `d38_shallow_scale_unchanged_after_refactor` and the existing parser/Display unit tests.

## Coordination

Depends on / coordinates with `rename/dwidth-1-cap-v0.4.0`. Both PRs branch off the same `main` and land independently; whichever lands second rebases. No surface-area overlap is expected — that PR renames things and caps `MAX_SCALE`; this PR touches `src/display.rs` and `src/macros/from_str.rs` only.