### PR TITLE
ci: comprehensive golden workflow (dispatch-only, own queue-of-one)

### DIFF
--- a/.github/workflows/golden-comprehensive.yml
+++ b/.github/workflows/golden-comprehensive.yml
@@ -1,0 +1,74 @@
+name: "🔬 golden (comprehensive)"
+
+# The FULL mpmath-oracle golden sweep: `ulp_strict_golden`'s opt-in
+# `golden_autodiscover` test over EVERY `tests/golden/*.txt` table (~1.6k
+# across all tiers) — not just the curated `decl_band!` subset that the
+# per-push `ci` → `golden (gate)` job runs. It is multi-hour at the wide
+# tiers, so it lives in its OWN concurrency queue (queue-of-one), kept off
+# the `ci` and `bench-branch-compare` queues: a deep golden pass must never
+# delay a pre-merge gate or a perf compare, and must not be starved by them.
+#
+# Trigger: workflow_dispatch only — run on demand against ANY ref (e.g.
+# release/0.5.0 to deep-verify a precision-sensitive change, or main before a
+# release). Manual-only by design: every multi-hour comprehensive run is then
+# deliberate, never auto-kicked by a push. The optional `filter` input maps to
+# GOLDEN_FILTER to narrow the sweep to file stems containing the substring
+# (e.g. `d924` for a ~1-minute single-tier scan, `mul_d`, etc.).
+
+on:
+  workflow_dispatch:
+    inputs:
+      filter:
+        description: "GOLDEN_FILTER substring (golden file-stem match; empty = ALL tables)"
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+
+concurrency:
+  # Own queue, independent of `ci` and `bench-branch-compare`. Queue-of-one:
+  # let the in-progress sweep finish (don't waste a multi-hour run), and let a
+  # newer push supersede only the QUEUED run.
+  group: golden-comprehensive-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  comprehensive:
+    name: golden (comprehensive)
+    runs-on: ubuntu-latest
+    # The auto-discovered sweep is multi-hour at the wide tiers; allow the
+    # GitHub-hosted job maximum.
+    timeout-minutes: 360
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry + git
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: cargo-golden-comprehensive-${{ runner.os }}-${{ hashFiles('Cargo.toml', 'macros/Cargo.toml') }}
+          restore-keys: |
+            cargo-golden-comprehensive-${{ runner.os }}-
+
+      - name: Install system libs (fontconfig for the plotters dev-dep)
+        # `cargo test` compiles ALL dev-dependencies regardless of `--test`
+        # scoping, and plotters (a dev-dep) pulls yeslogic-fontconfig-sys.
+        run: sudo apt-get update && sudo apt-get install -y libfontconfig1-dev pkg-config
+
+      - name: Comprehensive auto-discovered golden sweep (release, golden feature)
+        # `--ignored` runs the `#[ignore]`d `golden_autodiscover` over every
+        # `tests/golden/*.txt`. `--nocapture` surfaces its per-table progress
+        # so a long run is not opaque. GOLDEN_FILTER (empty on push) narrows it.
+        env:
+          GOLDEN_FILTER: ${{ github.event.inputs.filter }}
+        run: |
+          cargo test --release --features wide,x-wide,xx-wide,macros,golden \
+            --test ulp_strict_golden -- --ignored --nocapture golden_autodiscover


### PR DESCRIPTION
Adds the comprehensive mpmath-oracle golden sweep as its own GitHub Actions workflow, separate from the per-push `ci` golden gate.

- Runs `ulp_strict_golden`'s opt-in `golden_autodiscover` over every `tests/golden/*.txt` (~1.6k tables across all tiers) — the full sweep the curated `decl_band!` subset (the per-push `golden (gate)`) does not cover.
- Own concurrency group (queue-of-one), isolated from the `ci` and `bench-branch-compare` queues so a deep golden pass never delays a pre-merge gate or a perf compare, nor is starved by them.
- `workflow_dispatch` only — run on demand against any ref, with an optional `GOLDEN_FILTER` substring (e.g. `d924` for a ~1-minute single-tier scan). Manual by design so every multi-hour run is deliberate.

CI-only change; no library code. Landing it on `main` (the default branch) is what makes `workflow_dispatch` available repo-wide (incl. against release branches).