### PR TITLE
chore(deps): decimal-rs 0.1 -> 0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -214,7 +214,7 @@ dashu-float = "0.6"
 # dashu-int provides IBig for exact base-10 integer scaling of dashu-float
 # results in the comparison benches.
 dashu-int = { version = "0.6", default-features = false, features = ["std"] }
-decimal-rs = "0.1"
+decimal-rs = "0.2"
 scientific = "0.5"
 # Chart generation for docs/figures/library_comparison/*.png — pure
 # Rust, no Python dep. Driven by examples/chart_gen.rs.

--- a/golden-competitors/Cargo.toml
+++ b/golden-competitors/Cargo.toml
@@ -25,7 +25,7 @@ rust_decimal = { version = "1", default-features = false, features = ["maths"] }
 bigdecimal = "0.4"
 dashu-float = "0.6"
 fastnum = { version = "0.7", default-features = false, features = ["std"] }
-decimal-rs = "0.1"
+decimal-rs = "0.2"
 g_math = { version = "0.4", features = ["balanced"] }
 
 [features]


### PR DESCRIPTION
Replaces #55, which went CONFLICTING after #60: its `decimal-rs` line is adjacent to the `dashu-int` line #60 changed, and it carried a BOM-strip hunk that no longer applies. `gh pr update-branch` could not resolve it.

Same two-line change, applied on a clean branch off current main.

Envelope check: decimal-rs 0.2.0 leaves `MAX_PRECISION` (38), `MAX_SCALE` (130) and `MIN_SCALE` (-126) identical to 0.1.43, so `DecimalRsSubject`'s hardcoded `SIG_DIGITS = 38` and `(10^38-1)*10^126` envelope still hold — that matters because a stale envelope shows up as false MisRounded/over-skipping rather than a build break. `cargo check --all-targets` clean on the root crate and `golden-competitors`.

Closes #55