### PR TITLE
ci: publish timing/correctness data to a ci-data branch instead of main (Goal 1)

### DIFF
--- a/.github/workflows/bench-branch-compare.yml
+++ b/.github/workflows/bench-branch-compare.yml
@@ -333,23 +333,30 @@ jobs:
           cp "$tsv" results/timing/bbc_medians.tsv
           git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          # Re-render the docs that read these medians (the Performance page renders
-          # straight from results/timing/) so the committed page never lags the
-          # data — the refreshed TSV and its rendered page land in the SAME commit,
-          # keeping the docs-drift gate green. stdlib-only, no extra deps.
-          python3 scripts/render_docs.py
-          git add results/timing/bbc_medians.tsv
-          git add -u README.md docs/
-          if git diff --cached --quiet; then
-            echo "timing medians + docs unchanged — nothing to commit"
-            exit 0
+          if [ "$GITHUB_REF_NAME" = "main" ]; then
+            # `main` is protected — a self-commit is declined (GH006). Publish the
+            # raw medians to the unprotected `ci-data` data branch instead; the
+            # docs build reads them from there. Nothing is rendered or committed
+            # to `main` here (that stays the release-cadence snapshot).
+            bash scripts/push_ci_data.sh results/timing/bbc_medians.tsv
+          else
+            # release/* (unprotected): self-commit the fresh medians + re-rendered
+            # Performance page for the release PR — the RELEASING.md §3 refresh
+            # path, unchanged. stdlib-only, no extra deps.
+            python3 scripts/render_docs.py
+            git add results/timing/bbc_medians.tsv
+            git add -u README.md docs/
+            if git diff --cached --quiet; then
+              echo "timing medians + docs unchanged — nothing to commit"
+              exit 0
+            fi
+            git commit -m "results(timing): refresh medians + render Performance page"
+            # Incorporate any concurrent results/ self-commit (disjoint files) so
+            # the push isn't rejected non-fast-forward. The step only runs when
+            # inputs.ref is unset, so github.ref_name is the run's own branch.
+            git pull --rebase origin "${{ github.ref_name }}" || true
+            git push origin "HEAD:${{ github.ref_name }}"
           fi
-          git commit -m "results(timing): refresh medians + render Performance page"
-          # Incorporate any concurrent results/ self-commit (disjoint files) so
-          # the push isn't rejected non-fast-forward. The step only runs when
-          # inputs.ref is unset, so github.ref_name is the run's own branch.
-          git pull --rebase origin "${{ github.ref_name }}" || true
-          git push origin "HEAD:${{ github.ref_name }}"
 
       - name: Upload single aggregate artifact
         if: always()

--- a/.github/workflows/golden-comprehensive.yml
+++ b/.github/workflows/golden-comprehensive.yml
@@ -291,23 +291,29 @@ jobs:
           PY
           git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          # Re-render the docs that read this summary (the Precision surface renders
-          # straight from results/golden/) so the committed pages never lag the
-          # data — this is the self-heal: a refreshed summary AND its rendered page
-          # land in the SAME commit, keeping the docs-drift gate green. stdlib-only,
-          # no extra deps.
-          python3 scripts/render_docs.py
-          git add results/golden/summary.tsv
-          git add -u README.md docs/
-          if git diff --cached --quiet; then
-            echo "golden summary + docs unchanged — nothing to commit"
-            exit 0
+          if [ "$GITHUB_REF_NAME" = "main" ]; then
+            # `main` is protected — a self-commit is declined (GH006). Publish the
+            # raw summary to the unprotected `ci-data` data branch instead; the
+            # docs build reads it from there. Nothing is rendered or committed to
+            # `main` here (that stays the release-cadence snapshot).
+            bash scripts/push_ci_data.sh results/golden/summary.tsv
+          else
+            # release/* (unprotected): self-commit the fresh summary + re-rendered
+            # Precision page for the release PR — the RELEASING.md §3 refresh path,
+            # unchanged. stdlib-only, no extra deps.
+            python3 scripts/render_docs.py
+            git add results/golden/summary.tsv
+            git add -u README.md docs/
+            if git diff --cached --quiet; then
+              echo "golden summary + docs unchanged — nothing to commit"
+              exit 0
+            fi
+            git commit -m "results(golden): refresh correctness summary + render Precision page"
+            # Incorporate any concurrent results/ self-commit (disjoint files) so
+            # the push isn't rejected non-fast-forward.
+            git pull --rebase origin "${{ github.ref_name }}" || true
+            git push origin "HEAD:${{ github.ref_name }}"
           fi
-          git commit -m "results(golden): refresh correctness summary + render Precision page"
-          # Incorporate any concurrent results/ self-commit (disjoint files) so
-          # the push isn't rejected non-fast-forward.
-          git pull --rebase origin "${{ github.ref_name }}" || true
-          git push origin "HEAD:${{ github.ref_name }}"
 
       - name: Upload combined report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/history.yml
+++ b/.github/workflows/history.yml
@@ -221,17 +221,26 @@ jobs:
           fi
           git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          # Re-render the History page from the fresh medians in the SAME commit
-          # (self-heal: the committed page never lags the data; docs-drift stays green).
-          python3 scripts/render_docs.py
-          git add results/history/history.tsv
-          git add -u README.md docs/
-          if git diff --cached --quiet; then
-            echo "history medians + docs unchanged — nothing to commit"
-            exit 0
+          if [ "$GITHUB_REF_NAME" = "main" ]; then
+            # `main` is protected — a self-commit is declined (GH006). Publish the
+            # raw medians to the unprotected `ci-data` data branch instead; the
+            # docs build reads them from there. Nothing is rendered or committed
+            # to `main` here (that stays the release-cadence snapshot).
+            bash scripts/push_ci_data.sh results/history/history.tsv
+          else
+            # release/* (unprotected): self-commit the fresh medians + re-rendered
+            # History page for the release PR — the RELEASING.md §3 refresh path,
+            # unchanged.
+            python3 scripts/render_docs.py
+            git add results/history/history.tsv
+            git add -u README.md docs/
+            if git diff --cached --quiet; then
+              echo "history medians + docs unchanged — nothing to commit"
+              exit 0
+            fi
+            git commit -m "results(history): refresh per-version medians + render History page"
+            # Incorporate any concurrent results/ self-commit (disjoint files) so
+            # the push isn't rejected non-fast-forward.
+            git pull --rebase origin "${{ github.ref_name }}" || true
+            git push origin "HEAD:${{ github.ref_name }}"
           fi
-          git commit -m "results(history): refresh per-version medians + render History page"
-          # Incorporate any concurrent results/ self-commit (disjoint files) so
-          # the push isn't rejected non-fast-forward.
-          git pull --rebase origin "${{ github.ref_name }}" || true
-          git push origin "HEAD:${{ github.ref_name }}"

--- a/.github/workflows/lib-perf.yml
+++ b/.github/workflows/lib-perf.yml
@@ -212,21 +212,30 @@ jobs:
           fi
           git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          # Re-render docs from the fresh medians in the SAME commit (self-heal: the
-          # committed page never lags the data; docs-drift stays green). The
-          # Comparisons renderer (_libcmp_rows in scripts/render_docs.py) reads this
-          # file's schema directly (function/width/library/scale/nanos/min/max —
-          # decimal-scaled as one line per comparison scale, peers as markers at their
-          # capacity width; min/max feed the bands/whiskers).
-          python3 scripts/render_docs.py
-          git add results/lib_cmp/medians.tsv
-          git add -u README.md docs/
-          if git diff --cached --quiet; then
-            echo "lib-perf medians + docs unchanged — nothing to commit"
-            exit 0
+          if [ "$GITHUB_REF_NAME" = "main" ]; then
+            # `main` is protected — a self-commit is declined (GH006). Publish the
+            # raw medians to the unprotected `ci-data` data branch instead; the
+            # docs build reads them from there. Nothing is rendered or committed
+            # to `main` here (that stays the release-cadence snapshot).
+            bash scripts/push_ci_data.sh results/lib_cmp/medians.tsv
+          else
+            # release/* (unprotected): self-commit the fresh medians + re-rendered
+            # Comparisons page for the release PR — the RELEASING.md §3 refresh
+            # path, unchanged. The Comparisons renderer (_libcmp_rows in
+            # scripts/render_docs.py) reads this file's schema directly
+            # (function/width/library/scale/nanos/min/max — decimal-scaled as one
+            # line per comparison scale, peers as markers at their capacity width;
+            # min/max feed the bands/whiskers).
+            python3 scripts/render_docs.py
+            git add results/lib_cmp/medians.tsv
+            git add -u README.md docs/
+            if git diff --cached --quiet; then
+              echo "lib-perf medians + docs unchanged — nothing to commit"
+              exit 0
+            fi
+            git commit -m "results(lib-perf): refresh peer-crate timing medians + render Comparisons"
+            # Incorporate any concurrent results/ self-commit (disjoint files) so
+            # the push isn't rejected non-fast-forward.
+            git pull --rebase origin "${{ github.ref_name }}" || true
+            git push origin "HEAD:${{ github.ref_name }}"
           fi
-          git commit -m "results(lib-perf): refresh peer-crate timing medians + render Comparisons"
-          # Incorporate any concurrent results/ self-commit (disjoint files) so
-          # the push isn't rejected non-fast-forward.
-          git pull --rebase origin "${{ github.ref_name }}" || true
-          git push origin "HEAD:${{ github.ref_name }}"

--- a/scripts/push_ci_data.sh
+++ b/scripts/push_ci_data.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+#
+# push_ci_data.sh — publish one generated data file to the `ci-data` branch.
+#
+#   Usage: scripts/push_ci_data.sh <src-file> [<dest-path-in-branch>]
+#          (dest defaults to <src-file> — every caller keeps the same layout)
+#
+# WHY THIS EXISTS
+#   The timing / correctness producers (bench-branch-compare, golden-
+#   comprehensive, history, lib-perf) refresh a TSV under results/ on every
+#   run. On `main` they cannot self-commit it: `main` is a protected branch and
+#   a direct push is declined (GH006). `ci-data` is an unprotected, data-only
+#   ORPHAN branch that holds nothing but those refreshed TSVs — the producers
+#   push here instead, and a later docs build reads from it.
+#
+#   Loop-safe: a GITHUB_TOKEN push does NOT trigger workflows, and no workflow
+#   is configured to run on `ci-data`, so publishing data never starts another
+#   run. Each producer writes a DISJOINT file, so concurrent runs don't collide
+#   on content; the push retry below absorbs the non-fast-forward races.
+#
+# Isolated by construction: all work happens in a throwaway worktree, so the
+# caller's checkout (its ref, its build tree) is never touched.
+set -euo pipefail
+
+src="${1:?usage: push_ci_data.sh <src-file> [<dest-path>]}"
+dest="${2:-$src}"
+branch="${CI_DATA_BRANCH:-ci-data}"
+
+if [ ! -f "$src" ]; then
+  echo "push_ci_data: '$src' does not exist — nothing to publish"
+  exit 0
+fi
+
+git config user.name  "github-actions[bot]"
+git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+wt="$(mktemp -d)"
+cleanup() { git worktree remove --force "$wt" >/dev/null 2>&1 || rm -rf "$wt"; }
+trap cleanup EXIT
+
+# Materialise `ci-data` in the throwaway worktree: track the remote branch if
+# it already exists, otherwise start it as an EMPTY orphan (no main history).
+if git fetch --depth 1 origin "$branch:refs/remotes/origin/$branch" 2>/dev/null; then
+  git worktree add -B "$branch" "$wt" "refs/remotes/origin/$branch" >/dev/null
+else
+  echo "push_ci_data: '$branch' absent on origin — creating it as an orphan"
+  git worktree add --detach "$wt" >/dev/null
+  git -C "$wt" checkout --orphan "$branch" >/dev/null 2>&1
+  git -C "$wt" rm -rf . >/dev/null 2>&1 || true
+fi
+
+mkdir -p "$wt/$(dirname "$dest")"
+cp "$src" "$wt/$dest"
+git -C "$wt" add "$dest"
+
+if git -C "$wt" diff --cached --quiet; then
+  echo "push_ci_data: '$dest' unchanged on '$branch' — nothing to publish"
+  exit 0
+fi
+
+git -C "$wt" commit -q -m "data: refresh $dest"
+
+# Retry to absorb a sibling producer landing its own (disjoint) file first.
+for attempt in 1 2 3 4 5; do
+  if git -C "$wt" push origin "HEAD:$branch" 2>&1; then
+    echo "push_ci_data: published '$dest' to '$branch'"
+    exit 0
+  fi
+  echo "push_ci_data: push rejected (attempt $attempt/5) — rebasing on '$branch'"
+  git -C "$wt" fetch --depth 1 origin "$branch:refs/remotes/origin/$branch" || true
+  git -C "$wt" rebase "refs/remotes/origin/$branch" || git -C "$wt" rebase --abort || true
+done
+
+echo "push_ci_data: FAILED to publish '$dest' after 5 attempts" >&2
+exit 1


### PR DESCRIPTION
Fixes the four data producers that self-commit into `results/` and push to their run branch. On `main` that push is declined — `main` is protected (`GH006`) — so `history` and `lib-perf` (noisy timing medians, always a diff) have failed on **every** `main` push for weeks. `golden-comprehensive` and `bench-branch-compare` only *look* healthy: their data is deterministic and usually hits the `git diff --quiet` no-op guard, so they rarely try the push at all.

## Change

A shared **`scripts/push_ci_data.sh`** publishes one TSV to an unprotected, data-only **orphan `ci-data` branch**: isolated in a throwaway worktree, orphan-create on first use, no-op when unchanged, retry-with-rebase so the four disjoint files never reject each other. **No `--force` anywhere** — a push can only fail loudly, never overwrite `ci-data`. A `GITHUB_TOKEN` push does not trigger workflows and nothing runs on `ci-data`, so there is no refresh loop.

The four producers now branch on ref:

- **`main`** (protected) → `push_ci_data.sh` publishes the raw TSV to `ci-data`. Nothing rendered or committed to `main`.
- **`release/*`** (unprotected) → **unchanged**: the existing self-commit of fresh data + re-rendered page for the release PR, exactly as **RELEASING.md §3** documents.

This is **Goal 1 of two**: stop the red and stand up `ci-data` as the data spine. **Goal 2** (follow-up) teaches the docs build to render live from `ci-data` and unifies the release refresh onto it.

## Validation

- `scripts/push_ci_data.sh` exercised against a scratch bare remote with **CI-faithful fresh checkouts**: orphan-create (first use), fetch-and-extend (subsequent), no-op (unchanged), push-retry (one-shot reject → rebase → succeed), and a genuine **disjoint-file concurrent merge** (history + timing coexist, history intact). No orphan reset, no force-push.
- All four workflow YAMLs parse; every embedded `run:` block passes `bash -n`.

## Note for reviewers

These four workflows run only on **`main`-push / `workflow_dispatch`**, never on PRs — so this PR’s CI validates that nothing else regressed (the change touches only workflow files + a new script; `docs-drift` and the test gates are unaffected), but it **cannot exercise the producers themselves**. The `ci-data` publish is validated **post-merge** by dispatching a producer.