### PR TITLE
feat(limb): LimbSize matcher axis + u128 divide engine + const-generic BigRule

### DIFF
--- a/benches/micro/div_kernel_ab.rs
+++ b/benches/micro/div_kernel_ab.rs
@@ -34,7 +34,7 @@
 
 use criterion::Criterion;
 use decimal_scaled::__bench_internals::{
-    div_bz_forced_slice, div_dispatch_slice, div_knuth_slice,
+    div_bz_forced_slice, div_dispatch_slice, div_knuth_slice, div_knuth_u128_limb_slice,
 };
 
 #[path = "../support/ab_microbench.rs"]
@@ -81,6 +81,12 @@ fn run_bz(s: Shape) -> Vec<u64> {
     div_bz_forced_slice(&s.num, &s.den, &mut q, &mut r);
     r
 }
+fn run_u128(s: Shape) -> Vec<u64> {
+    let mut q = vec![0u64; s.num.len()];
+    let mut r = vec![0u64; s.num.len()];
+    div_knuth_u128_limb_slice(&s.num, &s.den, &mut q, &mut r);
+    r
+}
 
 fn compare_width(c: &mut Criterion, n: usize, label: &str, shapes: fn(usize) -> Vec<Shape>) {
     // Correctness gate: forced BZ and Knuth must agree before timing — they
@@ -100,6 +106,13 @@ fn compare_width(c: &mut Criterion, n: usize, label: &str, shapes: fn(usize) -> 
         div_dispatch_slice(&s.num, &s.den, &mut q2, &mut r2);
         assert_eq!(q0, q2, "knuth vs dispatch quot mismatch {label} {}", s.label);
         assert_eq!(r0, r2, "knuth vs dispatch rem mismatch {label} {}", s.label);
+        // And the u128-limb candidate (base 2^128); bit-identical, falling
+        // back to base-2^64 Knuth on odd / sub-4-limb divisors.
+        let mut q3 = vec![0u64; s.num.len()];
+        let mut r3 = vec![0u64; s.num.len()];
+        div_knuth_u128_limb_slice(&s.num, &s.den, &mut q3, &mut r3);
+        assert_eq!(q0, q3, "knuth vs u128 quot mismatch {label} {}", s.label);
+        assert_eq!(r0, r3, "knuth vs u128 rem mismatch {label} {}", s.label);
     }
     compare_all(
         c,
@@ -109,6 +122,7 @@ fn compare_width(c: &mut Criterion, n: usize, label: &str, shapes: fn(usize) -> 
         vec![
             ("knuth", run_knuth as fn(Shape) -> Vec<u64>),
             ("bz", run_bz),
+            ("u128", run_u128),
         ],
     );
 }

--- a/benches/micro/rem_kernel_ab.rs
+++ b/benches/micro/rem_kernel_ab.rs
@@ -115,22 +115,37 @@ fn compare_wide<const N: usize>(c: &mut Criterion, label: &str) {
 
 /// Decimal-rem dispatch seam (`src/policy/rem.rs` -> `rem_int_layer`).
 /// Narrow widths only: native hardware `%` vs the generic int-layer path.
-fn compare_dec_rem<const N: usize>(c: &mut Criterion, label: &str) {
-    for p in operand_set::<N>() {
-        assert_eq!(dec_rem_native::<N>(p.clone().a, p.clone().b),
-            dec_rem_int_layer::<N>(p.clone().a, p.clone().b),
-            "dec native vs int_layer disagree {label} {}", p.label);
-    }
-    compare_all(
-        c,
-        &format!("dec_rem/{label}"),
-        |p: &Pair<N>| p.label.to_string(),
-        operand_set::<N>(),
-        vec![
-            ("native", (|p: Pair<N>| dec_rem_native::<N>(p.a, p.b)) as fn(Pair<N>) -> Int<N>),
-            ("int_layer", |p: Pair<N>| dec_rem_int_layer::<N>(p.a, p.b)),
-        ],
-    );
+///
+/// A macro, not a generic fn: `dec_rem_int_layer` carries a `pub(crate)`
+/// `ComputeInt` bound a bench (a separate crate) cannot name, so the body
+/// must monomorphise at a concrete width `$n` — where `Int<$n>: ComputeInt`
+/// is discharged by the impl — rather than be checked for all `N`. Mirrors
+/// `hypot_ab`'s `hypot_cell!`.
+macro_rules! dec_rem_cell {
+    ($c:expr, $n:literal, $label:literal) => {{
+        for p in operand_set::<$n>() {
+            assert_eq!(
+                dec_rem_native::<$n>(p.clone().a, p.clone().b),
+                dec_rem_int_layer::<$n>(p.clone().a, p.clone().b),
+                "dec native vs int_layer disagree {} {}",
+                $label,
+                p.label
+            );
+        }
+        compare_all(
+            $c,
+            concat!("dec_rem/", $label),
+            |p: &Pair<$n>| p.label.to_string(),
+            operand_set::<$n>(),
+            vec![
+                (
+                    "native",
+                    (|p: Pair<$n>| dec_rem_native::<$n>(p.a, p.b)) as fn(Pair<$n>) -> Int<$n>,
+                ),
+                ("int_layer", |p: Pair<$n>| dec_rem_int_layer::<$n>(p.a, p.b)),
+            ],
+        );
+    }};
 }
 
 /// Build `k * 10^scale` in an `N`-limb magnitude (the exact live full_matrix
@@ -159,48 +174,61 @@ fn k_times_pow10<const N: usize>(k: u64, scale: u32) -> Int<N> {
 ///     shape that exposed the ~25x regression.
 ///   * `balanced` -- two full-width random magnitudes (general divmod): the
 ///     case that must NOT regress.
-fn compare_dec_rem_wide<const N: usize>(c: &mut Criterion, label: &str, scale: u32) {
-    let two = k_times_pow10::<N>(2, scale);
-    let one = k_times_pow10::<N>(1, scale);
-    let bal_a = synth::<N>(7919, N);
-    let bal_b = synth::<N>(104729, N);
-    // correctness: new path agrees with the old wrapping_rem on both shapes.
-    assert_eq!(dec_rem_int_layer::<N>(two, one), int_wrapping_rem_slice::<N>(two, one),
-        "dec rem short_circuit disagree {label}");
-    assert_eq!(dec_rem_int_layer::<N>(bal_a, bal_b), int_wrapping_rem_slice::<N>(bal_a, bal_b),
-        "dec rem balanced disagree {label}");
+macro_rules! dec_rem_wide_cell {
+    ($c:expr, $n:literal, $label:literal, $scale:expr) => {{
+        let two = k_times_pow10::<$n>(2, $scale);
+        let one = k_times_pow10::<$n>(1, $scale);
+        let bal_a = synth::<$n>(7919, $n);
+        let bal_b = synth::<$n>(104729, $n);
+        // correctness: new path agrees with the old wrapping_rem on both shapes.
+        assert_eq!(
+            dec_rem_int_layer::<$n>(two, one),
+            int_wrapping_rem_slice::<$n>(two, one),
+            "dec rem short_circuit disagree {}",
+            $label
+        );
+        assert_eq!(
+            dec_rem_int_layer::<$n>(bal_a, bal_b),
+            int_wrapping_rem_slice::<$n>(bal_a, bal_b),
+            "dec rem balanced disagree {}",
+            $label
+        );
 
-    let inputs = vec![
-        Pair { label: "short_circuit", a: two, b: one },
-        Pair { label: "balanced", a: bal_a, b: bal_b },
-    ];
-    compare_all(
-        c,
-        &format!("dec_rem_wide/{label}"),
-        |p: &Pair<N>| p.label.to_string(),
-        inputs,
-        vec![
-            ("operator_knuth", (|p: Pair<N>| dec_rem_int_layer::<N>(p.a, p.b)) as fn(Pair<N>) -> Int<N>),
-            ("old_wrapping_rem", |p: Pair<N>| int_wrapping_rem_slice::<N>(p.a, p.b)),
-        ],
-    );
+        let inputs = vec![
+            Pair { label: "short_circuit", a: two, b: one },
+            Pair { label: "balanced", a: bal_a, b: bal_b },
+        ];
+        compare_all(
+            $c,
+            concat!("dec_rem_wide/", $label),
+            |p: &Pair<$n>| p.label.to_string(),
+            inputs,
+            vec![
+                (
+                    "operator_knuth",
+                    (|p: Pair<$n>| dec_rem_int_layer::<$n>(p.a, p.b)) as fn(Pair<$n>) -> Int<$n>,
+                ),
+                ("old_wrapping_rem", |p: Pair<$n>| int_wrapping_rem_slice::<$n>(p.a, p.b)),
+            ],
+        );
+    }};
 }
 
 fn bench(c: &mut Criterion) {
     decimal_scaled_ab_sweep!(c =>
         Int<1> => |c: &mut Criterion| compare_narrow::<1>(c, "Int64_D18"),
         Int<2> => |c: &mut Criterion| compare_narrow::<2>(c, "Int128_D38"),
-        Int<1> => |c: &mut Criterion| compare_dec_rem::<1>(c, "D18"),
-        Int<2> => |c: &mut Criterion| compare_dec_rem::<2>(c, "D38"),
+        Int<1> => |c: &mut Criterion| dec_rem_cell!(c, 1, "D18"),
+        Int<2> => |c: &mut Criterion| dec_rem_cell!(c, 2, "D38"),
         Int<4> => |c: &mut Criterion| compare_wide::<4>(c, "Int256_D76"),
         Int<8> => |c: &mut Criterion| compare_wide::<8>(c, "Int512_D153"),
         Int<64> => |c: &mut Criterion| compare_wide::<64>(c, "Int4096_D1232"),
         // Wide decimal-rem regression recovery: operator/Knuth vs the old
         // wrapping_rem shift-subtract, on the live `k * 10^SCALE` shape.
-        Int<16> => |c: &mut Criterion| compare_dec_rem_wide::<16>(c, "D307_s153", 153),
-        Int<32> => |c: &mut Criterion| compare_dec_rem_wide::<32>(c, "D616_s308", 308),
-        Int<48> => |c: &mut Criterion| compare_dec_rem_wide::<48>(c, "D924_s462", 462),
-        Int<64> => |c: &mut Criterion| compare_dec_rem_wide::<64>(c, "D1232_s616", 616),
+        Int<16> => |c: &mut Criterion| dec_rem_wide_cell!(c, 16, "D307_s153", 153),
+        Int<32> => |c: &mut Criterion| dec_rem_wide_cell!(c, 32, "D616_s308", 308),
+        Int<48> => |c: &mut Criterion| dec_rem_wide_cell!(c, 48, "D924_s462", 462),
+        Int<64> => |c: &mut Criterion| dec_rem_wide_cell!(c, 64, "D1232_s616", 616),
     );
 }
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -179,6 +179,32 @@ exactly: that is the cross-tier size pollution the Constitution (rule 6)
 forbids, and it is a defect to be migrated to `single_limbs()` /
 `double_limbs()` / `quad_limbs()` / `u128_limbs()`.
 
+## Limb width — the matcher's second axis (`u64` / `u128`)
+
+A wide-tier kernel can run faster in **u128 limbs** (half the limbs and carries) than in
+u64. Which limb width wins is a per-`(N, SCALE)` property, so it is a **second matcher axis**
+alongside the algorithm: the policy `Select` verdict carries `(Algorithm, LimbSize)`, where
+`LimbSize` (`U64` / `U128`, defined in `compute_int.rs`) is the *const* part of the verdict
+(limb width is value-independent — never decided inside a `ByValue` closure). `dispatch`
+const-folds the verdict and runs the kernel at the chosen width.
+
+The width is delivered **by type, not by name**: a `Limb` trait (impl'd for `u64` and
+`u128`, carrying the scalar primitives) parameterises ONE generic kernel
+`fn k<const N: usize, L: Limb>(…) where Int<N>: ComputeInt`, dispatched by a const-folded
+`match limbsize { U64 => k::<N, u64>(…), U128 => k::<N, u128>(…) }`. There is **one generic
+kernel, never a per-limb-type copy** (rule 2) — the u128 path is simply the `L = u128`
+monomorphisation (so a hand-written u128 variant of an algorithm is a *superseded duplicate*
+once the generic exists).
+
+Mechanics: storage stays `Int<N>` (u64); a `u128` kernel packs its `N` u64 limbs into
+`⌈N/2⌉` u128 (a cheap little-endian reinterpret into the u128 `ComputeInt` buffer), runs,
+unpacks. Packing pairs two u64 into one u128, so it is exact only for an **even** limb count
+— the matcher returns `U128` only for even cells; odd/narrow tiers stay `U64`. The `L`-typed
+scratch comes from `ComputeInt` (which carries both the u64 and u128 buffer families); the
+`Limb` accessors route `L` to the matching family, so the kernel never names a build-max
+size. Rolled out pilot-first, microbench-gated per cell: a cell routes `U128` only where the
+benchmark shows the win.
+
 ## Algorithm choosing — and pruning
 
 A single function (say `sqrt`) has several possible algorithms — a

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -384,11 +384,24 @@ Rules that make this work:
 
 ### Keeping the alternatives
 
-Algorithms that lose at today's widths (FFT/NTT multiplication, AGM below
-~D1232, …) are not deleted. They are preserved as documented references
-and, where the implementation is genuinely different, as compiled-out
-code — because a future CPU/LLVM instruction or a platform-specific build
-can flip a today-loser into a winner. See `ALGORITHMS.md`.
+**Algorithms are never deleted.** A kernel that loses at today's widths
+(FFT/NTT multiplication, AGM below ~D1232, …), an **unwired candidate**
+awaiting a bench/policy seam, or a **reference baseline** (the schoolbook
+`Algorithm` variants) is *kept* — as a documented reference and, where the
+implementation genuinely differs, as compiled-out / unrouted code — because a
+future CPU/LLVM instruction, a platform-specific build, or a re-tuned
+threshold can flip a today-loser into a winner. **"Unwired" or "reached only
+by its own tests" is the EXPECTED state of a kept alternative, not dead code
+to remove.** See `ALGORITHMS.md`.
+
+The one thing that *is* removed is a **superseded duplicate** — the obsolete
+*shape* of an algorithm that a migration replaced in place (e.g. a
+`const`-work-width `fn f<W, const N>` once it became `fn f<W: ComputeInt>`):
+that is the same algorithm's dead skin, not an alternative, so it goes. The
+test of "alternative (keep) vs superseded duplicate (remove)": does it
+implement a *distinct* algorithm/shape that could win under different
+conditions (keep), or is it the leftover old signature of something that now
+exists in one canonical form (remove)?
 
 ## How the guarantees are enforced — by testing
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -205,35 +205,51 @@ scratch comes from `ComputeInt` (which carries both the u64 and u128 buffer fami
 size. Rolled out pilot-first, microbench-gated per cell: a cell routes `U128` only where the
 benchmark shows the win.
 
-The verdict lives in the function's policy `select` exactly like the algorithm axis — a
-`const fn` keyed on the width, returning the `(Algorithm, LimbSize)` pair, read in a
-`const { … }` block so it const-folds away. The limb width is **per-cell policy DATA**, not a
-blanket rule: a `limb_size<const N>()` helper enumerates the benched winners, with
+The limb width is selected in **two stages**, and the second stage is **owned by the
+algorithm**: `select` resolves the *algorithm* first (the existing `ByAlgorithm` / `ByValue`
+axis); then the chosen algorithm yields its *own* limb width via a `const fn limb_size<const
+N>(self) -> LimbSize` method — because the u64/u128 crossover is algorithm-dependent, it lives
+on the `Algorithm` enum, not in the verdict. `dispatch` resolves the algorithm, asks it for
+its limb width, and folds both in a `const { … }` block (when the algorithm is const) so the
+whole thing collapses to one direct typed call. The limb width is **per-cell policy DATA**,
+not a blanket: each algorithm's `limb_size` arm enumerates its benched winners, with
 `LimbSize::for_packing(N)` (the even-`N` validity gate) as the default. The canonical shape
-(the reference instance is `int/policy/mul_low.rs`, the truncated-low product):
+(reference instance `int/policy/mul_low.rs`, the truncated-low product):
 
 ```rust
-// 2. verdict — const in BOTH axes (limb width is value-independent).
-enum Select { ByAlgorithm(Algorithm, LimbSize) }
+enum Algorithm { LowLimb /* , … */ }
 
-// 3. policy DATA: the benched per-N limb-width table. U128 only where a
-//    microbench wins AND it is valid (even N — for_packing gates odd → U64).
-const fn limb_size<const N: usize>() -> LimbSize {
-    LimbSize::for_packing(N)        // ← carve out a losing even cell to U64 HERE
-}
-const fn select<const N: usize>() -> Select {
-    Select::ByAlgorithm(Algorithm::LowLimb, limb_size::<N>())
+impl Algorithm {
+    // SECOND axis — owned by the algorithm (the crossover is algorithm-dependent).
+    // U128 only where a microbench wins AND it is valid (even N — for_packing gates odd → U64).
+    const fn limb_size<const N: usize>(self) -> LimbSize {
+        match self {
+            Algorithm::LowLimb => LimbSize::for_packing(N), // ← carve a losing even cell to U64 HERE
+        }
+    }
 }
 
-// 4. dispatch — folds to ONE direct typed call, unchosen arm eliminated.
+enum Select { ByAlgorithm(Algorithm) /* + ByValue for a value-chosen algorithm */ }
+const fn select() -> Select { Select::ByAlgorithm(Algorithm::LowLimb) } // <const N> if width-keyed
+
+// dispatch — stage 1: resolve the algorithm; stage 2: ask it for its limb width.
 pub(crate) fn dispatch<const N: usize>(a: &[u64; N], b: &[u64; N], out: &mut [u64; N]) {
-    let (algo, limb) = match const { select::<N>() } { Select::ByAlgorithm(a, l) => (a, l) };
+    let (algo, limb) = const {
+        let algo = match select() { Select::ByAlgorithm(a) => a };
+        (algo, algo.limb_size::<N>())
+    };
     match (algo, limb) {
         (Algorithm::LowLimb, LimbSize::U64)  => mul_low_limb::<N, u64>(a, b, out),
         (Algorithm::LowLimb, LimbSize::U128) => mul_low_limb::<N, u128>(a, b, out),
     }
 }
 ```
+
+Under a `ByValue` algorithm choice the algorithm resolves at run time; `limb_size::<N>()` is
+then read inside the chosen arm (still const per `N`, still value-independent). A function
+whose limb form is a *different algorithm* rather than a knob (the slice **divide**: its u128
+form is base-2¹²⁸ Knuth, structurally distinct — see the const-vs-runtime note below) carries
+that as its own `Algorithm` variant, so there is simply no `limb_size` knob to select.
 
 **Const-`N` vs runtime-shape functions.** The const verdict above fits functions keyed on a
 compile-time width (the truncated-low product is `<const N>`). A function whose policy is

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -179,6 +179,85 @@ exactly: that is the cross-tier size pollution the Constitution (rule 6)
 forbids, and it is a defect to be migrated to `single_limbs()` /
 `double_limbs()` / `quad_limbs()` / `u128_limbs()`.
 
+## Const generics — the BigRule: pass the level's OWN, never any other
+
+A recurring pollution: a policy or function that **invents a const generic**
+beyond the ones that define its level. The rule is sharp and exhaustive.
+
+**The policy entry point (`dispatch`) SHOULD take exactly the level's defining
+const(s) — and NO OTHERS:**
+
+| level | `dispatch` consts |
+|-------|-------------------|
+| int unary | `<const N>` |
+| int binary | `<const Nthis, const Nother>` |
+| decimal unary | `<const N, const S>` (width **and** scale) |
+| decimal binary | `<const Nthis, const Sthis, const Nother, const Sother>` |
+
+These are free to take because **the caller already holds them in its types**
+— inferred at the call site, never computed (`D<Int<N>, SCALE>::sqrt` already
+knows `N` and `SCALE`, so `dispatch::<N, SCALE>(…)` costs it nothing).
+
+> **Decimal binary is genuinely four consts.** Binary decimal ops are meant to
+> work across *different* widths AND scales (`D<Int<Nthis>, Sthis> op
+> D<Int<Nother>, Sother>`), so `<Nthis, Sthis, Nother, Sother>` is the real
+> target — in scope, not a far-future reservation. Where the *current*
+> implementation is still same-type (`D<Int<N>, S> op D<Int<N>, S>`), the four
+> consts collapse to the dec-unary `<N, S>` and that is what those dispatchers
+> take today; they move to the full four-const form as cross-scale/width
+> binary lands. (A binary op that *needs* both operands to be the same type is
+> the transitional state, not the design.)
+
+- **No other const value is allowed.** No work-width const, no derived const,
+  no `const LW`, no `{2*N}` / `{<_>::U128_LIMBS}` const-generic argument. A
+  const that *encodes a width derived from another* (`fn f<W, const LW>` where
+  `LW == W::U128_LIMBS`) is the canonical defect — wider-than-`N` widths come
+  from `ComputeInt` (previous section), never a const param. That is the
+  const-work-width wall the `ComputeInt` associated types exist to remove.
+- **Inward is optional.** Threading these consts *inward* (`select`,
+  `select_for_limbs`, the kernels) is optional — a helper takes a const only
+  if it uses it. Taking the level const at the `dispatch` entry but not
+  inward is normal, never a defect.
+
+**The caller guardrail + the metadata test.** A caller must be able to invoke
+a policy with *exactly what it already has*. If calling forces the caller to
+**manufacture a const, create a type, or specialise**, the *policy signature
+is wrong* — not the caller.
+
+The **metadata test** for `dispatch`: it may **freely inspect the values
+passed to it** — limb lengths, magnitude, sign, any property of the operands
+— to choose an algorithm. That *is* the job of a `ByValue` / `ByShape`
+matcher, and it is never a violation (the divide stripping its own slices to
+`den_n` is exactly this). What `dispatch` must **not** need is **external
+metadata**: any const, type, or context *beyond* its level consts and the
+operands themselves. If a function cannot be picked or run without extra
+information threaded in from outside, the design is broken.
+
+### The one exception: division has no const-width axis
+
+Division is the **single policy with no const-width axis**: it looks like the
+int-binary case that should take `<const Nthis, const Nother>`, but it cannot.
+Its operands have *independent* runtime lengths that no const expresses:
+
+- the decimal `/` divides a **`2N`-limb** scaled numerator by an **`N`-limb**
+  divisor — two different widths, neither the caller's single `N`;
+- the slice roots (`isqrt_newton`, `icbrt_newton`, `newton_reciprocal`,
+  `div_rem_mag_slice`) divide **bare `&[u64]` of runtime length** — they hold
+  no `N` in their types at all.
+
+So `int::policy::div_rem`'s `select` and `dispatch` are **non-generic and
+slice-based** (`dispatch(num, den, quot, rem)`), and the shape decision lives
+entirely in the runtime `select_for_limbs(num, den)`. Threading a `<N>` would
+force the slice roots to *manufacture* a const they do not have — the exact
+caller-side specialisation the guardrail forbids — and the divide would not
+even use it: its engine choice (and any future limb-width refinement, e.g. a
+u128-limb engine for an even, wide divisor) is a **runtime arm inside
+`select_for_limbs`**, gated on the runtime `den_n`, because that is where the
+width information actually is. Contrast `mul_low` (a genuine `select<N>`
+policy): there the operands *are* width-`N`, so `N` is the level's own const
+and passing it is correct. Division is the slice/runtime exception, not a
+template to copy.
+
 ## Limb width — the matcher's second axis (`u64` / `u128`)
 
 A wide-tier kernel can run faster in **u128 limbs** (half the limbs and carries) than in

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -205,6 +205,44 @@ scratch comes from `ComputeInt` (which carries both the u64 and u128 buffer fami
 size. Rolled out pilot-first, microbench-gated per cell: a cell routes `U128` only where the
 benchmark shows the win.
 
+The verdict lives in the function's policy `select` exactly like the algorithm axis — a
+`const fn` keyed on the width, returning the `(Algorithm, LimbSize)` pair, read in a
+`const { … }` block so it const-folds away. The limb width is **per-cell policy DATA**, not a
+blanket rule: a `limb_size<const N>()` helper enumerates the benched winners, with
+`LimbSize::for_packing(N)` (the even-`N` validity gate) as the default. The canonical shape
+(the reference instance is `int/policy/mul_low.rs`, the truncated-low product):
+
+```rust
+// 2. verdict — const in BOTH axes (limb width is value-independent).
+enum Select { ByAlgorithm(Algorithm, LimbSize) }
+
+// 3. policy DATA: the benched per-N limb-width table. U128 only where a
+//    microbench wins AND it is valid (even N — for_packing gates odd → U64).
+const fn limb_size<const N: usize>() -> LimbSize {
+    LimbSize::for_packing(N)        // ← carve out a losing even cell to U64 HERE
+}
+const fn select<const N: usize>() -> Select {
+    Select::ByAlgorithm(Algorithm::LowLimb, limb_size::<N>())
+}
+
+// 4. dispatch — folds to ONE direct typed call, unchosen arm eliminated.
+pub(crate) fn dispatch<const N: usize>(a: &[u64; N], b: &[u64; N], out: &mut [u64; N]) {
+    let (algo, limb) = match const { select::<N>() } { Select::ByAlgorithm(a, l) => (a, l) };
+    match (algo, limb) {
+        (Algorithm::LowLimb, LimbSize::U64)  => mul_low_limb::<N, u64>(a, b, out),
+        (Algorithm::LowLimb, LimbSize::U128) => mul_low_limb::<N, u128>(a, b, out),
+    }
+}
+```
+
+**Const-`N` vs runtime-shape functions.** The const verdict above fits functions keyed on a
+compile-time width (the truncated-low product is `<const N>`). A function whose policy is
+**`ByShape`/`ByValue`** (keyed on *runtime* operand lengths — the slice divide, whose `2N`
+scaled numerator has no nameable type) cannot carry a const `LimbSize`: there its limb-width
+choice is a **runtime** decision and belongs as a distinct `Algorithm` engine variant the
+shape classifier selects (e.g. a u128-limb Knuth engine chosen when the effective limb counts
+are even and wide enough), not a const verdict. Same axis, delivered where the key allows.
+
 ## Algorithm choosing — and pruning
 
 A single function (say `sqrt`) has several possible algorithms — a

--- a/src/algos/div/div_widen_scale.rs
+++ b/src/algos/div/div_widen_scale.rs
@@ -50,7 +50,11 @@ fn sig_len(a: &[u64]) -> usize {
 /// the ordering of `rem` vs `divisor - rem` (the rounding half-comparison).
 #[inline]
 fn cmp_double_vs(rem: &[u64], divisor: &[u64]) -> core::cmp::Ordering {
-    let mut two_r = [0u64; 80];
+    // `2·rem` spans at most `rem.len() + 1` limbs, and `rem < divisor`, whose
+    // length is `≤ N ≤ MAX_WORK_N` (the widest enabled tier). A no-`N` slice
+    // helper, so it takes the build-max size (`MAX_WORK_N + 1`) — never a
+    // frozen literal that a wider tier could outgrow.
+    let mut two_r = [0u64; crate::int::algos::support::limbs::MAX_WORK_N + 1];
     let mut carry: u64 = 0;
     for (i, &r) in rem.iter().enumerate() {
         let v = ((r as u128) << 1) | carry as u128;

--- a/src/algos/mul/mul_schoolbook.rs
+++ b/src/algos/mul/mul_schoolbook.rs
@@ -141,8 +141,11 @@ where
 /// returning the ordering of `rem` vs `divisor - rem`.
 #[inline]
 fn cmp_double_vs(rem: &[u64], divisor: &[u64]) -> core::cmp::Ordering {
-    // Build 2*rem in a local buffer wide enough (divisor.len()+1).
-    let mut two_r = [0u64; 80];
+    // `2·rem` spans at most `rem.len() + 1` limbs, and `rem < divisor`, whose
+    // length is `≤ N ≤ MAX_WORK_N` (the widest enabled tier). A no-`N` slice
+    // helper, so it takes the build-max size (`MAX_WORK_N + 1`) — never a
+    // frozen literal that a wider tier could outgrow.
+    let mut two_r = [0u64; crate::int::algos::support::limbs::MAX_WORK_N + 1];
     let mut carry: u64 = 0;
     for (i, &r) in rem.iter().enumerate() {
         let v = (r as u128) << 1 | carry as u128;

--- a/src/int/algos/div/div_knuth_u128_limb.rs
+++ b/src/int/algos/div/div_knuth_u128_limb.rs
@@ -43,8 +43,6 @@
 //!
 //! [`LimbSize`]: crate::int::types::compute_int::LimbSize
 
-#![allow(dead_code)]
-
 use crate::int::algos::div::div_mg::Mg3By2;
 use crate::int::types::compute_int::{Limb, MAX_SINGLE_LIMBS};
 

--- a/src/int/algos/div/div_knuth_u128_limb.rs
+++ b/src/int/algos/div/div_knuth_u128_limb.rs
@@ -1,82 +1,61 @@
 // SPDX-FileCopyrightText: 2026 John Moxley
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-// candidate: u128-limb Knuth Algorithm D for the wide-tier rem/div
-// regression — NOT WIRED.
-//
-//! Knuth Algorithm D on **u128 limbs** (the `LimbSize` axis), recovering
-//! part of the wide-tier rem/div regression vs 0.4.4 (which used u128
-//! limbs natively).
+//! Knuth Algorithm D on **u128 limbs** (base 2¹²⁸) — the divide side of the
+//! [`LimbSize`] axis, parked pending the `div_kernel_ab` verdict.
 //!
-//! ## Why (research 2026-05-24, chunk 3)
+//! ## Why base 2¹²⁸ (and why NOT a u64-`q̂` hybrid)
 //!
-//! `div_knuth` (base 2^64) has an `O(m·n)` inner multiply-subtract over
-//! `n = den.len()` u64 limbs and `m+1` outer quotient steps. The 0.4.4→
-//! 0.5.0 u64-limb rewrite regressed the widest tiers (rem@D1232 +3323%)
-//! because 0.4.4 stored the dividend/divisor in **u128 limbs** (`n/2`
-//! limbs), so the inner loop was `~(m/2)·(n/2) = m·n/4` STEPS.
+//! The wide-tier rem/div runs [`div_knuth`] at base 2⁶⁴: its hot
+//! `O(m·n)` multiply-subtract walks `n = den.len()` u64 limbs. Storing the
+//! running dividend/divisor in **u128 limbs** halves the limb-slot count
+//! and the carry-chain hops — the same lever that makes the u128
+//! truncated-low multiply win (`mul_low_limb`).
 //!
-//! The naive "store in u128 limbs" recovery WASHES: a full 128×128→low
-//! product is ~4 u64-multiplies in software, so `m·n/4` steps × 4 = `m·n`
-//! u64-mults — exactly base-2^64 (this is the 1.1–1.2× the prior design
-//! experiment saw; the comment "software 128×128 ate it" is precisely
-//! this). The recovery only materialises if the per-step product is
-//! cheaper than 4 u64-mults.
+//! The multiply, though, is the opposite trade. A clean native u128
+//! carry-chain needs **u128-aligned** windows, which forces a **u128
+//! quotient digit** (base 2¹²⁸): a u64 `q̂` emits 64-bit digits at u64
+//! offsets, so half the multiply-subtract windows straddle a u128 boundary
+//! and cannot run as aligned u128 ops (a u64-`q̂` scheme therefore degrades
+//! to the u64 loop — no win, which is why the earlier scaffold delegated to
+//! a u64 lens). Base 2¹²⁸ keeps every window aligned, at the cost of a
+//! `q̂·v[i]` product that is a full 128×128→256 (4 u64-mults) instead of
+//! 64×64→128 (1): **2× the limb-multiplies for ½ the carry-chain.** Whether
+//! that nets out ahead of base-2⁶⁴ is a per-width microbench question
+//! (`benches/micro/div_kernel_ab.rs`); the campaign's earlier estimate was
+//! a wash, hence this kernel stays a parked candidate until the bench says
+//! otherwise.
 //!
-//! ## The lever — the `q̂·v[i]` product is 128×64, not 128×128
+//! ## Shape
 //!
-//! In Knuth D the running dividend (`u`) and divisor (`v`) are wide, but
-//! the **quotient digit `q̂` is a single base-limb**. If we keep `q̂` a
-//! **u64** (a HALF-limb of the u128 base) while storing `u`/`v` as u128
-//! limbs, each inner step is `q̂(64 bits) × v_limb(128 bits) → 192 bits`,
-//! which is **2 u64-multiplies** (lo·q̂, hi·q̂), not 4. A u64 `q̂` emits
-//! 64 quotient bits per outer step, so there are still `m` (not `m/2`)
-//! outer steps, but the INNER loop walks `n/2` u128 limbs at 2 u64-mults:
-//! `m · (n/2) · 2 = m·n` — still a wash on raw multiplies.
+//! A PURE slice engine, drop-in alongside [`div_knuth`]: same `&[u64]`
+//! operands and `&[u64]` quotient/remainder, so if it wins it wires as a
+//! `LimbSize`-gated `Algorithm` arm in [`crate::int::policy::div_rem`]
+//! (selected when the effective limb counts are EVEN and wide — packing
+//! pairs two u64 per u128, so an odd effective count has no u128 form). It
+//! normalises + packs in u64 space (reusing [`div_knuth`]'s proven
+//! normalisation: a top-u64-limb MSB also sets the top u128 limb's bit
+//! 127), runs base 2¹²⁸, then unpacks — no per-tier type, no macro
+//! duplication. Odd/single-limb shapes fall back to [`div_knuth`].
 //!
-//! The REAL saving is NOT the multiply count but the **carry-chain and
-//! index overhead**: storing `u`/`v` as u128 limbs halves the number of
-//! limb slots the inner loop indexes, halves the add/borrow carry hops
-//! (one 128-bit accumulate per two u64 columns instead of two), and
-//! halves the outer-loop normalisation / shift bookkeeping. On the wide
-//! tiers (D616–D1232, `n = 32..64` u64 limbs) the inner loop is dominated
-//! by the per-limb load/mul/sub/store *chain*, not the multiplier count,
-//! so halving the slot count is a measured **~1.3–1.5×** (partial
-//! recovery of the lost 4×, NOT the full 2× — the honest accounting after
-//! correcting the optimistic chunk-2 estimate). The full 4× needs a
-//! hardware 128-bit multiply, which the target lacks.
+//! Bit-identical to [`div_knuth`] (the `#[cfg(test)]` differential below);
+//! NOT WIRED.
 //!
-//! ## Architecture — generic over the `LimbSize` axis, NOT per-tier
-//!
-//! This kernel is a PURE slice engine like `div_knuth`: it takes the SAME
-//! `&[u64]` operands and produces the SAME `&[u64]` quotient/remainder, so
-//! it is a drop-in `Algorithm` arm in `int::policy::div_rem` selected by a
-//! `LimbSize`-style predicate (e.g. even effective limb count AND
-//! `n >= WIDE_U128_LIMB_THRESHOLD`). It packs the normalised operands into
-//! a u128 working buffer internally, runs the loop, and unpacks — no
-//! per-decimal-tier type, no macro duplication. The packing requires an
-//! EVEN effective u64-limb count after normalisation; odd counts fall back
-//! to base-2^64 `div_knuth` (the policy predicate gates this).
-//!
-//! NOT WIRED. Bit-identity test below is `#[cfg(test)]` and unrun here.
+//! [`LimbSize`]: crate::int::types::compute_int::LimbSize
 
 #![allow(dead_code)]
 
-use crate::int::algos::div::div_mg::Mg2By1;
-use crate::int::types::compute_int::MAX_SINGLE_LIMBS;
+use crate::int::algos::div::div_mg::Mg3By2;
+use crate::int::types::compute_int::{Limb, MAX_SINGLE_LIMBS};
 
-/// u128-limb working scratch: half the u64 `MAX_SINGLE_LIMBS`, +1 slack.
-const SCRATCH_LIMBS_128: usize = MAX_SINGLE_LIMBS / 2 + 1;
+/// u128-limb working scratch: half the u64 `MAX_SINGLE_LIMBS`, +2 slack
+/// (the one-above window limb plus an even-rounding limb).
+const SCRATCH_LIMBS_128: usize = MAX_SINGLE_LIMBS / 2 + 2;
 
-/// Knuth Algorithm D with a u128-limb running dividend/divisor and a
-/// 64-bit `q̂` quotient digit. `num` / `den` are little-endian u64 slices
-/// with an EVEN effective limb count (caller-gated); `quot` / `rem` are
-/// written in u64 limbs to match `div_knuth`'s contract exactly.
-///
-/// The quotient digits are 64-bit (one per outer step, `m+1` of them, as
-/// in base-2^64 Knuth), so `quot` is identical limb-for-limb to
-/// `div_knuth`. The only structural difference is that `u`/`v`/the inner
-/// multiply-subtract are carried in u128 limbs.
+/// Knuth Algorithm D at base 2¹²⁸. `num` / `den` are little-endian u64
+/// slices; `quot` / `rem` are written in u64 limbs to match [`div_knuth`]'s
+/// contract bit-for-bit. Even effective limb counts run the u128 core;
+/// odd / single-limb / `num < den` shapes fall back to [`div_knuth`].
 pub(crate) fn div_knuth_u128_limb(num: &[u64], den: &[u64], quot: &mut [u64], rem: &mut [u64]) {
     for q in quot.iter_mut() {
         *q = 0;
@@ -85,7 +64,7 @@ pub(crate) fn div_knuth_u128_limb(num: &[u64], den: &[u64], quot: &mut [u64], re
         *r = 0;
     }
 
-    // Effective u64 limb counts.
+    // Effective u64 limb counts (strip leading zeros).
     let mut n64 = den.len();
     while n64 > 0 && den[n64 - 1] == 0 {
         n64 -= 1;
@@ -101,18 +80,19 @@ pub(crate) fn div_knuth_u128_limb(num: &[u64], den: &[u64], quot: &mut [u64], re
         return;
     }
 
-    // This candidate handles the even-limb, multi-limb-divisor regime
-    // (the wide tiers). Anything else defers to base-2^64 Knuth: keeps
-    // the candidate's body focused on the win case. (The production
-    // policy predicate would route only the even/wide case here.)
-    if n64 < 2 || n64 % 2 != 0 || top64 % 2 != 0 {
+    // The u128 core needs an EVEN-u64-limb-count divisor of at least TWO
+    // u128 limbs (`n128 >= 2`, i.e. `n64 >= 4`): the base-2¹²⁸ 3-by-2 q̂
+    // refinement reads `v[n128 - 2]`. Everything else — odd `n64` (no exact
+    // u128 form), or `n64 < 4` — defers to base-2⁶⁴ Knuth.
+    if n64 < 4 || n64 % 2 != 0 {
         crate::int::algos::div::div_knuth::div_knuth(num, den, quot, rem);
         return;
     }
 
-    // Normalise so the top u128 limb of the divisor has its MSB set. We
-    // shift in u64 space (reusing div_knuth's proven normalisation), then
-    // pack pairs of u64 limbs into u128 limbs.
+    // Normalise so the divisor's top u64 limb has its MSB set; this ALSO
+    // normalises the top u128 limb (its bit 127 = the top u64 limb's bit
+    // 63), so the packed divisor is base-2¹²⁸ normalised. Shift in u64
+    // space (div_knuth's proven path), then pack pairs of u64 into u128.
     let shift = den[n64 - 1].leading_zeros();
     let mut u64buf = [0u64; MAX_SINGLE_LIMBS];
     let mut v64buf = [0u64; MAX_SINGLE_LIMBS];
@@ -137,45 +117,29 @@ pub(crate) fn div_knuth_u128_limb(num: &[u64], den: &[u64], quot: &mut [u64], re
         }
     }
 
-    // u128-limb counts. `top64` is even, but normalisation may push a
-    // carry into `u64buf[top64]`; round the dividend up to an even u64
-    // length so it packs cleanly, then to u128 limbs.
-    let u_len64 = if u64buf[top64] != 0 { top64 + 1 } else { top64 };
-    let u_len64 = u_len64 + (u_len64 & 1); // round up to even
+    // Round the dividend up to an even u64 length (so it packs cleanly),
+    // including the normalisation carry limb at `u64buf[top64]`.
+    let mut u_len64 = if u64buf[top64] != 0 { top64 + 1 } else { top64 };
+    u_len64 += u_len64 & 1; // round up to even
     let n128 = n64 / 2;
     let u_len128 = u_len64 / 2;
 
+    // Pack into u128 limbs (little-endian: limb = lo | hi << 64).
     let mut u = [0u128; SCRATCH_LIMBS_128];
     let mut v = [0u128; SCRATCH_LIMBS_128];
-    for i in 0..u_len128 {
-        u[i] = (u64buf[2 * i] as u128) | ((u64buf[2 * i + 1] as u128) << 64);
-    }
-    for i in 0..n128 {
-        v[i] = (v64buf[2 * i] as u128) | ((v64buf[2 * i + 1] as u128) << 64);
-    }
+    debug_assert!(u_len128 < SCRATCH_LIMBS_128 && n128 <= SCRATCH_LIMBS_128);
+    <u128 as Limb>::pack(&u64buf[..u_len64], &mut u[..u_len128]);
+    <u128 as Limb>::pack(&v64buf[..n64], &mut v[..n128]);
 
-    // Number of 64-bit quotient digits = (u_len64 - n64) inclusive of the
-    // top, matching base-2^64 Knuth's `m`. We produce them most-significant
-    // first by viewing the u128 buffer through a 64-bit lens for the q̂
-    // estimate, but doing the multiply-subtract in u128 limbs.
-    //
-    // NOTE: this candidate body is the STRUCTURE + bit-identity scaffold.
-    // The full inner loop is intentionally expressed in terms of the
-    // u64-lens q̂ estimate (Mg2By1 on the top u128 limb's high u64) and a
-    // u128-limb multiply-subtract; the precise carry merge is validated
-    // bit-for-bit against div_knuth in the test below. To keep the
-    // candidate honest and unrun, the inner loop delegates the q̂ +
-    // multiply-subtract to a helper that operates on the u128 buffers.
-    let m64 = u_len64 - n64; // number of 64-bit quotient steps - 1 region
+    // Base-2¹²⁸ Knuth D. The quotient has `m128 + 1` u128 digits; `u` has a
+    // zeroed limb above the live dividend (`u[u_len128]`) for the window top.
+    let m128 = u_len128 - n128;
+    knuth_d_base_u128(&mut u, &v, n128, m128, quot);
 
-    knuth_d_u128_core(&mut u, &v, n128, u_len128, m64, quot);
-
-    // Unpack remainder (low n64 u64 limbs of `u`), denormalise by `shift`.
+    // Unpack the remainder (low `n128` u128 limbs of `u` → `n64` u64 limbs),
+    // denormalise by `shift`.
     let mut r64 = [0u64; MAX_SINGLE_LIMBS];
-    for i in 0..n128 {
-        r64[2 * i] = u[i] as u64;
-        r64[2 * i + 1] = (u[i] >> 64) as u64;
-    }
+    <u128 as Limb>::unpack(&u[..n128], &mut r64[..n64]);
     if shift == 0 {
         let copy = n64.min(rem.len());
         rem[..copy].copy_from_slice(&r64[..copy]);
@@ -190,141 +154,130 @@ pub(crate) fn div_knuth_u128_limb(num: &[u64], den: &[u64], quot: &mut [u64], re
     }
 }
 
-/// The u128-limb Knuth D core: 64-bit `q̂` digits, u128-limb running
-/// dividend `u` (length `u_len128`) and divisor `v` (length `n128`),
-/// emitting `m64 + 1` 64-bit quotient limbs into `quot` (low-first).
+/// 256-by-128 → 128 division `(hi·2¹²⁸ + lo) / d`, requiring `hi < d` and
+/// `d` normalised (bit 127 set). Returns `(q, r)` with `q < 2¹²⁸`.
 ///
-/// Expressed as the structural scaffold; the q̂ estimate uses the top u64
-/// of the top u128 limb via [`Mg2By1`], and the multiply-subtract walks
-/// the u128 limbs with a `q̂(64) × v_limb(128)` product (2 u64-mults per
-/// limb). The carry merge mirrors `div_knuth`'s, validated by the
-/// bit-identity test.
+/// Implemented as a base-2⁶⁴ n=2 Knuth divide of the four u64 limbs by the
+/// two u64 limbs of `d`, two exact [`Mg3By2`] passes — no software u256
+/// reciprocal. `hi < d` guarantees each pass's `(n2, n1) < (d1, d0)`
+/// precondition and a 128-bit quotient.
 #[inline]
-fn knuth_d_u128_core(
-    u: &mut [u128],
-    v: &[u128],
-    n128: usize,
-    u_len128: usize,
-    m64: usize,
-    quot: &mut [u64],
-) {
-    // Top divisor limb, viewed as two u64 halves for the q̂ estimate.
-    let v_top128 = v[n128 - 1];
-    let v_top_hi = (v_top128 >> 64) as u64; // normalised: MSB set
-    let mg = Mg2By1::new(v_top_hi);
+fn div_256_by_128(hi: u128, lo: u128, d: u128) -> (u128, u128) {
+    debug_assert!(hi < d, "div_256_by_128: high word must be < divisor");
+    let d1 = (d >> 64) as u64;
+    let d0 = d as u64;
+    debug_assert!(d1 >> 63 == 1, "div_256_by_128: divisor must be normalised");
+    let a3 = (hi >> 64) as u64;
+    let a2 = hi as u64;
+    let a1 = (lo >> 64) as u64;
+    let a0 = lo as u64;
 
-    // Iterate 64-bit quotient digits most-significant first. We treat the
-    // u128 buffer as a u64 stream for indexing the dividend window, but
-    // the multiply-subtract operates on u128 limbs.
-    let u_len64 = u_len128 * 2;
-    let n64 = n128 * 2;
-    let mut step = m64 + 1;
-    while step > 0 {
-        step -= 1;
-        let j64 = step; // 64-bit quotient position
+    let mg = Mg3By2::new(d1, d0);
+    // High quotient limb: (a3·B² + a2·B + a1) / (d1·B + d0).
+    let (q1, r1, r0) = mg.div_rem(a3, a2, a1);
+    // Low quotient limb: (r·B + a0) / (d1·B + d0).
+    let (q0, s1, s0) = mg.div_rem(r1, r0, a0);
 
-        // Dividend window top two u64 limbs at this position.
-        let hi_idx = j64 + n64;
-        let u_hi = u64_at(u, hi_idx, u_len64);
-        let u_next = u64_at(u, hi_idx - 1, u_len64);
+    let q = ((q1 as u128) << 64) | (q0 as u128);
+    let r = ((s1 as u128) << 64) | (s0 as u128);
+    (q, r)
+}
 
-        let (mut q_hat, _r_hat) = if u_hi > v_top_hi {
-            (u64::MAX, u64::MAX)
-        } else if u_hi == v_top_hi {
-            (u64::MAX, u_next.wrapping_add(v_top_hi))
+/// Base-2¹²⁸ Knuth D core: u128-limb running dividend `u` (with a zeroed
+/// limb above the live window) and divisor `v` (length `n128`, normalised),
+/// emitting `m128 + 1` u128 quotient digits into `quot` as pairs of u64
+/// limbs (`quot[2·j] = q̂ as u64`, `quot[2·j + 1] = (q̂ >> 64) as u64`).
+///
+/// The multiply-subtract and add-back run natively on u128 limbs (one
+/// 128×128→256 [`Limb::widening_mul`] per limb, a u128 carry-merge), the
+/// aligned-window win this kernel exists to test.
+#[inline]
+fn knuth_d_base_u128(u: &mut [u128], v: &[u128], n128: usize, m128: usize, quot: &mut [u64]) {
+    let v_top = v[n128 - 1]; // normalised: bit 127 set
+    let v_below = v[n128 - 2];
+
+    let mut j = m128 + 1;
+    while j > 0 {
+        j -= 1;
+        let jn = j + n128;
+        let u_top = u[jn];
+        let u_next = u[jn - 1];
+
+        // q̂ = min(floor((u_top·2¹²⁸ + u_next) / v_top), 2¹²⁸ − 1), with the
+        // standard `u_top >= v_top` clamp so `div_256_by_128`'s `hi < d`
+        // precondition holds.
+        let (mut q_hat, mut r_hat, overflow) = if u_top >= v_top {
+            (u128::MAX, u_next.wrapping_add(v_top), u_next.wrapping_add(v_top) < u_next)
         } else {
-            mg.div_rem(u_hi, u_next)
+            let (q, r) = div_256_by_128(u_top, u_next, v_top);
+            (q, r, false)
         };
 
-        // q̂ × v multiply-subtract over u128 limbs: q̂ is 64-bit, each v[i]
-        // is 128-bit → 192-bit partial, 2 u64-mults. The product is added
-        // into a running u128 carry and subtracted from the dividend
-        // window starting at u64 offset j64.
-        //
-        // The exact merge + the single over-estimate correction (add-back)
-        // are the parts the bit-identity test pins; this scaffold computes
-        // them in u64 space against the packed buffer to stay provably
-        // equal to div_knuth, while the PRODUCTION wiring would do the
-        // add/sub directly on u128 limbs. (Candidate: structure first,
-        // exact carry-merge to be lifted to u128 when wired + benched.)
-        q_hat = mul_sub_correct_u64lens(u, v, n128, j64, u_len64, q_hat);
+        // Refinement against v[n128-2]: while q̂·v_below > r_hat·2¹²⁸ + u[jn-2],
+        // decrement q̂ (and bump r_hat by v_top). `overflow` means r_hat has
+        // already wrapped past 2¹²⁸, so the comparison is satisfied.
+        if !overflow {
+            loop {
+                let (p_lo, p_hi) = <u128 as Limb>::widening_mul(q_hat, v_below);
+                if p_hi < r_hat || (p_hi == r_hat && p_lo <= u[jn - 2]) {
+                    break;
+                }
+                q_hat = q_hat.wrapping_sub(1);
+                let (nr, of) = r_hat.overflowing_add(v_top);
+                r_hat = nr;
+                if of {
+                    break;
+                }
+            }
+        }
 
-        if j64 < quot.len() {
-            quot[j64] = q_hat;
+        // D4: u[j..=j+n128] -= q̂ · v[0..n128], native u128 carry-merge. The
+        // carry is a single u128 (the propagated high word): `q̂·v[i]` is a
+        // 256-bit (p_lo, p_hi); add the incoming carry into p_lo, subtract
+        // p_lo from u[j+i], propagate p_hi + borrow. Bounds (mirroring the
+        // base-2⁶⁴ proof): p_hi ≤ 2¹²⁸ − 2, so p_hi + 1 and carry + borrow
+        // never overflow the u128.
+        let mut carry: u128 = 0;
+        let mut i = 0;
+        while i < n128 {
+            let (p_lo, p_hi) = <u128 as Limb>::widening_mul(q_hat, v[i]);
+            let (acc_lo, k) = p_lo.overflowing_add(carry);
+            let acc_hi = p_hi + (k as u128);
+            let (res, b) = u[j + i].overflowing_sub(acc_lo);
+            u[j + i] = res;
+            carry = acc_hi + (b as u128);
+            i += 1;
+        }
+        let (s2, b1) = u[jn].overflowing_sub(carry);
+        u[jn] = s2;
+
+        // Over-estimate correction: q̂ was at most 1 too big (the 3-by-2
+        // refinement bounds the error), so a single add-back of v restores
+        // a non-negative dividend.
+        if b1 {
+            q_hat = q_hat.wrapping_sub(1);
+            let mut carry: u128 = 0;
+            let mut i = 0;
+            while i < n128 {
+                let (s1, c1) = u[j + i].overflowing_add(v[i]);
+                let (s2, c2) = s1.overflowing_add(carry);
+                u[j + i] = s2;
+                carry = (c1 as u128) + (c2 as u128);
+                i += 1;
+            }
+            u[jn] = u[jn].wrapping_add(carry);
+        }
+
+        // Store the u128 quotient digit as two u64 limbs (little-endian).
+        let lo64 = q_hat as u64;
+        let hi64 = (q_hat >> 64) as u64;
+        if 2 * j < quot.len() {
+            quot[2 * j] = lo64;
+        }
+        if 2 * j + 1 < quot.len() {
+            quot[2 * j + 1] = hi64;
         }
     }
-}
-
-/// Read the `idx`-th u64 limb of a u128 buffer (low-first), 0 past the end.
-#[inline]
-fn u64_at(u: &[u128], idx: usize, u_len64: usize) -> u64 {
-    if idx >= u_len64 {
-        return 0;
-    }
-    let limb = u[idx / 2];
-    if idx & 1 == 0 { limb as u64 } else { (limb >> 64) as u64 }
-}
-
-/// Write the `idx`-th u64 limb of a u128 buffer (low-first).
-#[inline]
-fn u64_set(u: &mut [u128], idx: usize, val: u64) {
-    let lo = idx / 2;
-    if idx & 1 == 0 {
-        u[lo] = (u[lo] & !(u64::MAX as u128)) | (val as u128);
-    } else {
-        u[lo] = (u[lo] & (u64::MAX as u128)) | ((val as u128) << 64);
-    }
-}
-
-/// `q̂·v` multiply-subtract from the dividend window at u64 offset `j64`,
-/// with the single Knuth add-back correction; returns the corrected q̂.
-/// Operates through the u64 lens of the u128 buffers so the result is
-/// provably bit-identical to `div_knuth`'s u64 body — the candidate's
-/// correctness anchor. The production version lifts this to native u128
-/// limb ops (the actual perf win); this scaffold proves the surrounding
-/// pack/normalise/unpack is sound.
-#[inline]
-fn mul_sub_correct_u64lens(
-    u: &mut [u128],
-    v: &[u128],
-    n128: usize,
-    j64: usize,
-    u_len64: usize,
-    mut q_hat: u64,
-) -> u64 {
-    let n64 = n128 * 2;
-    // D4: u[j..=j+n] -= q̂ · v   (v read through the u64 lens)
-    let mut carry: u128 = 0;
-    for i in 0..n64 {
-        let v_i = u64_at(v, i, n64);
-        carry += (q_hat as u128) * (v_i as u128);
-        let sub_lo = carry as u64;
-        let cur = u64_at(u, j64 + i, u_len64);
-        let (res, b) = cur.overflowing_sub(sub_lo);
-        u64_set(u, j64 + i, res);
-        carry = (carry >> 64) + (b as u128);
-    }
-    let cur = u64_at(u, j64 + n64, u_len64);
-    let sub_lo = carry as u64;
-    let (s2, b1) = cur.overflowing_sub(sub_lo);
-    u64_set(u, j64 + n64, s2);
-    let final_borrow = (b1 as u64) + ((carry >> 64) as u64);
-
-    if final_borrow != 0 {
-        q_hat = q_hat.wrapping_sub(1);
-        let mut carry: u64 = 0;
-        for i in 0..n64 {
-            let v_i = u64_at(v, i, n64);
-            let cur = u64_at(u, j64 + i, u_len64);
-            let (s1, c1) = cur.overflowing_add(v_i);
-            let (s2, c2) = s1.overflowing_add(carry);
-            u64_set(u, j64 + i, s2);
-            carry = (c1 as u64) + (c2 as u64);
-        }
-        let cur = u64_at(u, j64 + n64, u_len64);
-        u64_set(u, j64 + n64, cur.wrapping_add(carry));
-    }
-    q_hat
 }
 
 #[cfg(test)]
@@ -332,9 +285,10 @@ mod tests {
     use super::div_knuth_u128_limb;
     use crate::int::algos::div::div_knuth::div_knuth;
 
-    // Bit-identity vs the production base-2^64 div_knuth on even-limb,
-    // multi-limb-divisor shapes (the regime this kernel handles). DO NOT
-    // run as part of a sweep — focused differential only.
+    // Bit-identity vs the production base-2⁶⁴ div_knuth on even-limb,
+    // multi-limb-divisor shapes (the regime this kernel handles), across a
+    // spread of even divisor widths up to the widest wide tier. DO NOT run
+    // as part of a sweep — focused differential only.
     #[test]
     fn u128_limb_knuth_matches_div_knuth() {
         let mut state: u64 = 0x9E37_79B9_7F4A_7C15;
@@ -344,32 +298,55 @@ mod tests {
             state ^= state << 17;
             state
         };
-        for _ in 0..2000 {
-            // Even u64 limb counts, multi-limb divisor, num wider than den.
-            let n_pairs = 1 + (next() % 8) as usize; // 1..=8 → 2..=16 u64
-            let extra_pairs = 1 + (next() % 8) as usize;
-            let n64 = n_pairs * 2;
-            let top64 = n64 + extra_pairs * 2;
-            let mut num = alloc::vec![0u64; top64];
-            let mut den = alloc::vec![0u64; n64];
-            for x in num.iter_mut() {
-                *x = next();
+        // Even divisor widths covering D76(4)..D1232(64) + odd-shaped
+        // dividends to exercise the even-rounding of the dividend length.
+        for &n64 in &[2usize, 4, 6, 8, 12, 16, 24, 32, 48, 64] {
+            for _ in 0..400 {
+                let extra = 1 + (next() % (n64 as u64 + 2)) as usize; // 1..=n64+2 u64
+                let top64 = n64 + extra;
+                let mut num = alloc::vec![0u64; top64];
+                let mut den = alloc::vec![0u64; n64];
+                for x in num.iter_mut() {
+                    *x = next();
+                }
+                for x in den.iter_mut() {
+                    *x = next();
+                }
+                if den[n64 - 1] == 0 {
+                    den[n64 - 1] = 1; // ensure effective top limb
+                }
+                let mut q_ref = alloc::vec![0u64; top64 + 1];
+                let mut r_ref = alloc::vec![0u64; top64 + 1];
+                div_knuth(&num, &den, &mut q_ref, &mut r_ref);
+                let mut q_c = alloc::vec![0u64; top64 + 1];
+                let mut r_c = alloc::vec![0u64; top64 + 1];
+                div_knuth_u128_limb(&num, &den, &mut q_c, &mut r_c);
+                assert_eq!(q_c, q_ref, "quot mismatch n64={n64} num={num:?} den={den:?}");
+                assert_eq!(
+                    r_c[..n64],
+                    r_ref[..n64],
+                    "rem mismatch n64={n64} num={num:?} den={den:?}"
+                );
             }
-            for x in den.iter_mut() {
-                *x = next();
-            }
-            // Force an effective high limb on the divisor.
-            if den[n64 - 1] == 0 {
-                den[n64 - 1] = 1;
-            }
-            let mut q_ref = alloc::vec![0u64; top64];
-            let mut r_ref = alloc::vec![0u64; top64];
+        }
+    }
+
+    // The odd / single-limb fallback returns div_knuth's exact result.
+    #[test]
+    fn u128_limb_knuth_odd_falls_back() {
+        let num = alloc::vec![0x1234u64, 0x5678, 0x9abc, 0xdef0, 0x1111];
+        for den in [
+            alloc::vec![0x3u64],                 // single limb
+            alloc::vec![0x7u64, 0x9, 0xb],       // odd (3) limbs
+        ] {
+            let mut q_ref = alloc::vec![0u64; num.len() + 1];
+            let mut r_ref = alloc::vec![0u64; num.len() + 1];
             div_knuth(&num, &den, &mut q_ref, &mut r_ref);
-            let mut q_c = alloc::vec![0u64; top64];
-            let mut r_c = alloc::vec![0u64; top64];
+            let mut q_c = alloc::vec![0u64; num.len() + 1];
+            let mut r_c = alloc::vec![0u64; num.len() + 1];
             div_knuth_u128_limb(&num, &den, &mut q_c, &mut r_c);
-            assert_eq!(q_c, q_ref, "quot mismatch num={num:?} den={den:?}");
-            assert_eq!(r_c[..n64], r_ref[..n64], "rem mismatch num={num:?} den={den:?}");
+            assert_eq!(q_c, q_ref, "fallback quot mismatch den={den:?}");
+            assert_eq!(r_c, r_ref, "fallback rem mismatch den={den:?}");
         }
     }
 }

--- a/src/int/algos/div/mod.rs
+++ b/src/int/algos/div/mod.rs
@@ -34,6 +34,11 @@ pub(crate) mod div_fixed;
 // and both outputs. Sibling of int::algos::rem::rem_native_direct.
 pub(crate) mod div_native_direct;
 pub(crate) mod div_knuth;
+// candidate (not wired): Knuth Algorithm D on u128 limbs (base 2^128) — the
+// divide side of the LimbSize axis. Parked pending the div_kernel_ab verdict
+// (whether the aligned u128 carry-chain beats base-2^64 despite the 4-mult
+// q̂·v product). Bit-identical to div_knuth (its #[cfg(test)] differential).
+pub(crate) mod div_knuth_u128_limb;
 pub(crate) mod div_mg;
 pub(crate) mod div_rem;
 pub(crate) mod div_rem_schoolbook;

--- a/src/int/algos/icbrt/icbrt_newton.rs
+++ b/src/int/algos/icbrt/icbrt_newton.rs
@@ -81,17 +81,28 @@ pub(crate) fn icbrt_newton(n: &[u64], out: &mut [u64]) {
     // Invariant: x ≥ floor(cbrt(n)) at entry of each iteration.
     // The iteration s_new = (2*s + n/s²) / 3 is monotone-non-increasing
     // and halts when s_new ≥ s (i.e. s is the floor root).
+    //
+    // Working buffers hoisted OUT of the loop — no per-iteration build-max
+    // memset (the previous in-loop `[0u64; SCRATCH_LIMBS]` allocs were the
+    // wide-tier tax). Per pass only the live slices are touched: `sq` is
+    // re-zeroed (mul_schoolbook accumulates); the n/s² divide re-zeros
+    // `q`/`r`; the /3 divide's `y`/`rem3` are re-zeroed defensively (the
+    // single-limb divisor path may not). `x = y` is a `[..work]` copy.
+    let three = [3u64];
+    let mut sq = [0u64; SCRATCH_LIMBS];
+    let mut q = [0u64; SCRATCH_LIMBS];
+    let mut r = [0u64; SCRATCH_LIMBS];
+    let mut y = [0u64; SCRATCH_LIMBS];
+    let mut rem3_buf = [0u64; SCRATCH_LIMBS];
     loop {
         // t = s²  (2 * work limbs, but only work+1 matter)
         let sq_work = (work * 2).min(SCRATCH_LIMBS);
-        let mut sq = [0u64; SCRATCH_LIMBS];
+        for s in sq[..sq_work].iter_mut() {
+            *s = 0;
+        }
         mul_schoolbook(&x[..work], &x[..work], &mut sq[..sq_work]);
 
-        // q = n / s²
-        let mut q = [0u64; SCRATCH_LIMBS];
-        let mut r = [0u64; SCRATCH_LIMBS];
-        // Ensure the divisor has the right effective length (sq_work may
-        // over-estimate — div_rem_dispatch handles leading zeros).
+        // q = n / s²  (the divide engine re-zeros q[..work] / r[..sq_work])
         div_rem_dispatch(n, &sq[..sq_work], &mut q[..work], &mut r[..sq_work]);
 
         // t = 2*s + q: add 2*x into q.
@@ -101,15 +112,16 @@ pub(crate) fn icbrt_newton(n: &[u64], out: &mut [u64]) {
         add_assign(&mut q[..work], &x[..work]);
 
         // y = t / 3
-        let three = [3u64];
-        let mut y = [0u64; SCRATCH_LIMBS];
-        let mut rem3_buf = [0u64; SCRATCH_LIMBS];
+        for v in y[..work].iter_mut() {
+            *v = 0;
+        }
+        rem3_buf[0] = 0;
         div_rem_dispatch(&q[..work], &three, &mut y[..work], &mut rem3_buf[..1]);
 
         if cmp(&y[..work], &x[..work]) >= 0 {
             break;
         }
-        x = y;
+        x[..work].copy_from_slice(&y[..work]);
     }
     let copy_len = if out.len() < work { out.len() } else { work };
     out[..copy_len].copy_from_slice(&x[..copy_len]);

--- a/src/int/algos/isqrt/isqrt_newton.rs
+++ b/src/int/algos/isqrt/isqrt_newton.rs
@@ -56,17 +56,22 @@ pub(crate) fn isqrt_newton(n: &[u64], out: &mut [u64]) {
     // std-gated inherent f64) — `num_traits::Float`/libm is never reached.
     sqrt_seed(n, bits, &mut x[..work]);
 
+    // Newton working buffers hoisted OUT of the loop. The divide engine
+    // re-zeros `q`/`r` each pass and `shr` re-zeros `y`, so only the live
+    // `[..work]` slice is touched per iteration — no per-iteration build-max
+    // memset (the previous in-loop `[0u64; SCRATCH_LIMBS]` allocs were the
+    // wide-tier tax). `x = y` is likewise a `[..work]` copy, not a full array.
+    let mut q = [0u64; SCRATCH_LIMBS];
+    let mut r = [0u64; SCRATCH_LIMBS];
+    let mut y = [0u64; SCRATCH_LIMBS];
     loop {
-        let mut q = [0u64; SCRATCH_LIMBS];
-        let mut r = [0u64; SCRATCH_LIMBS];
         div_rem_dispatch(n, &x[..work], &mut q[..work], &mut r[..work]);
         add_assign(&mut q[..work], &x[..work]);
-        let mut y = [0u64; SCRATCH_LIMBS];
         shr(&q[..work], 1, &mut y[..work]);
         if cmp(&y[..work], &x[..work]) >= 0 {
             break;
         }
-        x = y;
+        x[..work].copy_from_slice(&y[..work]);
     }
     let copy_len = if out.len() < work { out.len() } else { work };
     out[..copy_len].copy_from_slice(&x[..copy_len]);

--- a/src/int/algos/mul/mod.rs
+++ b/src/int/algos/mul/mod.rs
@@ -25,7 +25,7 @@ mod tests {
         KARATSUBA_SCRATCH_LIMBS,
     };
     use super::mul_schoolbook::{
-        mul_low_fixed, mul_low_fixed_u128, mul_schoolbook, mul_schoolbook_fixed,
+        mul_low_fixed, mul_low_limb, mul_schoolbook, mul_schoolbook_fixed,
         mul_schoolbook_into,
     };
 
@@ -338,14 +338,14 @@ mod tests {
         }
     }
 
-    /// `mul_low_fixed_u128::<N>` (the u128-packed candidate) produces the
+    /// `mul_low_limb::<N, u128>` (the u128-packed candidate) produces the
     /// bit-identical low `N` limbs of `mul_low_fixed::<N>` across the
     /// carry-stressing corpus (at N = 4) and a wide spread of random
     /// inputs at the even wide-tier work widths (N = 128 / 192 / 256, the
     /// D616 / D924 / D1232 exp Taylor work integers). This is the
     /// correctness gate the u128-multiply pilot rides on.
     #[test]
-    fn mul_low_fixed_u128_matches_u64() {
+    fn mul_low_limb_u128_matches_u64() {
         // Edge corpus at N = 4 (all-ones / single-limb / mixed).
         const N4: usize = 4;
         for a in corpus() {
@@ -359,7 +359,7 @@ mod tests {
                 let mut lo_ref = [0u64; N4];
                 let mut lo_u128 = [0u64; N4];
                 mul_low_fixed::<N4>(&a_arr, &b_arr, &mut lo_ref);
-                mul_low_fixed_u128::<N4>(&a_arr, &b_arr, &mut lo_u128);
+                mul_low_limb::<N4, u128>(&a_arr, &b_arr, &mut lo_u128);
                 assert_eq!(lo_ref, lo_u128, "u128 low-mul mismatch (corpus N=4)");
             }
         }
@@ -388,7 +388,7 @@ mod tests {
                     let mut lo_ref = [0u64; N];
                     let mut lo_u128 = [0u64; N];
                     mul_low_fixed::<N>(&a, &b, &mut lo_ref);
-                    mul_low_fixed_u128::<N>(&a, &b, &mut lo_u128);
+                    mul_low_limb::<N, u128>(&a, &b, &mut lo_u128);
                     assert_eq!(
                         lo_ref, lo_u128,
                         "u128 low-mul mismatch at N = {}",
@@ -406,7 +406,7 @@ mod tests {
                 let mut lo_ref = [0u64; N];
                 let mut lo_u128 = [0u64; N];
                 mul_low_fixed::<N>(&a, &b, &mut lo_ref);
-                mul_low_fixed_u128::<N>(&a, &b, &mut lo_u128);
+                mul_low_limb::<N, u128>(&a, &b, &mut lo_u128);
                 assert_eq!(lo_ref, lo_u128, "u128 low-mul mismatch (all-ones N={})", N);
             }};
         }

--- a/src/int/algos/mul/mul_schoolbook.rs
+++ b/src/int/algos/mul/mul_schoolbook.rs
@@ -13,6 +13,8 @@
 //! Inner step uses the native `u64 × u64 → u128` widening multiply
 //! (`MUL` + `UMULH` on x86-64 / aarch64).
 
+use crate::int::types::compute_int::Limb;
+
 /// `out = a · b` schoolbook. `out.len() >= a.len() + b.len()` and `out`
 /// must be zeroed by the caller.
 ///
@@ -162,104 +164,54 @@ pub(crate) const fn mul_low_fixed<const N: usize>(a: &[u64; N], b: &[u64; N], ou
     }
 }
 
-/// `out = (a * b) mod 2^(64*N)` computed in **u128 limbs** -- the
-/// even-`N` u128-packed sibling of [`mul_low_fixed`].
+/// `out = (a · b) mod 2^(64·N)` — the truncated-low schoolbook, generic over
+/// the limb type `L` (the [`Limb`] axis). For `L = u64` it is base-2^64 over
+/// `N` limbs; for `L = u128` it packs the operands into `N/2` u128 limbs
+/// (`limb = lo | hi << 64`) and runs base-2^128 — half the limb count, so
+/// ~1/4 the partial products at the cost of a wider 128×128→256 inner step —
+/// then unpacks. Bit-identical low `N` u64 limbs either way.
 ///
-/// The operands are packed little-endian into `N/2` u128 limbs
-/// (`limb = lo | hi << 64`) and the truncated-low schoolbook runs in
-/// base-2^128 over those `N/2` limbs (half the limb count of the
-/// base-2^64 [`mul_low_fixed`], so ~1/4 the partial products at the cost
-/// of a wider 128x128->256 inner step). The low `N/2` u128 result limbs
-/// are unpacked back into the `N` u64 output limbs. **`N` must be even**
-/// (caller guarantees it; the wide-tier work integers are all even:
-/// 128/192/256 limbs). Bit-identical to the low `N` limbs of
-/// [`mul_low_fixed`].
+/// ONE kernel for both widths: the matcher's [`LimbSize`] verdict picks `L`
+/// (a const-folded `match` → `mul_low_limb::<N, u64>` / `::<N, u128>`), so
+/// there is no per-limb-type copy. The `u128` arm requires **even `N`**
+/// (`L::packed_len` halves it); callers gate on that. Scratch is `[L; N]`
+/// (the value's own width — `packed_len(N) ≤ N`), not a build-max blanket.
 ///
-/// The inner 128x128->256 product is formed from four `u64 * u64 -> u128`
-/// widening muls (`MUL`+`UMULH`), the same instruction the base-2^64
-/// kernel uses; only the carry/accumulate bookkeeping changes.
+/// The carry merge `hi.add_carries(c1, c2)` never overflows: the product
+/// high limb satisfies `hi ≤ L::MAX − 1` (maximal only when the low limb is
+/// 1), and `c1`/`c2` are never both set (`c1` needs `acc + lo` to wrap to 0,
+/// after which `+ carry` cannot wrap), so `hi + c1 + c2 ≤ L::MAX`.
+///
+/// [`LimbSize`]: crate::int::types::compute_int::LimbSize
 #[inline]
-pub(crate) fn mul_low_fixed_u128<const N: usize>(
-    a: &[u64; N],
-    b: &[u64; N],
-    out: &mut [u64; N],
-) {
-    debug_assert!(N % 2 == 0, "mul_low_fixed_u128: N must be even");
-    let h = N / 2;
-    // Pack operands into u128 limbs (little-endian: lo | hi << 64).
-    // Buffers sized `N` (only the low `h = N/2` entries are used);
-    // stable Rust cannot put `N / 2` in an array-length position.
-    let mut ap = [0u128; N];
-    let mut bp = [0u128; N];
-    let mut k = 0;
-    while k < h {
-        ap[k] = (a[2 * k] as u128) | ((a[2 * k + 1] as u128) << 64);
-        bp[k] = (b[2 * k] as u128) | ((b[2 * k + 1] as u128) << 64);
-        k += 1;
-    }
-    // Low-half schoolbook in base-2^128 over `h` limbs.
-    let mut acc = [0u128; N];
+pub(crate) fn mul_low_limb<const N: usize, L: Limb>(a: &[u64; N], b: &[u64; N], out: &mut [u64; N]) {
+    let h = L::packed_len(N);
+    // `[L; N]` covers `packed_len(N) ≤ N` for both limb types (stable Rust
+    // cannot put `N/2` in an array-length position; only the low `h` are used).
+    let mut ap = [L::ZERO; N];
+    let mut bp = [L::ZERO; N];
+    L::pack(a, &mut ap[..h]);
+    L::pack(b, &mut bp[..h]);
+    let mut acc = [L::ZERO; N];
     let mut i = 0;
     while i < h {
         let ai = ap[i];
-        if ai != 0 {
-            // carry spans up to 128 bits between columns.
-            let mut carry: u128 = 0;
+        if ai != L::ZERO {
+            let mut carry = L::ZERO;
             let mut j = 0;
-            // Stop once `i + j` reaches `h`: those partial products lie
-            // entirely above 2^(128*h) = 2^(64*N) and drop out.
+            // Stop once `i + j` reaches `h`: those partials lie above
+            // 2^(64·N) and drop out of the truncated-low result.
             while j < h - i {
-                let (lo, hi) = mul_u128_wide(ai, bp[j]);
+                let (lo, hi) = ai.widening_mul(bp[j]);
                 let idx = i + j;
-                // acc[idx] += lo; carry-in `carry`; carry-out -> hi.
                 let (s1, c1) = acc[idx].overflowing_add(lo);
                 let (s2, c2) = s1.overflowing_add(carry);
                 acc[idx] = s2;
-                // No overflow forming the next-column carry. The product
-                // high word satisfies `hi <= 2^128 - 2`, with `hi` maximal
-                // only when `lo == 1`. `c1` is set only when `s1 == 0`
-                // (acc[idx] + lo wrapped to 0); then `s1 + carry` cannot
-                // wrap, so `c2 == 0`: `c1` and `c2` are never both set.
-                // Hence `hi + c1 + c2 <= hi + 1 <= 2^128 - 1` fits u128.
-                carry = hi + (c1 as u128) + (c2 as u128);
+                carry = hi.add_carries(c1, c2);
                 j += 1;
             }
-            // Final row carry would land in limb `h` (above the width) --
-            // discarded.
         }
         i += 1;
     }
-    // Unpack low `h` u128 limbs into the `N` u64 output limbs.
-    let mut k = 0;
-    while k < h {
-        out[2 * k] = acc[k] as u64;
-        out[2 * k + 1] = (acc[k] >> 64) as u64;
-        k += 1;
-    }
-}
-
-/// `a * b -> (low128, high128)` for two `u128` operands, built from four
-/// `u64 * u64 -> u128` widening products (`MUL`+`UMULH`). The full
-/// 256-bit product is `lo + (hi << 128)`.
-#[inline(always)]
-fn mul_u128_wide(a: u128, b: u128) -> (u128, u128) {
-    let a_lo = a as u64 as u128;
-    let a_hi = (a >> 64) as u64 as u128;
-    let b_lo = b as u64 as u128;
-    let b_hi = (b >> 64) as u64 as u128;
-
-    let ll = a_lo * b_lo; // bits 0..128
-    let lh = a_lo * b_hi; // bits 64..192
-    let hl = a_hi * b_lo; // bits 64..192
-    let hh = a_hi * b_hi; // bits 128..256
-
-    // Sum the two middle terms (each < 2^128) into the bits-64..192 lane,
-    // tracking the overflow into bit 192.
-    let (mid, mid_carry) = lh.overflowing_add(hl);
-    // low 128 bits = ll + (mid << 64), with carry into the high word.
-    let mid_lo = mid << 64; // low 64 bits of `mid` land in bits 64..128
-    let mid_hi = mid >> 64; // high 64 bits of `mid` land in bits 128..192
-    let (low, c) = ll.overflowing_add(mid_lo);
-    let high = hh + mid_hi + (c as u128) + ((mid_carry as u128) << 64);
-    (low, high)
+    L::unpack(&acc[..h], out);
 }

--- a/src/int/policy/div_rem.rs
+++ b/src/int/policy/div_rem.rs
@@ -22,6 +22,7 @@
 
 use crate::int::algos::div::div_burnikel_ziegler_with_knuth::div_burnikel_ziegler_with_knuth;
 use crate::int::algos::div::div_knuth::div_knuth;
+use crate::int::algos::div::div_knuth_u128_limb::div_knuth_u128_limb;
 use crate::int::algos::div::div_rem::div_rem;
 use crate::int::algos::div::div_rem_schoolbook::div_rem_schoolbook;
 
@@ -42,6 +43,12 @@ enum Algorithm {
     /// [`div_burnikel_ziegler_with_knuth`] — Burnikel–Ziegler outer
     /// chunking, recursing to Knuth as its base case.
     BurnikelZieglerWithKnuth,
+    /// [`div_knuth_u128_limb`] — Knuth Algorithm D on u128 limbs (base
+    /// 2¹²⁸). The `LimbSize` axis as an engine: chosen only for the **wide
+    /// (`2n`-dividend) even-`n` divisor ≥ [`U128_DIV_THRESHOLD`]** shape,
+    /// where the aligned u128 carry-chain beats base-2⁶⁴ (it LOSES on the
+    /// balanced shape — see the threshold doc).
+    KnuthU128Limb,
     /// [`div_rem_schoolbook`] — binary shift-subtract long division,
     /// the naive reference baseline. Registered but unrouted:
     /// `select_for_limbs` never returns this variant; it exists for
@@ -115,6 +122,31 @@ enum Select {
 /// D307+ wide divide by engaging the slower block engine.)
 pub(crate) const BZ_THRESHOLD: usize = 65;
 
+/// u128-limb Knuth ([`Algorithm::KnuthU128Limb`]) engagement threshold, in
+/// u64 divisor limbs. **Policy data.**
+///
+/// **Benched** (`div_kernel_ab`, u128 base-2¹²⁸ vs u64 base-2⁶⁴). The
+/// limb-width win is **shape-dependent** — it materialises only on the
+/// **wide** `div` shape (a `2n`-limb dividend over an `n`-limb divisor; the
+/// decimal `/` scaled-numerator shape), and only once the divisor is wide
+/// enough for the aligned u128 carry-chain to outrun the doubled multiply
+/// count:
+///
+/// | divisor (limbs / tier) | wide `2n`/`n` | balanced `n`/`n` |
+/// |------------------------|---------------|------------------|
+/// | 16 / D307              | u64 1.04×     | u64 1.33×        |
+/// | 24 / D462              | **u128 1.25×**| u64 1.23×        |
+/// | 32 / D616              | **u128 1.33×**| u64 1.14×        |
+/// | 48 / D924              | **u128 1.26×**| u64 1.21×        |
+/// | 64 / D1232             | **u128 1.17×**| u64 1.29×        |
+///
+/// So u128 is routed ONLY for an **even** divisor of `≥ 24` limbs whose
+/// dividend is `≥ 2·n` (the wide shape); the balanced shape (square `rem` /
+/// the `Int<N>` `/` operator) and every narrow/odd divisor stay base-2⁶⁴
+/// Knuth, where u128 loses. The engine itself falls back to `div_knuth` for
+/// odd / `< 4`-limb divisors, so the matcher gate is the perf carve-out.
+const U128_DIV_THRESHOLD: usize = 24;
+
 // ── 3. the matcher: `select` (no const axis) → `select_for_limbs` ─────
 
 /// The top-level matcher. Division has no const-width axis (its operands'
@@ -154,14 +186,26 @@ const fn select() -> Select {
 fn select_for_limbs(num: &[u64], den: &[u64]) -> Algorithm {
     let den_n = effective_limbs(den);
     assert!(den_n > 0, "dispatch: divide by zero");
-
     if den_n == 1 {
-        Algorithm::Rem
-    } else if den_n >= BZ_THRESHOLD && effective_limbs(num) >= 2 * den_n {
-        Algorithm::BurnikelZieglerWithKnuth
-    } else {
-        Algorithm::Knuth
+        return Algorithm::Rem;
     }
+    // `den_n >= 2` here. Both the wide engines (Burnikel–Ziegler, u128) want
+    // a `≥ 2·n` dividend, so the dividend's effective length is computed
+    // once — and lazily: only for a divisor wide enough to reach the smaller
+    // threshold. Every common `2..U128_DIV_THRESHOLD`-limb divisor returns
+    // Knuth without stripping the dividend at all.
+    if den_n >= U128_DIV_THRESHOLD {
+        let num_m = effective_limbs(num);
+        if den_n >= BZ_THRESHOLD && num_m >= 2 * den_n {
+            return Algorithm::BurnikelZieglerWithKnuth;
+        }
+        // Wide (`2n`-dividend) even divisor → the u128 limb-width engine wins
+        // here (and only here — the balanced shape stays Knuth).
+        if den_n % 2 == 0 && num_m >= 2 * den_n {
+            return Algorithm::KnuthU128Limb;
+        }
+    }
+    Algorithm::Knuth
 }
 
 /// Effective limb count of a little-endian magnitude slice: its length with
@@ -203,6 +247,7 @@ pub(crate) fn dispatch(num: &[u64], den: &[u64], quot: &mut [u64], rem: &mut [u6
         Algorithm::BurnikelZieglerWithKnuth => {
             div_burnikel_ziegler_with_knuth(num, den, quot, rem)
         }
+        Algorithm::KnuthU128Limb => div_knuth_u128_limb(num, den, quot, rem),
         Algorithm::Schoolbook => div_rem_schoolbook(num, den, quot, rem),
     }
 }

--- a/src/int/policy/div_rem.rs
+++ b/src/int/policy/div_rem.rs
@@ -1,20 +1,24 @@
 //! Division policy — the divisor-shape algorithm matcher.
 //!
-//! The integer layer carries **no `SCALE`**, and the divmod choice does
-//! not key on the const limb count `N` — it keys on the **runtime shape**
-//! of the operands (their effective limb counts after stripping leading
-//! zeros). That makes division a [`Select::ByValue`] case in the
-//! canonical policy shape (see `docs/ARCHITECTURE.md` → "Policy file
-//! structure" and the value-matcher tier): the const layer settles on
-//! "the value decides", the value-matcher classifies the divisor/dividend
-//! shape and returns an [`Algorithm`] tag, and the dispatcher does an
-//! **exhaustive** `match algo` to a pure engine in
-//! [`crate::int::algos::div`].
+//! Canonical policy shape (see `docs/ARCHITECTURE.md` → "Policy file
+//! structure"), with one twist: division is the **one policy with no
+//! const-width axis**. Its operands have *independent* runtime lengths that
+//! no single level const expresses — the decimal `/` divides a `2N`-limb
+//! scaled numerator by an `N`-limb divisor, and the slice roots
+//! (`isqrt_newton` / `icbrt_newton` / `newton_reciprocal`) divide bare
+//! `&[u64]` of runtime length with no `N` in their types at all. So unlike
+//! a unary (`select<N>`) or binary (`select<Nthis, Nother>`) policy,
+//! [`select`] here is **non-generic**: it always returns [`Select::ByShape`],
+//! delegating the whole choice to the runtime [`select_for_limbs`]. (Forcing
+//! a `<N>` would make the slice roots manufacture a const they don't have —
+//! the kind of caller-side specialisation the architecture forbids — and
+//! the divide doesn't use `N` anyway, since its engine choice is runtime.)
 //!
-//! The engines stay pure — each takes an already-chosen algorithm. This
-//! file owns the *choice*: the benched crossover thresholds
-//! ([`BZ_THRESHOLD`]) are policy DATA here, not magic numbers buried in a
-//! kernel.
+//! Two selectors: [`select`] (the const matcher — here a no-op `ByShape`)
+//! and [`select_for_limbs`] (the runtime limb-shape decision it delegates
+//! to). The engines stay pure — each takes an already-chosen algorithm.
+//! This file owns the *choice*: the benched crossover threshold
+//! ([`BZ_THRESHOLD`]) is policy DATA here, not a magic number in a kernel.
 
 use crate::int::algos::div::div_burnikel_ziegler_with_knuth::div_burnikel_ziegler_with_knuth;
 use crate::int::algos::div::div_knuth::div_knuth;
@@ -39,27 +43,31 @@ enum Algorithm {
     /// chunking, recursing to Knuth as its base case.
     BurnikelZieglerWithKnuth,
     /// [`div_rem_schoolbook`] — binary shift-subtract long division,
-    /// the naive reference baseline. Registered but unrouted: `select`
-    /// never returns this variant; it exists for unit-test reachability
-    /// and future routing experiments. `#[allow(dead_code)]` suppresses
-    /// the compiler warning.
+    /// the naive reference baseline. Registered but unrouted:
+    /// `select_for_limbs` never returns this variant; it exists for
+    /// unit-test reachability and future routing experiments.
+    /// `#[allow(dead_code)]` suppresses the compiler warning.
     #[allow(dead_code)]
     Schoolbook,
 }
 
 // ── 2. the verdict ────────────────────────────────────────────────────
 
-/// A settled engine, or "the (runtime) shape decides". Division always
-/// returns `ByValue`: the choice is fully determined by the operands'
-/// effective limb counts, known only at run time. `ByAlgorithm` is part
-/// of the canonical shape for uniformity across functions.
+/// A settled engine, or "the (runtime) limb shape decides". For division
+/// every `N` resolves to [`Select::ByShape`] — the engine choice is
+/// determined by the operands' effective limb counts, known only at run
+/// time — so the `ByShape` arm delegates to [`select_for_limbs`].
+/// [`Select::ByAlgorithm`] is the canonical alternative (a width-keyed
+/// fixed engine); it is unused by this policy today but kept so `select<N>`
+/// could pin an engine for some `N` range without changing the verdict
+/// type.
 #[derive(Clone, Copy)]
 enum Select {
     #[allow(dead_code)]
     ByAlgorithm(Algorithm),
-    /// Classifier over the operands' effective limb counts `(den_n,
-    /// num_top)` (leading zeros stripped) → the chosen engine.
-    ByShape(fn(usize, usize) -> Algorithm),
+    /// The runtime limb shape decides: [`select_for_limbs`] applied to the
+    /// raw `(num, den)` operands (it strips leading zeros and counts itself).
+    ByShape(fn(&[u64], &[u64]) -> Algorithm),
 }
 
 // ── policy data: the benched crossover threshold ──────────────────────
@@ -96,7 +104,7 @@ enum Select {
 /// and 128-limb probe still favours Knuth ~1.10×, and the curve has
 /// plateaued — no crossover exists at any reachable width). The
 /// `balanced` (square `rem`/`div_rem`) shape never meets the
-/// `num_top ≥ 2·den_n` gate and favours Knuth ~1.4× throughout.
+/// `num_m ≥ 2·den_n` gate and favours Knuth ~1.4× throughout.
 ///
 /// Therefore the optimum is to **never engage** the block engine within
 /// the supported range: the widest storage tier is D1232 = 64 limbs (a
@@ -107,72 +115,89 @@ enum Select {
 /// D307+ wide divide by engaging the slower block engine.)
 pub(crate) const BZ_THRESHOLD: usize = 65;
 
-// ── 3. the matcher: keyed on the runtime divisor shape ────────────────
+// ── 3. the matcher: `select` (no const axis) → `select_for_limbs` ─────
 
-/// Pick the division engine for the operands' effective limb counts.
-/// Total over the shape; reproduces the exact byte-for-byte routing of
-/// the historic inline dispatcher:
-///
-/// * single-limb divisor → [`Algorithm::Rem`] (the const hardware path,
-///   covers every `10^scale` with `scale ≤ 19`);
-/// * `den_n ≥ BZ_THRESHOLD` and `num_top ≥ 2·den_n` → Burnikel–Ziegler;
-/// * everything else → Knuth.
+/// The top-level matcher. Division has no const-width axis (its operands'
+/// lengths are independent runtime values — see the module docs), so unlike
+/// a `select<N>` unary policy this is **non-generic** and always defers the
+/// choice to the runtime [`select_for_limbs`]. A future limb refinement
+/// (e.g. routing an even, wide divisor to a u128-limb engine) is a **runtime
+/// arm inside `select_for_limbs`** — gated on the runtime `den_n`, where the
+/// width information actually is — NOT a const verdict here.
 const fn select() -> Select {
-    Select::ByShape(|den_n: usize, num_top: usize| {
-        if den_n == 1 {
-            Algorithm::Rem
-        } else if den_n >= BZ_THRESHOLD && num_top >= 2 * den_n {
-            Algorithm::BurnikelZieglerWithKnuth
-        } else {
-            Algorithm::Knuth
-        }
-    })
+    Select::ByShape(select_for_limbs)
 }
 
-// ── 4. the dispatcher: classify the shape, then dispatch ──────────────
-
-/// Classify the operands' effective (leading-zero-stripped) shape and ask
-/// the matcher which engine handles it. The divisor must be non-zero. This
-/// is the policy's whole job — choose the engine; it allocates nothing.
+/// Select the division engine for an operand pair's **limb shape**. The
+/// sibling of [`select`]: `select` keys on the const width, this keys on
+/// the runtime effective limb counts, which it computes itself:
+///
+/// It works the counts out itself, and **only the ones a branch needs** —
+/// passing raw slices (rather than pre-computed counts from [`dispatch`])
+/// means the dividend is never walked on the paths that don't look at it:
+///
+/// * `den_n` — the **divisor's** effective limb count (Knuth's `n`):
+///   `den.len()` with trailing zero limbs stripped. `den_n == 0` is a
+///   divide-by-zero (asserted here). Always needed.
+/// * the **dividend's** effective limb count (`num.len()` with top zero
+///   limbs stripped) is computed **lazily**, only in the Burnikel–Ziegler
+///   guard — and the `&&` short-circuits, so it is reached only for a
+///   divisor of `≥ BZ_THRESHOLD` limbs. The common cases (single-limb
+///   divisor → `Rem`; any `2..BZ_THRESHOLD`-limb divisor → `Knuth`) never
+///   strip the dividend at all.
+///
+/// Routing: a single-limb divisor takes the hardware [`Algorithm::Rem`]
+/// path (covers every `10^scale`, `scale ≤ 19`); a divisor of at least
+/// [`BZ_THRESHOLD`] limbs whose dividend is at least twice as wide takes
+/// Burnikel–Ziegler; everything else takes Knuth.
 #[inline]
-fn classify(num: &[u64], den: &[u64]) -> Algorithm {
-    let mut n = den.len();
-    while n > 0 && den[n - 1] == 0 {
+fn select_for_limbs(num: &[u64], den: &[u64]) -> Algorithm {
+    let den_n = effective_limbs(den);
+    assert!(den_n > 0, "dispatch: divide by zero");
+
+    if den_n == 1 {
+        Algorithm::Rem
+    } else if den_n >= BZ_THRESHOLD && effective_limbs(num) >= 2 * den_n {
+        Algorithm::BurnikelZieglerWithKnuth
+    } else {
+        Algorithm::Knuth
+    }
+}
+
+/// Effective limb count of a little-endian magnitude slice: its length with
+/// trailing (most-significant) zero limbs stripped — `0` for an all-zero
+/// slice.
+#[inline]
+fn effective_limbs(limbs: &[u64]) -> usize {
+    let mut n = limbs.len();
+    while n > 0 && limbs[n - 1] == 0 {
         n -= 1;
     }
-    assert!(n > 0, "dispatch: divide by zero");
-
-    let mut top = num.len();
-    while top > 0 && num[top - 1] == 0 {
-        top -= 1;
-    }
-
-    match const { select() } {
-        Select::ByAlgorithm(a) => a,
-        Select::ByShape(f) => f(n, top),
-    }
+    n
 }
 
-/// Runtime divide dispatcher at u64 base — the single entry every
-/// multi-limb divide flows through. Classifies the effective shape, then
-/// routes to the chosen engine; `quot` / `rem` are written by that engine.
+// ── 4. the dispatcher: fold `select<N>`, run the selector, route ──────
+
+/// Runtime divide dispatcher — the single entry every multi-limb divide
+/// flows through. Folds the `select<N>` verdict (const per monomorphisation),
+/// runs the runtime [`select_for_limbs`], and routes to the chosen engine;
+/// `quot` / `rem` are written by that engine.
 ///
-/// Slice-based (not typed): the numerator and divisor have *independent*
-/// runtime lengths that no single `const N` expresses (decimal `/` divides
-/// a `2N`-limb scaled numerator by an `N`-limb divisor; the transcendental
-/// reciprocal divides work-width values; `newton_reciprocal` passes
-/// runtime-length slices). The build-max Knuth `u`/`v` scratch lives in the
-/// engine ([`div_knuth`] owns it), not here — the matcher allocates nothing.
-/// A concrete-`N` caller that can size scratch exactly (`Int<N>: ComputeInt`)
-/// sources its own buffer family (`single_limbs` / `double_limbs`) and calls
-/// the Knuth engine [`div_knuth_into`] directly — single-limb divisors route
-/// to the hardware path inside the engine and Burnikel–Ziegler never engages
-/// at supported widths, so the engine call is this matcher's identical
-/// choice without the build-max blanket.
-///
-/// [`div_knuth_into`]: crate::int::algos::div::div_knuth::div_knuth_into
+/// Slice-based (no `<N>`): the numerator and divisor have *independent*
+/// runtime lengths that no single const width expresses — the decimal `/`
+/// divides a `2N`-limb scaled numerator by an `N`-limb divisor, the slice
+/// roots divide bare runtime-length slices. Every caller already holds its
+/// operands as slices, so none has to manufacture a const to call this. The
+/// build-max Knuth `u`/`v` scratch lives in the engine ([`div_knuth`] owns
+/// it), not here — the matcher allocates nothing. A concrete-`N` caller that
+/// can size scratch exactly (`Int<N>: ComputeInt`) sources its own buffer
+/// family and calls the chosen engine's `*_into` variant.
 pub(crate) fn dispatch(num: &[u64], den: &[u64], quot: &mut [u64], rem: &mut [u64]) {
-    match classify(num, den) {
+    let algo = match const { select() } {
+        Select::ByAlgorithm(fixed) => fixed,
+        Select::ByShape(selector) => selector(num, den),
+    };
+    match algo {
         Algorithm::Rem => div_rem(num, den, quot, rem),
         Algorithm::Knuth => div_knuth(num, den, quot, rem),
         Algorithm::BurnikelZieglerWithKnuth => {

--- a/src/int/policy/mod.rs
+++ b/src/int/policy/mod.rs
@@ -113,6 +113,8 @@ pub(crate) mod icbrt;
 pub(crate) mod isqrt;
 /// Multiply policy: schoolbook-vs-Karatsuba algorithm matcher.
 pub(crate) mod mul;
+/// Truncated-low multiply policy: the `u64`/`u128` limb-width matcher.
+pub(crate) mod mul_low;
 /// Negate policy: default-delegating two's-complement matcher for `Int<N>`.
 pub(crate) mod neg;
 /// Integer exponentiation policy: square-and-multiply matcher for `Uint<N>`.

--- a/src/int/policy/mul.rs
+++ b/src/int/policy/mul.rs
@@ -91,7 +91,17 @@ const fn select() -> Select {
 /// `out` must be sized `>= a.len() + b.len()`. The Karatsuba arm zeroes
 /// `out` itself; the schoolbook arm requires the caller to have zeroed it
 /// (matching the historic contract).
-pub(crate) fn dispatch(a: &[u64], b: &[u64], out: &mut [u64]) {
+///
+/// Takes the level const `N` (the operand storage width — its sole caller
+/// `Int::<N>::widen_mul` already holds it) per the const-generic BigRule
+/// (`docs/ARCHITECTURE.md`): a policy entry point carries its level's
+/// defining const even when the schoolbook-vs-Karatsuba choice is settled
+/// at run time from the operand lengths (`select` inspects those — the
+/// metadata test allows reading the operands; only *external* metadata is
+/// barred). `N` is not threaded inward today; it is the seam for any future
+/// per-`N` refinement.
+pub(crate) fn dispatch<const N: usize>(a: &[u64], b: &[u64], out: &mut [u64]) {
+    let _ = N;
     let algo = match const { select() } {
         Select::ByAlgorithm(a) => a,
         Select::ByShape(f) => f(a.len(), b.len()),

--- a/src/int/policy/mul_low.rs
+++ b/src/int/policy/mul_low.rs
@@ -1,0 +1,118 @@
+// SPDX-FileCopyrightText: 2026 John Moxley
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Truncated-low multiply policy — the limb-width (`u64` / `u128`) matcher.
+//!
+//! [`BigInt::wrapping_mul_low_u128`] computes `(a · b) mod 2^(64·N)` — the
+//! low `N` limbs of the product, the high half never formed — via the ONE
+//! generic kernel [`mul_low_limb`]`<N, L: Limb>`. There is a single
+//! algorithm (truncated-low schoolbook); what this policy owns is the
+//! **second matcher axis** (`docs/ARCHITECTURE.md` → "Limb width — the
+//! matcher's second axis"): the [`LimbSize`] the kernel runs in.
+//!
+//! `u128` limbs halve the limb count (≈¼ the partial products at the cost
+//! of a wider 128×128 inner step), so they win on the **wide even** work
+//! widths but lose to plain `u64` at narrow even widths (the pack/unpack
+//! and wider-multiply overhead is not amortised). Which cells win is a
+//! per-`N` property settled by microbench (`benches/micro/mul_low_u128_ab.rs`)
+//! and recorded in [`limb_size`] as policy DATA — NOT a blanket rule and
+//! NOT a kernel literal. `u128` is gated to **even `N`** by
+//! [`LimbSize::for_packing`] (packing pairs two `u64` per `u128`; an odd
+//! `N` would drop the top limb), so every entry stays even-`N`-correct.
+//!
+//! [`BigInt::wrapping_mul_low_u128`]: crate::int::types::traits::BigInt::wrapping_mul_low_u128
+//! [`mul_low_limb`]: crate::int::algos::mul::mul_schoolbook::mul_low_limb
+//! [`LimbSize`]: crate::int::types::compute_int::LimbSize
+
+use crate::int::algos::mul::mul_schoolbook::mul_low_limb;
+use crate::int::types::compute_int::LimbSize;
+
+// ── 1. the algorithm — singleton: truncated-low schoolbook ────────────
+
+/// The truncated-low multiply algorithm. A singleton: there is one
+/// algorithm (the truncated-low schoolbook, [`mul_low_limb`] — the variant
+/// is the CamelCase of the kernel fn minus the `mul_` prefix). The matcher's
+/// real work is the [`LimbSize`] axis it pairs with this; the variant keeps
+/// the canonical `(Algorithm, LimbSize)` verdict shape uniform with the
+/// other policies (and leaves room for a future second low-mul algorithm).
+///
+/// [`mul_low_limb`]: crate::int::algos::mul::mul_schoolbook::mul_low_limb
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Algorithm {
+    LowLimb,
+}
+
+// ── 2. the verdict — (Algorithm, LimbSize), const in BOTH axes ────────
+
+/// A settled `(algorithm, limb width)`. Both axes are const properties of
+/// `N` (limb width is value-independent — never a `ByValue` decision), so
+/// the whole verdict const-folds per monomorphisation and [`dispatch`]
+/// collapses to a single direct typed call.
+#[derive(Clone, Copy)]
+enum Select {
+    ByAlgorithm(Algorithm, LimbSize),
+}
+
+// ── policy DATA: the benched per-N limb-width table ───────────────────
+
+/// The benched limb width for the truncated-low product over `N` u64
+/// limbs. **Per-cell policy data**, not a blanket: `u128` is returned only
+/// where a microbench shows it wins, and only where it is valid (even `N`
+/// — enforced by [`LimbSize::for_packing`], which drives an odd `N` to
+/// `U64`).
+///
+/// **Benched** (`benches/micro/mul_low_u128_ab.rs`, `u128` vs `u64`
+/// truncated-low schoolbook). `u128` wins at every even width measured,
+/// decisively at the three live work-integer widths every
+/// [`BigInt::wrapping_mul_low_u128`] call lands on (the wide-tier exp/powf
+/// Taylor multiply runs there):
+///
+/// | N (work integer) | `u128` vs `u64` |
+/// |------------------|-----------------|
+/// | 128 (D616 work)  | 1.20× faster    |
+/// | 192 (D924 work)  | 1.35× faster    |
+/// | 256 (D1232 work) | 1.29× faster    |
+/// | 48 / 64 (storage, not call sites) | 1.16× faster |
+/// | 32 (storage, not a call site)     | 1.04× (tie)  |
+///
+/// So `U128` for every even `N` is the measured optimum here — no even
+/// cell regresses. This is the tuning seam: if a future bench shows `u128`
+/// losing at some even cell, carve that `N` out to `U64` HERE (edit only
+/// this fn) — the kernel and dispatch stay untouched.
+///
+/// [`BigInt::wrapping_mul_low_u128`]: crate::int::types::traits::BigInt::wrapping_mul_low_u128
+#[inline]
+const fn limb_size<const N: usize>() -> LimbSize {
+    LimbSize::for_packing(N)
+}
+
+// ── 3. the matcher ────────────────────────────────────────────────────
+
+/// Pick `(algorithm, limb width)` for an `N`-limb truncated-low product.
+/// One algorithm; the limb width is the benched [`limb_size`] verdict.
+const fn select<const N: usize>() -> Select {
+    Select::ByAlgorithm(Algorithm::LowLimb, limb_size::<N>())
+}
+
+// ── 4. the dispatcher: fold the verdict, then exhaustive match ────────
+
+/// Truncated-low product `out = (a · b) mod 2^(64·N)` — the single site
+/// [`BigInt::wrapping_mul_low_u128`] flows through. The verdict const-folds
+/// (`const { select::<N>() }`), so this compiles to one direct
+/// `mul_low_limb::<N, _>` call per monomorphisation with the unchosen arm
+/// dead-arm eliminated. `out` is written in full (the kernel zeroes its own
+/// accumulator); bit-identical to [`BigInt::wrapping_mul`] mod `2^(64·N)`
+/// at either limb width.
+///
+/// [`BigInt::wrapping_mul_low_u128`]: crate::int::types::traits::BigInt::wrapping_mul_low_u128
+/// [`BigInt::wrapping_mul`]: crate::int::types::traits::BigInt::wrapping_mul
+#[inline]
+pub(crate) fn dispatch<const N: usize>(a: &[u64; N], b: &[u64; N], out: &mut [u64; N]) {
+    let (algo, limb) = match const { select::<N>() } {
+        Select::ByAlgorithm(a, l) => (a, l),
+    };
+    match (algo, limb) {
+        (Algorithm::LowLimb, LimbSize::U64) => mul_low_limb::<N, u64>(a, b, out),
+        (Algorithm::LowLimb, LimbSize::U128) => mul_low_limb::<N, u128>(a, b, out),
+    }
+}

--- a/src/int/policy/mul_low.rs
+++ b/src/int/policy/mul_low.rs
@@ -31,10 +31,12 @@ use crate::int::types::compute_int::LimbSize;
 
 /// The truncated-low multiply algorithm. A singleton: there is one
 /// algorithm (the truncated-low schoolbook, [`mul_low_limb`] — the variant
-/// is the CamelCase of the kernel fn minus the `mul_` prefix). The matcher's
-/// real work is the [`LimbSize`] axis it pairs with this; the variant keeps
-/// the canonical `(Algorithm, LimbSize)` verdict shape uniform with the
-/// other policies (and leaves room for a future second low-mul algorithm).
+/// is the CamelCase of the kernel fn minus the `mul_` prefix).
+///
+/// The [`LimbSize`] axis is the algorithm's OWN second-stage choice
+/// ([`Algorithm::limb_size`]), selected *after* the algorithm and *by* it —
+/// the u64/u128 crossover is algorithm-dependent, so it is co-located with
+/// the algorithm, not the verdict.
 ///
 /// [`mul_low_limb`]: crate::int::algos::mul::mul_schoolbook::mul_low_limb
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -42,74 +44,86 @@ enum Algorithm {
     LowLimb,
 }
 
-// ── 2. the verdict — (Algorithm, LimbSize), const in BOTH axes ────────
-
-/// A settled `(algorithm, limb width)`. Both axes are const properties of
-/// `N` (limb width is value-independent — never a `ByValue` decision), so
-/// the whole verdict const-folds per monomorphisation and [`dispatch`]
-/// collapses to a single direct typed call.
-#[derive(Clone, Copy)]
-enum Select {
-    ByAlgorithm(Algorithm, LimbSize),
+impl Algorithm {
+    /// The benched limb width THIS algorithm runs in at `N` u64 limbs — the
+    /// matcher's **second axis**, selected after (and owned by) the
+    /// algorithm because the u64/u128 crossover is algorithm-dependent.
+    /// **Per-cell policy DATA**, not a blanket: `U128` only where a
+    /// microbench shows it wins AND it is valid (even `N` — enforced by
+    /// [`LimbSize::for_packing`], which drives an odd `N` to `U64`). A
+    /// `const fn`, so when the algorithm is const-known the whole verdict
+    /// folds; under a `ByValue` algorithm choice the arm is picked at run
+    /// time and this is read per-arm (still value-independent).
+    ///
+    /// **`LowLimb`** (benched `benches/micro/mul_low_u128_ab.rs`, `u128` vs
+    /// `u64` truncated-low schoolbook). `u128` wins at every even width
+    /// measured, decisively at the three live work-integer widths every
+    /// [`BigInt::wrapping_mul_low_u128`] call lands on (the wide-tier
+    /// exp/powf Taylor multiply runs there):
+    ///
+    /// | N (work integer) | `u128` vs `u64` |
+    /// |------------------|-----------------|
+    /// | 128 (D616 work)  | 1.20× faster    |
+    /// | 192 (D924 work)  | 1.35× faster    |
+    /// | 256 (D1232 work) | 1.29× faster    |
+    /// | 48 / 64 (storage, not call sites) | 1.16× faster |
+    /// | 32 (storage, not a call site)     | 1.04× (tie)  |
+    ///
+    /// So `U128` for every even `N` is the measured optimum — no even cell
+    /// regresses. This is the tuning seam: if a future bench shows `u128`
+    /// losing at some even cell, carve that `N` out to `U64` in THIS arm —
+    /// the kernel and dispatch stay untouched.
+    ///
+    /// [`BigInt::wrapping_mul_low_u128`]: crate::int::types::traits::BigInt::wrapping_mul_low_u128
+    #[inline]
+    const fn limb_size<const N: usize>(self) -> LimbSize {
+        match self {
+            Algorithm::LowLimb => LimbSize::for_packing(N),
+        }
+    }
 }
 
-// ── policy DATA: the benched per-N limb-width table ───────────────────
+// ── 2. the verdict — the algorithm (limb width is the algorithm's own) ─
 
-/// The benched limb width for the truncated-low product over `N` u64
-/// limbs. **Per-cell policy data**, not a blanket: `u128` is returned only
-/// where a microbench shows it wins, and only where it is valid (even `N`
-/// — enforced by [`LimbSize::for_packing`], which drives an odd `N` to
-/// `U64`).
-///
-/// **Benched** (`benches/micro/mul_low_u128_ab.rs`, `u128` vs `u64`
-/// truncated-low schoolbook). `u128` wins at every even width measured,
-/// decisively at the three live work-integer widths every
-/// [`BigInt::wrapping_mul_low_u128`] call lands on (the wide-tier exp/powf
-/// Taylor multiply runs there):
-///
-/// | N (work integer) | `u128` vs `u64` |
-/// |------------------|-----------------|
-/// | 128 (D616 work)  | 1.20× faster    |
-/// | 192 (D924 work)  | 1.35× faster    |
-/// | 256 (D1232 work) | 1.29× faster    |
-/// | 48 / 64 (storage, not call sites) | 1.16× faster |
-/// | 32 (storage, not a call site)     | 1.04× (tie)  |
-///
-/// So `U128` for every even `N` is the measured optimum here — no even
-/// cell regresses. This is the tuning seam: if a future bench shows `u128`
-/// losing at some even cell, carve that `N` out to `U64` HERE (edit only
-/// this fn) — the kernel and dispatch stay untouched.
-///
-/// [`BigInt::wrapping_mul_low_u128`]: crate::int::types::traits::BigInt::wrapping_mul_low_u128
-#[inline]
-const fn limb_size<const N: usize>() -> LimbSize {
-    LimbSize::for_packing(N)
+/// A settled algorithm. The canonical verdict shape: one algorithm at every
+/// `N`, so it is always `ByAlgorithm` (matching the const `add`/`sub`/`cmp`
+/// policies). The limb width is NOT carried here — it is the chosen
+/// algorithm's own [`Algorithm::limb_size`], derived in [`dispatch`].
+#[derive(Clone, Copy)]
+enum Select {
+    ByAlgorithm(Algorithm),
 }
 
 // ── 3. the matcher ────────────────────────────────────────────────────
 
-/// Pick `(algorithm, limb width)` for an `N`-limb truncated-low product.
-/// One algorithm; the limb width is the benched [`limb_size`] verdict.
-const fn select<const N: usize>() -> Select {
-    Select::ByAlgorithm(Algorithm::LowLimb, limb_size::<N>())
+/// Pick the algorithm for the truncated-low product. One algorithm at every
+/// width, so this is width-independent; the chosen algorithm's own
+/// [`Algorithm::limb_size`] carries the only `N`-dependent decision.
+const fn select() -> Select {
+    Select::ByAlgorithm(Algorithm::LowLimb)
 }
 
-// ── 4. the dispatcher: fold the verdict, then exhaustive match ────────
+// ── 4. the dispatcher: resolve the algorithm, then its limb width ─────
 
 /// Truncated-low product `out = (a · b) mod 2^(64·N)` — the single site
-/// [`BigInt::wrapping_mul_low_u128`] flows through. The verdict const-folds
-/// (`const { select::<N>() }`), so this compiles to one direct
-/// `mul_low_limb::<N, _>` call per monomorphisation with the unchosen arm
-/// dead-arm eliminated. `out` is written in full (the kernel zeroes its own
-/// accumulator); bit-identical to [`BigInt::wrapping_mul`] mod `2^(64·N)`
-/// at either limb width.
+/// [`BigInt::wrapping_mul_low_u128`] flows through. Two-stage verdict: the
+/// algorithm is resolved first, then asked for its own benched limb width
+/// ([`Algorithm::limb_size`]). Both are const here, so the `const { … }`
+/// block folds them and this compiles to one direct `mul_low_limb::<N, _>`
+/// call per monomorphisation with the unchosen arm dead-arm eliminated.
+/// `out` is written in full (the kernel zeroes its own accumulator);
+/// bit-identical to [`BigInt::wrapping_mul`] mod `2^(64·N)` at either width.
 ///
 /// [`BigInt::wrapping_mul_low_u128`]: crate::int::types::traits::BigInt::wrapping_mul_low_u128
 /// [`BigInt::wrapping_mul`]: crate::int::types::traits::BigInt::wrapping_mul
 #[inline]
 pub(crate) fn dispatch<const N: usize>(a: &[u64; N], b: &[u64; N], out: &mut [u64; N]) {
-    let (algo, limb) = match const { select::<N>() } {
-        Select::ByAlgorithm(a, l) => (a, l),
+    // Stage 1: resolve the algorithm. Stage 2: ask it for its limb width.
+    let (algo, limb) = const {
+        let algo = match select() {
+            Select::ByAlgorithm(a) => a,
+        };
+        (algo, algo.limb_size::<N>())
     };
     match (algo, limb) {
         (Algorithm::LowLimb, LimbSize::U64) => mul_low_limb::<N, u64>(a, b, out),

--- a/src/int/types/compute_int.rs
+++ b/src/int/types/compute_int.rs
@@ -106,6 +106,128 @@ pub(crate) fn max_u128_limb() -> [u128; MAX_U128_LIMB] {
     [0u128; MAX_U128_LIMB]
 }
 
+// ── The `Limb` axis — `u64` / `u128` width-generic kernels ─────────────────
+//
+// A wide-tier kernel can run faster in u128 limbs (half the limbs/carries).
+// Which width wins is a per-`(N, SCALE)` const property, so it is a second
+// matcher axis (the `Select` verdict carries a `LimbSize`). The width is
+// delivered BY TYPE: a `<L: Limb>`-generic kernel is monomorphised per width
+// via a const-folded `match` on the verdict — ONE kernel, never a per-limb
+// copy. See `docs/ARCHITECTURE.md` → "Limb width — the matcher's second axis".
+
+/// The limb width a `<L: Limb>` kernel runs in, chosen by the matcher per
+/// `(N, SCALE)`. A const, value-independent property (the const part of the
+/// `Select` verdict) — packing pairs two u64 into one u128, so `U128` is only
+/// valid for an even limb count (the matcher gates this).
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[allow(dead_code)]
+pub(crate) enum LimbSize {
+    U64,
+    U128,
+}
+
+/// The scalar limb type a width-generic kernel computes in — `u64`, or the
+/// packed `u128` (two storage u64 limbs per limb). Carries the primitives a
+/// slice kernel needs plus the pack/unpack to/from the `Int<N>` u64 storage.
+/// Implemented for exactly `u64` and `u128`.
+pub(crate) trait Limb: Copy + PartialEq {
+    /// Additive identity (the array-repeat seed for scratch buffers).
+    const ZERO: Self;
+    /// Number of `L` limbs holding an `n`-u64-limb value: `n` for `u64`,
+    /// `n / 2` for `u128` (caller guarantees even `n` for the `u128` impl).
+    fn packed_len(n_u64: usize) -> usize;
+    /// Pack the low `dst.len()` little-endian u64 limbs of `src_u64` into
+    /// `dst` `L` limbs.
+    fn pack(src_u64: &[u64], dst: &mut [Self]);
+    /// Unpack `src` `L` limbs back into the low little-endian u64 limbs of
+    /// `dst_u64`.
+    fn unpack(src: &[Self], dst_u64: &mut [u64]);
+    /// Full widening product `self · rhs → (low, high)` limbs.
+    fn widening_mul(self, rhs: Self) -> (Self, Self);
+    /// `self + rhs → (sum, carry)`.
+    fn overflowing_add(self, rhs: Self) -> (Self, bool);
+    /// `self + c1 + c2` — the schoolbook carry merge. The column bound
+    /// (`hi ≤ MAX − 1`, and `c1`/`c2` never both set) guarantees no overflow.
+    fn add_carries(self, c1: bool, c2: bool) -> Self;
+}
+
+impl Limb for u64 {
+    const ZERO: Self = 0;
+    #[inline]
+    fn packed_len(n_u64: usize) -> usize {
+        n_u64
+    }
+    #[inline]
+    fn pack(src_u64: &[u64], dst: &mut [Self]) {
+        let h = dst.len();
+        dst.copy_from_slice(&src_u64[..h]);
+    }
+    #[inline]
+    fn unpack(src: &[Self], dst_u64: &mut [u64]) {
+        let h = src.len();
+        dst_u64[..h].copy_from_slice(src);
+    }
+    #[inline]
+    fn widening_mul(self, rhs: Self) -> (Self, Self) {
+        let p = (self as u128) * (rhs as u128);
+        (p as u64, (p >> 64) as u64)
+    }
+    #[inline]
+    fn overflowing_add(self, rhs: Self) -> (Self, bool) {
+        u64::overflowing_add(self, rhs)
+    }
+    #[inline]
+    fn add_carries(self, c1: bool, c2: bool) -> Self {
+        self.wrapping_add(c1 as u64).wrapping_add(c2 as u64)
+    }
+}
+
+impl Limb for u128 {
+    const ZERO: Self = 0;
+    #[inline]
+    fn packed_len(n_u64: usize) -> usize {
+        n_u64 / 2
+    }
+    #[inline]
+    fn pack(src_u64: &[u64], dst: &mut [Self]) {
+        for (k, d) in dst.iter_mut().enumerate() {
+            *d = (src_u64[2 * k] as u128) | ((src_u64[2 * k + 1] as u128) << 64);
+        }
+    }
+    #[inline]
+    fn unpack(src: &[Self], dst_u64: &mut [u64]) {
+        for (k, &s) in src.iter().enumerate() {
+            dst_u64[2 * k] = s as u64;
+            dst_u64[2 * k + 1] = (s >> 64) as u64;
+        }
+    }
+    #[inline]
+    fn widening_mul(self, rhs: Self) -> (Self, Self) {
+        // `a · b → (low128, high128)` from four u64·u64→u128 partials
+        // (`MUL`+`UMULH`); the full 256-bit product is `low + (high << 128)`.
+        let a_lo = self as u64 as u128;
+        let a_hi = (self >> 64) as u64 as u128;
+        let b_lo = rhs as u64 as u128;
+        let b_hi = (rhs >> 64) as u64 as u128;
+        let ll = a_lo * b_lo;
+        let lh = a_lo * b_hi;
+        let hl = a_hi * b_lo;
+        let hh = a_hi * b_hi;
+        let (mid, mid_carry) = lh.overflowing_add(hl);
+        let (low, c) = ll.overflowing_add(mid << 64);
+        let high = hh + (mid >> 64) + (c as u128) + ((mid_carry as u128) << 64);
+        (low, high)
+    }
+    #[inline]
+    fn overflowing_add(self, rhs: Self) -> (Self, bool) {
+        u128::overflowing_add(self, rhs)
+    }
+    #[inline]
+    fn add_carries(self, c1: bool, c2: bool) -> Self {
+        self.wrapping_add(c1 as u128).wrapping_add(c2 as u128)
+    }
+}
+
 /// The storage integer's compute-scratch capability: clean limb-multiple
 /// stack buffers for the operations that work wider than `N` limbs.
 ///

--- a/src/int/types/compute_int.rs
+++ b/src/int/types/compute_int.rs
@@ -120,10 +120,31 @@ pub(crate) fn max_u128_limb() -> [u128; MAX_U128_LIMB] {
 /// `Select` verdict) — packing pairs two u64 into one u128, so `U128` is only
 /// valid for an even limb count (the matcher gates this).
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
-#[allow(dead_code)]
 pub(crate) enum LimbSize {
     U64,
     U128,
+}
+
+impl LimbSize {
+    /// The limb-width verdict for a kernel over `n` u64 limbs: `U128` when the
+    /// packing is exact (even `n` — two u64 fold into one u128, the wide-tier
+    /// win), else `U64`. A `const fn` so callers fold it in a `const { … }`
+    /// block per monomorphisation (the unchosen `match` arm is then dead-arm
+    /// eliminated, like any policy verdict).
+    ///
+    /// This is the limb-width axis as a verdict; the algorithm axis composes
+    /// alongside it where a function also chooses *which* algorithm (a full
+    /// `Select<N>` carrying `(Algorithm, LimbSize)`). The even-`n` rule is the
+    /// correctness gate; a per-`(N, SCALE)` *perf* refinement (which even
+    /// widths actually win the u128 packing) is a microbench tuning follow-up.
+    #[inline]
+    pub(crate) const fn for_packing(n: usize) -> Self {
+        if n % 2 == 0 {
+            LimbSize::U128
+        } else {
+            LimbSize::U64
+        }
+    }
 }
 
 /// The scalar limb type a width-generic kernel computes in — `u64`, or the

--- a/src/int/types/mod.rs
+++ b/src/int/types/mod.rs
@@ -1994,7 +1994,7 @@ impl<const N: usize> Int<N> {
         // non-allocating Karatsuba kernel at or above it.
         let mut prod_buf = <Int<N> as ComputeInt>::double_limbs();
         let prod = prod_buf.as_mut();
-        mul_fast(&a, &b, &mut prod[..2 * N]);
+        mul_fast::<N>(&a, &b, &mut prod[..2 * N]);
         // Pack the `2·N`-u64 product into `N` u128 limbs for the kept
         // `BigInt::from_mag_sign_u128` bridge. The result `W` holds the
         // product, so its `ComputeInt::u128_limbs()` buffer (`≥ N`) sizes

--- a/src/int/types/mod.rs
+++ b/src/int/types/mod.rs
@@ -4085,6 +4085,7 @@ mod unified_mg_feasibility {
     /// scaled wider-width quotient.
     fn scaled<const N: usize, const M: usize>(a: Int<N>, b: Int<N>, scale: u32) -> Int<M>
     where
+        Int<N>: ComputeInt,
         Int<M>: BigInt + ComputeInt,
     {
         let prod: Int<M> = a.widen_mul::<Int<M>>(b);

--- a/src/int/types/traits.rs
+++ b/src/int/types/traits.rs
@@ -200,22 +200,15 @@ impl<const N: usize> BigInt for Int<N> {
 
     #[inline]
     fn wrapping_mul_low_u128(self, rhs: Self) -> Self {
-        // Truncated-low product via the ONE `<L: Limb>` kernel `mul_low_limb`,
-        // monomorphised at the limb width the `LimbSize` verdict picks. The
-        // verdict `LimbSize::for_packing(N)` const-folds (the `const { … }`
-        // block), so the `match` collapses to a single direct typed call per
-        // monomorphisation and the unchosen arm is dead-arm eliminated — the
-        // canonical const-folded policy-verdict shape. Both arms are the same
-        // generic kernel, bit-identical to `wrapping_mul` (mod 2^64N).
-        use crate::int::algos::mul::mul_schoolbook::mul_low_limb;
-        use crate::int::types::compute_int::LimbSize;
+        // Truncated-low product through the limb-width matcher
+        // `int::policy::mul_low`: it owns the `(Algorithm, LimbSize)`
+        // verdict (the architecture's second axis) and const-folds it to a
+        // single direct `mul_low_limb::<N, _>` call per monomorphisation.
+        // Bit-identical to `wrapping_mul` (mod 2^64N) at either limb width.
         let a = *self.as_limbs();
         let b = *rhs.as_limbs();
         let mut out = [0u64; N];
-        match const { LimbSize::for_packing(N) } {
-            LimbSize::U64 => mul_low_limb::<N, u64>(&a, &b, &mut out),
-            LimbSize::U128 => mul_low_limb::<N, u128>(&a, &b, &mut out),
-        }
+        crate::int::policy::mul_low::dispatch::<N>(&a, &b, &mut out);
         Int::from_limbs(out)
     }
 

--- a/src/int/types/traits.rs
+++ b/src/int/types/traits.rs
@@ -200,21 +200,21 @@ impl<const N: usize> BigInt for Int<N> {
 
     #[inline]
     fn wrapping_mul_low_u128(self, rhs: Self) -> Self {
-        // Truncated-low product via the ONE `<L: Limb>` kernel `mul_low_limb`
-        // (`crate::int::types::compute_int::Limb` axis). The `LimbSize` choice
-        // is the const `N % 2`: even `N` packs into u128 (half the limbs /
-        // carries — the wide-tier win), odd `N` runs base-2^64; both are the
-        // same generic kernel, bit-identical to `wrapping_mul` (mod 2^64N).
-        // (This const branch is the per-method stand-in for the policy
-        // `LimbSize` verdict until the matcher axis is wired.)
+        // Truncated-low product via the ONE `<L: Limb>` kernel `mul_low_limb`,
+        // monomorphised at the limb width the `LimbSize` verdict picks. The
+        // verdict `LimbSize::for_packing(N)` const-folds (the `const { … }`
+        // block), so the `match` collapses to a single direct typed call per
+        // monomorphisation and the unchosen arm is dead-arm eliminated — the
+        // canonical const-folded policy-verdict shape. Both arms are the same
+        // generic kernel, bit-identical to `wrapping_mul` (mod 2^64N).
         use crate::int::algos::mul::mul_schoolbook::mul_low_limb;
+        use crate::int::types::compute_int::LimbSize;
         let a = *self.as_limbs();
         let b = *rhs.as_limbs();
         let mut out = [0u64; N];
-        if N % 2 == 0 {
-            mul_low_limb::<N, u128>(&a, &b, &mut out);
-        } else {
-            mul_low_limb::<N, u64>(&a, &b, &mut out);
+        match const { LimbSize::for_packing(N) } {
+            LimbSize::U64 => mul_low_limb::<N, u64>(&a, &b, &mut out),
+            LimbSize::U128 => mul_low_limb::<N, u128>(&a, &b, &mut out),
         }
         Int::from_limbs(out)
     }

--- a/src/int/types/traits.rs
+++ b/src/int/types/traits.rs
@@ -200,19 +200,23 @@ impl<const N: usize> BigInt for Int<N> {
 
     #[inline]
     fn wrapping_mul_low_u128(self, rhs: Self) -> Self {
-        // The u128-packed low-half schoolbook requires an even limb
-        // count (it folds pairs of u64 limbs into u128 limbs); for even
-        // `N` it is bit-identical to `wrapping_mul` and faster at the
-        // wide work widths. Odd `N` keeps the base-2^64 path.
+        // Truncated-low product via the ONE `<L: Limb>` kernel `mul_low_limb`
+        // (`crate::int::types::compute_int::Limb` axis). The `LimbSize` choice
+        // is the const `N % 2`: even `N` packs into u128 (half the limbs /
+        // carries — the wide-tier win), odd `N` runs base-2^64; both are the
+        // same generic kernel, bit-identical to `wrapping_mul` (mod 2^64N).
+        // (This const branch is the per-method stand-in for the policy
+        // `LimbSize` verdict until the matcher axis is wired.)
+        use crate::int::algos::mul::mul_schoolbook::mul_low_limb;
+        let a = *self.as_limbs();
+        let b = *rhs.as_limbs();
+        let mut out = [0u64; N];
         if N % 2 == 0 {
-            let a = *self.as_limbs();
-            let b = *rhs.as_limbs();
-            let mut out = [0u64; N];
-            crate::int::algos::mul::mul_schoolbook::mul_low_fixed_u128::<N>(&a, &b, &mut out);
-            Int::from_limbs(out)
+            mul_low_limb::<N, u128>(&a, &b, &mut out);
         } else {
-            Int::wrapping_mul(self, rhs)
+            mul_low_limb::<N, u64>(&a, &b, &mut out);
         }
+        Int::from_limbs(out)
     }
 
     #[inline]

--- a/src/int/types/traits.rs
+++ b/src/int/types/traits.rs
@@ -280,7 +280,10 @@ impl<const N: usize> BigInt for Int<N> {
         let negative = self.is_negative();
         // Reuse the direct u64→u128 pack the concrete `mag_into_u128`
         // override performs, then rebuild `T` from the magnitude/sign.
-        let mut u128_mag = [0u128; 144];
+        // `resize_to` is a blanket `BigInt` method (every `N`), so it can't
+        // carry a `ComputeInt` bound (the cycle) — it uses the gated build-max
+        // blanket `MAX_U128_LIMB`, not a frozen literal.
+        let mut u128_mag = [0u128; crate::int::types::compute_int::MAX_U128_LIMB];
         let u128_len = (N + 1) / 2;
         self.mag_into_u128(&mut u128_mag[..u128_len]);
         T::from_mag_sign_u128(&u128_mag[..u128_len], negative)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -212,15 +212,16 @@ pub mod __bench_internals {
     /// Exposed for the `mul_low_u128_ab` pilot microbench.
     #[inline(never)]
     pub fn mul_low_u64<const N: usize>(a: &[u64; N], b: &[u64; N], out: &mut [u64; N]) {
-        crate::int::algos::mul::mul_schoolbook::mul_low_fixed::<N>(a, b, out)
+        crate::int::algos::mul::mul_schoolbook::mul_low_limb::<N, u64>(a, b, out)
     }
-    /// u128-limb-packed truncated-low schoolbook multiply candidate
-    /// (even `N` only): bit-identical low `N` limbs to [`mul_low_u64`],
-    /// computed in `N/2` base-2^128 limbs. Exposed for the
-    /// `mul_low_u128_ab` pilot microbench.
+    /// u128-limb-packed truncated-low schoolbook multiply (even `N` only):
+    /// bit-identical low `N` limbs to [`mul_low_u64`], computed in `N/2`
+    /// base-2^128 limbs — the `L = u128` monomorphisation of the one
+    /// `mul_low_limb` kernel. Exposed for the `mul_low_u128_ab` `LimbSize`
+    /// microbench (u64 vs u128 of the same generic kernel).
     #[inline(never)]
     pub fn mul_low_u128<const N: usize>(a: &[u64; N], b: &[u64; N], out: &mut [u64; N]) {
-        crate::int::algos::mul::mul_schoolbook::mul_low_fixed_u128::<N>(a, b, out)
+        crate::int::algos::mul::mul_schoolbook::mul_low_limb::<N, u128>(a, b, out)
     }
     #[inline(never)]
     pub fn mul_fixed<const L: usize, const D: usize>(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -252,6 +252,15 @@ pub mod __bench_internals {
     pub fn div_dispatch_slice(num: &[u64], den: &[u64], quot: &mut [u64], rem: &mut [u64]) {
         crate::int::policy::div_rem::dispatch(num, den, quot, rem)
     }
+    /// Base-2¹²⁸ (u128-limb) Knuth candidate for `div_kernel_ab` — the
+    /// divide side of the `LimbSize` axis, PARKED (not wired into any
+    /// policy). Bit-identical to [`div_knuth_slice`]; A/B measures whether
+    /// the aligned u128 carry-chain beats base-2⁶⁴ despite the 4-mult q̂·v
+    /// product.
+    #[inline(never)]
+    pub fn div_knuth_u128_limb_slice(num: &[u64], den: &[u64], quot: &mut [u64], rem: &mut [u64]) {
+        crate::int::algos::div::div_knuth_u128_limb::div_knuth_u128_limb(num, den, quot, rem)
+    }
     /// Burnikel-Ziegler chunking engine FORCED on (production engagement
     /// guard bypassed) so the Knuth-vs-BZ crossover can be timed at
     /// sub-threshold widths in `div_kernel_ab`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -437,7 +437,10 @@ pub mod __bench_internals {
     pub fn dec_rem_int_layer<const N: usize>(
         a: crate::int::types::Int<N>,
         b: crate::int::types::Int<N>,
-    ) -> crate::int::types::Int<N> {
+    ) -> crate::int::types::Int<N>
+    where
+        crate::int::types::Int<N>: crate::int::types::compute_int::ComputeInt,
+    {
         crate::algos::rem::rem_int_layer::rem_int_layer::<N>(a, b)
     }
     /// The OLD wide decimal-remainder path: `Int::wrapping_rem` (the const

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -434,6 +434,7 @@ pub mod __bench_internals {
     /// Decimal remainder kernels exposed for the `rem_kernel_ab` microbench
     /// (the narrow native-vs-int-layer decimal rem A/B at the dispatch seam).
     #[inline(never)]
+    #[allow(private_bounds)]
     pub fn dec_rem_int_layer<const N: usize>(
         a: crate::int::types::Int<N>,
         b: crate::int::types::Int<N>,

--- a/src/policy/exp.rs
+++ b/src/policy/exp.rs
@@ -1,24 +1,24 @@
-//! Exponential policy â€” the per-(N, SCALE) algorithm matcher (plus the
+//! Exponential policy — the per-(N, SCALE) algorithm matcher (plus the
 //! derived exp2).
 //!
 //! `D<Int<N>, SCALE>::exp_strict_with(mode)` delegates directly to the one
-//! shared [`dispatch`] generic function â€” the canonical matcher-only
+//! shared [`dispatch`] generic function — the canonical matcher-only
 //! policy shape (see `docs/ARCHITECTURE.md`), mirrored from `sqrt`:
 //!
-//! 1. an [`Algorithm`] enum â€” Series / Tang / Schoolbook, no `Default`;
+//! 1. an [`Algorithm`] enum — Series / Tang / Schoolbook, no `Default`;
 //! 2. a [`Select`] verdict;
 //! 3. a `const fn` [`select`] keyed on `(N, SCALE)`, total over the key;
 //! 4. dispatch via `const { select::<N, SCALE>() }`, then an exhaustive
-//!    `match algo` â€” no `_`, no panic.
+//!    `match algo` — no `_`, no panic.
 //!
 //! The narrow tiers run the 256-bit `Fixed` kernel (`exp_series_2limb`,
 //! D18 widened to Int<2>); the wide tiers run the tier-generic `exp_series`
 //! over `WideTrigCore`, or the per-tier `exp_tang` band kernel, reached by
 //! a `match N` with `resize_to` bridges (identity at the matched `N`).
 //!
-//! exp2 is derived (`2^x = exp(xÂ·ln2)` with an exact-power pin) and routes
+//! exp2 is derived (`2^x = exp(x·ln2)` with an exact-power pin) and routes
 //! DOWN to the narrow `exp_series_2limb::exp2_*` kernels or the wide
-//! per-tier `wide_trig_<tier>::exp2_{strict,approx}_with_kernel` free fns â€”
+//! per-tier `wide_trig_<tier>::exp2_{strict,approx}_with_kernel` free fns —
 //! never back through a sibling decimal policy.
 
 use crate::int::types::traits::BigInt;

--- a/src/support/bench_alt.rs
+++ b/src/support/bench_alt.rs
@@ -18,8 +18,6 @@
 
 #![cfg(feature = "bench-alt")]
 
-use crate::types::widths::D38;
-
 // D38 — every strict transcendental is an `override` (hand-tuned
 // per `algos/support/fixed.rs`). The `_default` alias would be the
 // macro-generated `decl_wide_transcendental!` path; that path is


### PR DESCRIPTION
Consolidates the `feature/limbsize` work into the 0.5.0 line. All commits golden-264 green; final architecture review compliant (rules 1-6).

## Highlights
- **LimbSize as the matcher second axis.** `int/policy/mul_low.rs` two-stage verdict: `select` picks the algorithm, then `Algorithm::limb_size::<N>()` (a const method on the enum) yields the u64/u128 width - the crossover is algorithm-dependent, so it lives on the algorithm. Benched: u128 wins every even work width (128/192/256).
- **`mul` BigRule conformance** - `dispatch<const N>` (its sole caller `widen_mul` holds `N`).
- **`div_rem` refactor** - slice/non-generic `select`/`select_for_limbs`/`effective_limbs` (the division exception: no const-width axis); lazy dividend measurement.
- **u128 divide engine wired** - genuine base-2^128 Knuth (`KnuthU128Limb`), gated to the wide even >=24 divisor shape where `div_kernel_ab` shows it wins 1.17-1.33x (it loses on balanced - validated per cell, not a blanket).
- **Const-generic BigRule** codified in `docs/ARCHITECTURE.md` (+ the audit skill): a `dispatch` takes only its level's defining consts (int-unary N, int-binary Nthis/Nother, dec-unary N/S, dec-binary Nthis/Sthis/Nother/Sother), no derived consts; the metadata test; the caller guardrail; the division exception.
- **Fixes** - `cmp_double_vs` scratch sized from `MAX_WORK_N` (was a frozen `[0u64;80]`); `rem_kernel_ab` bench compiles; `exp.rs` UTF-8 mojibake.

## Known follow-ups (tracked, not in this PR)
- Class-G decimal-path routing (`rem_int_layer` / `div_widen_scale` bypass) - next.
- Wide-exp Series->Tang regression.
- Decimal-binary cross-scale/width (4-const) feature.
