### PR TITLE
ci(deps): bump codeql-action init+analyze+upload-sarif to v4.36.3

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,12 +35,12 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           languages: rust
           build-mode: none
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           category: "/language:rust"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -66,6 +66,6 @@ jobs:
           retention-days: 5
 
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
Bumps all three `github/codeql-action/*` refs to **v4.36.3** (`54f647b`) in one commit:

- `init` (codeql.yml) — 4.36.2 → 4.36.3  *(Dependabot never opened a PR for this one)*
- `analyze` (codeql.yml) — 4.36.2 → 4.36.3  (was #32)
- `upload-sarif` (scorecard.yml) — 4.36.2 → 4.36.3  (was #33)

**Why combined:** CodeQL requires `init` and `analyze` to run the same version. Dependabot's #32 bumped only `analyze`, leaving `init` at 4.36.2, which failed the analyze step:

```
##[error]Loaded a configuration file for version '4.36.2', but running version '4.36.3'
```

Bumping all three together keeps `codeql.yml` internally consistent and green. **Supersedes #32 and #33.**