### PR TITLE
chore(deps): syn 2->3 (macros), dashu-float/dashu-int 0.4->0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -210,10 +210,10 @@ g_math = "0.4"
 # All bench-only; never compiled into a normal build.
 fastnum = { version = "0.7", default-features = false, features = ["std"] }
 bigdecimal = "0.4"
-dashu-float = "0.4"
+dashu-float = "0.5"
 # dashu-int provides IBig for exact base-10 integer scaling of dashu-float
 # results in the comparison benches.
-dashu-int = { version = "0.4", default-features = false, features = ["std"] }
+dashu-int = { version = "0.5", default-features = false, features = ["std"] }
 decimal-rs = "0.1"
 scientific = "0.5"
 # Chart generation for docs/figures/library_comparison/*.png — pure

--- a/golden-competitors/Cargo.toml
+++ b/golden-competitors/Cargo.toml
@@ -23,7 +23,7 @@ decimal-scaled-golden = { path = "../decimal-scaled-golden" }
 
 rust_decimal = { version = "1", default-features = false, features = ["maths"] }
 bigdecimal = "0.4"
-dashu-float = "0.4"
+dashu-float = "0.5"
 fastnum = { version = "0.7", default-features = false, features = ["std"] }
 decimal-rs = "0.1"
 g_math = { version = "0.4", features = ["balanced"] }

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -19,7 +19,7 @@ proc-macro = true
 default = []
 
 [dependencies]
-syn = { version = "2", features = ["full"] }
+syn = { version = "3", features = ["full"] }
 quote = "1"
 proc-macro2 = "1"
 # Resolves the consuming crate's actual import name for


### PR DESCRIPTION
Supersedes #40 and #41 (syn — byte-identical duplicates, see #46 for why Dependabot raised it twice), #35 (dashu-float) and #36 (dashu-int).

Applied by hand rather than merged so the diff is **the version strings only**. Dependabot's TOML rewriter additionally strips the UTF-8 BOM from `Cargo.toml` (`-﻿[package]` → `+[package]`) — an unrelated encoding change that has no business riding in on a dependency bump.

Both dashu crates move together: `dashu-int` supplies the `IBig` used to scale `dashu-float` results in the comparison benches, so a split bump would mismatch them.

## Blast radius

All three are **build- or dev-only**; no runtime dependency of the published crate changes.

- `syn` — proc-macro build-time only (`macros/`)
- `dashu-float` / `dashu-int` — benches + `golden-competitors`, never compiled into a normal build

Resolves to syn 3.0.3, dashu-float 0.5.0, dashu-int 0.5.0. syn 2.0.119 remains in the graph for other crates — two majors coexisting is expected.

## Verification

- `cargo check --workspace --all-targets --features wide,x-wide,xx-wide,macros` — exit 0, **zero errors**. The 37 warnings are pre-existing `criterion::black_box` deprecations confined to the `pr_gate` bench; none are syn- or dashu-related.
- `cargo test --features macros --doc` — 55 passed, 0 failed. `cargo check` proves the proc-macros *compile* under syn 3, but a proc-macro regression can yield a wrong *value* that still type-checks, so the macro-expansion doctests were run explicitly.
- Dependabot's own PRs already went green through the full gate on these exact diffs (#40/#41 through `tests (gate)` and all 11 consolidated shards; #35/#36 likewise).

One caveat: this PR combines both bumps, a combination no single Dependabot PR tested. They are independent (proc-macro vs bench deps), and CI gates the combination here.