### PR TITLE
chore(deps): dashu-int and dashu-float 0.5 -> 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -210,10 +210,10 @@ g_math = "0.4"
 # All bench-only; never compiled into a normal build.
 fastnum = { version = "0.7", default-features = false, features = ["std"] }
 bigdecimal = "0.4"
-dashu-float = "0.5"
+dashu-float = "0.6"
 # dashu-int provides IBig for exact base-10 integer scaling of dashu-float
 # results in the comparison benches.
-dashu-int = { version = "0.5", default-features = false, features = ["std"] }
+dashu-int = { version = "0.6", default-features = false, features = ["std"] }
 decimal-rs = "0.1"
 scientific = "0.5"
 # Chart generation for docs/figures/library_comparison/*.png — pure

--- a/golden-competitors/Cargo.toml
+++ b/golden-competitors/Cargo.toml
@@ -23,7 +23,7 @@ decimal-scaled-golden = { path = "../decimal-scaled-golden" }
 
 rust_decimal = { version = "1", default-features = false, features = ["maths"] }
 bigdecimal = "0.4"
-dashu-float = "0.5"
+dashu-float = "0.6"
 fastnum = { version = "0.7", default-features = false, features = ["std"] }
 decimal-rs = "0.1"
 g_math = { version = "0.4", features = ["balanced"] }


### PR DESCRIPTION
Combines dependabot #57 (dashu-int) and #58 (dashu-float) into one change.

dashu-float 0.5 depends on dashu-int 0.5, so bumping either crate on its own leaves dashu-int 0.5 and 0.6 side by side in the dependency graph. Bumping both together resolves a single `dashu-int` 0.6 (verified: `dashu-base`, `dashu-float`, `dashu-int` all resolve to 0.6.0).

Neither #57 nor #58 exercised this combination — #57 built dashu-int 0.6 against dashu-float 0.5, #58 the reverse. Verified locally: `cargo check --all-targets` clean on both the root crate and `golden-competitors` (whose adapter is the dashu-float consumer), so 0.6 introduces no API breakage.

Closes #57
Closes #58