### PR TITLE
ci: fix the red cargo-audit gate, land the codeql trio, stop dependabot re-breaking both

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,8 +2,15 @@ version: 2
 
 # Dependabot configuration for decimal-scaled.
 #
-# Two cargo ecosystems are tracked because each Cargo.toml lives in
-# its own root (the root crate and the `macros/` proc-macro crate).
+# ONE cargo entry covers the whole repo: `/` is a cargo WORKSPACE and
+# dependabot walks every member listed in its `[workspace] members`
+# (./macros, ./decimal-scaled-golden, ./decimal-scaled-cells,
+# ./decimal-scale-test, ./golden-competitors). A second entry for a
+# member directory does NOT add coverage -- it duplicates it, and
+# dependabot raises the SAME bump twice from two branches (the
+# byte-identical syn 2->3 pair #40 `cargo/syn-3` and #41
+# `cargo/macros/syn-3`, 2026-07-20). Add a member to the workspace,
+# not to this file.
 #
 # All schedules are Monday morning UTC, off-minute, to spread PR
 # creation across the week's start without colliding with the security
@@ -22,18 +29,6 @@ updates:
       - dependencies
       - dependabot
 
-  - package-ecosystem: cargo
-    directory: "/macros"
-    schedule:
-      interval: weekly
-      day: monday
-      time: "09:23"
-      timezone: Etc/UTC
-    open-pull-requests-limit: 5
-    labels:
-      - dependencies
-      - dependabot
-
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
@@ -46,6 +41,18 @@ updates:
       - dependencies
       - dependabot
       - github-actions
+    groups:
+      # codeql-action ships init / analyze / upload-sarif as three action
+      # paths out of ONE repo, and CodeQL refuses a run whose init and
+      # analyze versions differ. Ungrouped, dependabot opens one PR per
+      # path, so each PR on its own IS a version mismatch and fails
+      # "Analyze (Rust)" -- hit at 4.36.3 (#34), then again at 4.37.0 and
+      # 4.37.1 (#42/#43/#45), every time needing a hand-built lockstep
+      # commit. Grouping raises the trio as a single PR, which is the only
+      # state CodeQL accepts.
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"
     ignore:
       # dtolnay/rust-toolchain@1.89 is the MSRV pin for the `msrv (gate)` job — it
       # deliberately matches Cargo.toml `rust-version`. Raising the MSRV is a manual,

--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -42,3 +42,15 @@ jobs:
         uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          # RUSTSEC-2026-0192 — `ttf-parser` is unmaintained. This is an
+          # INFORMATIONAL notice, not a vulnerability: the scan reports
+          # zero vulnerabilities. The crate is a dev-only transitive
+          # (plotters -> ttf-parser, via the `ttf` feature used to render
+          # text on docs/figures/library_comparison/*.png); it is never
+          # compiled into the published crate or any consumer build.
+          #
+          # Scoped to the one advisory id on purpose — a future *actual*
+          # vulnerability in ttf-parser gets a different id and still
+          # fails this gate. Revisit when plotters moves to `skrifa`
+          # (the maintained successor) and drop this line.
+          ignore: RUSTSEC-2026-0192

--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -51,6 +51,29 @@ jobs:
           #
           # Scoped to the one advisory id on purpose — a future *actual*
           # vulnerability in ttf-parser gets a different id and still
-          # fails this gate. Revisit when plotters moves to `skrifa`
-          # (the maintained successor) and drop this line.
+          # fails this gate.
+          #
+          # Bumping ttf-parser does NOT clear this: the advisory is
+          # "unmaintained", which covers the crate at every version (the
+          # author declared it finished). Only dropping the dependency
+          # clears it, and that is plotters' call, not ours.
+          #
+          # Upstream state (checked 2026-07-24): plotters is aware
+          # (plotters-rs/plotters#740) and PR #736 replaces ttf-parser +
+          # font-kit + pathfinder with fontique + skrifa — skrifa being
+          # the maintained successor the advisory recommends. Unreleased:
+          # plotters' latest is still 0.3.7 (2024-09), so there is nothing
+          # to act on yet.
+          #
+          # WHEN THAT RELEASES, IT IS A PAIRED CHANGE. #736 also DELETES
+          # the `ttf` feature outright, and Cargo.toml requests it
+          # explicitly (plotters features = [..., "ttf"]), so the upgrade
+          # breaks the feature list with an unknown-feature error rather
+          # than falling back silently. Drop `ttf` from that feature list
+          # AND drop this ignore line together.
+          #
+          # Worth weighing at that point: fontique + skrifa pull in the
+          # linebender stack, a much larger surface than ttf-parser for a
+          # dev-only chart generator (examples/chart_gen.rs is the sole
+          # consumer). Dropping plotters may beat following it.
           ignore: RUSTSEC-2026-0192

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,12 +35,12 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
+        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           languages: rust
           build-mode: none
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
+        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           category: "/language:rust"

--- a/.github/workflows/docs-drift.yml
+++ b/.github/workflows/docs-drift.yml
@@ -47,7 +47,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.x"
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -52,7 +52,7 @@ jobs:
           toolchain: stable
 
       - name: Install Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.x"
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -66,6 +66,6 @@ jobs:
           retention-days: 5
 
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
+        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
Clears the whole current bot backlog on the workflow side, and fixes the two config defects that keep regenerating it.

## 1. cargo-audit has been red on `main` since 2026-07-21

Eleven consecutive failures. It is **not** a vulnerability — the scan reports `"vulnerabilities":{"found":false,"count":0}`. It fails on `RUSTSEC-2026-0192`, an *informational* "unmaintained" notice for `ttf-parser`, a dev-only transitive (`plotters` → `ttf-parser` via the `ttf` feature used to render text on the comparison figures). It never compiles into the published crate.

The job then errored outright with `Resource not accessible by integration`: on push/schedule events `audit-check` tries to open an issue per finding, which the workflow's `contents: read` token cannot do. PR runs were unaffected, which is why this only ever went red on `main`.

Fixed by scoping `ignore:` to the single advisory id — deliberately **not** by widening the token or muting informational warnings wholesale. A future *actual* vulnerability in `ttf-parser` carries a different id and still fails the gate.

Trade-off worth naming: this permanently silences the unmaintained notice for that id, so we stop being told `ttf-parser` is abandoned. The revisit condition (plotters moving to `skrifa`) is recorded inline.

## 2. codeql-action trio → v4.37.1 — supersedes #42, #43, #45

`init` / `analyze` / `upload-sarif` are three action paths from one repo that CodeQL requires to be on the same version. Dependabot raises one PR per path, so **each PR alone is a version mismatch** — #43 and #45 were both already failing `Analyze (Rust)`. All three refs move together here, the only state CodeQL accepts. Same SHA (`7188fc36…`) Dependabot resolved.

## 3. setup-python → v7.0.0 — supersedes #44

## 4. dependabot.yml — the two defects behind the mess

**Duplicate cargo PRs.** A second cargo entry for `/macros` duplicated `/`. The `/` root is a *workspace* and Dependabot already walks every member, so the extra entry added no coverage and raised each macros bump twice — the byte-identical syn 2→3 pair #40/#41. Proof `/` already reaches members: #40 came from the `/` ecosystem branch (`cargo/syn-3`) yet edits `macros/Cargo.toml`, and #35 (also `/`) edits `golden-competitors/Cargo.toml`.

**Split codeql trio.** Added a `groups:` block so the three action paths ship as one PR. This trap recurred at 4.36.3 (#34), 4.37.0, and 4.37.1 — three hand-built lockstep commits. Grouping ends it.

The `dtolnay/rust-toolchain` MSRV ignore is unchanged.

## Verification

- All 5 changed workflows + `dependabot.yml` parse; the `ignore` input resolves to `RUSTSEC-2026-0192`
- Both new action SHAs verified as **real commits** matching Dependabot's own (an earlier attempt used the annotated *tag object* SHA, which is not a commit and would have broken every CodeQL run)
- No CRLF flips