### PR TITLE
ci: run bench-branch-compare on main push, publishing timing to ci-data

### DIFF
--- a/.github/workflows/bench-branch-compare.yml
+++ b/.github/workflows/bench-branch-compare.yml
@@ -25,14 +25,20 @@ name: "\U0001FA83 bench-branch-compare (branch vs latest tag)"
 #               table printed to the run summary, plus a single `bbc-aggregate`
 #               artifact (combined tree + medians .tsv + rendered .md).
 #
-# Triggers: (1) push to a release branch (queue-of-1 via the concurrency block);
-# (2) manual workflow_dispatch against any ref. Push runs from the branch itself,
-# so this does NOT need to live on the default branch.
+# Triggers: (1) push to `main` — publishes the fresh timing medians to the `ci-data`
+# data branch, exactly like the other producers (history / lib-perf / golden); (2)
+# manual workflow_dispatch against any ref. NOT release/* (see the `on:` note).
 
 on:
-  # On-demand only. This branch-vs-latest-tag bench SELF-COMMITS its timing medians;
-  # a push trigger on a release branch with an open PR would churn the PR head onto a
-  # bot commit the REQUIRED gates never run on. Run it against any ref via dispatch.
+  # Push to `main` runs the branch-vs-latest-tag bench and publishes its timing medians
+  # to the unprotected, data-only `ci-data` branch (via scripts/push_ci_data.sh — a
+  # GITHUB_TOKEN push there is loop-safe and never touches protected `main`), matching
+  # history / lib-perf / golden. NOT release/*: on a release branch with an open PR the
+  # else-path self-commit would churn the PR head onto a commit the REQUIRED gates never
+  # run on, so the release-branch refresh stays dispatch-only.
+  push:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       ref:


### PR DESCRIPTION
The one remaining producer gap. `bench-branch-compare` was dispatch-only, so `results/timing/bbc_medians.tsv` never reached `ci-data` and the docs Performance page fell back to the committed snapshot.

## Change

Add a `push: main` trigger (mirroring history / lib-perf / golden). bbc already carried the Goal-1 `main` → `push_ci_data.sh` conditional from #52, and the commit-step guard `if: ${{ !inputs.ref }}` was already written to fire on push events — the author’s own comment reads *"a push event (inputs.ref unset)."* So this activates a path already built and anticipated; it just needed the trigger.

**Why it is safe now (and was not before):** bbc was kept off push because its self-commit *"churns the PR head onto a commit the REQUIRED gates never run on."* That risk is specific to `release/*` (an open PR head), not `main`. `ci-data` removes it for `main` entirely — a `main`-push run publishes the raw TSV to the unprotected, data-only `ci-data` branch, never touching protected `main` and never churning a PR head. `release/*` stays dispatch-only for the same churn reason (so it is deliberately NOT added).

## Effect

Closes the fourth `ci-data` file. Once merged, the `main`-push run publishes `results/timing/bbc_medians.tsv`, and the docs Performance page renders live instead of the snapshot fallback.

## Cost note

bbc is the heaviest producer (compile-all-widths build + a width×scale criterion sweep). Running it on every `main` push is real runner time — matching the other producers, as requested. If that proves too heavy, a lighter cadence (e.g. a daily `schedule:` instead of every push) is a one-line follow-up.

## Validation

actionlint + YAML + parsed-trigger check clean. bbc runs only on push/dispatch, never on PRs, so end-to-end is validated post-merge: the `main`-push run publishes `timing` to `ci-data` and the next docs build overlays it.