### PR TITLE
fix: the wide-feature build break, and tie the Karatsuba ceiling to the build-max family

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,12 +144,21 @@ exact-scratch-nightly = ["exact-scratch"]
 # be heap-cached (`thread_local!` + `alloc::vec::Vec`); those runtime
 # caches were removed in favour of stateless on-stack recompute, so the
 # wide-support path no longer needs `alloc`. This marker pulls in NO
-# features — `_wide-support = []` keeps it as the heap-free backstop: a
+# heap-bearing feature — it stays the heap-free backstop: a
 # `no_std` single-tier build (`--no-default-features --features d57`) gets
 # no `alloc`, so any reintroduced `alloc::vec::Vec` on the wide path is a
 # hard compile error rather than a silent heap allocation. (`std` still
 # pulls `alloc` for the std build; that is the std backend's own affair.)
-_wide-support = []
+#
+# It DOES pull `exact-scratch`, which is itself `[]` and so costs the
+# heap-free property nothing. Without it a wide tier lands on the blanket
+# `ComputeLimbs` impl, which sizes buffers at `4·MAX_WORK_N` while the
+# widest work integer a wide tier declares is `8·MAX_WORK_N` — half what
+# the type needs. Nothing checks that relation, and the failure mode is a
+# SILENT truncation (`mag_into_u128` clamps and returns the sign, not a
+# fits flag), not a panic. Requiring it here makes the mismatch
+# unbuildable rather than documented. See issue #92.
+_wide-support = ["exact-scratch"]
 wide = ["d57", "d76", "d115", "d153", "d230", "d307"]
 d57 = ["_wide-support"]
 d76 = ["_wide-support"]

--- a/decimal-scale-test/tests/regressions/powf_integer.rs
+++ b/decimal-scale-test/tests/regressions/powf_integer.rs
@@ -268,7 +268,13 @@ mod from_powf_wide_integer_exact {
     /// Trunc/Floor keep, Ceiling bumps).
     mod fractional_base {
         use super::MODES;
-        use decimal_scaled::{RoundingMode, D1232, D57};
+        use decimal_scaled::{RoundingMode, D57};
+        // `D1232` is gated behind `d1232` / `xx-wide`, and its only use here is
+        // `d1232_fractional_exact_and_reciprocal` below. The import carries the
+        // SAME cfg as that test so neither a wide-only build (unresolved import)
+        // nor an xx-wide build (unused import) is left broken.
+        #[cfg(feature = "xx-wide")]
+        use decimal_scaled::D1232;
 
         fn sixes_with_last(scale: usize, last: char) -> String {
             let mut s = String::from("0.");

--- a/src/int/algos/mul/mod.rs
+++ b/src/int/algos/mul/mod.rs
@@ -23,7 +23,7 @@ pub(crate) mod mul_toom3;
 mod tests {
     use super::mul_karatsuba::{
         karatsuba_scratch_needed_th, mul_karatsuba, mul_karatsuba_with_threshold,
-        KARATSUBA_SCRATCH_LIMBS,
+        KARATSUBA_MAX_WIDTH, KARATSUBA_SCRATCH_LIMBS,
     };
     use super::mul_schoolbook::{
         mul_low_fixed, mul_low_limb, mul_schoolbook, mul_schoolbook_fixed,
@@ -174,12 +174,24 @@ mod tests {
         }
     }
 
-    /// The widest equal-length multiply (256 limbs, Int<256>) routes
-    /// through the production [`mul_karatsuba`] entry — which declares the
-    /// fixed `[u64; KARATSUBA_SCRATCH_LIMBS]` stack buffer — without
-    /// tripping the scratch-overflow `debug_assert` and matches schoolbook.
-    /// Guards the scratch sizing against future threshold drops that deepen
-    /// the recursion.
+    /// A 256-limb equal-length multiply routes through the production
+    /// [`mul_karatsuba`] entry — which declares the fixed
+    /// `[u64; KARATSUBA_SCRATCH_LIMBS]` stack buffer — and matches schoolbook.
+    ///
+    /// The sizing assert is stated against [`KARATSUBA_MAX_WIDTH`] rather than
+    /// a frozen 256, because that ceiling is now DERIVED from `MAX_WORK_N`: it
+    /// is 16 in a narrow build and 512 at xx-wide. The 256-limb product is kept
+    /// at every width regardless, and is the more interesting half of the test
+    /// now — below the ceiling it drives the Karatsuba path, above it the
+    /// fail-closed schoolbook fallback, and the product must be identical
+    /// either way. That is precisely the property the fallback promises.
+    ///
+    /// On the thresholds: the entry recurses to a base case at `threshold`, so
+    /// a LOWER threshold recurses deeper and needs MORE scratch. 8 is deeper
+    /// than production's 48 (so this over-tests the buffer), while
+    /// `KARATSUBA_SCRATCH_LIMBS` is sized at the floor of 4 — deeper still, and
+    /// therefore an upper bound for both. Guards the sizing against future
+    /// threshold drops that deepen the recursion.
     #[test]
     fn nonalloc_karatsuba_max_width_fits_fixed_scratch() {
         let mut state: u64 = 0xC0FF_EE00_1357_9BDF;
@@ -191,8 +203,9 @@ mod tests {
             z ^ (z >> 31)
         };
         assert!(
-            karatsuba_scratch_needed_th(256, 8) <= KARATSUBA_SCRATCH_LIMBS,
-            "fixed scratch too small for n=256 at a threshold of 8"
+            karatsuba_scratch_needed_th(KARATSUBA_MAX_WIDTH, 8) <= KARATSUBA_SCRATCH_LIMBS,
+            "fixed scratch too small for the ceiling width {KARATSUBA_MAX_WIDTH} \
+             at a threshold of 8"
         );
 
         let n = 256;
@@ -208,8 +221,10 @@ mod tests {
         let mut got = vec![0u64; 2 * n];
         mul_schoolbook(&a, &b, &mut oracle);
         // Deep threshold (8) drives maximal recursion at n=256 — the worst
-        // case for the fixed scratch (matches the sizing assert above, and is
-        // well below the production threshold, so this over-tests the buffer).
+        // case for the fixed scratch, and well below the production threshold,
+        // so this over-tests the buffer. Where 256 exceeds the derived ceiling
+        // the entry fails closed to schoolbook instead; the product is the
+        // same, which is what the comparison below actually pins.
         mul_karatsuba(&a, &b, &mut got, 8);
         assert_eq!(got, oracle, "max-width Karatsuba mismatch via fixed scratch");
     }

--- a/src/int/algos/mul/mul_karatsuba.rs
+++ b/src/int/algos/mul/mul_karatsuba.rs
@@ -20,26 +20,58 @@
 //! copy (rule 2 of the architecture constitution). The choice of which
 //! limb width wins per (N, SCALE) cell is the policy matcher's job.
 
-use crate::int::algos::support::limbs::{add_assign, sub_assign};
+use crate::int::algos::support::limbs::{add_assign, sub_assign, MAX_WORK_N};
 use crate::int::algos::mul::mul_schoolbook::mul_schoolbook;
 use crate::int::types::compute_limbs::{ComputeLimbs, Limb, Limbs};
 
 // ---- Slice-entry scratch (width-erased build-max) ---------------------------
 
-/// The widest equal-length product the crate forms: Int<256> -- the widest
-/// transcendental work integer (4*MAX_WORK_N at the xx-wide tier). The
-/// int-layer multiply matcher (int::policy::mul) engages Karatsuba only at
-/// even N >= 128, and no work width exceeds 256 (a wider operand would route
-/// through the concrete-N kernel's exact ComputeLimbs scratch, not this slice
-/// path), so the WIDTH-ERASED slice entries below cover up to this width.
-const KARATSUBA_MAX_WIDTH: usize = 256;
+/// Ceiling on the operand length the WIDTH-ERASED slice entries
+/// (`mul_karatsuba` / `mul_karatsuba_forced`) will run Karatsuba for; past it
+/// they fall back to schoolbook.
+///
+/// DERIVED from `MAX_WORK_N`, not frozen. The widest work integer any tier
+/// declares is its `Wexp`, which is `8 x storage` at the top of every feature
+/// band (`wide` 16 -> `Int<128>` at D307; `x-wide` 32 -> `Int<256>` at D616;
+/// `xx-wide` 64 -> `Int<512>` at D1232). Deriving it means adding a tier
+/// resizes this automatically instead of leaving two constants to be kept in
+/// step by hand -- and it stops a narrow build carrying a frame sized for a
+/// width it can never present.
+///
+/// It bounds ONLY the slice door. The const-`N` door
+/// (`int::policy::mul::dispatch` -> `mul_karatsuba_limb`) sources EXACT per-`N`
+/// scratch from `ComputeLimbs`, so no `Int<N>` operand of any width -- D1232's
+/// `Wexp = Int<512>` included -- can reach this constant. That asymmetry is
+/// what makes the hazard tractable: only a runtime-length caller is exposed,
+/// and only the entry check in `mul_karatsuba` can bound a runtime length.
+///
+/// (The previous doc here claimed a wider operand "would route through the
+/// concrete-N kernel's exact ComputeLimbs scratch, not this slice path". That
+/// is true of the const door and CANNOT be true of the slice door, which has
+/// no `N` to route by. What protects the slice door is a property of its call
+/// sites, not of routing.)
+///
+/// Every slice caller (`sqrt_newton`, `cbrt_newton`, `newton_reciprocal`,
+/// `div_widen_scale`, `wide_trig_core`) carves operands from storage-derived
+/// `ComputeLimbs` buffers and shrinks them with `sig_len`, so the longest
+/// equal-length pair any can present today is about **96** limbs (`cbrt` at
+/// D1232) -- below the matcher's engage point, leaving the slice Karatsuba arm
+/// unreached in production.
+///
+/// That 96 is a MEASUREMENT OF TODAY'S CALL SITES, NOT A PROPERTY of the code.
+/// A new slice caller, or a work width fed here as a value rather than as a
+/// widened storage magnitude, moves it without anything complaining -- which
+/// is why the entry fails closed rather than trusting the number.
+pub(crate) const KARATSUBA_MAX_WIDTH: usize = 8 * MAX_WORK_N;
 
 /// Build-max stack scratch (in u64 limbs) for the WIDTH-ERASED slice Karatsuba
 /// entries mul_karatsuba / mul_karatsuba_forced. Those take &[u64] of RUNTIME
 /// length, so they cannot size per-N and use this sanctioned build-max blanket
 /// (like the width-erased slice-divide engines). It is sized to the deepest
-/// recursion (the threshold floor 4) at the widest width via the kernel's own
-/// recursion arithmetic -- derived, not a frozen guess. The concrete-N kernel
+/// recursion (the threshold floor 4) at [`KARATSUBA_MAX_WIDTH`] via the
+/// kernel's own recursion arithmetic -- derived, not a frozen guess, and now
+/// feature-scoped through that ceiling rather than pinned to the widest
+/// tier the crate can be built with. The concrete-N kernel
 /// mul_karatsuba_limb sources its EXACT per-N scratch from ComputeLimbs instead
 /// (no build-max on the hot wide-multiply path -- Constitution rule 6).
 pub(crate) const KARATSUBA_SCRATCH_LIMBS: usize =

--- a/src/int/algos/mul/mul_karatsuba.rs
+++ b/src/int/algos/mul/mul_karatsuba.rs
@@ -52,13 +52,23 @@ pub(crate) const KARATSUBA_SCRATCH_LIMBS: usize =
 pub(crate) fn mul_karatsuba(a: &[u64], b: &[u64], out: &mut [u64], threshold: usize) {
     debug_assert_eq!(a.len(), b.len());
     debug_assert!(out.len() >= 2 * a.len());
-    debug_assert!(
-        karatsuba_scratch_needed_th(a.len(), threshold) <= KARATSUBA_SCRATCH_LIMBS,
-        "Karatsuba scratch overflow: n={} needs {} limbs, have {}",
-        a.len(),
-        karatsuba_scratch_needed_th(a.len(), threshold),
-        KARATSUBA_SCRATCH_LIMBS,
-    );
+    // FAIL CLOSED. This entry is width-erased, so `a.len()` is a RUNTIME
+    // length that no const assertion can bound -- the scratch below is a
+    // fixed build-max frame. An operand past the ceiling takes the
+    // schoolbook path (slower, same product) instead of overrunning the
+    // scratch, which `karatsuba_rec` would otherwise turn into a
+    // `split_at_mut` panic in release as well as debug.
+    //
+    // Sizing argument: `KARATSUBA_SCRATCH_LIMBS` covers `KARATSUBA_MAX_WIDTH`
+    // at the threshold FLOOR (4), and `karatsuba_scratch_needed_th` is
+    // non-decreasing in `n` and non-increasing in `threshold` -- so it covers
+    // every `(n <= ceiling, threshold >= 4)` caller, and `a.len()` alone is a
+    // sufficient test. ONE compare against a const at the entry; the
+    // recursion is untouched.
+    if a.len() > KARATSUBA_MAX_WIDTH {
+        mul_schoolbook(a, b, out);
+        return;
+    }
     let mut scratch = [0u64; KARATSUBA_SCRATCH_LIMBS];
     karatsuba_rec(a, b, out, &mut scratch, threshold);
 }
@@ -68,11 +78,13 @@ pub(crate) fn mul_karatsuba(a: &[u64], b: &[u64], out: &mut [u64], threshold: us
 pub(crate) fn mul_karatsuba_forced(a: &[u64], b: &[u64], out: &mut [u64], threshold: usize) {
     debug_assert_eq!(a.len(), b.len());
     debug_assert!(out.len() >= 2 * a.len());
-    debug_assert!(
-        karatsuba_scratch_needed_th(a.len(), threshold) <= KARATSUBA_SCRATCH_LIMBS,
-        "Karatsuba scratch overflow in forced bench entry"
-    );
     for o in out.iter_mut() { *o = 0; }
+    // Same fail-closed ceiling as `mul_karatsuba` -- see the sizing argument
+    // there. `out` is already zeroed above, which is the schoolbook contract.
+    if a.len() > KARATSUBA_MAX_WIDTH {
+        mul_schoolbook(a, b, out);
+        return;
+    }
     let mut scratch = [0u64; KARATSUBA_SCRATCH_LIMBS];
     karatsuba_rec(a, b, out, &mut scratch, threshold);
 }

--- a/src/int/policy/mul.rs
+++ b/src/int/policy/mul.rs
@@ -30,7 +30,10 @@
 //! recursion depth ([`KARATSUBA_RECURSE`]) are policy DATA here, not magic
 //! numbers in a kernel.
 
-use crate::int::algos::mul::mul_karatsuba::{mul_karatsuba, mul_karatsuba_limb};
+use crate::int::algos::mul::mul_karatsuba::{
+    mul_karatsuba, mul_karatsuba_limb, KARATSUBA_MAX_WIDTH,
+};
+use crate::int::algos::support::limbs::MAX_WORK_N;
 use crate::int::algos::mul::mul_schoolbook::{mul_full_limb, mul_schoolbook};
 use crate::int::types::compute_limbs::{ComputeLimbs, Limbs, LimbSize};
 
@@ -108,6 +111,29 @@ enum Select {
 /// in `(96, 128]` is academic — no shipped storage tier (<=64) or work width
 /// (96/128/192/256) lies strictly between 96 and 128.
 const KARATSUBA_ENGAGE: usize = 128;
+
+// The relation whose violation actually costs something, tied here because
+// this is the only place both constants are visible: the engage point is
+// policy data private to this file, and the ceiling belongs to the kernel.
+//
+// `dispatch_slice` routes to Karatsuba at or above KARATSUBA_ENGAGE, and the
+// slice entry falls back to schoolbook above KARATSUBA_MAX_WIDTH. If the
+// ceiling ever drops below the engage point, those two windows stop
+// overlapping and EVERY slice Karatsuba silently becomes schoolbook -- correct
+// output, benched 1.34-1.39x win gone, and no test failing (the kernel tests
+// assert the product, and policy tests must not pin routing).
+//
+// MAX_WORK_N is 2 only when no wide tier is enabled. There the widest slice
+// operand any caller can carve from a storage-derived ComputeLimbs buffer is a
+// handful of limbs -- far below the engage point -- so a ceiling under it is
+// correct, and the entry simply always takes schoolbook. From the `wide` band
+// up (MAX_WORK_N >= 16, so the ceiling is >= 128) the overlap MUST hold.
+const _: () = assert!(
+    MAX_WORK_N == 2 || KARATSUBA_ENGAGE <= KARATSUBA_MAX_WIDTH,
+    "Karatsuba scratch ceiling sits below the engage point: every slice \
+     multiply the matcher routes to Karatsuba would silently fall back to \
+     schoolbook"
+);
 
 /// Karatsuba **recursion** base: the limb-count below which the kernel stops
 /// splitting and runs schoolbook. **`48`** is the swept optimum (`kara_t48`

--- a/src/macros/full.rs
+++ b/src/macros/full.rs
@@ -115,6 +115,26 @@ macro_rules! decl_decimal_full {
         $exp_tang_m:literal,
         $table_mode:ident
     ) => {
+        // Per-tier invariant, issue #78. The directed-Ziv "reach" of a tier is
+        // `W::BITS/8 - 8`, derived from its transcendental work integer, and
+        // `atan2`'s sign argument in `tiny_x_deep_directed_adjust` holds only
+        // while `TINY_X_DEEP_JMAX < reach - MAX_SCALE` at every tier. Both
+        // sides are independently tuned constants that do not mention each
+        // other: raising `TINY_X_DEEP_JMAX` (whose own doc calls 41 "wide
+        // headroom") opens it from one side, and narrowing a tier's `$Work` or
+        // widening its `$max_scale` opens it from the other.
+        //
+        // This is the only site where a tier's work integer and its MAX_SCALE
+        // are both in scope, which is why the check lives in the macro. It was
+        // measured to hold at all ten tiers, with margins from 43 (D462,
+        // 504 - 461) to 198 (D307, 504 - 306); D76 is 45 (120 - 75). Either
+        // change now breaks the build instead of silently making the `atan2`
+        // assertion reachable at a plateau boundary.
+        const _: () = assert!(
+            <$Work as $crate::int::types::traits::BigInt>::BITS / 8 - 8 > $max_scale,
+            "work integer too narrow for this tier's MAX_SCALE: the directed-Ziv \
+             reach (W::BITS/8 - 8) must exceed MAX_SCALE (issue #78)"
+        );
         $crate::macros::basics::decl_decimal_basics!(wide $Type, $Storage, $max_scale);
         $crate::macros::arithmetic::decl_decimal_arithmetic!(wide $Type, $Storage, $Wider);
         $crate::macros::display::decl_decimal_display!(wide $Type, $Unsigned);


### PR DESCRIPTION
Two defects of one root cause, plus the per-tier assertion deferred from #78.

Independent of pull request 88 — cut from its tip but touching different files, so it can land in either order.

## #85 — `decimal-scale-test` did not build under `--features wide`

`cargo check -p decimal-scale-test --tests --features wide` failed on `unresolved import decimal_scaled::D1232`.

**Only one of the three sites the issue lists was actually broken.** `parsing.rs` sits inside a module gated on all three umbrellas; `overflow.rs` inside one gated `any(d1232, xx-wide)`, matching the library's own gate. Only `powf_integer.rs:271` lacked a guard — and there the *use* site was already gated on `xx-wide`; just the import was not.

The import now carries the **identical** cfg as its sole consumer, rather than the library's broader `any(d1232, xx-wide)`, which would leave an unused import on a `wide,d1232` build.

**Severity, corrected:** this affected contributors building the repo's tests, **not** consumers of the published crate. `decimal-scale-test` carries `publish = false`, and the library itself builds fine under `wide` alone. The issue text overstated it and has been corrected.

Verified across five configurations with zero warnings, and no test lost — confirmed by enumerating what survives `cfg` (`cargo test -- --list`) rather than by reading the source, and then by name, since equal counts can mask a swap.

## #87 — the Karatsuba ceiling, relocated

**The issue as filed pointed at the wrong constants, and that is recorded on it.** It claimed the hazard was `KARATSUBA_MAX_WIDTH = 256` meeting `Wagm = Int<256>` with zero margin. Tracing all eleven `dispatch_slice` call sites shows the operand set is **empty**: no work integer reaches the multiply slice door. Even where the *buffers* come from `Wk::Scratch`, the *values* are storage magnitudes resized in, so `sig_len` collapses them to at most 64 limbs. `Wagm` reaches the *divide* door — which is what #86 tripped over — not this one.

The two squarings that scale with width are structurally excluded with margin: `sqrt_newton` would need `N >= 102`, `cbrt_newton` `N >= 86`. Max shipped `N` is 64.

So an assertion over `$AgmWork`/`$Wexp` would have been **inert while carrying the tier macro's blast radius** — and the naive form would not have compiled at all, since D1232 declares `Wexp = Int<512>`, twice the bound.

Three commits, in the order the dependencies require:

| commit | what |
| :-- | :-- |
| `de712c18` | **fail closed** when a slice operand outgrows the scratch — route to schoolbook instead of aborting. This has to land first: it is what makes the derivation safe. |
| `e93cf344` | **derive** the ceiling as `8 * MAX_WORK_N` instead of a frozen `256`, and tie it to the engage point. Adding a tier now resizes the scratch automatically rather than breaking the build, and two constants that could drift become one that cannot. |
| `e5910869` | the **per-tier assertion** from #78: `$Work::BITS/8 - 8 > $max_scale`, verified at all ten tiers, minimum margin 43 at D462. |

The frozen `256` was itself a build-max leak: a narrow build paid a ~17 KB zeroed frame for a width it can never present. Derived, that is ~1.3 KB. (Figures hand-computed, not compiled.)

**The invariant that is actually load-bearing** is one level up from where the issue put it: `KARATSUBA_ENGAGE = 128` against a max-presentable of about 96 — two more constants with no knowledge of each other. `ENGAGE <= MAX_WIDTH` is the relation whose violation aborts, and it is now checked. The 96 is recorded as a measurement of today's call sites, not a property.

**The assertion is proved to fire.** A green build alone would be worthless here — the default narrow config never expands `decl_decimal_full!`, so nothing would be asserted. With the predicate temporarily inverted, `wide,x-wide,xx-wide` produced ten distinct compile errors at ten distinct tier sites, one per tier, then reverted to green.

## Also filed

**#92** — the blanket `ComputeLimbs` family is undersized by exactly 2x at every feature level, in the legal no_std `--no-default-features --features xx-wide` build, and every layer clamps rather than checks (`mag_into_u128` returns the sign, not a fits flag). It would corrupt rather than abort **if reached** — but the trigger was measured and is **not reachable**: the worst case needs 10,510 bits against 16,384 available, a 36% margin, because the peak is bounded by the *storage* range rather than the work integer's width. Filed as latent.

**#93** — `--features wide,d1232` still fails, in a different file and target: a macro-generated test calls `.narrow()` on D1232, dropping to a tier that does not exist in that configuration. Same class as #85, not fixed here — the fix likely belongs in the tier-decl macro.

## The pattern behind all of these

**CI only ever builds the *paired* feature combinations.** Every job uses `wide,x-wide,xx-wide,macros`; nothing builds an advertised combination alone. #85 shipped in 0.5.0 because of that, #93 is still open for the same reason, and #92's exposed configuration compiles clean and is never exercised.

A CI job checking the umbrellas solo would have caught #85. It would **not** have caught #93 — that needs an umbrella-plus-single-tier pairing, because `d1232` alone compiles the enclosing module out entirely. Recommended on both issues; not added here, since `wide,d1232` is currently red and adding that surface now would land CI red.

## Verification

`cargo check` green on all four configurations per commit. CRLF parity exact across the branch — worth knowing that `src/macros/full.rs` is a CRLF file that both the editor and `sed -i` flatten to LF, turning a 20-line change into a 364-line diff.