### PR TITLE
ci: land lib-cmp comparison-bench workflows on main (fidelity + perf)

### DIFF
--- a/.github/workflows/lib-cmp-perf.yml
+++ b/.github/workflows/lib-cmp-perf.yml
@@ -1,0 +1,245 @@
+name: "\U0001F4DA lib-cmp perf (peer-crate timing, width × scale)"
+
+# Peer-crate TIMING comparison (NOT precision — that is lib-cmp-precision.yml,
+# which this must not touch). Times decimal-scaled against the peer libraries
+# (rust_decimal, fastnum, fixed, g_math, bigdecimal, dashu-float, decimal-rs)
+# across the shared op surface, fanned out over BOTH width AND scale so a
+# peer-timing gap is visible at the scale it occurs (single-scale-per-width
+# blindness has repeatedly misled the perf campaign).
+#
+# Each per-width bench (`benches/libcmp/lib_cmp_d{N}.rs`) instantiates its tier
+# at that tier's scale set (dedup{0, 30, S/2, S-1}), naming criterion groups
+# `lib_cmp/<bit>bit_s<scale>` so a single scale is selectable by a name-filter
+# (`-- _s<scale>/`).
+#
+# Job graph — mirrors bench-branch-compare: compile ONCE, fan out, then join:
+#   build     : `cargo bench --no-run` for ALL lib_cmp width targets once
+#               (all width features enabled), upload the compiled exes.
+#   bench      : matrix of explicit (width, scale) cells; download the exes,
+#               run the matching prebuilt exe with a `-- _s<scale>/` filter
+#               (NO recompile), upload that cell's criterion subtree.
+#   aggregate  : needs ALL cells; merge into one tree, run summarise_libcmp.py
+#               -> a worst-first (decimal-scaled vs fastest-peer) table to the
+#               run summary + ONE `lib-cmp-perf-aggregate` artifact.
+#
+# Triggers (advisory — NOT a required status check / merge gate), matching
+# the lib-cmp family convention: (1) pull_request whose BASE is main — runs
+# on any PR into main; (2) manual workflow_dispatch on any branch (the
+# dispatch button only appears once this file is on the default branch main).
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: lib-cmp-perf-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: "\U0001F4DA build (compile all lib_cmp widths once)"
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install system libs
+        run: sudo apt-get update && sudo apt-get install -y libfontconfig1-dev pkg-config
+
+      - name: Cache cargo registry + git
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: cargo-lib-cmp-perf-${{ runner.os }}-${{ hashFiles('benches/libcmp/lib_cmp_common.rs') }}
+          restore-keys: |
+            cargo-lib-cmp-perf-${{ runner.os }}-
+
+      - name: Compile every lib_cmp width bench exe (no run)
+        run: |
+          set -euo pipefail
+          # All width tiers in one compile; the cells just run the exes.
+          # Widest tiers need x-wide / xx-wide; macros mirrors the crate's
+          # other bench builds.
+          cargo bench --no-run --features "wide x-wide xx-wide macros" \
+            $(for w in 18 38 57 76 115 153 230 307 462 616 924 1232; do echo --bench lib_cmp_d$w; done)
+          echo "--- compiled lib_cmp exes ---"
+          ls -1 target/release/deps/lib_cmp_d*-* | grep -v '\.d$' || true
+
+      - name: Stage the compiled exes
+        run: |
+          set -euo pipefail
+          mkdir -p staged/deps
+          for f in target/release/deps/lib_cmp_d*-*; do
+            case "$f" in
+              *.d) ;;                      # skip depfiles
+              *lib_cmp_precision*) ;;      # precision is a separate workflow
+              *) cp "$f" staged/deps/ ;;
+            esac
+          done
+          echo "--- staged ---"; ls -1 staged/deps/
+
+      - name: Upload compiled bench exes
+        uses: actions/upload-artifact@v7
+        with:
+          name: lib-cmp-perf-compiled
+          path: staged/
+          if-no-files-found: error
+          retention-days: 7
+
+  bench:
+    name: "\U0001F4DA ${{ matrix.width }} s${{ matrix.scale }}"
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      # Explicit (width, scale) pairs — scales differ per width, so an
+      # include list, not a cross-product. scales = dedup{0, 30, S/2, S-1}.
+      matrix:
+        include:
+          - { width: d18,   scale: 0 }
+          - { width: d18,   scale: 9 }
+          - { width: d18,   scale: 17 }
+          - { width: d38,   scale: 0 }
+          - { width: d38,   scale: 19 }
+          - { width: d38,   scale: 30 }
+          - { width: d38,   scale: 37 }
+          - { width: d57,   scale: 0 }
+          - { width: d57,   scale: 28 }
+          - { width: d57,   scale: 30 }
+          - { width: d57,   scale: 56 }
+          - { width: d76,   scale: 0 }
+          - { width: d76,   scale: 30 }
+          - { width: d76,   scale: 38 }
+          - { width: d76,   scale: 75 }
+          - { width: d115,  scale: 0 }
+          - { width: d115,  scale: 30 }
+          - { width: d115,  scale: 57 }
+          - { width: d115,  scale: 114 }
+          - { width: d153,  scale: 0 }
+          - { width: d153,  scale: 30 }
+          - { width: d153,  scale: 76 }
+          - { width: d153,  scale: 152 }
+          - { width: d230,  scale: 0 }
+          - { width: d230,  scale: 30 }
+          - { width: d230,  scale: 115 }
+          - { width: d230,  scale: 229 }
+          - { width: d307,  scale: 0 }
+          - { width: d307,  scale: 30 }
+          - { width: d307,  scale: 153 }
+          - { width: d307,  scale: 306 }
+          - { width: d462,  scale: 0 }
+          - { width: d462,  scale: 30 }
+          - { width: d462,  scale: 231 }
+          - { width: d462,  scale: 461 }
+          - { width: d616,  scale: 0 }
+          - { width: d616,  scale: 30 }
+          - { width: d616,  scale: 308 }
+          - { width: d616,  scale: 615 }
+          - { width: d924,  scale: 0 }
+          - { width: d924,  scale: 30 }
+          - { width: d924,  scale: 462 }
+          - { width: d924,  scale: 923 }
+          - { width: d1232, scale: 0 }
+          - { width: d1232, scale: 30 }
+          - { width: d1232, scale: 616 }
+          - { width: d1232, scale: 1231 }
+
+    steps:
+      - name: Install system libs (criterion runtime)
+        run: sudo apt-get update && sudo apt-get install -y libfontconfig1
+
+      - name: Download compiled bench exes
+        uses: actions/download-artifact@v8
+        with:
+          name: lib-cmp-perf-compiled
+          path: lib-cmp-compiled
+
+      - name: Run cell ${{ matrix.width }} s${{ matrix.scale }}
+        run: |
+          set -euo pipefail
+          # Resolve the hashed exe name by globbing: lib_cmp_<width>-<hash>.
+          EXE=$(ls lib-cmp-compiled/deps/lib_cmp_${{ matrix.width }}-* | grep -v '\.d$' | head -1)
+          if [ -z "$EXE" ]; then echo "no exe for lib_cmp_${{ matrix.width }}"; exit 1; fi
+          chmod +x "$EXE"
+          # Each benched id is `lib_cmp/<bit>bit_s<scale>/<lib>/<op>`. Filter on
+          # `_s<scale>/` (trailing `/` anchors the scale so `_s30/` matches
+          # `..._s30/...` but NOT `..._s306/...`).
+          FILTER="_s${{ matrix.scale }}/"
+          echo "running: $EXE --bench $FILTER --"
+          "$EXE" --bench "$FILTER" --
+          echo "--- produced groups ---"
+          ls -1 target/criterion 2>/dev/null || true
+
+      - name: Upload cell criterion subtree
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: lib-cmp-perf-${{ matrix.width }}-s${{ matrix.scale }}
+          path: target/criterion/
+          if-no-files-found: warn
+          retention-days: 7
+
+  aggregate:
+    name: "\U0001F4DA aggregate (decimal-scaled vs peers table)"
+    needs: bench
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout (for summarise_libcmp.py)
+        uses: actions/checkout@v6
+
+      - name: Download every (width, scale) bench cell
+        uses: actions/download-artifact@v8
+        with:
+          pattern: lib-cmp-perf-*-s*
+          path: lib-cmp-cells
+
+      - name: Merge every cell into one criterion tree
+        run: |
+          set -euo pipefail
+          mkdir -p target/criterion
+          shopt -s nullglob
+          for d in lib-cmp-cells/lib-cmp-perf-*-s*/; do
+            [ -d "$d" ] || continue
+            echo "merging $d"
+            cp -a "$d/." target/criterion/ 2>/dev/null || true
+          done
+          ls -1 target/criterion > /tmp/lcp_groups.txt
+          echo "--- merged group dirs (sample) ---"
+          head -40 /tmp/lcp_groups.txt
+          echo "--- group count ---"
+          wc -l < /tmp/lcp_groups.txt
+
+      - name: Collate -> decimal-scaled-vs-peers table (+ tsv + md)
+        env:
+          PYTHONIOENCODING: utf-8
+        run: |
+          set -euo pipefail
+          mkdir -p aggregate
+          python3 benches/libcmp/summarise_libcmp.py --tsv aggregate/lib_cmp_medians.tsv --md aggregate/lib_cmp_table.md | tee aggregate/lib_cmp_table.txt
+          {
+            echo ""
+            cat aggregate/lib_cmp_table.md
+          } >> "$GITHUB_STEP_SUMMARY"
+          cp -a target/criterion aggregate/criterion
+
+      - name: Upload single aggregate artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: lib-cmp-perf-aggregate
+          path: aggregate/
+          if-no-files-found: warn
+          retention-days: 30

--- a/.github/workflows/lib-cmp-precision.yml
+++ b/.github/workflows/lib-cmp-precision.yml
@@ -1,0 +1,128 @@
+name: "\U0001F4CF lib-cmp precision (LSBε shootout refresh)"
+
+# Comparative precision shootout. Runs the ONE precision-comparison path —
+# `benches/lib_cmp_precision`, built on the shared PrecisionSubject harness
+# that also backs the correctness gate (tests/ulp_strict_golden.rs). The
+# runner sweeps (method × width × scale) over decimal-scaled plus the five
+# peer libraries, scores every cell against the mpmath golden oracle,
+# WRITES the deterministic per-library result files under
+# results/precision/<library>.tsv, and renders the LSBε(ULP) shootout table
+# FROM those committed files.
+#
+# This workflow self-refreshes: after the run it commits the regenerated
+# results/precision/*.tsv straight back to the branch the run executed on,
+# so the committed result files (the single source of truth for the README
+# precision tables) never drift from the harness output. The self-commit
+# pattern mirrors the `regenerate` job in bench-full.yml.
+#
+# Triggers (advisory — NOT a required status check / merge gate):
+#   * pull_request (base = main) — runs on any PR INTO main so a kernel
+#     change that shifts an LSBε cell or a fidelity grade shows up under
+#     review (refreshes the result files on the PR branch + surfaces the
+#     fidelity grade report on the run's step summary).
+#   * workflow_dispatch — manual run on any branch (the dispatch button
+#     only appears once this file is on the default branch main).
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: lib-cmp-precision-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  refresh:
+    name: refresh results/precision
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      # Push the regenerated results/precision/*.tsv back to the branch
+      # this run executed on.
+      contents: write
+
+    steps:
+      - name: Checkout the run's ref
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.head_ref || github.ref_name }}
+
+      - name: Guard — never self-commit to a default/protected branch
+        env:
+          REF: ${{ github.head_ref || github.ref_name }}
+        run: |
+          set -euo pipefail
+          case "$REF" in
+            main|master)
+              echo "::error::refusing to self-commit precision results to '$REF'"
+              exit 1
+              ;;
+          esac
+          echo "Will refresh + commit results/precision on '$REF'."
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install system libs (fontconfig for plotters dev-dep)
+        run: sudo apt-get update && sudo apt-get install -y libfontconfig1-dev pkg-config
+
+      - name: Cache cargo registry + git
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: cargo-lib-cmp-precision-${{ runner.os }}-${{ hashFiles('Cargo.toml', 'macros/Cargo.toml') }}
+          restore-keys: |
+            cargo-lib-cmp-precision-${{ runner.os }}-
+
+      - name: Run the comparative precision runner
+        # Writes results/precision/*.tsv, renders the LSBε(ULP) shootout
+        # tables, and renders the fidelity grade report (per-function +
+        # overall worst/aggregate dual-grade, the rubric, per-library
+        # coverage). The runner itself appends the fidelity report to
+        # $GITHUB_STEP_SUMMARY (UTF-8, so the ×/→/ε glyphs render); we also
+        # tee the full stdout into a file for the downloadable artifact.
+        # `harness = false` — accuracy harness, not timing.
+        env:
+          # Belt-and-suspenders so any tooling in the chain treats text as
+          # UTF-8 (the Rust runner already emits UTF-8 to the summary file).
+          PYTHONIOENCODING: utf-8
+        run: |
+          cargo bench --bench lib_cmp_precision \
+            --features wide,x-wide,xx-wide,macros \
+            | tee results/precision/REPORT.md
+
+      - name: Upload precision results + fidelity grade report
+        # Single downloadable artifact: the per-library TSVs plus the
+        # rendered shootout + fidelity grade table (REPORT.md).
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: lib-cmp-precision-results
+          path: |
+            results/precision/*.tsv
+            results/precision/REPORT.md
+          if-no-files-found: warn
+
+      - name: Commit refreshed precision results back to the run's branch
+        env:
+          REF: ${{ github.head_ref || github.ref_name }}
+        run: |
+          set -euo pipefail
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # Only the committed TSV source of truth — REPORT.md is an
+          # artifact-only render, not a tracked file.
+          git add results/precision/*.tsv
+          if git diff --cached --quiet; then
+            echo "No precision result changes to commit."
+            exit 0
+          fi
+          # Plain message, no attribution trailer (commit-hygiene gate).
+          git commit -m "results(precision): regenerate from lib_cmp_precision sweep"
+          git push origin "HEAD:${REF}"


### PR DESCRIPTION
Lands the two comparison-bench workflows on the default branch so they become **UI-dispatchable** (the `workflow_dispatch` 'Run workflow' control only appears for workflows on the default branch) and so the **`pull_request`->main hook fires** (GitHub reads dispatch/PR workflow definitions from the default branch).

- **lib-cmp-precision.yml** — the Fidelity / LSBε precision shootout (decimal-scaled vs 6 peers; per-cell precision-relative grade, score + %CR two-letter grade, report to the run summary + artifact).
- **lib-cmp-perf.yml** — the peer-crate timing comparison (width × scale).

Both are **advisory** — never required status checks. Trigger: `pull_request` -> main + `workflow_dispatch`. They run against the **selected ref's** tree (release/0.5.0 carries the lib_cmp benches today; they arrive on main with the 0.5.0 release), so on main they stay dormant-but-valid until then. No source changes — workflow files only.