### PR TITLE
ci(docs): render the published site live from the ci-data branch (Goal 2)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -86,6 +86,39 @@ jobs:
           [ -f CONTRIBUTORS.md ] && cp CONTRIBUTORS.md docs/CONTRIBUTORS.md
           [ -f SECURITY.md ]   && cp SECURITY.md   docs/SECURITY.md
 
+      - name: Overlay live benchmark data from ci-data + re-render
+        # The timing/correctness producers (bench-branch-compare, golden-
+        # comprehensive, history, lib-perf) publish their fresh TSVs to the
+        # data-only `ci-data` branch — they cannot self-commit to protected
+        # `main` (see scripts/push_ci_data.sh). Overlay those four files onto the
+        # committed release snapshot and re-render the data-driven pages so the
+        # PUBLISHED site tracks the latest measurements.
+        #
+        # Ephemeral by construction: nothing is committed. The committed
+        # docs/*.md stay the release snapshot and the `docs-drift` gate keeps
+        # checking THAT against the committed results/ — this step never runs
+        # there. Each file is copied individually, so results/precision/* (not on
+        # ci-data) is untouched. If `ci-data` is absent (before the first
+        # producer run) or a file is missing, the snapshot is used unchanged, so
+        # the build can only fall back, never break.
+        run: |
+          set -euo pipefail
+          if git fetch --depth 1 origin ci-data 2>/dev/null; then
+            for p in results/history/history.tsv \
+                     results/lib_cmp/medians.tsv \
+                     results/golden/summary.tsv \
+                     results/timing/bbc_medians.tsv; do
+              if git show "FETCH_HEAD:$p" > "$p.cidata" 2>/dev/null; then
+                mv "$p.cidata" "$p"; echo "overlaid $p from ci-data"
+              else
+                rm -f "$p.cidata"; echo "ci-data has no $p yet — keeping snapshot"
+              fi
+            done
+          else
+            echo "ci-data branch absent — rendering the committed snapshot"
+          fi
+          python3 scripts/render_docs.py
+
       - name: Build MkDocs site
         run: mkdocs build --strict --site-dir _site
 


### PR DESCRIPTION
Goal 2 of two (Goal 1 = #52, merged). Makes the published docs site track the latest measurements instead of only the release-cadence snapshot.

## Change

One step added to `docs.yml`, before the mkdocs build: fetch the `ci-data` branch, overlay its four producer TSVs (`history`, `lib_cmp`, `golden`, `timing`) onto the committed snapshot via `git show ci-data:<path>`, then `render_docs.py`. The existing mkdocs build then serves the freshly-rendered pages.

## Why it is safe

- **Ephemeral** — nothing is committed. The committed `docs/*.md` stay the release snapshot; `docs-drift` (which renders the committed snapshot and never fetches `ci-data`) is unaffected.
- **Per-file overlay** — each of the four files is copied individually, so `results/precision/*` (not on `ci-data`) is left untouched.
- **Fail-safe** — if `ci-data` is absent (before the first producer run) or a file is not yet published, the snapshot renders unchanged. The build can only fall back, never break.

## Validation (local, against the REAL ci-data branch)

`history.yml` has already published `results/history/history.tsv` to `ci-data`. Running the exact overlay commands from this workflow:

- extracted the live 812-line `history.tsv` from `ci-data`;
- the three not-yet-published files (`lib_cmp`/`golden`/`timing`) correctly kept the snapshot (per-file fallback);
- `render_docs.py` picked up the live data and re-rendered `docs/history/*.md`;
- the live data genuinely differs from the committed snapshot (811 rows) — i.e. the site will show fresher numbers than the last release.

Also confirmed: `render_docs.py` is a no-op on the committed snapshot (the absent-`ci-data` fallback), and actionlint / YAML / `bash -n` are clean.

## Note for reviewers

`docs.yml` runs only on `main`-push / dispatch, never on PRs — so this PR’s standard gates confirm nothing else regressed, and the overlay itself is validated by the local run above plus the post-merge `docs` deploy.

## Model after both goals

Committed `docs/*.md` = release snapshot (what the repo shows). Live site = snapshot overlaid with the latest `ci-data` (one-cycle lag: `docs.yml` and the producers both run on the same `main` push). No branch protection weakened, no secret, Scorecard unaffected.