### PR TITLE
0.5.0 finalize: green the docs deploy, ureq 3 / criterion 0.8, dependabot MSRV ignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -46,3 +46,8 @@ updates:
       - dependencies
       - dependabot
       - github-actions
+    ignore:
+      # dtolnay/rust-toolchain@1.89 is the MSRV pin for the `msrv (gate)` job — it
+      # deliberately matches Cargo.toml `rust-version`. Raising the MSRV is a manual,
+      # paired change (Cargo.toml + the job together), never an automatic action bump.
+      - dependency-name: "dtolnay/rust-toolchain"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -188,7 +188,7 @@ decimal_scaled_macros = { path = "macros", version = "0.5.0", default-features =
 tracing = { version = "0.1", default-features = false, features = ["std"], optional = true }
 
 [dev-dependencies]
-criterion = { version = "0.5", default-features = false, features = ["cargo_bench_support"] }
+criterion = { version = "0.8", default-features = false, features = ["cargo_bench_support"] }
 i256 = { version = "0.2", default-features = false }
 serde_json = "1"
 postcard = { version = "1", default-features = false, features = ["alloc"] }

--- a/decimal-scale-test/Cargo.toml
+++ b/decimal-scale-test/Cargo.toml
@@ -94,7 +94,7 @@ num-traits = { version = "0.2", default-features = false }
 proptest = "1"
 # Live-vs-pinned-history microbenches (benches/add_history_ab.rs): same
 # criterion dev-dep + self-pin affinity helper the root crate's benches use.
-criterion = { version = "0.5", default-features = false, features = ["cargo_bench_support"] }
+criterion = { version = "0.8", default-features = false, features = ["cargo_bench_support"] }
 core_affinity = "0.8"
 
 # Mirror the root crate's rust-lint envelope so the relocated tests keep the

--- a/decimal-scaled-cells/src/lib.rs
+++ b/decimal-scaled-cells/src/lib.rs
@@ -9,10 +9,10 @@
 //! heavy-monomorphisation bill, and pays it AGAIN for every additional target
 //! that re-instantiates the same cells (a lib's own unit-test harness, a second
 //! test binary). This crate is the compile-once home for that bill: the
-//! [`cells!`]-generated fan-out — parse → compute → format ([`dispatch_compute`])
+//! `cells!`-generated fan-out — parse → compute → format ([`dispatch_compute`])
 //! and the storage envelope ([`dispatch_limits`]), per cell — compiles here,
 //! exactly once, into a leaf rlib. The subjects above it (the erased
-//! `DsSubject` in decimal-scale-test, the historical adapters in [`history`])
+//! `DsSubject` in decimal-scale-test, the historical adapters in `history`)
 //! call these concrete, non-generic entry points and stay light.
 //!
 //! Pure codegen placement: no new types, no algorithm bodies, no per-tier

--- a/decimal-scaled-golden/Cargo.toml
+++ b/decimal-scaled-golden/Cargo.toml
@@ -33,5 +33,5 @@ bench = ["dep:criterion"]
 net = ["dep:ureq"]
 
 [dependencies]
-criterion = { version = "0.5", optional = true, default-features = false, features = ["cargo_bench_support"] }
-ureq = { version = "2", optional = true }
+criterion = { version = "0.8", optional = true, default-features = false, features = ["cargo_bench_support"] }
+ureq = { version = "3", optional = true }

--- a/decimal-scaled-golden/src/loader/url.rs
+++ b/decimal-scaled-golden/src/loader/url.rs
@@ -78,7 +78,9 @@ impl UrlLoader {
         }
         let url = format!("{}{}.au", self.base_url, func.name());
         match ureq::get(&url).call() {
-            Ok(resp) => match resp.into_string() {
+            // ureq 3: the body is read via `body_mut()`. Raise the read limit well
+            // above the largest golden file (~8 MB) so a big `.au` is never truncated.
+            Ok(mut resp) => match resp.body_mut().with_config().limit(64 * 1024 * 1024).read_to_string() {
                 Ok(body) => {
                     if let Err(e) = std::fs::write(&path, body) {
                         eprintln!("UrlLoader: caching {}: {e}", path.display());

--- a/src/policy/trig.rs
+++ b/src/policy/trig.rs
@@ -3514,6 +3514,11 @@ mod forward_rung_tests {
     /// gets the full spread + the 1e9 out-of-budget probe; asin its unit
     /// domain; sinh/exp/asinh the EXP_ARG_BUDGET region + the x50
     /// out-of-budget probe at s0), rung == tier across all six modes.
+    // Defined only when a consuming test is compiled: its invocations live in `#[test]`
+    // grids gated `#[cfg(feature = "d307")]` / `#[cfg(feature = "d1232")]` below, so gate
+    // the definition on `test` AND those tiers — then no build (test or not, narrow or
+    // wide) carries an uninvoked macro.
+    #[cfg(all(test, any(feature = "d307", feature = "d1232")))]
     macro_rules! bench_grid_cell {
         ($Core:ty, $N:literal, $SCALE:literal, $with_big:expr) => {{
             type C = $Core;


### PR DESCRIPTION
Completes the 0.5.0 release (not yet tagged/published) — no version bump.

- **Greens the docs deploy**: de-link the private `cells!` macro and the cfg-gated `history` module in the decimal-scaled-cells crate doc (the workspace rustdoc build runs `-D warnings` and failed on these).
- **Drops the unused-macro warning**: `bench_grid_cell!` gated on `all(test, any(d307, d1232))` to match its only invocations.
- **Deps**: ureq 2 -> 3 (UrlLoader migrated to the 3.x body API) and criterion 0.5 -> 0.8 (no code change needed).
- **dependabot**: ignore `dtolnay/rust-toolchain` (the MSRV pin).

Verified locally: `cargo doc --features wide,x-wide,xx-wide,macros --workspace` clean; golden `net`+`bench`, root/scale-test benches, and the d307 tests all build warning-free.