### PR TITLE
refactor: name the parameters and locals across the tree (#90)

### DIFF
--- a/src/algo_x_support/seed.rs
+++ b/src/algo_x_support/seed.rs
@@ -128,7 +128,7 @@ pub(crate) const fn extract_top_u64(n: &[u64], bits: u32) -> (u64, u32) {
             // `bit_off != 0` here, so `64 - bit_off` is in `1..=63`; the
             // `checked_shl` keeps the kernel's original defensive form.
             match n[limb_idx + 1].checked_shl(64 - bit_off) {
-                Some(v) => v,
+                Some(shifted) => shifted,
                 None => 0,
             }
         } else {
@@ -156,7 +156,7 @@ pub(crate) const fn extract_top_u64(n: &[u64], bits: u32) -> (u64, u32) {
 /// Computational Perspective" §9.2.1.
 #[inline]
 pub(crate) fn sqrt_seed(n: &[u64], bits: u32, out: &mut [u64]) {
-    let work = out.len();
+    let work_len = out.len();
 
     // Under `std`, the f64 bootstrap needs the top-64-bit window to carry
     // enough magnitude to be worth it; for tiny `n` (`bits < 8`) it falls
@@ -190,18 +190,18 @@ pub(crate) fn sqrt_seed(n: &[u64], bits: u32, out: &mut [u64]) {
         let seed_int: u128 = truncated
             .saturating_add(if frac_nonzero { 1 } else { 0 })
             .saturating_add(1);
-        place_seed(seed_int, half_shift - frac_bits, out, work);
+        place_seed(seed_int, half_shift - frac_bits, out, work_len);
         return;
     }
 
     // Pure-integer 1-bit seed `2^ceil(bits/2)` — the no_std path always,
     // and the `std` tiny-`n` fallback. `n`-derived top bits unused here.
     let _ = n;
-    let e = bits.div_ceil(2);
-    let idx = (e / 64) as usize;
-    if idx < work {
-        out[idx] |= 1u64 << (e % 64);
-    } else if work > 0 {
+    let seed_exponent = bits.div_ceil(2);
+    let idx = (seed_exponent / 64) as usize;
+    if idx < work_len {
+        out[idx] |= 1u64 << (seed_exponent % 64);
+    } else if work_len > 0 {
         out[0] |= 1;
     }
 }
@@ -272,18 +272,19 @@ pub(crate) fn sqrt_seed_u128(n: u128, bits: u32) -> u128 {
 /// Hasselgren seed strategy — Crandall & Pomerance 2005 §9.2.1.
 #[inline]
 pub(crate) fn cbrt_seed(n: &[u64], bits: u32, out: &mut [u64]) {
-    let work = out.len();
+    let work_len = out.len();
 
     #[cfg(feature = "std")]
     if bits >= 9 {
         let (top_u64, shift) = extract_top_u64(n, bits);
-        let rem3 = shift % 3;
+        let shift_residue = shift % 3;
         // Exact fractional residue: cbrt(top · 2^shift) =
         // cbrt(top) · 2^(shift/3); the integral `shift/3` is absorbed into
         // `half_shift` below, the fractional residue stays here as an
-        // exact f64 multiplier (vs the earlier coarse `1u64 << rem3` ≡
+        // exact f64 multiplier (vs the earlier coarse
+        // `1u64 << shift_residue` ≡
         // `×2` / `×4`).
-        let factor = match rem3 {
+        let factor = match shift_residue {
             1 => 1.259_921_049_894_873_2_f64, // 2^(1/3)
             2 => 1.587_401_051_968_199_5_f64, // 2^(2/3)
             _ => 1.0_f64,
@@ -299,18 +300,18 @@ pub(crate) fn cbrt_seed(n: &[u64], bits: u32, out: &mut [u64]) {
         let seed_int: u128 = truncated
             .saturating_add(if frac_nonzero { 1 } else { 0 })
             .saturating_add(1);
-        place_seed(seed_int, half_shift, out, work);
+        place_seed(seed_int, half_shift, out, work_len);
         return;
     }
 
     // Pure-integer 1-bit seed `2^ceil(bits/3)` — the no_std path always,
     // and the `std` tiny-`n` fallback.
     let _ = n;
-    let e = bits.div_ceil(3);
-    let idx = (e / 64) as usize;
-    if idx < work {
-        out[idx] |= 1u64 << (e % 64);
-    } else if work > 0 {
+    let seed_exponent = bits.div_ceil(3);
+    let idx = (seed_exponent / 64) as usize;
+    if idx < work_len {
+        out[idx] |= 1u64 << (seed_exponent % 64);
+    } else if work_len > 0 {
         out[0] |= 1;
     }
 }
@@ -342,30 +343,30 @@ pub(crate) fn cbrt_seed_f64_full(value: f64) -> f64 {
 /// both `std` seed bodies.
 #[cfg(feature = "std")]
 #[inline]
-fn place_seed(seed_int: u128, half_shift: u32, out: &mut [u64], work: usize) {
+fn place_seed(seed_int: u128, half_shift: u32, out: &mut [u64], work_len: usize) {
     let seed_limb_idx = (half_shift / 64) as usize;
     let seed_bit_off = half_shift % 64;
     let shifted: u128 = seed_int << seed_bit_off;
     let seed_lo = shifted as u64;
     let seed_hi = (shifted >> 64) as u64;
-    if seed_limb_idx < work {
+    if seed_limb_idx < work_len {
         out[seed_limb_idx] |= seed_lo;
     }
-    if seed_limb_idx + 1 < work {
+    if seed_limb_idx + 1 < work_len {
         out[seed_limb_idx + 1] |= seed_hi;
     }
     // If the placement landed entirely outside the work slice, force a
     // minimal non-zero seed so the Newton loop's `x >= 1` invariant holds.
     let mut all_zero = true;
     let mut i = 0;
-    while i < work {
+    while i < work_len {
         if out[i] != 0 {
             all_zero = false;
             break;
         }
         i += 1;
     }
-    if all_zero && work > 0 {
+    if all_zero && work_len > 0 {
         out[0] = 1;
     }
 }

--- a/src/algos/add/add_int_layer.rs
+++ b/src/algos/add/add_int_layer.rs
@@ -13,6 +13,6 @@ use crate::int::types::Int;
 /// modular / `None` / clamp / flag policies). No rescaling needed —
 /// same-SCALE operands share the scale factor.
 #[inline]
-pub(crate) fn add_int_layer<const N: usize>(a: Int<N>, b: Int<N>) -> Int<N> {
-    a.checked_add(b).expect("attempt to add with overflow")
+pub(crate) fn add_int_layer<const N: usize>(lhs: Int<N>, rhs: Int<N>) -> Int<N> {
+    lhs.checked_add(rhs).expect("attempt to add with overflow")
 }

--- a/src/algos/cbrt/cbrt_mg_divide.rs
+++ b/src/algos/cbrt/cbrt_mg_divide.rs
@@ -44,13 +44,13 @@ fn cbrt_mg_divide_raw(raw: i128, scale: u32, mode: RoundingMode) -> i128 {
     if raw == 0 {
         return 0;
     }
-    let negative = raw < 0;
-    let q =
-        crate::algos::support::mg_divide::cbrt_raw_with_signed(raw.unsigned_abs(), scale, negative, mode);
-    let result = q as i128;
-    if negative {
-        -result
+    let is_negative = raw < 0;
+    let root = crate::algos::support::mg_divide::cbrt_raw_with_signed(
+        raw.unsigned_abs(), scale, is_negative, mode);
+    let root_magnitude = root as i128;
+    if is_negative {
+        -root_magnitude
     } else {
-        result
+        root_magnitude
     }
 }

--- a/src/algos/cbrt/cbrt_native.rs
+++ b/src/algos/cbrt/cbrt_native.rs
@@ -16,8 +16,8 @@
 //! is slow for those cells. This kernel instead runs Newton
 //! directly in a concrete `Int<W>` (whose width `W` the policy picks per
 //! `(N, SCALE)` cell to just cover `mag · 10^(2·SCALE)`), so each
-//! `n / x²` is one wide multiply + one Knuth divide on tight operands with
-//! no build-max zeroing.
+//! `radicand / x²` is one wide multiply + one Knuth divide on tight operands
+//! with no build-max zeroing.
 //!
 //! # Newton seed via the shared seed leaf (std / no_std agnostic)
 //!
@@ -46,25 +46,25 @@ use crate::support::rounding::RoundingMode;
 
 /// `⌊∛n⌋` over `Int<W>`, seeded via the shared seed leaf.
 ///
-/// Returns `⌊∛n⌋` for `n > 0`. The seed comes from
+/// Returns `⌊∛n⌋` for a positive `radicand`. The seed comes from
 /// [`crate::algo_x_support::seed::cbrt_seed`] — the `f64::cbrt` of the top
 /// 64 significant bits scaled back under `std`, the classical pure-integer
 /// `2^⌈bits/3⌉` under `no_std` — so it is a safe over-estimate at **any**
-/// work width `W` (no `f64::MAX` ceiling, unlike a direct `n.as_f64()`),
+/// work width `W` (no `f64::MAX` ceiling, unlike a direct `as_f64()`),
 /// and the std/no_std divergence stays inside the leaf. The
 /// monotone-decrease Newton loop then settles on `⌊∛n⌋`.
 #[inline]
-fn icbrt_w_seeded<const W: usize>(n: Int<W>) -> Int<W> {
-    let bits = n.bit_length();
-    let mag = n.unsigned_abs();
+fn icbrt_w_seeded<const W: usize>(radicand: Int<W>) -> Int<W> {
+    let bits = radicand.bit_length();
+    let magnitude = radicand.unsigned_abs();
     let mut seed_limbs = [0u64; W];
-    cbrt_seed(mag.as_limbs(), bits, &mut seed_limbs);
+    cbrt_seed(magnitude.as_limbs(), bits, &mut seed_limbs);
     let x0 = Int::<W>::from_mag_limbs(&seed_limbs, false);
     let x0 = if x0 <= Int::<W>::ZERO { Int::<W>::ONE } else { x0 };
     let three = Int::<W>::from_i128(3);
     let mut x = x0;
     loop {
-        let y = (x + x + n / (x * x)) / three;
+        let y = (x + x + radicand / (x * x)) / three;
         if y >= x {
             break x;
         }
@@ -93,38 +93,38 @@ pub(crate) fn cbrt_native<const N: usize, const W: usize>(
     let zero = Int::<W>::ZERO;
     let one = Int::<W>::ONE;
     let widened: Int<W> = raw.resize_to::<Int<W>>();
-    let negative = widened < zero;
-    let mag = if negative { -widened } else { widened };
+    let is_negative = widened < zero;
+    let magnitude = if is_negative { -widened } else { widened };
     // `pow10_2scale` is `10^(2·SCALE)` in `Int<W>`, supplied pre-computed by
     // the caller so it folds at compile time (`const { Int::<W>::TEN.pow(2 *
     // SCALE) }` in the dispatch) instead of running the int pow at runtime
     // per call.
-    let n: Int<W> = mag * pow10_2scale;
+    let radicand: Int<W> = magnitude * pow10_2scale;
 
-    let q = icbrt_w_seeded::<W>(n);
+    let root = icbrt_w_seeded::<W>(radicand);
 
     // ── single half-step round (same logic as cbrt_newton). ─────────
-    let eight_n = n << 3u32;
-    let t = q + q + one;
-    let cube = t * t * t;
-    let halfway_geq = eight_n >= cube;
-    let halfway_gt = eight_n > cube;
+    let eight_radicand = radicand << 3u32;
+    let doubled_midpoint = root + root + one;
+    let cube = doubled_midpoint * doubled_midpoint * doubled_midpoint;
+    let halfway_geq = eight_radicand >= cube;
+    let halfway_gt = eight_radicand > cube;
     let tie = halfway_geq && !halfway_gt;
-    let two_q = q + q;
-    let eight_q_cubed = if q == zero { zero } else { two_q * two_q * two_q };
-    let residual_nonzero = eight_n > eight_q_cubed;
-    let q_is_odd = (q % (one + one)) != zero;
+    let two_root = root + root;
+    let eight_root_cubed = if root == zero { zero } else { two_root * two_root * two_root };
+    let residual_nonzero = eight_radicand > eight_root_cubed;
+    let root_is_odd = (root % (one + one)) != zero;
     let bump = match mode {
-        RoundingMode::HalfToEven => halfway_gt || (tie && q_is_odd),
+        RoundingMode::HalfToEven => halfway_gt || (tie && root_is_odd),
         RoundingMode::HalfAwayFromZero => halfway_geq,
         RoundingMode::HalfTowardZero => halfway_gt,
         RoundingMode::Trunc => false,
-        RoundingMode::Floor => negative && residual_nonzero,
-        RoundingMode::Ceiling => !negative && residual_nonzero,
+        RoundingMode::Floor => is_negative && residual_nonzero,
+        RoundingMode::Ceiling => !is_negative && residual_nonzero,
     };
-    let q = if bump { q + one } else { q };
-    let signed = if negative { -q } else { q };
-    signed.resize_to::<Int<N>>()
+    let root = if bump { root + one } else { root };
+    let signed_root = if is_negative { -root } else { root };
+    signed_root.resize_to::<Int<N>>()
 }
 
 /// `(D57, SCALE == 20)` cube-root entry point — the original bespoke cell
@@ -138,7 +138,7 @@ pub(crate) fn cbrt_native_d57s20(raw: Int<3>, mode: RoundingMode) -> Int<3> {
 }
 
 // These tests drive Newton directly in a wide work `Int<W>`; the
-// `n / (x·x)` step's build-max Knuth-divide scratch is sized
+// `radicand / (x·x)` step's build-max Knuth-divide scratch is sized
 // `4·MAX_WORK_N + 2` u64 limbs, which only covers the work width `W` once a
 // wide tier raises `MAX_WORK_N` to 16 (a narrow/default build sizes it 2).
 // So each test/case is gated to exactly the `dNN` tier whose storage width
@@ -187,12 +187,12 @@ mod tests {
     where
         crate::int::types::compute_limbs::Limbs<N>: crate::int::types::compute_limbs::ComputeLimbs,
     {
-        for &r in raws {
-            let raw = Int::<N>::from_i128(r);
+        for &raw_value in raws {
+            let raw = Int::<N>::from_i128(raw_value);
             for mode in ALL_MODES {
                 let got = cbrt_native::<N, W>(raw, Int::<W>::TEN.pow(2 * scale), mode);
                 let want = cbrt_newton::<N>(raw, scale, mode);
-                assert_eq!(got, want, "N={N} W={W} scale={scale} raw={r} mode={mode:?}");
+                assert_eq!(got, want, "N={N} W={W} scale={scale} raw={raw_value} mode={mode:?}");
             }
         }
     }
@@ -276,13 +276,13 @@ mod tests {
     /// must still be bit-identical to the slice. Proves the literal `W`
     /// chosen in the policy is wide enough (a too-small `W` would overflow
     /// and diverge / be release-mode UB). Both signs.
-    fn near_max<const N: usize>(neg: bool) -> Int<N> {
-        let mut mag = [0u64; N];
-        for m in mag.iter_mut() {
-            *m = u64::MAX;
+    fn near_max<const N: usize>(is_negative: bool) -> Int<N> {
+        let mut magnitude = [0u64; N];
+        for limb in magnitude.iter_mut() {
+            *limb = u64::MAX;
         }
-        mag[N - 1] = u64::MAX >> 1;
-        Int::<N>::from_mag_limbs(&mag, neg)
+        magnitude[N - 1] = u64::MAX >> 1;
+        Int::<N>::from_mag_limbs(&magnitude, is_negative)
     }
 
     #[test]
@@ -291,22 +291,22 @@ mod tests {
         // storage width `N` it instantiates (W up to 32 — safe once the
         // tier sets MAX_WORK_N=16). Every covered tier appears here, so any
         // single-tier build runs exactly its own cell.
-        for &neg in &[false, true] {
+        for &is_negative in &[false, true] {
             for mode in ALL_MODES {
                 #[cfg(feature = "d57")]
-                assert_eq!(cbrt_native::<3, 6>(near_max::<3>(neg), Int::<6>::TEN.pow(2 * 20), mode), cbrt_newton::<3>(near_max::<3>(neg), 20, mode), "D57 neg={neg} mode {mode:?}");
+                assert_eq!(cbrt_native::<3, 6>(near_max::<3>(is_negative), Int::<6>::TEN.pow(2 * 20), mode), cbrt_newton::<3>(near_max::<3>(is_negative), 20, mode), "D57 neg={is_negative} mode {mode:?}");
                 #[cfg(feature = "d76")]
-                assert_eq!(cbrt_native::<4, 8>(near_max::<4>(neg), Int::<8>::TEN.pow(2 * 35), mode), cbrt_newton::<4>(near_max::<4>(neg), 35, mode), "D76 neg={neg} mode {mode:?}");
+                assert_eq!(cbrt_native::<4, 8>(near_max::<4>(is_negative), Int::<8>::TEN.pow(2 * 35), mode), cbrt_newton::<4>(near_max::<4>(is_negative), 35, mode), "D76 neg={is_negative} mode {mode:?}");
                 #[cfg(feature = "d115")]
-                assert_eq!(cbrt_native::<6, 12>(near_max::<6>(neg), Int::<12>::TEN.pow(2 * 57), mode), cbrt_newton::<6>(near_max::<6>(neg), 57, mode), "D115 neg={neg} mode {mode:?}");
+                assert_eq!(cbrt_native::<6, 12>(near_max::<6>(is_negative), Int::<12>::TEN.pow(2 * 57), mode), cbrt_newton::<6>(near_max::<6>(is_negative), 57, mode), "D115 neg={is_negative} mode {mode:?}");
                 #[cfg(feature = "d153")]
-                assert_eq!(cbrt_native::<8, 16>(near_max::<8>(neg), Int::<16>::TEN.pow(2 * 75), mode), cbrt_newton::<8>(near_max::<8>(neg), 75, mode), "D153s75 neg={neg} mode {mode:?}");
+                assert_eq!(cbrt_native::<8, 16>(near_max::<8>(is_negative), Int::<16>::TEN.pow(2 * 75), mode), cbrt_newton::<8>(near_max::<8>(is_negative), 75, mode), "D153s75 neg={is_negative} mode {mode:?}");
                 #[cfg(feature = "d153")]
-                assert_eq!(cbrt_native::<8, 16>(near_max::<8>(neg), Int::<16>::TEN.pow(2 * 76), mode), cbrt_newton::<8>(near_max::<8>(neg), 76, mode), "D153s76 neg={neg} mode {mode:?}");
+                assert_eq!(cbrt_native::<8, 16>(near_max::<8>(is_negative), Int::<16>::TEN.pow(2 * 76), mode), cbrt_newton::<8>(near_max::<8>(is_negative), 76, mode), "D153s76 neg={is_negative} mode {mode:?}");
                 #[cfg(feature = "d230")]
-                assert_eq!(cbrt_native::<12, 25>(near_max::<12>(neg), Int::<25>::TEN.pow(2 * 115), mode), cbrt_newton::<12>(near_max::<12>(neg), 115, mode), "D230 neg={neg} mode {mode:?}");
+                assert_eq!(cbrt_native::<12, 25>(near_max::<12>(is_negative), Int::<25>::TEN.pow(2 * 115), mode), cbrt_newton::<12>(near_max::<12>(is_negative), 115, mode), "D230 neg={is_negative} mode {mode:?}");
                 #[cfg(feature = "d307")]
-                assert_eq!(cbrt_native::<16, 32>(near_max::<16>(neg), Int::<32>::TEN.pow(2 * 150), mode), cbrt_newton::<16>(near_max::<16>(neg), 150, mode), "D307 neg={neg} mode {mode:?}");
+                assert_eq!(cbrt_native::<16, 32>(near_max::<16>(is_negative), Int::<32>::TEN.pow(2 * 150), mode), cbrt_newton::<16>(near_max::<16>(is_negative), 150, mode), "D307 neg={is_negative} mode {mode:?}");
             }
         }
     }

--- a/src/algos/cbrt/cbrt_native_fast.rs
+++ b/src/algos/cbrt/cbrt_native_fast.rs
@@ -65,46 +65,46 @@ use crate::support::rounding::RoundingMode;
 
 /// The single half-step round + sign reattachment, factored out so both
 /// candidates share `cbrt_native`'s exact logic verbatim. Given the floor
-/// cube root `q = ⌊∛n⌋` (in `Int<W>`), the radicand `n`, the input sign and
+/// cube `root` (`⌊∛n⌋` in `Int<W>`), the `radicand`, the input sign and
 /// the rounding mode, returns the rounded, signed, narrowed `Int<N>`.
 #[inline]
 fn round_and_narrow<const N: usize, const W: usize>(
-    q: Int<W>,
-    n: Int<W>,
-    negative: bool,
+    root: Int<W>,
+    radicand: Int<W>,
+    is_negative: bool,
     mode: RoundingMode,
 ) -> Int<N> {
     let zero = Int::<W>::ZERO;
     let one = Int::<W>::ONE;
-    let eight_n = n << 3u32;
-    let t = q + q + one;
-    let cube = t * t * t;
-    let halfway_geq = eight_n >= cube;
-    let halfway_gt = eight_n > cube;
+    let eight_radicand = radicand << 3u32;
+    let doubled_midpoint = root + root + one;
+    let cube = doubled_midpoint * doubled_midpoint * doubled_midpoint;
+    let halfway_geq = eight_radicand >= cube;
+    let halfway_gt = eight_radicand > cube;
     let tie = halfway_geq && !halfway_gt;
-    let two_q = q + q;
-    let eight_q_cubed = if q == zero { zero } else { two_q * two_q * two_q };
-    let residual_nonzero = eight_n > eight_q_cubed;
-    let q_is_odd = (q % (one + one)) != zero;
+    let two_root = root + root;
+    let eight_root_cubed = if root == zero { zero } else { two_root * two_root * two_root };
+    let residual_nonzero = eight_radicand > eight_root_cubed;
+    let root_is_odd = (root % (one + one)) != zero;
     let bump = match mode {
-        RoundingMode::HalfToEven => halfway_gt || (tie && q_is_odd),
+        RoundingMode::HalfToEven => halfway_gt || (tie && root_is_odd),
         RoundingMode::HalfAwayFromZero => halfway_geq,
         RoundingMode::HalfTowardZero => halfway_gt,
         RoundingMode::Trunc => false,
-        RoundingMode::Floor => negative && residual_nonzero,
-        RoundingMode::Ceiling => !negative && residual_nonzero,
+        RoundingMode::Floor => is_negative && residual_nonzero,
+        RoundingMode::Ceiling => !is_negative && residual_nonzero,
     };
-    let q = if bump { q + one } else { q };
-    let signed = if negative { -q } else { q };
-    signed.resize_to::<Int<N>>()
+    let root = if bump { root + one } else { root };
+    let signed_root = if is_negative { -root } else { root };
+    signed_root.resize_to::<Int<N>>()
 }
 
 // ── candidate A: full-radicand f64::cbrt seed ────────
 
 /// `⌊∛n⌋` over `Int<W>`, seeded from the **full** radicand via
-/// `n.as_f64().cbrt()`. Caller MUST
-/// guarantee `n` is within the `f64` range (`bit_length ≲ 1023`); the
-/// `cbrt_native_fast_a` entry guards this and falls back otherwise.
+/// `as_f64().cbrt()`. Caller MUST
+/// guarantee the `radicand` is within the `f64` range (`bit_length ≲ 1023`);
+/// the `cbrt_native_fast_a` entry guards this and falls back otherwise.
 ///
 /// `as_f64` keeps 53 mantissa bits and `f64::cbrt` is correctly rounded, so
 /// `seed` sits within ~2⁻⁵² *relative* of `∛n` — it may under- OR
@@ -114,18 +114,18 @@ fn round_and_narrow<const N: usize, const W: usize>(
 /// kernel's fixed point.
 #[cfg(feature = "std")]
 #[inline]
-fn icbrt_w_f64_full<const W: usize>(n: Int<W>) -> Int<W> {
-    let seed_f64 = crate::algo_x_support::seed::cbrt_seed_f64_full(n.as_f64());
+fn icbrt_w_f64_full<const W: usize>(radicand: Int<W>) -> Int<W> {
+    let seed_f64 = crate::algo_x_support::seed::cbrt_seed_f64_full(radicand.as_f64());
     let seed = Int::<W>::from_f64(seed_f64);
     let x0 = if seed <= Int::<W>::ZERO { Int::<W>::ONE } else { seed };
     let three = Int::<W>::from_i128(3);
     // Unconditional first Newton step: lifts any positive seed to ≥ ⌈∛n⌉.
-    let mut x = (x0 + x0 + n / (x0 * x0)) / three;
+    let mut x = (x0 + x0 + radicand / (x0 * x0)) / three;
     if x <= Int::<W>::ZERO {
         x = Int::<W>::ONE;
     }
     loop {
-        let y = (x + x + n / (x * x)) / three;
+        let y = (x + x + radicand / (x * x)) / three;
         if y >= x {
             break x;
         }
@@ -138,17 +138,17 @@ fn icbrt_w_f64_full<const W: usize>(n: Int<W>) -> Int<W> {
 /// [`crate::algo_x_support::seed::cbrt_seed`]). Used by candidate A when the
 /// radicand would overflow `f64`, and is the whole no_std body.
 #[inline]
-fn icbrt_w_shipped_seed<const W: usize>(n: Int<W>) -> Int<W> {
-    let bits = n.bit_length();
-    let mag = n.unsigned_abs();
+fn icbrt_w_shipped_seed<const W: usize>(radicand: Int<W>) -> Int<W> {
+    let bits = radicand.bit_length();
+    let magnitude = radicand.unsigned_abs();
     let mut seed_limbs = [0u64; W];
-    crate::algo_x_support::seed::cbrt_seed(mag.as_limbs(), bits, &mut seed_limbs);
+    crate::algo_x_support::seed::cbrt_seed(magnitude.as_limbs(), bits, &mut seed_limbs);
     let x0 = Int::<W>::from_mag_limbs(&seed_limbs, false);
     let x0 = if x0 <= Int::<W>::ZERO { Int::<W>::ONE } else { x0 };
     let three = Int::<W>::from_i128(3);
     let mut x = x0;
     loop {
-        let y = (x + x + n / (x * x)) / three;
+        let y = (x + x + radicand / (x * x)) / three;
         if y >= x {
             break x;
         }
@@ -172,24 +172,24 @@ pub(crate) fn cbrt_native_fast_a<const N: usize, const W: usize>(
     }
     let zero = Int::<W>::ZERO;
     let widened: Int<W> = raw.resize_to::<Int<W>>();
-    let negative = widened < zero;
-    let mag = if negative { -widened } else { widened };
-    let n: Int<W> = mag * pow10_2scale;
+    let is_negative = widened < zero;
+    let magnitude = if is_negative { -widened } else { widened };
+    let radicand: Int<W> = magnitude * pow10_2scale;
 
     // `f64::cbrt` seed only when the radicand is inside the f64 range
     // (`as_f64` would otherwise saturate to ±inf → a degenerate seed). The
     // D57<20> radicand (≤ 10^97 ≈ 322 bits) always passes; the wider cells
     // pass for all but their largest magnitudes, which fall back cleanly.
     #[cfg(feature = "std")]
-    let q = if n.bit_length() <= 1020 {
-        icbrt_w_f64_full::<W>(n)
+    let root = if radicand.bit_length() <= 1020 {
+        icbrt_w_f64_full::<W>(radicand)
     } else {
-        icbrt_w_shipped_seed::<W>(n)
+        icbrt_w_shipped_seed::<W>(radicand)
     };
     #[cfg(not(feature = "std"))]
-    let q = icbrt_w_shipped_seed::<W>(n);
+    let root = icbrt_w_shipped_seed::<W>(radicand);
 
-    round_and_narrow::<N, W>(q, n, negative, mode)
+    round_and_narrow::<N, W>(root, radicand, is_negative, mode)
 }
 
 // ── candidate B: width-safe top-bits seed with exact 2^(r/3) residue ────
@@ -208,22 +208,22 @@ pub(crate) fn cbrt_native_fast_a<const N: usize, const W: usize>(
 /// `⌊∛n⌋`. The unconditional pre-step (one redundant Newton step from a
 /// guaranteed over-estimate) is retained to keep candidate B's loop shape.
 #[inline]
-fn icbrt_w_tight_topbits<const W: usize>(n: Int<W>) -> Int<W> {
-    let bits = n.bit_length();
-    let mag = n.unsigned_abs();
+fn icbrt_w_tight_topbits<const W: usize>(radicand: Int<W>) -> Int<W> {
+    let bits = radicand.bit_length();
+    let magnitude = radicand.unsigned_abs();
     let mut seed_limbs = [0u64; W];
-    crate::algo_x_support::seed::cbrt_seed(mag.as_limbs(), bits, &mut seed_limbs);
+    crate::algo_x_support::seed::cbrt_seed(magnitude.as_limbs(), bits, &mut seed_limbs);
     let x0 = Int::<W>::from_mag_limbs(&seed_limbs, false);
     let x0 = if x0 <= Int::<W>::ZERO { Int::<W>::ONE } else { x0 };
     let three = Int::<W>::from_i128(3);
     // Unconditional pre-step: AM-GM lifts any positive seed to ≥ ⌈∛n⌉, so a
     // mild under-shoot from the tighter seed is corrected before the loop.
-    let mut x = (x0 + x0 + n / (x0 * x0)) / three;
+    let mut x = (x0 + x0 + radicand / (x0 * x0)) / three;
     if x <= Int::<W>::ZERO {
         x = Int::<W>::ONE;
     }
     loop {
-        let y = (x + x + n / (x * x)) / three;
+        let y = (x + x + radicand / (x * x)) / three;
         if y >= x {
             break x;
         }
@@ -246,21 +246,21 @@ pub(crate) fn cbrt_native_fast_b<const N: usize, const W: usize>(
     }
     let zero = Int::<W>::ZERO;
     let widened: Int<W> = raw.resize_to::<Int<W>>();
-    let negative = widened < zero;
-    let mag = if negative { -widened } else { widened };
-    let n: Int<W> = mag * pow10_2scale;
+    let is_negative = widened < zero;
+    let magnitude = if is_negative { -widened } else { widened };
+    let radicand: Int<W> = magnitude * pow10_2scale;
 
     // The seed library is std/no_std-agnostic (it cfg-swaps internally), so
     // a single call covers both builds — no per-build kernel split.
-    let q = icbrt_w_tight_topbits::<W>(n);
+    let root = icbrt_w_tight_topbits::<W>(radicand);
 
-    round_and_narrow::<N, W>(q, n, negative, mode)
+    round_and_narrow::<N, W>(root, radicand, is_negative, mode)
 }
 
 // ── bit-identity test (NOT run here — run by the full suite) ───────
 
 // Same gating rationale as `cbrt_native`'s test module: these candidates run
-// Newton in a wide work `Int<W>`, whose `n / (x·x)` build-max Knuth-divide
+// Newton in a wide work `Int<W>`, whose `radicand / (x·x)` build-max Knuth-divide
 // scratch (`4·MAX_WORK_N + 2` u64) only covers `W` once a wide tier raises
 // MAX_WORK_N to 16. Each test/case is gated to exactly the `dNN` tier whose
 // storage width it instantiates; the module guard is the precise union of
@@ -297,27 +297,27 @@ mod tests {
     /// every routed cell, sign, and rounding mode. Matching it certifies the
     /// candidate seeds change only the divide count, never the result.
     fn check_cell<const N: usize, const W: usize>(scale: u32, raws: &[i128]) {
-        let pow = Int::<W>::TEN.pow(2 * scale);
-        for &r in raws {
-            let raw = Int::<N>::from_i128(r);
+        let pow10_2scale = Int::<W>::TEN.pow(2 * scale);
+        for &raw_value in raws {
+            let raw = Int::<N>::from_i128(raw_value);
             for mode in ALL_MODES {
-                let want = cbrt_native::<N, W>(raw, pow, mode);
-                let got_a = cbrt_native_fast_a::<N, W>(raw, pow, mode);
-                let got_b = cbrt_native_fast_b::<N, W>(raw, pow, mode);
-                assert_eq!(got_a, want, "A: N={N} W={W} scale={scale} raw={r} mode={mode:?}");
-                assert_eq!(got_b, want, "B: N={N} W={W} scale={scale} raw={r} mode={mode:?}");
+                let want = cbrt_native::<N, W>(raw, pow10_2scale, mode);
+                let got_a = cbrt_native_fast_a::<N, W>(raw, pow10_2scale, mode);
+                let got_b = cbrt_native_fast_b::<N, W>(raw, pow10_2scale, mode);
+                assert_eq!(got_a, want, "A: N={N} W={W} scale={scale} raw={raw_value} mode={mode:?}");
+                assert_eq!(got_b, want, "B: N={N} W={W} scale={scale} raw={raw_value} mode={mode:?}");
             }
         }
     }
 
     /// Near-storage-max radicand at each native cell (widest `mag·10^(2·SCALE)`).
-    fn near_max<const N: usize>(neg: bool) -> Int<N> {
-        let mut mag = [0u64; N];
-        for m in mag.iter_mut() {
-            *m = u64::MAX;
+    fn near_max<const N: usize>(is_negative: bool) -> Int<N> {
+        let mut magnitude = [0u64; N];
+        for limb in magnitude.iter_mut() {
+            *limb = u64::MAX;
         }
-        mag[N - 1] = u64::MAX >> 1;
-        Int::<N>::from_mag_limbs(&mag, neg)
+        magnitude[N - 1] = u64::MAX >> 1;
+        Int::<N>::from_mag_limbs(&magnitude, is_negative)
     }
 
     // D57 storage (N=3), work `Int<6>`.
@@ -394,15 +394,15 @@ mod tests {
     ))]
     #[test]
     fn fast_a_routed_3n_widths_near_max() {
-        for &neg in &[false, true] {
+        for &is_negative in &[false, true] {
             for mode in ALL_MODES {
                 macro_rules! chk {
                     ($n:literal, $w:literal, $($s:literal),+) => {{
                         $(
-                            let pow = Int::<$w>::TEN.pow(2 * $s);
-                            let raw = near_max::<$n>(neg);
-                            let want = cbrt_native::<$n, $w>(raw, pow, mode);
-                            assert_eq!(cbrt_native_fast_a::<$n, $w>(raw, pow, mode), want, "A 3N N={} W={} s={} neg={neg} mode={mode:?}", $n, $w, $s);
+                            let pow10_2scale = Int::<$w>::TEN.pow(2 * $s);
+                            let raw = near_max::<$n>(is_negative);
+                            let want = cbrt_native::<$n, $w>(raw, pow10_2scale, mode);
+                            assert_eq!(cbrt_native_fast_a::<$n, $w>(raw, pow10_2scale, mode), want, "A 3N N={} W={} s={} neg={is_negative} mode={mode:?}", $n, $w, $s);
                         )+
                     }};
                 }
@@ -420,15 +420,15 @@ mod tests {
 
     #[test]
     fn fast_candidates_match_native_near_max_all_cells() {
-        for &neg in &[false, true] {
+        for &is_negative in &[false, true] {
             for mode in ALL_MODES {
                 macro_rules! chk {
                     ($n:literal, $w:literal, $s:literal) => {{
-                        let pow = Int::<$w>::TEN.pow(2 * $s);
-                        let raw = near_max::<$n>(neg);
-                        let want = cbrt_native::<$n, $w>(raw, pow, mode);
-                        assert_eq!(cbrt_native_fast_a::<$n, $w>(raw, pow, mode), want, "A near_max N={} neg={neg} mode={mode:?}", $n);
-                        assert_eq!(cbrt_native_fast_b::<$n, $w>(raw, pow, mode), want, "B near_max N={} neg={neg} mode={mode:?}", $n);
+                        let pow10_2scale = Int::<$w>::TEN.pow(2 * $s);
+                        let raw = near_max::<$n>(is_negative);
+                        let want = cbrt_native::<$n, $w>(raw, pow10_2scale, mode);
+                        assert_eq!(cbrt_native_fast_a::<$n, $w>(raw, pow10_2scale, mode), want, "A near_max N={} neg={is_negative} mode={mode:?}", $n);
+                        assert_eq!(cbrt_native_fast_b::<$n, $w>(raw, pow10_2scale, mode), want, "B near_max N={} neg={is_negative} mode={mode:?}", $n);
                     }};
                 }
                 #[cfg(feature = "d57")]

--- a/src/algos/cbrt/cbrt_newton.rs
+++ b/src/algos/cbrt/cbrt_newton.rs
@@ -6,8 +6,8 @@
 //! limbs.
 //!
 //! For a `D<Int<N>, SCALE>` value with raw storage `r`, the cube-root raw
-//! storage is `round(cbrt(r) · 10^SCALE)`; working with
-//! `n = |r| · 10^(2·SCALE)` keeps the radicand exact, takes the floor cube
+//! storage is `round(cbrt(r) · 10^SCALE)`; working with the radicand
+//! `|r| · 10^(2·SCALE)` keeps it exact, takes the floor cube
 //! root via the int layer's width-agnostic slice kernel
 //! ([`crate::int::algos::icbrt::icbrt_newton::icbrt_newton`]), and a single
 //! half-step lands the result on the type's last place (within 0.5 ULP under
@@ -31,59 +31,59 @@ use crate::int::types::compute_limbs::{ComputeLimbs, Limbs};
 use crate::int::types::Int;
 use crate::support::rounding::RoundingMode;
 
-/// Significant limb length of `a` (index of the highest non-zero limb + 1),
-/// clamped to at least 1.
+/// Significant limb length of `limbs` (index of the highest non-zero limb
+/// + 1), clamped to at least 1.
 #[inline]
-fn sig_len(a: &[u64]) -> usize {
-    let mut l = a.len();
-    while l > 1 && a[l - 1] == 0 {
-        l -= 1;
-    }
-    l
-}
-
-/// `dst[..len] = src[..src_len] * 10^pow`, returning the new significant
-/// length. `dst` must be wide enough for the result.
-#[inline]
-fn mul_pow10_into<const N: usize>(src: &[u64], pow: u32, dst: &mut [u64]) -> usize
-where
-    Limbs<N>: ComputeLimbs,
-{
-    let s = sig_len(src);
-    dst[..s].copy_from_slice(&src[..s]);
-    let mut len = s;
-    let mut tmp_buf = Limbs::<N>::quad_buffered_u64();
-    let tmp = tmp_buf.as_mut();
-    for _ in 0..pow {
-        let out = len + 1;
-        for t in tmp[..out].iter_mut() {
-            *t = 0;
-        }
-        mul_slice(&dst[..len], &[10u64], &mut tmp[..out]);
-        dst[..out].copy_from_slice(&tmp[..out]);
-        len = sig_len(&dst[..out]);
+fn sig_len(limbs: &[u64]) -> usize {
+    let mut len = limbs.len();
+    while len > 1 && limbs[len - 1] == 0 {
+        len -= 1;
     }
     len
 }
 
-/// `out[..2*la] = a[..la]³` (cube via two schoolbook multiplies), returning
-/// the cube's significant length.
+/// `dst[..len] = src[..src_len] * 10^exponent`, returning the new significant
+/// length. `dst` must be wide enough for the result.
 #[inline]
-fn cube_into<const N: usize>(a: &[u64], la: usize, out: &mut [u64]) -> usize
+fn mul_pow10_into<const N: usize>(src: &[u64], exponent: u32, dst: &mut [u64]) -> usize
 where
     Limbs<N>: ComputeLimbs,
 {
-    let mut sq_buf = Limbs::<N>::quad_buffered_u64();
-    let sq = sq_buf.as_mut();
-    let sq_cap = sq.len();
-    let sq_len = (2 * la).min(sq_cap);
-    mul_slice(&a[..la], &a[..la], &mut sq[..sq_len]);
-    let sq_sig = sig_len(&sq[..sq_len]);
-    let out_len = (sq_sig + la).min(sq_cap);
-    for o in out[..out_len].iter_mut() {
-        *o = 0;
+    let src_len = sig_len(src);
+    dst[..src_len].copy_from_slice(&src[..src_len]);
+    let mut len = src_len;
+    let mut product_buf = Limbs::<N>::quad_buffered_u64();
+    let product = product_buf.as_mut();
+    for _ in 0..exponent {
+        let product_len = len + 1;
+        for limb in product[..product_len].iter_mut() {
+            *limb = 0;
+        }
+        mul_slice(&dst[..len], &[10u64], &mut product[..product_len]);
+        dst[..product_len].copy_from_slice(&product[..product_len]);
+        len = sig_len(&dst[..product_len]);
     }
-    mul_slice(&sq[..sq_sig], &a[..la], &mut out[..out_len]);
+    len
+}
+
+/// `out[..2*base_len] = base[..base_len]³` (cube via two schoolbook
+/// multiplies), returning the cube's significant length.
+#[inline]
+fn cube_into<const N: usize>(base: &[u64], base_len: usize, out: &mut [u64]) -> usize
+where
+    Limbs<N>: ComputeLimbs,
+{
+    let mut square_buf = Limbs::<N>::quad_buffered_u64();
+    let square = square_buf.as_mut();
+    let square_cap = square.len();
+    let square_len = (2 * base_len).min(square_cap);
+    mul_slice(&base[..base_len], &base[..base_len], &mut square[..square_len]);
+    let square_sig_len = sig_len(&square[..square_len]);
+    let out_len = (square_sig_len + base_len).min(square_cap);
+    for limb in out[..out_len].iter_mut() {
+        *limb = 0;
+    }
+    mul_slice(&square[..square_sig_len], &base[..base_len], &mut out[..out_len]);
     sig_len(&out[..out_len])
 }
 
@@ -98,81 +98,84 @@ where
     if raw == Int::<N>::ZERO {
         return Int::<N>::ZERO;
     }
-    let negative = raw.is_negative();
+    let is_negative = raw.is_negative();
 
-    // ── radicand n = |raw| · 10^(2·scale) ───────────────────────────────
-    let mut n_buf = Limbs::<N>::quad_buffered_u64();
-    let n = n_buf.as_mut();
-    let nl = mul_pow10_into::<N>(raw.unsigned_abs().as_limbs(), 2 * scale, n);
+    // ── radicand = |raw| · 10^(2·scale) ─────────────────────────────────
+    let mut radicand_buf = Limbs::<N>::quad_buffered_u64();
+    let radicand = radicand_buf.as_mut();
+    let radicand_len =
+        mul_pow10_into::<N>(raw.unsigned_abs().as_limbs(), 2 * scale, radicand);
 
-    // ── q = floor(cbrt(n)) via the int slice kernel ─────────────────────
-    let mut q_buf = Limbs::<N>::quad_buffered_u64();
-    let q = q_buf.as_mut();
-    icbrt_newton(&n[..nl], &mut q[..nl]);
-    let ql = sig_len(&q[..nl]);
+    // ── root = floor(cbrt(radicand)) via the int slice kernel ───────────
+    let mut root_buf = Limbs::<N>::quad_buffered_u64();
+    let root = root_buf.as_mut();
+    icbrt_newton(&radicand[..radicand_len], &mut root[..radicand_len]);
+    let root_len = sig_len(&root[..radicand_len]);
 
     // ── single half-step round (all six modes), via cube comparisons ────
-    // eight_n = 8n
-    let mut eight_n_buf = Limbs::<N>::quad_buffered_u64();
-    let eight_n = eight_n_buf.as_mut();
-    shl(&n[..nl], 3, &mut eight_n[..nl + 1]);
-    let en_len = sig_len(&eight_n[..nl + 1]);
+    // eight_radicand = 8·radicand
+    let mut eight_radicand_buf = Limbs::<N>::quad_buffered_u64();
+    let eight_radicand = eight_radicand_buf.as_mut();
+    shl(&radicand[..radicand_len], 3, &mut eight_radicand[..radicand_len + 1]);
+    let eight_radicand_len = sig_len(&eight_radicand[..radicand_len + 1]);
 
-    // t = 2q + 1; cube = t³
-    let mut t_buf = Limbs::<N>::quad_buffered_u64();
-    let t = t_buf.as_mut();
-    shl(&q[..ql], 1, &mut t[..ql + 1]);
+    // doubled_midpoint = 2·root + 1; cube = doubled_midpoint³
+    let mut doubled_midpoint_buf = Limbs::<N>::quad_buffered_u64();
+    let doubled_midpoint = doubled_midpoint_buf.as_mut();
+    shl(&root[..root_len], 1, &mut doubled_midpoint[..root_len + 1]);
     // +1
     {
         let mut i = 0;
         loop {
-            let (v, c) = t[i].overflowing_add(1);
-            t[i] = v;
-            if !c {
+            let (sum, carry) = doubled_midpoint[i].overflowing_add(1);
+            doubled_midpoint[i] = sum;
+            if !carry {
                 break;
             }
             i += 1;
         }
     }
-    let tl = sig_len(&t[..ql + 1]);
+    let doubled_midpoint_len = sig_len(&doubled_midpoint[..root_len + 1]);
     let mut cube_buf = Limbs::<N>::quad_buffered_u64();
     let cube = cube_buf.as_mut();
-    let cube_len = cube_into::<N>(t, tl, cube);
+    let cube_len = cube_into::<N>(doubled_midpoint, doubled_midpoint_len, cube);
 
-    // eight_q_cubed = (2q)³  (0 when q == 0)
-    let mut two_q_buf = Limbs::<N>::quad_buffered_u64();
-    let two_q = two_q_buf.as_mut();
-    shl(&q[..ql], 1, &mut two_q[..ql + 1]);
-    let tql = sig_len(&two_q[..ql + 1]);
-    let mut eight_q_cubed_buf = Limbs::<N>::quad_buffered_u64();
-    let eight_q_cubed = eight_q_cubed_buf.as_mut();
-    let eqc_len = if ql == 1 && q[0] == 0 {
-        eight_q_cubed[0] = 0;
+    // eight_root_cubed = (2·root)³  (0 when root == 0)
+    let mut two_root_buf = Limbs::<N>::quad_buffered_u64();
+    let two_root = two_root_buf.as_mut();
+    shl(&root[..root_len], 1, &mut two_root[..root_len + 1]);
+    let two_root_len = sig_len(&two_root[..root_len + 1]);
+    let mut eight_root_cubed_buf = Limbs::<N>::quad_buffered_u64();
+    let eight_root_cubed = eight_root_cubed_buf.as_mut();
+    let eight_root_cubed_len = if root_len == 1 && root[0] == 0 {
+        eight_root_cubed[0] = 0;
         1
     } else {
-        cube_into::<N>(two_q, tql, eight_q_cubed)
+        cube_into::<N>(two_root, two_root_len, eight_root_cubed)
     };
 
-    let cmp_cube = cmp_cross(&eight_n[..en_len], &cube[..cube_len]);
+    let cmp_cube = cmp_cross(&eight_radicand[..eight_radicand_len], &cube[..cube_len]);
     let halfway_geq = cmp_cube >= 0;
     let halfway_gt = cmp_cube > 0;
     let tie = halfway_geq && !halfway_gt;
-    let residual_nonzero = cmp_cross(&eight_n[..en_len], &eight_q_cubed[..eqc_len]) > 0;
-    let q_is_odd = (q[0] & 1) == 1;
+    let residual_nonzero = cmp_cross(
+        &eight_radicand[..eight_radicand_len],
+        &eight_root_cubed[..eight_root_cubed_len]) > 0;
+    let root_is_odd = (root[0] & 1) == 1;
     let bump = match mode {
-        RoundingMode::HalfToEven => halfway_gt || (tie && q_is_odd),
+        RoundingMode::HalfToEven => halfway_gt || (tie && root_is_odd),
         RoundingMode::HalfAwayFromZero => halfway_geq,
         RoundingMode::HalfTowardZero => halfway_gt,
         RoundingMode::Trunc => false,
-        RoundingMode::Floor => negative && residual_nonzero,
-        RoundingMode::Ceiling => !negative && residual_nonzero,
+        RoundingMode::Floor => is_negative && residual_nonzero,
+        RoundingMode::Ceiling => !is_negative && residual_nonzero,
     };
     if bump {
         let mut i = 0;
         loop {
-            let (v, c) = q[i].overflowing_add(1);
-            q[i] = v;
-            if !c {
+            let (sum, carry) = root[i].overflowing_add(1);
+            root[i] = sum;
+            if !carry {
                 break;
             }
             i += 1;
@@ -180,12 +183,12 @@ where
     }
 
     // ── narrow + apply sign ─────────────────────────────────────────────
-    let mut out = [0u64; N];
-    out.copy_from_slice(&q[..N]);
-    let v = Int::<N>::from_limbs(out);
-    if negative {
-        -v
+    let mut root_limbs = [0u64; N];
+    root_limbs.copy_from_slice(&root[..N]);
+    let root_magnitude = Int::<N>::from_limbs(root_limbs);
+    if is_negative {
+        -root_magnitude
     } else {
-        v
+        root_magnitude
     }
 }

--- a/src/algos/cbrt/cbrt_newton_with_table_seed.rs
+++ b/src/algos/cbrt/cbrt_newton_with_table_seed.rs
@@ -55,32 +55,33 @@ pub(crate) fn cbrt_newton_with_table_seed(raw: Int<3>, mode: RoundingMode) -> In
     let zero = Int::<6>::ZERO;
     let one = Int::<6>::ONE;
     let widened: Int<6> = raw.resize_to::<Int<6>>();
-    let negative = widened < zero;
-    let mag = if negative { -widened } else { widened };
-    let n: Int<6> = mag * const { crate::consts::pow10::dispatch_int::<6>(2 * SCALE) };
+    let is_negative = widened < zero;
+    let magnitude = if is_negative { -widened } else { widened };
+    let radicand: Int<6> =
+        magnitude * const { crate::consts::pow10::dispatch_int::<6>(2 * SCALE) };
 
-    let q: Int<6> = n.icbrt();
+    let root: Int<6> = radicand.icbrt();
 
     // ── single half-step round (same logic as cbrt_newton). ──────────
-    let eight_n = n << 3u32;
-    let t = q + q + one;
-    let cube = t * t * t;
-    let halfway_geq = eight_n >= cube;
-    let halfway_gt = eight_n > cube;
+    let eight_radicand = radicand << 3u32;
+    let doubled_midpoint = root + root + one;
+    let cube = doubled_midpoint * doubled_midpoint * doubled_midpoint;
+    let halfway_geq = eight_radicand >= cube;
+    let halfway_gt = eight_radicand > cube;
     let tie = halfway_geq && !halfway_gt;
-    let two_q = q + q;
-    let eight_q_cubed = if q == zero { zero } else { two_q * two_q * two_q };
-    let residual_nonzero = eight_n > eight_q_cubed;
-    let q_is_odd = (q % (one + one)) != zero;
+    let two_root = root + root;
+    let eight_root_cubed = if root == zero { zero } else { two_root * two_root * two_root };
+    let residual_nonzero = eight_radicand > eight_root_cubed;
+    let root_is_odd = (root % (one + one)) != zero;
     let bump = match mode {
-        RoundingMode::HalfToEven => halfway_gt || (tie && q_is_odd),
+        RoundingMode::HalfToEven => halfway_gt || (tie && root_is_odd),
         RoundingMode::HalfAwayFromZero => halfway_geq,
         RoundingMode::HalfTowardZero => halfway_gt,
         RoundingMode::Trunc => false,
-        RoundingMode::Floor => negative && residual_nonzero,
-        RoundingMode::Ceiling => !negative && residual_nonzero,
+        RoundingMode::Floor => is_negative && residual_nonzero,
+        RoundingMode::Ceiling => !is_negative && residual_nonzero,
     };
-    let q = if bump { q + one } else { q };
-    let signed = if negative { -q } else { q };
-    signed.resize_to::<Int<3>>()
+    let root = if bump { root + one } else { root };
+    let signed_root = if is_negative { -root } else { root };
+    signed_root.resize_to::<Int<3>>()
 }

--- a/src/algos/div/div_native.rs
+++ b/src/algos/div/div_native.rs
@@ -12,14 +12,14 @@
 //! Two specialised arms, selected on `N` at compile time (the unused arm is
 //! dead-code-eliminated per monomorphisation):
 //!
-//! * **`N == 1` (D18):** the scaled numerator `a * 10^SCALE` fits `i128` (an
-//!   `i64` magnitude times `10^18 < 2^60`) and the divisor `b` is an `i64`
-//!   magnitude that fits `u64`. The rescale is therefore an `i128 / u64`
+//! * **`N == 1` (D18):** the scaled numerator `dividend * 10^SCALE` fits
+//!   `i128` (an `i64` magnitude times `10^18 < 2^60`) and the `divisor` is an
+//!   `i64` magnitude that fits `u64`. The rescale is therefore an `i128 / u64`
 //!   schoolbook divide -- two hardware `divq` via
 //!   [`crate::macros::arithmetic::i128_divrem_by_u64_with_mode`] -- not the
 //!   LLVM `__divti3` soft-call an `i128 / i128` (the `apply_rounding`
-//!   double-divmod) would lower to. `b`'s sign is folded into the numerator so
-//!   the directed-rounding tie-break sees the true quotient sign.
+//!   double-divmod) would lower to. The divisor's sign is folded into the
+//!   numerator so the directed-rounding tie-break sees the true quotient sign.
 //! * **`N == 2` (D38):** the divisor can be a full `i128` and the scaled
 //!   numerator can exceed `i128`, so the rescale delegates to the shared
 //!   hardware kernel
@@ -52,51 +52,53 @@ use crate::support::rounding::RoundingMode;
 
 /// Hardware-`i128` decimal divide kernel for narrow storage (`N <= 2`).
 ///
-/// Computes `(a * 10^SCALE) / b` rounded under `mode`. Panics on a zero
+/// Computes `(dividend * 10^SCALE) / divisor` rounded under `mode`. Panics on a zero
 /// divisor and on `i128` overflow of the quotient in BOTH debug and release
 /// per the decimal default-operator contract.
 #[inline]
 #[must_use]
 pub(crate) fn div_native<const N: usize, const SCALE: u32>(
-    a: Int<N>,
-    b: Int<N>,
+    dividend: Int<N>,
+    divisor: Int<N>,
     mode: RoundingMode,
 ) -> Int<N> {
-    if b == Int::<N>::ZERO {
+    if divisor == Int::<N>::ZERO {
         panic!("attempt to divide by zero");
     }
 
     if N == 1 {
-        // D18: numerator a * 10^SCALE fits i128 (i64 magnitude * 10^18 < 2^124),
-        // and the divisor b is an i64 magnitude that fits u64. The rescale
-        // divide is therefore an i128 / u64 schoolbook divide -- two hardware
-        // divq instructions via i128_divrem_by_u64_with_mode -- not the
-        // __divti3 soft-call an i128 / i128 (apply_rounding) would lower to.
-        let bi = b.as_i128();
-        // Fold b's sign into the numerator so the signed numerator passed to
-        // `i128_divrem_by_u64` carries the TRUE result sign (`sign(a) ^
-        // sign(b)`). The helper decides the directed-rounding tie-break from
+        // D18: numerator dividend * 10^SCALE fits i128 (i64 magnitude * 10^18
+        // < 2^124), and the divisor is an i64 magnitude that fits u64. The
+        // rescale divide is therefore an i128 / u64 schoolbook divide -- two
+        // hardware divq instructions via i128_divrem_by_u64_with_mode -- not
+        // the __divti3 soft-call an i128 / i128 (apply_rounding) would lower to.
+        let divisor_raw = divisor.as_i128();
+        // Fold the divisor's sign into the numerator so the signed numerator
+        // passed to `i128_divrem_by_u64` carries the TRUE result sign
+        // (`sign(dividend) ^ sign(divisor)`). The helper decides the
+        // directed-rounding tie-break from
         // the numerator sign (`result_positive = !n_neg`), so the divisor it
         // sees must be the positive magnitude AND the numerator must already
         // bear the quotient sign -- otherwise Floor / Ceiling round the wrong
         // way for a negative divisor.
-        let b_neg = bi < 0;
-        let n = a.as_i128() * crate::consts::pow10::dispatch_i128(SCALE);
-        let n = if b_neg { -n } else { n };
-        let b_mag: u64 = bi.unsigned_abs() as u64;
-        let result = crate::macros::arithmetic::i128_divrem_by_u64_with_mode(n, b_mag, mode);
+        let divisor_is_negative = divisor_raw < 0;
+        let numerator = dividend.as_i128() * crate::consts::pow10::dispatch_i128(SCALE);
+        let numerator = if divisor_is_negative { -numerator } else { numerator };
+        let divisor_mag: u64 = divisor_raw.unsigned_abs() as u64;
+        let quotient =
+            crate::macros::arithmetic::i128_divrem_by_u64_with_mode(numerator, divisor_mag, mode);
         assert!(
-            result >= i64::MIN as i128 && result <= i64::MAX as i128,
+            quotient >= i64::MIN as i128 && quotient <= i64::MAX as i128,
             "attempt to divide with overflow"
         );
-        return Int::<N>::from_i128(result);
+        return Int::<N>::from_i128(quotient);
     }
 
     // N == 2 (D38): the shared i128 / 256-bit kernel.
-    let ai = a.as_i128();
-    let bi = b.as_i128();
-    match div_pow10_div_with::<SCALE>(ai, bi, mode) {
-        Some(q) => Int::<N>::from_i128(q),
+    let dividend_raw = dividend.as_i128();
+    let divisor_raw = divisor.as_i128();
+    match div_pow10_div_with::<SCALE>(dividend_raw, divisor_raw, mode) {
+        Some(quotient) => Int::<N>::from_i128(quotient),
         None => panic!("attempt to divide with overflow"),
     }
 }

--- a/src/algos/div/div_schoolbook.rs
+++ b/src/algos/div/div_schoolbook.rs
@@ -4,16 +4,17 @@
 //! `div_schoolbook` -- naive schoolbook decimal division reference,
 //! generic over the storage width `N` only.
 //!
-//! Computes `a / b` for two same-`SCALE` decimals stored as `Int<N>`.
-//! The logical quotient is `(a / 10^SCALE) / (b / 10^SCALE) = a / b`,
+//! Computes `dividend / divisor` for two same-`SCALE` decimals stored as
+//! `Int<N>`. The logical quotient is
+//! `(dividend / 10^SCALE) / (divisor / 10^SCALE) = dividend / divisor`,
 //! but to retain `SCALE` fractional digits the numerator is first scaled
 //! up by `10^SCALE` before dividing.
 //!
 //! This is the unambiguous schoolbook reference: it forms the scaled
-//! numerator `|a| * 10^SCALE` in a `2N`-limb scratch buffer and divides by
-//! `|b|` via the int layer's width-agnostic `div_rem`, with no leading-zero
-//! narrow shortcut. Since decimal division's divisor is the runtime operand
-//! `b` (not `10^SCALE`), there is no MG / Newton path to forgo here — both
+//! numerator `|dividend| * 10^SCALE` in a `2N`-limb scratch buffer and divides
+//! by `|divisor|` via the int layer's width-agnostic `div_rem`, with no
+//! leading-zero narrow shortcut. Since decimal division's divisor is the
+//! runtime operand (not `10^SCALE`), there is no MG / Newton path to forgo here — both
 //! this reference and
 //! [`div_widen_scale`](super::div_widen_scale::div_widen_scale) divide via
 //! the same int-layer engine. The kernel exists as an explicit
@@ -26,17 +27,17 @@ use crate::int::types::compute_limbs::{ComputeLimbs, Limbs};
 use crate::int::types::Int;
 use crate::support::rounding::RoundingMode;
 
-/// Naive schoolbook decimal division for storage `Int<N>`. `mult` is the
-/// pre-computed `10^SCALE` multiplier (same convention as
+/// Naive schoolbook decimal division for storage `Int<N>`. `multiplier` is
+/// the pre-computed `10^SCALE` multiplier (same convention as
 /// [`div_widen_scale`](super::div_widen_scale::div_widen_scale)).
 ///
 /// Forms the scaled numerator and divides via the int layer, rounding under
 /// `mode`. Requires `Limbs<N>: ComputeLimbs`. Panics on a zero divisor.
 #[inline]
 pub(crate) fn div_schoolbook<const N: usize>(
-    a: Int<N>,
-    b: Int<N>,
-    mult: Int<N>,
+    dividend: Int<N>,
+    divisor: Int<N>,
+    multiplier: Int<N>,
     mode: RoundingMode,
 ) -> Int<N>
 where
@@ -45,5 +46,5 @@ where
     // The scaled-numerator-then-int-divide pipeline is the schoolbook
     // reference; `div_widen_scale` is the same pipeline (decimal division
     // has no MG / Newton arm to drop), so delegate to it.
-    super::div_widen_scale::div_widen_scale::<N>(a, b, mult, mode)
+    super::div_widen_scale::div_widen_scale::<N>(dividend, divisor, multiplier, mode)
 }

--- a/src/algos/div/div_widen_scale.rs
+++ b/src/algos/div/div_widen_scale.rs
@@ -4,10 +4,11 @@
 //! `div_widen_scale` — decimal division by the widen-then-divide method,
 //! generic over the storage width `N` only.
 //!
-//! Divides `a / b` for two same-`SCALE` decimals stored as `Int<N>`. The
-//! logical quotient is `(a / 10^SCALE) / (b / 10^SCALE) = a / b`, but to
+//! Divides `dividend / divisor` for two same-`SCALE` decimals stored as
+//! `Int<N>`. The logical quotient is
+//! `(dividend / 10^SCALE) / (divisor / 10^SCALE) = dividend / divisor`, but to
 //! keep `SCALE` fractional digits the numerator is first scaled up by
-//! `10^SCALE` (`a * 10^SCALE`). Scaling can overflow `Int<N>`, so the
+//! `10^SCALE` (`dividend * 10^SCALE`). Scaling can overflow `Int<N>`, so the
 //! scaled numerator spans up to `2N` limbs and is formed in a limb
 //! **scratch buffer** rather than a work *type* `Int<2N>`.
 //!
@@ -16,16 +17,16 @@
 //! Following the `sqrt`/`cbrt`/`hypot` template, the kernel is generic over
 //! `N` alone:
 //!
-//! 1. form `|a| * 10^SCALE` (`2N` u64 limbs) in a [`ComputeLimbs::double_buffered_u64`]
+//! 1. form `|dividend| * 10^SCALE` (`2N` u64 limbs) in a [`ComputeLimbs::double_buffered_u64`]
 //!    buffer via the int slice multiply;
-//! 2. divide it by `|b|` via the int layer's width-agnostic divide
+//! 2. divide it by `|divisor|` via the int layer's width-agnostic divide
 //!    ([`crate::int::algos::div::div_fixed::div_rem_mag_slice`], which
 //!    fronts the divisor-shape policy — Knuth / single-limb fast paths),
 //!    rounding under `mode`;
 //! 3. rebuild the signed `Int<N>` quotient (panics on overflow in both
 //!    debug and release).
 //!
-//! The divisor here is the runtime operand `b`, not `10^SCALE`, so the MG
+//! The divisor here is the runtime operand, not `10^SCALE`, so the MG
 //! magic-divide does not apply — the int-layer `div_rem` (with its own
 //! hardware fast paths) is the right engine, exactly as the prior
 //! `Int<W>::div_rem` path used.
@@ -43,44 +44,46 @@ use crate::support::rounding::{should_bump, RoundingMode};
 
 /// Significant limb length (highest non-zero limb index + 1, min 1).
 #[inline]
-fn sig_len(a: &[u64]) -> usize {
-    let mut l = a.len();
-    while l > 1 && a[l - 1] == 0 {
-        l -= 1;
+fn sig_len(limbs: &[u64]) -> usize {
+    let mut len = limbs.len();
+    while len > 1 && limbs[len - 1] == 0 {
+        len -= 1;
     }
-    l
+    len
 }
 
-/// Compare `2*rem` against `divisor` (little-endian magnitudes), returning
-/// the ordering of `rem` vs `divisor - rem` (the rounding half-comparison).
+/// Compare `2*remainder` against `divisor` (little-endian magnitudes),
+/// returning the ordering of `remainder` vs `divisor - remainder` (the
+/// rounding half-comparison).
 #[inline]
-fn cmp_double_vs<const N: usize>(rem: &[u64], divisor: &[u64]) -> core::cmp::Ordering
+fn cmp_double_vs<const N: usize>(remainder: &[u64], divisor: &[u64]) -> core::cmp::Ordering
 where
     Limbs<N>: ComputeLimbs,
 {
-    // `2·rem` spans at most `rem.len() + 1` limbs, and `rem < divisor`, whose
+    // `2·remainder` spans at most `remainder.len() + 1` limbs, and
+    // `remainder < divisor`, whose
     // length is `≤ N`; the `single_buffered_u64` buffer (`N + 2`) holds it
     // exactly per-`N`.
-    let mut two_r_buf = Limbs::<N>::single_buffered_u64();
-    let two_r = two_r_buf.as_mut();
+    let mut double_remainder_buf = Limbs::<N>::single_buffered_u64();
+    let double_remainder = double_remainder_buf.as_mut();
     let mut carry: u64 = 0;
-    for (i, &r) in rem.iter().enumerate() {
-        let v = ((r as u128) << 1) | carry as u128;
-        two_r[i] = v as u64;
-        carry = (v >> 64) as u64;
+    for (i, &limb) in remainder.iter().enumerate() {
+        let doubled = ((limb as u128) << 1) | carry as u128;
+        double_remainder[i] = doubled as u64;
+        carry = (doubled >> 64) as u64;
     }
-    let mut len = rem.len();
+    let mut len = remainder.len();
     if carry != 0 {
-        two_r[len] = carry;
+        double_remainder[len] = carry;
         len += 1;
     }
-    let dl = divisor.len();
-    let maxl = len.max(dl);
-    let mut k = maxl;
-    while k > 0 {
-        k -= 1;
-        let lhs = if k < len { two_r[k] } else { 0 };
-        let rhs = if k < dl { divisor[k] } else { 0 };
+    let divisor_len = divisor.len();
+    let max_len = len.max(divisor_len);
+    let mut idx = max_len;
+    while idx > 0 {
+        idx -= 1;
+        let lhs = if idx < len { double_remainder[idx] } else { 0 };
+        let rhs = if idx < divisor_len { divisor[idx] } else { 0 };
         if lhs != rhs {
             return if lhs > rhs {
                 core::cmp::Ordering::Greater
@@ -92,59 +95,61 @@ where
     core::cmp::Ordering::Equal
 }
 
-/// Rebuild a signed `Int<N>` from magnitude limbs `out` and sign `neg`,
+/// Rebuild a signed `Int<N>` from `magnitude_limbs` and sign `is_negative`,
 /// panicking on overflow in BOTH debug and release (the decimal default
 /// operator never silently wraps a wrong number).
 #[inline]
-fn apply_sign<const N: usize>(out: [u64; N], neg: bool, msg: &str) -> Int<N> {
-    let mag = Int::<N>::from_limbs(out);
-    if mag.is_negative() && !(neg && mag == Int::<N>::MIN) {
+fn apply_sign<const N: usize>(magnitude_limbs: [u64; N], is_negative: bool, msg: &str) -> Int<N> {
+    let magnitude = Int::<N>::from_limbs(magnitude_limbs);
+    if magnitude.is_negative() && !(is_negative && magnitude == Int::<N>::MIN) {
         panic!("{msg}");
     }
-    if neg {
-        mag.wrapping_neg()
+    if is_negative {
+        magnitude.wrapping_neg()
     } else {
-        mag
+        magnitude
     }
 }
 
 /// Widen-then-divide decimal division kernel, generic over `N`. Requires
 /// `Limbs<N>: ComputeLimbs` for the `2N`-limb scaled-numerator scratch.
 ///
-/// `mult` is the pre-computed `10^SCALE` multiplier in `Int<N>` storage
+/// `multiplier` is the pre-computed `10^SCALE` multiplier in `Int<N>` storage
 /// (the policy evaluates the per-type `multiplier()` const so it folds at
-/// compile time). Forms `|a| * mult` in scratch, divides by `|b|` via the
+/// compile time). Forms `|dividend| * multiplier` in scratch, divides by
+/// `|divisor|` via the
 /// int layer, rounds under `mode`, and rebuilds the signed quotient.
 ///
 /// Panics on a zero divisor.
 #[inline]
 pub(crate) fn div_widen_scale<const N: usize>(
-    a: Int<N>,
-    b: Int<N>,
-    mult: Int<N>,
+    dividend: Int<N>,
+    divisor: Int<N>,
+    multiplier: Int<N>,
     mode: RoundingMode,
 ) -> Int<N>
 where
     Limbs<N>: ComputeLimbs,
 {
-    if b == Int::<N>::ZERO {
+    if divisor == Int::<N>::ZERO {
         panic!("attempt to divide by zero");
     }
-    let neg = a.is_negative() != b.is_negative();
-    let a_mag = *a.unsigned_abs().as_limbs();
-    let m_mag = *mult.as_limbs(); // mult >= 0
-    let b_mag = *b.unsigned_abs().as_limbs();
-    let al = sig_len(&a_mag);
-    let ml = sig_len(&m_mag);
-    let bl = sig_len(&b_mag);
+    let is_negative = dividend.is_negative() != divisor.is_negative();
+    let dividend_mag = *dividend.unsigned_abs().as_limbs();
+    let multiplier_mag = *multiplier.as_limbs(); // multiplier >= 0
+    let divisor_mag = *divisor.unsigned_abs().as_limbs();
+    let dividend_len = sig_len(&dividend_mag);
+    let multiplier_len = sig_len(&multiplier_mag);
+    let divisor_len = sig_len(&divisor_mag);
 
-    // ── Fast path: the scaled numerator |a|·10^SCALE fits Int<N> ─────────
-    // When `lz(|a|) + lz(10^SCALE) > Int<N>::BITS` the product fits Int<N>, so
+    // ── Fast path: the scaled numerator |dividend|·10^SCALE fits Int<N> ──
+    // When `lz(|dividend|) + lz(10^SCALE) > Int<N>::BITS` the product fits Int<N>, so
     // divide in N limbs and skip the 2N widen machinery (the ×10^SCALE into a
     // double-buffered scratch, the 2N-sized divide setup). Mirrors
     // `mul_widen_divide`'s fits-Int<N> arm (at SCALE==0,
-    // `mult == 1`, so it engages for any operand with ≥2 leading zero bits).
-    // Bit-identical: the same `round(|a|·10^SCALE / |b|)`, an N-limb Knuth
+    // `multiplier == 1`, so it engages for any operand with ≥2 leading zero
+    // bits).
+    // Bit-identical: the same `round(|dividend|·10^SCALE / |divisor|)`, an N-limb Knuth
     // divide instead of 2N. Hardcoding Knuth is the matcher's choice for this
     // shape: the dividend fits N limbs (≤ the divisor width `n`), so the u128
     // engine's `dividend ≥ 2n` precondition is false and `select_for_limbs`
@@ -152,34 +157,35 @@ where
     // sound ONLY while the matcher's verdict for this shape IS Knuth; MUST
     // be re-verified whenever an Algorithm arm joins `int::policy::div_rem`
     // (a new engine winning for small-`n` dividends would void this fast path).
-    let lz_a = a.unsigned_abs().leading_zeros();
-    let lz_m = mult.unsigned_abs().leading_zeros();
-    if lz_a + lz_m > <Int<N>>::BITS {
-        let num_mag = *a.wrapping_mul(mult).unsigned_abs().as_limbs();
-        let nl_fast = sig_len(&num_mag);
-        let mut quot = [0u64; N];
-        let mut rem = [0u64; N];
+    let dividend_leading_zeros = dividend.unsigned_abs().leading_zeros();
+    let multiplier_leading_zeros = multiplier.unsigned_abs().leading_zeros();
+    if dividend_leading_zeros + multiplier_leading_zeros > <Int<N>>::BITS {
+        let numerator_mag = *dividend.wrapping_mul(multiplier).unsigned_abs().as_limbs();
+        let numerator_len = sig_len(&numerator_mag);
+        let mut quotient = [0u64; N];
+        let mut remainder = [0u64; N];
         let mut u_buf = Limbs::<N>::single_buffered_u64();
         let mut v_buf = Limbs::<N>::single_buffered_u64();
         div_knuth_into(
-            &num_mag[..nl_fast],
-            &b_mag[..bl],
-            &mut quot,
-            &mut rem,
+            &numerator_mag[..numerator_len],
+            &divisor_mag[..divisor_len],
+            &mut quotient,
+            &mut remainder,
             u_buf.as_mut(),
             v_buf.as_mut(),
         );
-        let rl = sig_len(&rem[..bl.max(1)]);
-        let rem_nonzero = !(rl == 1 && rem[0] == 0);
-        if rem_nonzero {
-            let cmp_r = cmp_double_vs::<N>(&rem[..bl.max(1)], &b_mag[..bl]);
-            let q_is_odd = (quot[0] & 1) != 0;
-            if should_bump(mode, cmp_r, q_is_odd, !neg) {
+        let remainder_len = sig_len(&remainder[..divisor_len.max(1)]);
+        let remainder_nonzero = !(remainder_len == 1 && remainder[0] == 0);
+        if remainder_nonzero {
+            let remainder_cmp = cmp_double_vs::<N>(
+                &remainder[..divisor_len.max(1)], &divisor_mag[..divisor_len]);
+            let quotient_is_odd = (quotient[0] & 1) != 0;
+            if should_bump(mode, remainder_cmp, quotient_is_odd, !is_negative) {
                 let mut carry: u64 = 1;
-                for limb in quot.iter_mut() {
-                    let (s, c) = limb.overflowing_add(carry);
-                    *limb = s;
-                    if !c {
+                for limb in quotient.iter_mut() {
+                    let (sum, overflowed) = limb.overflowing_add(carry);
+                    *limb = sum;
+                    if !overflowed {
                         carry = 0;
                         break;
                     }
@@ -187,29 +193,31 @@ where
                 let _ = carry;
             }
         }
-        return apply_sign::<N>(quot, neg, "attempt to divide with overflow");
+        return apply_sign::<N>(quotient, is_negative, "attempt to divide with overflow");
     }
 
-    // Scaled numerator |a| * 10^SCALE (up to 2N u64 limbs) in scratch.
-    let mut num_buf = Limbs::<N>::double_buffered_u64();
-    let num = num_buf.as_mut();
-    let nlen = (al + ml).min(num.len());
-    for slot in num[..nlen].iter_mut() {
+    // Scaled numerator |dividend| * 10^SCALE (up to 2N u64 limbs) in scratch.
+    let mut numerator_buf = Limbs::<N>::double_buffered_u64();
+    let numerator = numerator_buf.as_mut();
+    let numerator_len = (dividend_len + multiplier_len).min(numerator.len());
+    for slot in numerator[..numerator_len].iter_mut() {
         *slot = 0;
     }
-    mul_slice(&a_mag[..al], &m_mag[..ml], &mut num[..nlen]);
-    let ntop = sig_len(&num[..nlen]);
+    mul_slice(&dividend_mag[..dividend_len], &multiplier_mag[..multiplier_len],
+        &mut numerator[..numerator_len]);
+    let numerator_sig_len = sig_len(&numerator[..numerator_len]);
 
-    // q = num / b, r = num % b (magnitudes, via the int layer).
-    let mut quot_buf = Limbs::<N>::double_buffered_u64();
-    let quot = quot_buf.as_mut();
-    let mut rem_buf = Limbs::<N>::double_buffered_u64();
-    let rem = rem_buf.as_mut();
-    let qlen = ntop.max(1);
-    for slot in quot[..qlen].iter_mut() {
+    // quotient = numerator / divisor, remainder = numerator % divisor
+    // (magnitudes, via the int layer).
+    let mut quotient_buf = Limbs::<N>::double_buffered_u64();
+    let quotient = quotient_buf.as_mut();
+    let mut remainder_buf = Limbs::<N>::double_buffered_u64();
+    let remainder = remainder_buf.as_mut();
+    let quotient_len = numerator_sig_len.max(1);
+    for slot in quotient[..quotient_len].iter_mut() {
         *slot = 0;
     }
-    for slot in rem[..bl.max(1)].iter_mut() {
+    for slot in remainder[..divisor_len.max(1)].iter_mut() {
         *slot = 0;
     }
     // Route on the divide matcher's verdict, with exact `ComputeLimbs` scratch
@@ -218,13 +226,13 @@ where
     // even divisor of ≥ 24 limbs whose dividend is ≥ 2·n — so it picks up the
     // wide-tier `/` win; every other shape takes Knuth (a single-limb divisor
     // is handled inside `div_knuth_into`). Burnikel–Ziegler can't engage (the
-    // divisor `b` is `N ≤ 64 < 65` limbs) and `Schoolbook` is never returned,
+    // divisor is `N ≤ 64 < 65` limbs) and `Schoolbook` is never returned,
     // but both are matched (no `_`) so a new engine forces a decision here.
-    let num_s = &num[..ntop];
-    let den_s = &b_mag[..bl];
-    let q = &mut quot[..qlen];
-    let r = &mut rem[..bl.max(1)];
-    match select_for_limbs(num_s, den_s) {
+    let numerator_slice = &numerator[..numerator_sig_len];
+    let divisor_slice = &divisor_mag[..divisor_len];
+    let quotient_slice = &mut quotient[..quotient_len];
+    let remainder_slice = &mut remainder[..divisor_len.max(1)];
+    match select_for_limbs(numerator_slice, divisor_slice) {
         Algorithm::KnuthU128Limb => {
             // `u` = `2N`-value normalised dividend in u128 (`double_buffered`);
             // `v` = `N`-value divisor in u128 (`single`); the u64 buffers hold
@@ -234,10 +242,10 @@ where
             let mut u128_u = Limbs::<N>::double_buffered_u128();
             let mut u128_v = Limbs::<N>::single_u128();
             div_knuth_u128_limb_into(
-                num_s,
-                den_s,
-                q,
-                r,
+                numerator_slice,
+                divisor_slice,
+                quotient_slice,
+                remainder_slice,
                 u64buf.as_mut(),
                 v64buf.as_mut(),
                 u128_u.as_mut(),
@@ -249,26 +257,28 @@ where
         | Algorithm::BurnikelZieglerWithKnuth
         | Algorithm::Schoolbook => {
             // The scaled numerator spans up to `2N` limbs, so its normalised
-            // `u` needs `double_buffered_u64` (`≥ 2N + 2`); the divisor `b` is
+            // `u` needs `double_buffered_u64` (`≥ 2N + 2`); the divisor is
             // `N`-wide, so `v` needs `single_buffered_u64` (`N + 2`).
             let mut u_buf = Limbs::<N>::double_buffered_u64();
             let mut v_buf = Limbs::<N>::single_buffered_u64();
-            div_knuth_into(num_s, den_s, q, r, u_buf.as_mut(), v_buf.as_mut());
+            div_knuth_into(numerator_slice, divisor_slice, quotient_slice, remainder_slice,
+                u_buf.as_mut(), v_buf.as_mut());
         }
     }
 
-    // Round per `mode`: compare remainder against b - remainder.
-    let rl = sig_len(&rem[..bl.max(1)]);
-    let rem_nonzero = !(rl == 1 && rem[0] == 0);
-    if rem_nonzero {
-        let cmp_r = cmp_double_vs::<N>(&rem[..bl.max(1)], &b_mag[..bl]);
-        let q_is_odd = (quot[0] & 1) != 0;
-        if should_bump(mode, cmp_r, q_is_odd, !neg) {
+    // Round per `mode`: compare remainder against divisor - remainder.
+    let remainder_len = sig_len(&remainder[..divisor_len.max(1)]);
+    let remainder_nonzero = !(remainder_len == 1 && remainder[0] == 0);
+    if remainder_nonzero {
+        let remainder_cmp = cmp_double_vs::<N>(
+            &remainder[..divisor_len.max(1)], &divisor_mag[..divisor_len]);
+        let quotient_is_odd = (quotient[0] & 1) != 0;
+        if should_bump(mode, remainder_cmp, quotient_is_odd, !is_negative) {
             let mut carry: u64 = 1;
-            for limb in quot.iter_mut() {
-                let (s, c) = limb.overflowing_add(carry);
-                *limb = s;
-                if !c {
+            for limb in quotient.iter_mut() {
+                let (sum, overflowed) = limb.overflowing_add(carry);
+                *limb = sum;
+                if !overflowed {
                     carry = 0;
                     break;
                 }
@@ -277,7 +287,7 @@ where
         }
     }
 
-    let mut out = [0u64; N];
-    out.copy_from_slice(&quot[..N]);
-    apply_sign::<N>(out, neg, "attempt to divide with overflow")
+    let mut quotient_limbs = [0u64; N];
+    quotient_limbs.copy_from_slice(&quotient[..N]);
+    apply_sign::<N>(quotient_limbs, is_negative, "attempt to divide with overflow")
 }

--- a/src/algos/div/mod.rs
+++ b/src/algos/div/mod.rs
@@ -3,8 +3,8 @@
 
 //! Decimal division algorithm family.
 //!
-//! One algorithm: [`div_widen_scale`] — widens `a * 10^SCALE` to the
-//! next-up work width `W` then divides by `b`, rounding under `mode`, with
+//! One algorithm: [`div_widen_scale`] — widens `dividend * 10^SCALE` to the
+//! next-up work width `W` then divides by `divisor`, rounding under `mode`, with
 //! a value-gated fast path that skips the widen step when the scaled
 //! numerator provably fits the storage width. The per-`(N, SCALE)` choice
 //! lives in [`crate::policy::div`], which delegates *down* to this kernel.

--- a/src/algos/exp/exp_generic.rs
+++ b/src/algos/exp/exp_generic.rs
@@ -31,42 +31,42 @@ use crate::support::rounding::RoundingMode;
     pub(crate) const SERIES_CAP: u128 = 20_000;
 
     #[inline]
-    pub(crate) fn lit<S: BigInt>(n: i128) -> S {
-        S::from_i128(n)
+    pub(crate) fn lit<S: BigInt>(value: i128) -> S {
+        S::from_i128(value)
     }
     #[inline]
     pub(crate) fn zero<S: BigInt>() -> S {
         S::ZERO
     }
     #[inline]
-    pub(crate) fn pow10<S: BigInt>(n: u32) -> S {
-        crate::consts::pow10::dispatch::<S>(n)
+    pub(crate) fn pow10<S: BigInt>(exponent: u32) -> S {
+        crate::consts::pow10::dispatch::<S>(exponent)
     }
     #[inline]
-    pub(crate) fn one<S: BigInt>(w: u32) -> S {
-        pow10::<S>(w)
+    pub(crate) fn one<S: BigInt>(working_scale: u32) -> S {
+        pow10::<S>(working_scale)
     }
     /// Bit length of `|v|` (0 for zero).
-    pub(crate) fn bit_length<S: BigInt>(v: S) -> u32 {
-        <S as BigInt>::BITS - v.abs().leading_zeros()
+    pub(crate) fn bit_length<S: BigInt>(value: S) -> u32 {
+        <S as BigInt>::BITS - value.abs().leading_zeros()
     }
     /// Unpacks a non-negative `S` magnitude into a little-endian u64 limb
     /// buffer through the trait's u128 magnitude exit (`mag_into_u128`).
     /// `dst` must be freshly zeroed and at least `S`'s width.
-    pub(crate) fn unpack_mag<S: BigInt>(v: S, dst: &mut [u64])
+    pub(crate) fn unpack_mag<S: BigInt>(value: S, dst: &mut [u64])
     where
         S::Scratch: ComputeLimbs,
     {
-        let mut tmp = <S::Scratch as ComputeLimbs>::single_u128();
-        v.mag_into_u128(tmp.as_mut());
+        let mut limbs = <S::Scratch as ComputeLimbs>::single_u128();
+        value.mag_into_u128(limbs.as_mut());
         let mut i = 0;
-        for &x in tmp.as_ref() {
+        for &chunk in limbs.as_ref() {
             if i < dst.len() {
-                dst[i] = x as u64;
+                dst[i] = chunk as u64;
                 i += 1;
             }
             if i < dst.len() {
-                dst[i] = (x >> 64) as u64;
+                dst[i] = (chunk >> 64) as u64;
                 i += 1;
             }
         }
@@ -90,54 +90,55 @@ use crate::support::rounding::RoundingMode;
     /// ≥ 24 limbs, which no narrow probe and no in-range work value here
     /// produces) falls to the value-identical base-2⁶⁴ Knuth. Truncated
     /// semantics, identical to `Int::div_rem`.
-    pub(crate) fn div_rem_exact<S: BigInt>(n: S, d: S) -> (S, S)
+    pub(crate) fn div_rem_exact<S: BigInt>(numerator: S, divisor: S) -> (S, S)
     where
         S::Scratch: ComputeLimbs,
     {
         use crate::int::policy::div_rem::{select_for_limbs, Algorithm};
-        let n_neg = n < S::ZERO;
-        let d_neg = d < S::ZERO;
-        let mut nbuf = <S::Scratch as ComputeLimbs>::single_u64();
-        let mut dbuf = <S::Scratch as ComputeLimbs>::single_u64();
-        unpack_mag(n.abs(), nbuf.as_mut());
-        unpack_mag(d.abs(), dbuf.as_mut());
-        let mut qbuf = <S::Scratch as ComputeLimbs>::single_u64();
-        let mut rbuf = <S::Scratch as ComputeLimbs>::single_u64();
-        match select_for_limbs(nbuf.as_ref(), dbuf.as_ref()) {
+        let numerator_is_negative = numerator < S::ZERO;
+        let divisor_is_negative = divisor < S::ZERO;
+        let mut numerator_limbs = <S::Scratch as ComputeLimbs>::single_u64();
+        let mut divisor_limbs = <S::Scratch as ComputeLimbs>::single_u64();
+        unpack_mag(numerator.abs(), numerator_limbs.as_mut());
+        unpack_mag(divisor.abs(), divisor_limbs.as_mut());
+        let mut quotient_limbs = <S::Scratch as ComputeLimbs>::single_u64();
+        let mut remainder_limbs = <S::Scratch as ComputeLimbs>::single_u64();
+        match select_for_limbs(numerator_limbs.as_ref(), divisor_limbs.as_ref()) {
             // Single-limb divisor: the hardware remainder engine, no
             // normalisation scratch involved.
             Algorithm::Rem => crate::int::algos::div::div_rem::div_rem(
-                nbuf.as_ref(),
-                dbuf.as_ref(),
-                qbuf.as_mut(),
-                rbuf.as_mut(),
+                numerator_limbs.as_ref(),
+                divisor_limbs.as_ref(),
+                quotient_limbs.as_mut(),
+                remainder_limbs.as_mut(),
             ),
             // Knuth — with exact caller-sized scratch (see above).
             _ => {
-                let mut u = <S::Scratch as ComputeLimbs>::single_buffered_u64();
-                let mut v = <S::Scratch as ComputeLimbs>::single_buffered_u64();
+                let mut dividend_scratch = <S::Scratch as ComputeLimbs>::single_buffered_u64();
+                let mut divisor_scratch = <S::Scratch as ComputeLimbs>::single_buffered_u64();
                 crate::int::algos::div::div_knuth::div_knuth_into(
-                    nbuf.as_ref(),
-                    dbuf.as_ref(),
-                    qbuf.as_mut(),
-                    rbuf.as_mut(),
-                    u.as_mut(),
-                    v.as_mut(),
+                    numerator_limbs.as_ref(),
+                    divisor_limbs.as_ref(),
+                    quotient_limbs.as_mut(),
+                    remainder_limbs.as_mut(),
+                    dividend_scratch.as_mut(),
+                    divisor_scratch.as_mut(),
                 );
             }
         }
-        let q = S::from_mag_sign_u64(qbuf.as_ref(), n_neg != d_neg);
-        let r = S::from_mag_sign_u64(rbuf.as_ref(), n_neg);
-        (q, r)
+        let quotient = S::from_mag_sign_u64(
+            quotient_limbs.as_ref(), numerator_is_negative != divisor_is_negative);
+        let remainder = S::from_mag_sign_u64(remainder_limbs.as_ref(), numerator_is_negative);
+        (quotient, remainder)
     }
 
     /// Half-to-even round of `numerator / divisor` for `S`.
     #[inline]
-    pub(crate) fn round_div<S: BigInt>(n: S, d: S) -> S
+    pub(crate) fn round_div<S: BigInt>(numerator: S, divisor: S) -> S
     where
         S::Scratch: ComputeLimbs,
     {
-        round_div_sided(n, d).0
+        round_div_sided(numerator, divisor).0
     }
 
     /// [`round_div`] plus which side of the returned quotient the EXACT
@@ -153,54 +154,55 @@ use crate::support::rounding::RoundingMode;
     /// # The polarity is READ, never assumed
     ///
     /// [`div_rem_exact`] truncates toward zero and its remainder carries the
-    /// numerator's sign, so the exact quotient always sits `|r/d| < 1` on the
-    /// AWAY-from-zero side of `q`. Keeping `q` therefore leaves the truth
+    /// numerator's sign, so the exact quotient always sits
+    /// `|remainder/divisor| < 1` on the AWAY-from-zero side of `quotient`.
+    /// Keeping `quotient` therefore leaves the truth
     /// away from zero of the answer; bumping steps a full unit — necessarily
     /// past it — and leaves the truth on the toward-zero side. Both
     /// polarities occur at both signs, because this rounds HALF-TO-EVEN and
     /// not toward zero, so a fixed direction would be wrong wherever the
     /// residual passes the half.
     #[inline]
-    fn round_div_sided<S: BigInt>(n: S, d: S) -> (S, Option<TailSign>)
+    fn round_div_sided<S: BigInt>(numerator: S, divisor: S) -> (S, Option<TailSign>)
     where
         S::Scratch: ComputeLimbs,
     {
-        let (q, r) = div_rem_exact(n, d);
-        if r == S::ZERO {
-            return (q, None);
+        let (quotient, remainder) = div_rem_exact(numerator, divisor);
+        if remainder == S::ZERO {
+            return (quotient, None);
         }
-        let ar = r.abs();
-        let comp = d.abs() - ar;
-        let cmp_r = if ar < comp {
+        let abs_remainder = remainder.abs();
+        let complement = divisor.abs() - abs_remainder;
+        let remainder_cmp = if abs_remainder < complement {
             ::core::cmp::Ordering::Less
-        } else if ar > comp {
+        } else if abs_remainder > complement {
             ::core::cmp::Ordering::Greater
         } else {
             ::core::cmp::Ordering::Equal
         };
-        let q_is_odd = q.bit(0);
-        let result_positive = (n < S::ZERO) == (d < S::ZERO);
+        let quotient_is_odd = quotient.bit(0);
+        let result_is_positive = (numerator < S::ZERO) == (divisor < S::ZERO);
         let bump = crate::support::rounding::should_bump(
             RoundingMode::HalfToEven,
-            cmp_r,
-            q_is_odd,
-            result_positive,
+            remainder_cmp,
+            quotient_is_odd,
+            result_is_positive,
         );
         // Away-from-zero for a positive result is UP, for a negative one DOWN
         // — so the truth is above the answer exactly when those two disagree.
-        let side = if result_positive != bump {
+        let side = if result_is_positive != bump {
             TailSign::Above
         } else {
             TailSign::Below
         };
         let rounded = if bump {
-            if result_positive {
-                q + S::ONE
+            if result_is_positive {
+                quotient + S::ONE
             } else {
-                q - S::ONE
+                quotient - S::ONE
             }
         } else {
-            q
+            quotient
         };
         (rounded, Some(side))
     }
@@ -235,7 +237,7 @@ use crate::support::rounding::RoundingMode;
         (reconstructed - product).abs() < divisor && reconstructed.abs() <= product.abs()
     }
 
-    /// Half-to-even quotient `n / 10^w`, via the MG (magic-multiply)
+    /// Half-to-even quotient `numerator / 10^exponent`, via the MG (magic-multiply)
     /// reciprocal — the same fast divide the per-tier
     /// `decl_wide_transcendental!` core uses, here for the width-generic
     /// path the hyperbolics run through. For `1 ≤ w ≤ 38` the
@@ -246,21 +248,21 @@ use crate::support::rounding::RoundingMode;
     /// hyperbolic/exp cost. The buffer comes from `S`'s scratch carrier ([`ComputeLimbs`]), so no
     /// const-generic limb count appears here.
     #[inline]
-    pub(crate) fn round_div_pow10<S: BigInt>(n: S, w: u32) -> S
+    pub(crate) fn round_div_pow10<S: BigInt>(numerator: S, exponent: u32) -> S
     where
         S::Scratch: ComputeLimbs,
     {
-        if w == 0 {
-            return n;
+        if exponent == 0 {
+            return numerator;
         }
-        if w <= 38 {
+        if exponent <= 38 {
             return crate::algos::support::mg_divide::div_wide_pow10::<S>(
-                n,
-                w,
+                numerator,
+                exponent,
                 RoundingMode::HalfToEven,
             );
         }
-        // `w > 38` rescale: route through the rescale MATCHER (not
+        // `exponent > 38` rescale: route through the rescale MATCHER (not
         // `div_wide_pow10_chain` directly) so the wide / high-scale band gets
         // the baked-reciprocal Newton arm + the 9.24 magnitude-trim, exactly
         // as the per-tier `wide_transcendental` cores do. The matcher only
@@ -270,14 +272,14 @@ use crate::support::rounding::RoundingMode;
         // never slower. Single source for the wide rescale across exp/ln/the
         // generic Tang kernel.
         crate::algos::support::rescale::dispatch_wide_pow10::<S>(
-            n,
-            w,
+            numerator,
+            exponent,
             RoundingMode::HalfToEven,
         )
     }
-    /// `(a · b) / 10^w`, rounded half-to-even.
+    /// `(lhs · rhs) / 10^working_scale`, rounded half-to-even.
     #[inline]
-    pub(crate) fn mul<S: BigInt>(a: S, b: S, w: u32) -> S
+    pub(crate) fn mul<S: BigInt>(lhs: S, rhs: S, working_scale: u32) -> S
     where
         S::Scratch: ComputeLimbs,
     {
@@ -286,143 +288,148 @@ use crate::support::rounding::RoundingMode;
         // falls back to the base-2^64 schoolbook for odd N. This is the hot
         // Taylor-term / squaring multiply, run at `Wexp` (up to Int<256>) for
         // exp + the hyperbolics.
-        round_div_pow10(a.wrapping_mul_low_u128(b), w)
+        round_div_pow10(lhs.wrapping_mul_low_u128(rhs), working_scale)
     }
     /// Loop-friendly `mul` with a precomputed `10^w` divisor.
     #[inline]
-    fn mul_cached<S: BigInt>(a: S, b: S, pow10_w: S) -> S
+    fn mul_cached<S: BigInt>(lhs: S, rhs: S, cached_pow10: S) -> S
     where
         S::Scratch: ComputeLimbs,
     {
-        round_div(a.wrapping_mul_low_u128(b), pow10_w)
+        round_div(lhs.wrapping_mul_low_u128(rhs), cached_pow10)
     }
-    /// `(a · 10^w) / b`, rounded half-to-even (precomputed numerator
-    /// factor).
+    /// `(numerator · 10^w) / divisor`, rounded half-to-even (precomputed
+    /// numerator factor).
     #[inline]
-    pub(crate) fn div_cached<S: BigInt>(a: S, b: S, pow10_w: S) -> S
+    pub(crate) fn div_cached<S: BigInt>(numerator: S, divisor: S, cached_pow10: S) -> S
     where
         S::Scratch: ComputeLimbs,
     {
-        div_cached_sided(a, b, pow10_w).0
+        div_cached_sided(numerator, divisor, cached_pow10).0
     }
 
     /// [`div_cached`] plus the side its rounding left the exact quotient on
     /// — see [`round_div_sided`]. Same single rounding body, same value.
     #[inline]
-    fn div_cached_sided<S: BigInt>(a: S, b: S, pow10_w: S) -> (S, Option<TailSign>)
+    fn div_cached_sided<S: BigInt>(
+        numerator: S, divisor: S, cached_pow10: S) -> (S, Option<TailSign>)
     where
         S::Scratch: ComputeLimbs,
     {
-        round_div_sided(a.wrapping_mul_low_u128(pow10_w), b)
+        round_div_sided(numerator.wrapping_mul_low_u128(cached_pow10), divisor)
     }
-    /// `a · n` for a small unsigned multiplier.
+    /// `value · multiplier` for a small unsigned multiplier.
     #[inline]
-    fn mul_u<S: BigInt>(a: S, n: u128) -> S {
-        if n <= u64::MAX as u128 {
-            a.mul_u64(n as u64)
+    fn mul_u<S: BigInt>(value: S, multiplier: u128) -> S {
+        if multiplier <= u64::MAX as u128 {
+            value.mul_u64(multiplier as u64)
         } else {
-            a * S::from_i128(n as i128)
+            value * S::from_i128(multiplier as i128)
         }
     }
     /// `k · c` where `k` is a signed range-reduction count. An n-by-1-word
     /// product (`mul_u64`) — O(limbs), not the full schoolbook —
     /// since `|k|` always fits one word on the range-reduction paths.
     #[inline]
-    pub(crate) fn scale_by_k<S: BigInt>(c: S, k: i128) -> S {
+    pub(crate) fn scale_by_k<S: BigInt>(constant: S, k: i128) -> S {
         if k >= 0 {
-            mul_u(c, k as u128)
+            mul_u(constant, k as u128)
         } else {
-            -mul_u(c, k.unsigned_abs())
+            -mul_u(constant, k.unsigned_abs())
         }
     }
     /// Rounds a working-scale value to the nearest integer (ties away
     /// from zero); used for the range-reduction quotient.
-    pub(crate) fn round_to_nearest_int<S: BigInt>(v: S, w: u32) -> i128
+    pub(crate) fn round_to_nearest_int<S: BigInt>(working_value: S, working_scale: u32) -> i128
     where
         S::Scratch: ComputeLimbs,
     {
-        let divisor = pow10::<S>(w);
-        let (q, r) = div_rem_exact(v, divisor);
+        let divisor = pow10::<S>(working_scale);
+        let (quotient, remainder) = div_rem_exact(working_value, divisor);
         let half = divisor >> 1;
-        let qi = if r.abs() >= half {
-            if v < S::ZERO { q - S::ONE } else { q + S::ONE }
+        let rounded_quotient = if remainder.abs() >= half {
+            if working_value < S::ZERO { quotient - S::ONE } else { quotient + S::ONE }
         } else {
-            q
+            quotient
         };
-        crate::int::types::traits::BigInt::to_i128(qi)
+        crate::int::types::traits::BigInt::to_i128(rounded_quotient)
     }
 
-    /// `ln 2` at working scale `w`, sourced from the unified constant
+    /// `ln 2` at `working_scale`, sourced from the unified constant
     /// table (`consts::ln2_by_working_scale`) — a static lookup +
     /// zero-extend, NOT a recompute. Replaces the former `2·artanh(1/3)`
     /// series (~`w` terms), which dominated the wide-tier exp/hyperbolic
     /// cost; the table's `ln2` band is sized (gen_const_table.py
     /// `LN2_MAXES`) to the peak `w_ext` this path can request. Mode is
     /// half-to-even, matching the per-tier core's `ln2_cf`.
-    fn ln2<S: BigInt>(w: u32) -> S {
-        crate::consts::ln2_by_working_scale::<S>(w, RoundingMode::HalfToEven)
+    fn ln2<S: BigInt>(working_scale: u32) -> S {
+        crate::consts::ln2_by_working_scale::<S>(working_scale, RoundingMode::HalfToEven)
     }
 
-    /// `√v` at working scale `w`: `√(|v| · 10^w)`, truncating. Width-generic
+    /// `√v` at `working_scale`: `√(|v| · 10^w)`, truncating. Width-generic
     /// twin of the per-tier `$core::sqrt_fixed` (the multi-level argument
     /// reduction `ln_fixed` runs); bit-identical (same seed-library bootstrap
     /// + monotone-downward Newton). `|v| · 10^w` must fit `S`.
-    pub(crate) fn sqrt_fixed<S: BigInt>(v: S, w: u32) -> S
+    pub(crate) fn sqrt_fixed<S: BigInt>(value: S, working_scale: u32) -> S
     where
         S::Scratch: ComputeLimbs,
     {
-        let av = v.abs();
-        let n = av * pow10::<S>(w);
-        if n <= zero::<S>() {
+        let abs_value = value.abs();
+        let radicand = abs_value * pow10::<S>(working_scale);
+        if radicand <= zero::<S>() {
             return zero::<S>();
         }
         // Seed from the shared cross-algorithm seed leaf (std f64 bootstrap /
         // no_std 1-bit), both guaranteed over-estimates, so the AM-GM pre-step
         // + monotone-downward loop converge to the identical floor either way.
-        let seed = crate::algos::support::seed_bridge::sqrt_seed_w::<S>(n);
-        let x0 = if seed <= zero::<S>() { lit::<S>(1) } else { seed };
+        let seed = crate::algos::support::seed_bridge::sqrt_seed_w::<S>(radicand);
+        let initial_estimate = if seed <= zero::<S>() { lit::<S>(1) } else { seed };
         // `div_rem_exact` (not the `/` operator): the Newton divides run at
         // the full work width, past the narrow build's blanket divide
         // scratch — see [`div_rem_exact`].
-        let mut x = (x0 + div_rem_exact(n, x0).0) >> 1;
+        let mut estimate =
+            (initial_estimate + div_rem_exact(radicand, initial_estimate).0) >> 1;
         loop {
-            let y = (x + div_rem_exact(n, x).0) >> 1;
-            if y >= x {
-                return x;
+            let next_estimate = (estimate + div_rem_exact(radicand, estimate).0) >> 1;
+            if next_estimate >= estimate {
+                return estimate;
             }
-            x = y;
+            estimate = next_estimate;
         }
     }
 
     /// Natural logarithm of a positive working-scale value, generic over the
     /// work integer `S`. Width-generic twin of the per-tier
     /// `$core::ln_fixed`: range-reduces `v = 2^k·m` with `m ∈ [1, 2)`, applies
-    /// `sqrt_l` levels of sqrt argument reduction (Brent 1976), evaluates
-    /// `ln(m) = 2^(l+1)·artanh((m−1)/(m+1))`, returns `k·ln2 + ln(m)`. `ln2_w`
-    /// is `ln 2` at scale `w`, supplied by the caller (the primitive wrapper
-    /// passes the const-folded `ln2_cf::<SCALE>`; a composition passes its
-    /// wide-work `ln2`), so this stays free of the `SCALE` const. Bit-identical
-    /// to the per-tier core for the same `(v, w, ln2_w)`.
-    pub(crate) fn ln_fixed<S: BigInt>(v_w: S, w: u32, ln2_w: S) -> S
+    /// `sqrt_levels` levels of sqrt argument reduction (Brent 1976), evaluates
+    /// `ln(m) = 2^(l+1)·artanh((m−1)/(m+1))`, returns `k·ln2 + ln(m)`.
+    /// `ln2_at_working_scale` is `ln 2` at `working_scale`, supplied by the
+    /// caller (the primitive wrapper passes the const-folded
+    /// `ln2_cf::<SCALE>`; a composition passes its wide-work `ln2`), so this
+    /// stays free of the `SCALE` const. Bit-identical to the per-tier core for
+    /// the same `(v, w, ln2_w)`.
+    pub(crate) fn ln_fixed<S: BigInt>(
+        working_value: S, working_scale: u32, ln2_at_working_scale: S) -> S
     where
         S::Scratch: ComputeLimbs,
     {
-        let one_w = one::<S>(w);
-        let two_w = one_w + one_w;
-        let pow10_w = one_w;
-        let mut k: i32 = bit_length::<S>(v_w) as i32 - bit_length::<S>(one_w) as i32;
-        let mut m_w = loop {
-            let m = if k >= 0 {
-                v_w >> (k as u32)
+        let one_at_working_scale = one::<S>(working_scale);
+        let two_at_working_scale = one_at_working_scale + one_at_working_scale;
+        let pow10_at_working_scale = one_at_working_scale;
+        let mut k: i32 = bit_length::<S>(working_value) as i32
+            - bit_length::<S>(one_at_working_scale) as i32;
+        let mut mantissa_w = loop {
+            let candidate_mantissa = if k >= 0 {
+                working_value >> (k as u32)
             } else {
-                v_w << ((-k) as u32)
+                working_value << ((-k) as u32)
             };
-            if m >= two_w {
+            if candidate_mantissa >= two_at_working_scale {
                 k += 1;
-            } else if m < one_w {
+            } else if candidate_mantissa < one_at_working_scale {
                 k -= 1;
             } else {
-                break m;
+                break candidate_mantissa;
             }
         };
 
@@ -432,49 +439,52 @@ use crate::support::rounding::RoundingMode;
         // perfect square `10^2w`), `t = (m−1)/(m+1) = 0`, and the artanh
         // series' first term is already zero — but skips the multi-level
         // sqrt reduction those steps would burn. Mirrors the Tang kernel's
-        // `m == one_w` arm.
-        if m_w == one_w {
-            return scale_by_k::<S>(ln2_w, k as i128);
+        // `mantissa_w == one_at_working_scale` arm.
+        if mantissa_w == one_at_working_scale {
+            return scale_by_k::<S>(ln2_at_working_scale, k as i128);
         }
 
-        // Multi-level sqrt argument reduction: `l ≈ √p_bits / 4`.
-        let p_bits = w.saturating_mul(3).saturating_add(1);
-        let sqrt_l: u32 = {
-            let mut n: u32 = 0;
-            while (n + 1) * (n + 1) <= p_bits {
-                n += 1;
+        // Multi-level sqrt argument reduction: `l ≈ √level_bound / 4`.
+        let level_bound = working_scale.saturating_mul(3).saturating_add(1);
+        let sqrt_levels: u32 = {
+            let mut levels: u32 = 0;
+            while (levels + 1) * (levels + 1) <= level_bound {
+                levels += 1;
             }
-            n / 4
+            levels / 4
         };
         let mut i = 0;
-        while i < sqrt_l {
-            m_w = sqrt_fixed::<S>(m_w, w);
+        while i < sqrt_levels {
+            mantissa_w = sqrt_fixed::<S>(mantissa_w, working_scale);
             i += 1;
         }
 
-        let t = div_cached::<S>(m_w - one_w, m_w + one_w, pow10_w);
-        let t2 = mul::<S>(t, t, w);
-        let mut sum = t;
-        let mut term = t;
-        let mut j: u128 = 1;
+        let atanh_arg = div_cached::<S>(
+            mantissa_w - one_at_working_scale,
+            mantissa_w + one_at_working_scale,
+            pow10_at_working_scale);
+        let atanh_arg_sq = mul::<S>(atanh_arg, atanh_arg, working_scale);
+        let mut sum = atanh_arg;
+        let mut term = atanh_arg;
+        let mut term_index: u128 = 1;
         loop {
-            term = mul::<S>(term, t2, w);
-            let contrib = term / lit::<S>((2 * j + 1) as i128);
-            if contrib == zero::<S>() {
+            term = mul::<S>(term, atanh_arg_sq, working_scale);
+            let contribution = term / lit::<S>((2 * term_index + 1) as i128);
+            if contribution == zero::<S>() {
                 break;
             }
-            sum = sum + contrib;
-            j += 1;
-            if j > SERIES_CAP {
+            sum = sum + contribution;
+            term_index += 1;
+            if term_index > SERIES_CAP {
                 break;
             }
         }
-        // ln(m) = 2^(l+1)·artanh(t) = sum << (sqrt_l + 1).
-        let ln_m = sum << (sqrt_l + 1);
-        scale_by_k::<S>(ln2_w, k as i128) + ln_m
+        // ln(m) = 2^(l+1)·artanh(t) = sum << (sqrt_levels + 1).
+        let ln_mantissa = sum << (sqrt_levels + 1);
+        scale_by_k::<S>(ln2_at_working_scale, k as i128) + ln_mantissa
     }
 
-    /// `log1p(t) = ln(1 + t)` at working scale `w`, evaluated without
+    /// `log1p(t) = ln(1 + t)` at `working_scale`, evaluated without
     /// ever forming `1 + t` — generic over the work integer `S` (the
     /// single source; the per-tier `decl_wide_transcendental!`
     /// `log1p_fixed` forwards here).
@@ -489,11 +499,11 @@ use crate::support::rounding::RoundingMode;
     /// Reference: N. J. Higham, *Accuracy and Stability of Numerical
     /// Algorithms* 2nd ed. (2002), 1.14.1 and Problem 1.4; J.-M. Muller,
     /// *Elementary Functions* 3rd ed. (2016), 4.4.
-    pub(crate) fn log1p_fixed<S: BigInt>(t: S, w: u32) -> S
+    pub(crate) fn log1p_fixed<S: BigInt>(argument: S, working_scale: u32) -> S
     where
         S::Scratch: ComputeLimbs,
     {
-        log1p_fixed_inner::<S>(t, w, None).0
+        log1p_fixed_inner::<S>(argument, working_scale, None).0
     }
 
     /// [`log1p_fixed`] plus the side of the returned value the TRUE value
@@ -504,28 +514,28 @@ use crate::support::rounding::RoundingMode;
     /// tag is the only difference, and it is `None` whenever it cannot be
     /// PROVED (see [`log1p_fixed_inner`]).
     ///
-    /// `guard` is the caller's sub-storage granularity — the `10^guard` it will
-    /// divide this value by to reach the storage grid. It buys nothing in the
-    /// answer and everything in the cost: a tag is only ever CONSULTED where
-    /// the caller's own residual cannot decide, so knowing that granularity
-    /// lets the proof be skipped wherever it would be discarded. See
-    /// [`side_by_deeper_probe`].
+    /// `guard_digits` is the caller's sub-storage granularity — the
+    /// `10^guard_digits` it will divide this value by to reach the storage
+    /// grid. It buys nothing in the answer and everything in the cost: a tag is
+    /// only ever CONSULTED where the caller's own residual cannot decide, so
+    /// knowing that granularity lets the proof be skipped wherever it would be
+    /// discarded. See [`side_by_deeper_probe`].
     pub(crate) fn log1p_fixed_tagged<S: BigInt>(
-        t: S,
-        w: u32,
-        guard: u32,
+        argument: S,
+        working_scale: u32,
+        guard_digits: u32,
     ) -> (S, Option<TailSign>)
     where
         S::Scratch: ComputeLimbs,
     {
-        log1p_fixed_inner::<S>(t, w, Some(guard))
+        log1p_fixed_inner::<S>(argument, working_scale, Some(guard_digits))
     }
 
     /// The one series loop behind [`log1p_fixed`] and
     /// [`log1p_fixed_tagged`].
     ///
-    /// `tag_at_guard` is `Some(guard)` to ask for the tag at the caller's sub-storage
-    /// granularity, `None` for the bare value. `None` keeps the untagged path's
+    /// `tag_at_guard` is `Some(guard_digits)` to ask for the tag at the caller's
+    /// sub-storage granularity, `None` for the bare value. `None` keeps the untagged path's
     /// arithmetic *exactly* what it was, for the reason [`expm1_fixed_inner`]
     /// documents: reading a rounding's direction costs a multiply-back, and the
     /// untagged path must not pay it.
@@ -539,7 +549,7 @@ use crate::support::rounding::RoundingMode;
     /// and it is unavoidable:
     ///
     /// ```text
-    /// u = round_div(t·10^w, 2·10^w + t)
+    /// u = round_div(argument·10^w, 2·10^w + argument)
     /// ```
     ///
     /// and that divide is **provably never exact for the tiny-`t` family**:
@@ -629,20 +639,21 @@ use crate::support::rounding::RoundingMode;
     ///   measuring the two against each other is not, which is what the probe
     ///   does.
     fn log1p_fixed_inner<S: BigInt>(
-        t: S,
-        w: u32,
+        argument: S,
+        working_scale: u32,
         tag_at_guard: Option<u32>,
     ) -> (S, Option<TailSign>)
     where
         S::Scratch: ComputeLimbs,
     {
         let want_tag = tag_at_guard.is_some();
-        let one_w = one::<S>(w);
-        let two_w = one_w + one_w;
-        let pow10_w = one_w;
+        let one_at_working_scale = one::<S>(working_scale);
+        let two_at_working_scale = one_at_working_scale + one_at_working_scale;
+        let pow10_at_working_scale = one_at_working_scale;
         // The seed divide, with the side its rounding left the true quotient
         // on. `div_cached` IS this with the side dropped.
-        let (u, div_side) = div_cached_sided::<S>(t, two_w + t, pow10_w);
+        let (u, div_side) = div_cached_sided::<S>(
+            argument, two_at_working_scale + argument, pow10_at_working_scale);
         // The side EVERY error term has to agree with: the dropped tail's,
         // which is `u`'s sign unconditionally (artanh's series does not
         // alternate). Read here so the loop can test each rounding against it;
@@ -655,15 +666,15 @@ use crate::support::rounding::RoundingMode;
         // `u²` feeds every term, so which way ITS rounding went gates all of
         // them.
         let (u2, u2_toward_zero) = if want_tag {
-            let prod = u.wrapping_mul_low_u128(u);
-            let scaled = round_div_pow10::<S>(prod, w);
-            (scaled, rounded_toward_zero::<S>(scaled, prod, one_w))
+            let product = u.wrapping_mul_low_u128(u);
+            let scaled = round_div_pow10::<S>(product, working_scale);
+            (scaled, rounded_toward_zero::<S>(scaled, product, one_at_working_scale))
         } else {
-            (mul::<S>(u, u, w), true)
+            (mul::<S>(u, u, working_scale), true)
         };
         let mut sum = u;
         let mut term = u;
-        let mut j: u128 = 1;
+        let mut term_index: u128 = 1;
         // Every rounding that has actually reached `sum` moved it TOWARD zero,
         // so the truth still lies on the away-from-zero side the dropped tail
         // is on. The seed divide is the first such term, and the only one whose
@@ -673,35 +684,36 @@ use crate::support::rounding::RoundingMode;
             Some(s) => s == tail_side,
         };
         loop {
-            // `j` is bounded by SERIES_CAP (20_000), so the cast to the
-            // generic `lit`'s i128 argument is lossless.
-            let d = lit::<S>((2 * j + 1) as i128);
+            // `term_index` is bounded by SERIES_CAP (20_000), so the cast to
+            // the generic `lit`'s i128 argument is lossless.
+            let divisor = lit::<S>((2 * term_index + 1) as i128);
             // `step_toward_zero`: this term's rounding did not push the partial
             // sum away from zero, so it cannot oppose the tail.
-            let (contrib, step_toward_zero) = if want_tag {
-                // The same value `mul::<S>(term, u2, w)` produces, with the
-                // direction of its rounding recorded on the way through.
-                let prod = term.wrapping_mul_low_u128(u2);
-                let scaled = round_div_pow10::<S>(prod, w);
-                let mul_toward_zero = rounded_toward_zero::<S>(scaled, prod, one_w);
+            let (contribution, step_toward_zero) = if want_tag {
+                // The same value `mul::<S>(term, u2, working_scale)` produces,
+                // with the direction of its rounding recorded on the way through.
+                let product = term.wrapping_mul_low_u128(u2);
+                let scaled = round_div_pow10::<S>(product, working_scale);
+                let mul_toward_zero =
+                    rounded_toward_zero::<S>(scaled, product, one_at_working_scale);
                 term = scaled;
                 // The division truncates, so it can only ever pull the term
                 // toward zero — the tail's own side. It is the one step that
                 // never needs testing, which is why its remainder is dropped.
-                let (q, _r) = div_rem_exact::<S>(term, d);
-                (q, mul_toward_zero && u2_toward_zero)
+                let (quotient, _remainder) = div_rem_exact::<S>(term, divisor);
+                (quotient, mul_toward_zero && u2_toward_zero)
             } else {
-                term = mul::<S>(term, u2, w);
-                (term / d, true)
+                term = mul::<S>(term, u2, working_scale);
+                (term / divisor, true)
             };
-            if contrib == zero::<S>() {
+            if contribution == zero::<S>() {
                 break;
             }
             // Only a term that is actually ADDED can carry error into `sum`.
             agree = agree && step_toward_zero;
-            sum = sum + contrib;
-            j += 1;
-            if j > SERIES_CAP {
+            sum = sum + contribution;
+            term_index += 1;
+            if term_index > SERIES_CAP {
                 break;
             }
         }
@@ -711,14 +723,15 @@ use crate::support::rounding::RoundingMode;
             // No tag asked for; no tail to carry a sign; or an argument whose
             // dropped terms need not share one.
             None => None,
-            Some(_) if u == zero::<S>() || u.abs() >= one_w => None,
+            Some(_) if u == zero::<S>() || u.abs() >= one_at_working_scale => None,
             // Every error term reaching `sum` pushes the same way, so their sum
             // does too — no magnitude comparison anywhere.
             Some(_) if agree => Some(tail_side),
             // They genuinely oppose, so the total turns on their SIZES — an
             // opposing term can cancel the rest or flip it — and no reading of
             // signs can see that. Measure it rather than assert it.
-            Some(guard) => side_by_deeper_probe::<S>(t, w, value, guard),
+            Some(guard_digits) => side_by_deeper_probe::<S>(
+                argument, working_scale, value, guard_digits),
         };
         (value, tag)
     }
@@ -780,7 +793,7 @@ use crate::support::rounding::RoundingMode;
         argument: S,
         working_scale: u32,
         shallow_value: S,
-        guard: u32,
+        guard_digits: u32,
     ) -> Option<TailSign>
     where
         S::Scratch: ComputeLimbs,
@@ -798,7 +811,7 @@ use crate::support::rounding::RoundingMode;
         // that build's 2-limb storage while this kernel probes in a far wider
         // work integer — the hazard `round_to_storage_*` already avoids the same
         // way.
-        let divisor = pow10::<S>(guard);
+        let divisor = pow10::<S>(guard_digits);
         let (_quotient, remainder) = div_rem_exact::<S>(shallow_value.abs(), divisor);
         if remainder != zero::<S>() && remainder + remainder != divisor {
             return None;
@@ -808,12 +821,14 @@ use crate::support::rounding::RoundingMode;
         // so twice that width plus the slack has to fit the work integer.
         // Inverting `bits(10^d) = d·log2(10) < (d·10 + 2)/3` for the largest
         // `d` that leaves room: `d ≤ 3·(BITS − slack)/20`.
-        let bits = u64::from(<S as BigInt>::BITS);
+        let work_integer_bits = u64::from(<S as BigInt>::BITS);
         // Fail closed on the (unreachable) overflow rather than fall back to a
         // depth the width cannot hold.
-        let deep_scale = u32::try_from(3 * bits.saturating_sub(TAG_PROBE_SLACK_BITS) / 20).ok()?;
+        let deep_scale =
+            u32::try_from(3 * work_integer_bits.saturating_sub(TAG_PROBE_SLACK_BITS) / 20).ok()?;
         // No room to probe any deeper than the value was already computed at.
-        let extra_digits = deep_scale.checked_sub(working_scale).filter(|e| *e > 0)?;
+        let extra_digits =
+            deep_scale.checked_sub(working_scale).filter(|digits| *digits > 0)?;
         let lift = pow10::<S>(extra_digits);
         let deep_value = log1p_fixed_inner::<S>(argument * lift, deep_scale, None).0;
         let gap = deep_value - shallow_value * lift;
@@ -878,7 +893,7 @@ use crate::support::rounding::RoundingMode;
         Below,
     }
 
-    /// `expm1(s) = exp(s) - 1` at working scale `w`, evaluated as the
+    /// `expm1(s) = exp(s) - 1` at `working_scale`, evaluated as the
     /// Taylor series with the leading `1` term dropped so the
     /// `exp(s) - 1` subtraction of two values both `~ 1` never occurs:
     /// `expm1(s) = s + s^2/2! + s^3/3! + ...`. For tiny `s` the result
@@ -895,11 +910,11 @@ use crate::support::rounding::RoundingMode;
     /// Reference: J.-M. Muller, *Elementary Functions* 3rd ed. (2016),
     /// 4.4; N. J. Higham, *Accuracy and Stability of Numerical
     /// Algorithms* 2nd ed. (2002), 1.14.1.
-    pub(crate) fn expm1_fixed<S: BigInt>(s: S, w: u32) -> S
+    pub(crate) fn expm1_fixed<S: BigInt>(reduced_arg: S, working_scale: u32) -> S
     where
         S::Scratch: ComputeLimbs,
     {
-        expm1_fixed_inner::<S>(s, w, false).0
+        expm1_fixed_inner::<S>(reduced_arg, working_scale, false).0
     }
 
     /// [`expm1_fixed`] plus the sign of the terms it DROPPED — see
@@ -908,11 +923,12 @@ use crate::support::rounding::RoundingMode;
     /// The sum is bit-identical to [`expm1_fixed`]'s at every argument; the
     /// tag is the only difference, and it is `None` whenever it cannot be
     /// justified (see [`expm1_fixed_inner`]).
-    pub(crate) fn expm1_fixed_tagged<S: BigInt>(s: S, w: u32) -> (S, Option<TailSign>)
+    pub(crate) fn expm1_fixed_tagged<S: BigInt>(
+        reduced_arg: S, working_scale: u32) -> (S, Option<TailSign>)
     where
         S::Scratch: ComputeLimbs,
     {
-        expm1_fixed_inner::<S>(s, w, true)
+        expm1_fixed_inner::<S>(reduced_arg, working_scale, true)
     }
 
     /// One step of the accumulated-error recurrence: the exact rational
@@ -927,7 +943,7 @@ use crate::support::rounding::RoundingMode;
     ///
     /// where `rho_j = prod - scaled * 10^w` is the `/10^w` rounding remainder
     /// and `r_j` the truncating `/j` remainder — both already in the loop's
-    /// hand. Substituting `eps_{j-1} = num/den` turns that into
+    /// hand. Substituting `eps_{j-1} = numerator/denominator` turns that into
     /// `(Z / 10^w - den * r_j) / (den * j)` with `Z = num * s - den * rho_j`,
     /// so the error stays a SMALL-denominator rational exactly while `10^w`
     /// divides `Z` — which is the whole reason it can be tracked at all in a
@@ -943,24 +959,24 @@ use crate::support::rounding::RoundingMode;
         eps: (S, i128),
         rho: S,
         rem_j: S,
-        j: i128,
-        s: S,
-        w: u32,
+        term_index: i128,
+        reduced_arg: S,
+        working_scale: u32,
     ) -> Option<(S, i128)>
     where
         S::Scratch: ComputeLimbs,
     {
-        let (num, den) = eps;
-        let z = num
-            .checked_mul(s)?
-            .checked_sub(lit::<S>(den).checked_mul(rho)?)?;
-        let (y, z_rem) = div_rem_exact::<S>(z, one::<S>(w));
-        if z_rem != zero::<S>() {
+        let (numerator, denominator) = eps;
+        let z = numerator
+            .checked_mul(reduced_arg)?
+            .checked_sub(lit::<S>(denominator).checked_mul(rho)?)?;
+        let (scaled_z, z_remainder) = div_rem_exact::<S>(z, one::<S>(working_scale));
+        if z_remainder != zero::<S>() {
             return None;
         }
         Some((
-            y.checked_sub(lit::<S>(den).checked_mul(rem_j)?)?,
-            den.checked_mul(j)?,
+            scaled_z.checked_sub(lit::<S>(denominator).checked_mul(rem_j)?)?,
+            denominator.checked_mul(term_index)?,
         ))
     }
 
@@ -971,14 +987,14 @@ use crate::support::rounding::RoundingMode;
     /// handful of terms, and the only thing ever read back out is whether the
     /// NUMERATOR is zero — which no common factor can change. `None` on any
     /// overflow, failing closed exactly as [`term_error`] does.
-    fn add_error<S: BigInt>(a: (S, i128), b: (S, i128)) -> Option<(S, i128)> {
-        let (a_num, a_den) = a;
-        let (b_num, b_den) = b;
+    fn add_error<S: BigInt>(lhs: (S, i128), rhs: (S, i128)) -> Option<(S, i128)> {
+        let (lhs_num, lhs_den) = lhs;
+        let (rhs_num, rhs_den) = rhs;
         Some((
-            a_num
-                .checked_mul(lit::<S>(b_den))?
-                .checked_add(b_num.checked_mul(lit::<S>(a_den))?)?,
-            a_den.checked_mul(b_den)?,
+            lhs_num
+                .checked_mul(lit::<S>(rhs_den))?
+                .checked_add(rhs_num.checked_mul(lit::<S>(lhs_den))?)?,
+            lhs_den.checked_mul(rhs_den)?,
         ))
     }
 
@@ -1015,7 +1031,8 @@ use crate::support::rounding::RoundingMode;
     ///
     /// It fails CLOSED — every caller treats `None` as "make no adjustment":
     ///
-    /// * `want_tag` was not asked for, or `s == 0` (`expm1(0) = 0`, no tail);
+    /// * `want_tag` was not asked for, or `reduced_arg == 0` (`expm1(0) = 0`,
+    ///   no tail);
     /// * `|s| > 1`, where `|s^j / j!|` is not yet monotonically decreasing,
     ///   so the tail need not carry its first term's sign;
     /// * the loop stopped at [`SERIES_CAP`] rather than because a term
@@ -1031,13 +1048,14 @@ use crate::support::rounding::RoundingMode;
     /// whenever it was not already zero — but it never enters the sum and so
     /// cannot contribute error. Counting it would leave the error non-zero on
     /// essentially every input and the tag permanently `None`.
-    fn expm1_fixed_inner<S: BigInt>(s: S, w: u32, want_tag: bool) -> (S, Option<TailSign>)
+    fn expm1_fixed_inner<S: BigInt>(
+        reduced_arg: S, working_scale: u32, want_tag: bool) -> (S, Option<TailSign>)
     where
         S::Scratch: ComputeLimbs,
     {
-        let mut sum = s;
-        let mut term = s;
-        let mut iter: u128 = 2;
+        let mut sum = reduced_arg;
+        let mut term = reduced_arg;
+        let mut term_index: u128 = 2;
         // The accumulated rounding error of the INCLUDED terms, as an exact
         // rational: `err` is the running total and `eps` the previous term's
         // own contribution (the recurrence needs it). `sum` is still the exact
@@ -1051,27 +1069,29 @@ use crate::support::rounding::RoundingMode;
         // first term of the neglected tail. `None` = the loop hit the cap.
         let mut vanished_at: ::core::option::Option<u128> = ::core::option::Option::None;
         loop {
-            // `iter` is bounded by SERIES_CAP (20_000), so the cast to the
-            // generic `lit`'s i128 argument is lossless.
-            let d = lit::<S>(iter as i128);
+            // `term_index` is bounded by SERIES_CAP (20_000), so the cast to
+            // the generic `lit`'s i128 argument is lossless.
+            let divisor = lit::<S>(term_index as i128);
             // `rho` / `rem_j`: this term's two rounding remainders — the one the
             // `÷10^w` shed and the one the truncating `÷j` shed. They are what
             // the error recurrence consumes; the untagged path never reads
             // them.
-            let (next, rho, rem_j) = if want_tag {
-                // The same value `mul::<S>(term, s, w) / d` produces, with the
-                // two remainders recorded on the way through.
-                let prod = term.wrapping_mul_low_u128(s);
-                let scaled = round_div_pow10::<S>(prod, w);
-                let back = scaled.wrapping_mul_low_u128(one::<S>(w));
-                let (q, r) = div_rem_exact::<S>(scaled, d);
-                (q, prod - back, r)
+            let (next_term, rho, rem_j) = if want_tag {
+                // The same value `mul::<S>(term, reduced_arg, working_scale)
+                // / divisor` produces, with the two remainders recorded on the
+                // way through.
+                let product = term.wrapping_mul_low_u128(reduced_arg);
+                let scaled = round_div_pow10::<S>(product, working_scale);
+                let reconstructed = scaled.wrapping_mul_low_u128(one::<S>(working_scale));
+                let (quotient, remainder) = div_rem_exact::<S>(scaled, divisor);
+                (quotient, product - reconstructed, remainder)
             } else {
-                (mul::<S>(term, s, w) / d, zero::<S>(), zero::<S>())
+                (mul::<S>(term, reduced_arg, working_scale) / divisor,
+                    zero::<S>(), zero::<S>())
             };
-            term = next;
+            term = next_term;
             if term == zero::<S>() {
-                vanished_at = ::core::option::Option::Some(iter);
+                vanished_at = ::core::option::Option::Some(term_index);
                 break;
             }
             // Only a term that is actually ADDED can carry error into `sum`,
@@ -1085,47 +1105,49 @@ use crate::support::rounding::RoundingMode;
             // previous rule wrote off as `None` anyway.
             let quiet = eps.0 == zero::<S>() && rho == zero::<S>() && rem_j == zero::<S>();
             if want_tag && !err_lost && !quiet {
-                match term_error::<S>(eps, rho, rem_j, iter as i128, s, w)
-                    .and_then(|e| add_error::<S>(err, e).map(|t| (e, t)))
+                match term_error::<S>(
+                    eps, rho, rem_j, term_index as i128, reduced_arg, working_scale)
+                    .and_then(|step| add_error::<S>(err, step).map(|total| (step, total)))
                 {
-                    ::core::option::Option::Some((e, t)) => {
-                        eps = e;
-                        err = t;
+                    ::core::option::Option::Some((step, total)) => {
+                        eps = step;
+                        err = total;
                     }
                     ::core::option::Option::None => err_lost = true,
                 }
             }
             sum = sum + term;
-            iter += 1;
-            if iter > SERIES_CAP {
+            term_index += 1;
+            if term_index > SERIES_CAP {
                 break;
             }
         }
         let tag = match vanished_at {
-            ::core::option::Option::Some(n)
+            ::core::option::Option::Some(vanish_index)
                 if want_tag
                     && !err_lost
                     && err.0 == zero::<S>()
-                    && s != zero::<S>()
-                    && s.abs() <= one::<S>(w) =>
+                    && reduced_arg != zero::<S>()
+                    && reduced_arg.abs() <= one::<S>(working_scale) =>
             {
                 // The tail is `s^n/n! + s^(n+1)/(n+1)! + ...`, alternating and
                 // strictly decreasing in magnitude for `|s| <= 1`, so it
                 // carries its first term's sign: positive throughout for
                 // `s > 0`, else `(-1)^n`.
-                ::core::option::Option::Some(if s > zero::<S>() || n % 2 == 0 {
-                    TailSign::Above
-                } else {
-                    TailSign::Below
-                })
+                ::core::option::Option::Some(
+                    if reduced_arg > zero::<S>() || vanish_index % 2 == 0 {
+                        TailSign::Above
+                    } else {
+                        TailSign::Below
+                    })
             }
             _ => ::core::option::Option::None,
         };
         (sum, tag)
     }
 
-    /// Argument-magnitude regime of `e^v` for a working-scale value `v_w`
-    /// at scale `w` in the work integer `S`, decided BEFORE the
+    /// Argument-magnitude regime of `e^v` for a `working_value`
+    /// at `working_scale` in the work integer `S`, decided BEFORE the
     /// `k = round(v / ln 2)` range-reduction division runs.
     ///
     /// [`exp_fixed`] / [`exp_internal_peak_bits`] first compute `k` with a
@@ -1145,16 +1167,16 @@ use crate::support::rounding::RoundingMode;
     ///   `e^v · 10^w < 2^BITS`, i.e. `v < BITS·ln 2 − w·ln 10`. With
     ///   `R = ⌊BITS·6932/10000⌋ + 1 − ⌊w·23025/10000⌋ ≥ BITS·ln 2 − w·ln 10`
     ///   (0.6932 over-approximates ln 2, 2.3025 under-approximates ln 10),
-    ///   and `|v| ≥ 2^(bl−1)/10^w` for `bl = bit_length(v_w)`, the result
-    ///   provably overflows `S` once
-    ///   `bl ≥ ⌈w·33220/10000⌉ + bits(R) + 2`
+    ///   and `|v| ≥ 2^(bl−1)/10^w` for `bit_len = bit_length(working_value)`,
+    ///   the result provably overflows `S` once
+    ///   `bit_len ≥ ⌈w·33220/10000⌉ + bits(R) + 2`
     ///   (because `2^(bl−1) ≥ 2^⌈w·3.3220⌉ · 2^bits(R) · 2 ≥ 10^w · R`,
     ///   with 3.3220 over-approximating log2 10 and `2^bits(R) ≥ R`).
     /// * **Underflow** (`v < 0`): `e^v < 10^−(w+1)` — strictly below the
     ///   working resolution — once `|v| ≥ (w+1)·ln 10`. With
     ///   `U = ⌊(w+1)·23026/10000⌋ + 1 ≥ (w+1)·ln 10` (2.3026 over-
     ///   approximates ln 10) the same bit-length argument gives the
-    ///   threshold `bl ≥ ⌈w·33220/10000⌉ + bits(U) + 2`.
+    ///   threshold `bit_len ≥ ⌈w·33220/10000⌉ + bits(U) + 2`.
     ///
     /// A cell that does NOT fire has `|v|` within a small constant factor of
     /// the fired bound, so `|k| = |v|/ln 2` stays of order `BITS` — every
@@ -1170,29 +1192,29 @@ use crate::support::rounding::RoundingMode;
         Underflow,
     }
 
-    /// Classifies `v_w` per [`ArgRegime`]'s analytic bounds. See the enum
-    /// docs for the derivation.
-    fn arg_regime<S: BigInt>(v_w: S, w: u32) -> ArgRegime {
-        if v_w == S::ZERO {
+    /// Classifies `working_value` per [`ArgRegime`]'s analytic bounds. See the
+    /// enum docs for the derivation.
+    fn arg_regime<S: BigInt>(working_value: S, working_scale: u32) -> ArgRegime {
+        if working_value == S::ZERO {
             return ArgRegime::Fits;
         }
-        let bl = bit_length::<S>(v_w) as u64;
+        let bit_len = bit_length::<S>(working_value) as u64;
         // ⌈w · log2(10)⌉, over-approximated (33220/10000 ≥ log2 10).
-        let w_bits = ((w as u64) * 33220).div_ceil(10000);
+        let working_scale_bits = ((working_scale as u64) * 33220).div_ceil(10000);
         // bits(x) = floor(log2 x) + 1, so 2^bits(x) ≥ x.
         let bits_of = |x: u64| 64 - x.leading_zeros() as u64;
-        if v_w > S::ZERO {
+        if working_value > S::ZERO {
             let bits_ln2 = (<S as BigInt>::BITS as u64) * 6932 / 10000 + 1;
-            let w_ln10 = (w as u64) * 23025 / 10000;
+            let scale_ln10 = (working_scale as u64) * 23025 / 10000;
             // R ≥ BITS·ln2 − w·ln10; clamp at 1 (a degenerate `w` no caller
             // forms — 10^w would not even fit S — but keep the math total).
-            let r = bits_ln2.saturating_sub(w_ln10).max(1);
-            if bl >= w_bits + bits_of(r) + 2 {
+            let overflow_arg_bound = bits_ln2.saturating_sub(scale_ln10).max(1);
+            if bit_len >= working_scale_bits + bits_of(overflow_arg_bound) + 2 {
                 return ArgRegime::Overflow;
             }
         } else {
-            let u = ((w as u64) + 1) * 23026 / 10000 + 1;
-            if bl >= w_bits + bits_of(u) + 2 {
+            let underflow_arg_bound = ((working_scale as u64) + 1) * 23026 / 10000 + 1;
+            if bit_len >= working_scale_bits + bits_of(underflow_arg_bound) + 2 {
                 return ArgRegime::Underflow;
             }
         }
@@ -1200,14 +1222,15 @@ use crate::support::rounding::RoundingMode;
     }
 
     /// True worst-case bit-width the [`exp_fixed`] body reaches internally
-    /// for a working-scale value `v_w` at scale `w`, in a work integer `S`
+    /// for a `working_value` at `working_scale`, in a work integer `S`
     /// of capacity `S::BITS` bits.
     ///
-    /// Mirrors [`exp_fixed`]'s own `k` / `extra` / `w_ext` arithmetic
-    /// EXACTLY (range-reduce `v = k·ln2 + s`, lift the working scale by
-    /// `extra` digits, run the Taylor squarings at `w_ext`, then reassemble
+    /// Mirrors [`exp_fixed`]'s own `k` / `extra_digits` /
+    /// `extended_working_scale` arithmetic EXACTLY (range-reduce
+    /// `v = k·ln2 + s`, lift the working scale by
+    /// `extra_digits`, run the Taylor squarings at the extended scale, then reassemble
     /// `2^k · exp(s)`), so the fit gate models the real squaring-reassembly
-    /// PEAK — `2·w_ext` decimal digits for the symmetric `sum²` plus the
+    /// PEAK — twice the extended scale in decimal digits for the symmetric `sum²` plus the
     /// `sum << k` shift — NOT just the final result magnitude. The body's
     /// `wrapping_sqr_low_u128` / `wrapping_mul_low_u128` return the low bits,
     /// so an internal peak that exceeds `S::BITS` silently TRUNCATES (an
@@ -1218,7 +1241,7 @@ use crate::support::rounding::RoundingMode;
     /// This is the width-generic single source for the peak estimate; the
     /// per-tier `decl_wide_transcendental!` `exp_internal_peak_bits` /
     /// `exp_fits_w` / `hyper_fits_w` gates delegate to it.
-    pub(crate) fn exp_internal_peak_bits<S: BigInt>(v_w: S, w: u32) -> u64 {
+    pub(crate) fn exp_internal_peak_bits<S: BigInt>(working_value: S, working_scale: u32) -> u64 {
         // Argument-magnitude pre-gate (see [`ArgRegime`]): a deep argument
         // must not reach the `k` division below — its quotient can exceed
         // `i128` and its dividend the divide scratch. BOTH non-`Fits`
@@ -1226,8 +1249,8 @@ use crate::support::rounding::RoundingMode;
         // result. For Underflow the VALUE is tiny, but this function models
         // the peak of the UNGATED per-tier body its `exp_fits_w` callers
         // would run — and that body's range reduction provisions
-        // `extra ≈ |k|·0.30103` digits even for a deep NEGATIVE `k`,
-        // pushing `w_ext` and the `k·ln2` term past the tier work integer
+        // `extra_digits ≈ |k|·0.30103` even for a deep NEGATIVE `k`,
+        // pushing the extended scale and the `k·ln2` term past the tier work integer
         // (an `Int: mul overflow`). Reporting "does not fit" keeps such a
         // cell on the wider-lift route the deep band always took, where
         // [`exp_fixed`]'s own pre-gate / `k < -1` short-circuit returns the
@@ -1241,84 +1264,87 @@ use crate::support::rounding::RoundingMode;
         // status-quo path, whose per-tier operands the build blanket has
         // always covered. The exact-scratch path ([`try_exp_fixed`]) feeds
         // its own `k` to [`exp_peak_bits_model`] instead.
-        if !matches!(arg_regime::<S>(v_w, w), ArgRegime::Fits) {
+        if !matches!(arg_regime::<S>(working_value, working_scale), ArgRegime::Fits) {
             return u64::MAX;
         }
-        let one_w_pre = one::<S>(w);
-        let l2_pre = ln2::<S>(w);
+        let one_at_working_scale = one::<S>(working_scale);
+        let ln2_at_working_scale = ln2::<S>(working_scale);
         let k = round_to_nearest_int_blanket(
-            round_div_blanket(v_w.wrapping_mul_low_u128(one_w_pre), l2_pre),
-            w,
+            round_div_blanket(
+                working_value.wrapping_mul_low_u128(one_at_working_scale),
+                ln2_at_working_scale),
+            working_scale,
         );
-        exp_peak_bits_model::<S>(w, k)
+        exp_peak_bits_model::<S>(working_scale, k)
     }
 
     /// Blanket-scratch sibling of [`round_div`] (the `Int` operator's own
     /// `div_rem`), kept ONLY for [`exp_internal_peak_bits`]'s macro-facing
     /// unbounded signature — see there.
-    fn round_div_blanket<S: BigInt>(n: S, d: S) -> S {
-        let (q, r) = n.div_rem(d);
-        if r == S::ZERO {
-            return q;
+    fn round_div_blanket<S: BigInt>(numerator: S, divisor: S) -> S {
+        let (quotient, remainder) = numerator.div_rem(divisor);
+        if remainder == S::ZERO {
+            return quotient;
         }
-        let ar = r.abs();
-        let comp = d.abs() - ar;
-        let cmp_r = if ar < comp {
+        let abs_remainder = remainder.abs();
+        let complement = divisor.abs() - abs_remainder;
+        let remainder_cmp = if abs_remainder < complement {
             ::core::cmp::Ordering::Less
-        } else if ar > comp {
+        } else if abs_remainder > complement {
             ::core::cmp::Ordering::Greater
         } else {
             ::core::cmp::Ordering::Equal
         };
-        let q_is_odd = q.bit(0);
-        let result_positive = (n < S::ZERO) == (d < S::ZERO);
+        let quotient_is_odd = quotient.bit(0);
+        let result_is_positive = (numerator < S::ZERO) == (divisor < S::ZERO);
         if crate::support::rounding::should_bump(
             RoundingMode::HalfToEven,
-            cmp_r,
-            q_is_odd,
-            result_positive,
+            remainder_cmp,
+            quotient_is_odd,
+            result_is_positive,
         ) {
-            if result_positive { q + S::ONE } else { q - S::ONE }
+            if result_is_positive { quotient + S::ONE } else { quotient - S::ONE }
         } else {
-            q
+            quotient
         }
     }
 
     /// Blanket-scratch sibling of [`round_to_nearest_int`] — see
     /// [`round_div_blanket`].
-    fn round_to_nearest_int_blanket<S: BigInt>(v: S, w: u32) -> i128 {
-        let divisor = pow10::<S>(w);
-        let (q, r) = v.div_rem(divisor);
+    fn round_to_nearest_int_blanket<S: BigInt>(working_value: S, working_scale: u32) -> i128 {
+        let divisor = pow10::<S>(working_scale);
+        let (quotient, remainder) = working_value.div_rem(divisor);
         let half = divisor >> 1;
-        let qi = if r.abs() >= half {
-            if v < S::ZERO { q - S::ONE } else { q + S::ONE }
+        let rounded_quotient = if remainder.abs() >= half {
+            if working_value < S::ZERO { quotient - S::ONE } else { quotient + S::ONE }
         } else {
-            q
+            quotient
         };
-        crate::int::types::traits::BigInt::to_i128(qi)
+        crate::int::types::traits::BigInt::to_i128(rounded_quotient)
     }
 
     /// Number of repeated-squaring levels the [`try_exp_fixed`] Taylor core
-    /// runs at working scale `w_ext`: the largest `n ≥ 1` with
-    /// `(n+1)² ≤ p_bits` for `p_bits = 3·w_ext + 1` (so `n ≈ √(3·w_ext)`).
+    /// runs at `extended_working_scale`: the largest `n ≥ 1` with
+    /// `(n+1)² ≤ level_bound` for `level_bound = 3·ext + 1` (so
+    /// `n ≈ √(3·ext)`).
     /// Shared by the body and the `k < 0` internal-peak clamp, which must
     /// evaluate the chain depth at the CLAMPED width.
-    fn squaring_levels(w_ext: u32) -> u32 {
-        let p_bits = w_ext.saturating_mul(3).saturating_add(1);
-        let mut n: u32 = 1;
-        while (n + 1) * (n + 1) <= p_bits {
-            n += 1;
+    fn squaring_levels(extended_working_scale: u32) -> u32 {
+        let level_bound = extended_working_scale.saturating_mul(3).saturating_add(1);
+        let mut levels: u32 = 1;
+        while (levels + 1) * (levels + 1) <= level_bound {
+            levels += 1;
         }
-        n
+        levels
     }
 
     /// The pure peak model for an ALREADY-computed range-reduction `k` —
     /// the divide-free tail of [`exp_internal_peak_bits`], shared with
     /// [`try_exp_fixed`] (which holds `k` from its own exact-scratch
     /// divide and must not re-derive it through the blanket).
-    fn exp_peak_bits_model<S: BigInt>(w: u32, k: i128) -> u64 {
+    fn exp_peak_bits_model<S: BigInt>(working_scale: u32, k: i128) -> u64 {
         let abs_k_u128 = if k < 0 { -k } else { k } as u128;
-        let extra: u32 = if abs_k_u128 == 0 {
+        let extra_digits: u32 = if abs_k_u128 == 0 {
             0
         } else {
             // Saturating: `Fits` bounds `|k|` to order `BITS`, far inside
@@ -1329,23 +1355,24 @@ use crate::support::rounding::RoundingMode;
             let capped = digits.min((<S as BigInt>::BITS / 4) as u128) as u32;
             capped + 12 + (capped >> 2)
         };
-        let w_ext = (w + extra) as u64;
+        let extended_working_scale = (working_scale + extra_digits) as u64;
         // digits → bits: `log2(10) ≈ 3.3220 ≈ 3322/1000`.
         // Squaring peak: the symmetric `sum²` before the round-divide spans
-        // `2·w_ext` decimal digits.
-        let sqr_bits = 2 * w_ext * 3322 / 1000;
-        // Reassembly peak: `sum << k` lifts the `w_ext`-digit Taylor sum by
+        // twice the extended scale in decimal digits.
+        let squaring_bits = 2 * extended_working_scale * 3322 / 1000;
+        // Reassembly peak: `sum << k` lifts the extended-scale Taylor sum by
         // `|k|` bits. Saturating narrowing, same upper-bound rationale as
         // the `digits` product above.
-        let reasm_bits =
-            (w_ext * 3322 / 1000).saturating_add(u64::try_from(abs_k_u128).unwrap_or(u64::MAX));
-        let peak = if sqr_bits > reasm_bits { sqr_bits } else { reasm_bits };
+        let reassembly_bits = (extended_working_scale * 3322 / 1000)
+            .saturating_add(u64::try_from(abs_k_u128).unwrap_or(u64::MAX));
+        let peak =
+            if squaring_bits > reassembly_bits { squaring_bits } else { reassembly_bits };
         // Small safety slack on top of the modelled peak. The model can
         // under-count the TRUE internal peak by only a few bits: `sum` can
-        // reach `√2·10^w_ext` (e^(ln2/2)), so the symmetric `sum²` reaches
-        // `2·10^(2·w_ext)` — `2·w_ext` digits PLUS the leading factor `2`
-        // (≈ +2 bits the `2·w_ext·3322/1000` digit count omits) — plus the
-        // half-LSB residue of the rounded `÷10^w_ext`. ~4 bits suffices to
+        // reach `√2·10^ext` (e^(ln2/2)), so the symmetric `sum²` reaches
+        // `2·10^(2·ext)` — `2·ext` digits PLUS the leading factor `2`
+        // (≈ +2 bits the `2·ext·3322/1000` digit count omits) — plus the
+        // half-LSB residue of the rounded `÷10^ext`. ~4 bits suffices to
         // keep `peak` an UPPER bound (so the gate never lets a genuine wrap
         // through); one u64 limb (64) is a generous, clean pad.
         //
@@ -1365,17 +1392,18 @@ use crate::support::rounding::RoundingMode;
     }
 
     /// Whether [`exp_fixed`]'s internal squaring-reassembly peak for
-    /// `(v_w, w)` fits the work integer `S` without wrapping. Used by the
-    /// per-tier `exp_fits_w` / `hyper_fits_w` regime-routing gates.
+    /// `(working_value, working_scale)` fits the work integer `S` without
+    /// wrapping. Used by the per-tier `exp_fits_w` / `hyper_fits_w`
+    /// regime-routing gates.
     #[inline]
-    pub(crate) fn exp_peak_fits<S: BigInt>(v_w: S, w: u32) -> bool {
-        exp_internal_peak_bits::<S>(v_w, w) < <S as BigInt>::BITS as u64
+    pub(crate) fn exp_peak_fits<S: BigInt>(working_value: S, working_scale: u32) -> bool {
+        exp_internal_peak_bits::<S>(working_value, working_scale) < <S as BigInt>::BITS as u64
     }
 
-    /// `e^v` for a working-scale value `v`, generic over the work
+    /// `e^v` for a `working_value`, generic over the work
     /// integer `S`. Mirrors the per-tier `$core::exp_fixed` exactly
     /// (range-reduce `v = k·ln2 + s`, extend the working scale by
-    /// `extra` to absorb the `2^k` amplification, run the
+    /// `extra_digits` to absorb the `2^k` amplification, run the
     /// repeated-squaring Taylor core, reassemble `2^k · exp(s)`), but
     /// stays width-generic so the caller can run it in a wider integer
     /// for the large-result regime.
@@ -1395,11 +1423,11 @@ use crate::support::rounding::RoundingMode;
     /// runs this in the WIDEST work integer it can (`Wexp` / `WNarrow`); the
     /// panic fires only when even that cannot hold the peak — a genuinely
     /// unrepresentable result.
-    pub(crate) fn exp_fixed<S: BigInt>(v_w: S, w: u32) -> S
+    pub(crate) fn exp_fixed<S: BigInt>(working_value: S, working_scale: u32) -> S
     where
         S::Scratch: ComputeLimbs,
     {
-        try_exp_fixed::<S>(v_w, w)
+        try_exp_fixed::<S>(working_value, working_scale)
             .unwrap_or_else(|| panic!("exp_generic::exp_fixed: result out of range"))
     }
 
@@ -1475,8 +1503,8 @@ use crate::support::rounding::RoundingMode;
         S::Scratch: ComputeLimbs,
     {
         if direct_series_pays::<S>(working_value, working_scale) {
-            let (expm1_value, tail) = expm1_fixed_tagged::<S>(working_value, working_scale);
-            (one::<S>(working_scale) + expm1_value, tail)
+            let (expm1_value, tail_sign) = expm1_fixed_tagged::<S>(working_value, working_scale);
+            (one::<S>(working_scale) + expm1_value, tail_sign)
         } else {
             (fallback(), None)
         }
@@ -1495,7 +1523,7 @@ use crate::support::rounding::RoundingMode;
     /// (their policy dispatch wrapper applies the default form's
     /// contractual panic), while [`exp_fixed`] panics directly for the
     /// unseamed callers — one detection, each wrapper applies its policy.
-    pub(crate) fn try_exp_fixed<S: BigInt>(v_w: S, w: u32) -> Option<S>
+    pub(crate) fn try_exp_fixed<S: BigInt>(working_value: S, working_scale: u32) -> Option<S>
     where
         S::Scratch: ComputeLimbs,
     {
@@ -1510,26 +1538,31 @@ use crate::support::rounding::RoundingMode;
         // the smallest positive working value exactly as the in-body
         // short-circuits below do (the caller's rounding turns it into 0,
         // or 1 ULP under Ceiling).
-        match arg_regime::<S>(v_w, w) {
+        match arg_regime::<S>(working_value, working_scale) {
             ArgRegime::Overflow => return None,
             ArgRegime::Underflow => return Some(lit::<S>(1)),
             ArgRegime::Fits => {}
         }
-        let one_w_pre = one::<S>(w);
-        let l2_pre = ln2::<S>(w);
-        let pow10_w_pre = one_w_pre;
-        let k = round_to_nearest_int(div_cached(v_w, l2_pre, pow10_w_pre), w);
+        let one_at_working_scale = one::<S>(working_scale);
+        let ln2_at_working_scale = ln2::<S>(working_scale);
+        let pow10_at_working_scale = one_at_working_scale;
+        let k = round_to_nearest_int(
+            div_cached(working_value, ln2_at_working_scale, pow10_at_working_scale),
+            working_scale);
         // Deep underflow: e^v < 10^-w, so its working value is sub-resolution. For
         // a very negative k the extra-guard range reduction below provisions
-        // `extra ≈ |k|·0.3` digits, pushing `w_ext` and the `k·ln2` term past the
+        // `extra_digits ≈ |k|·0.3`, pushing the extended scale and the `k·ln2`
+        // term past the
         // work integer S's capacity (an `Int: mul overflow`). Short-circuit to the
         // smallest positive working value, preserving the positive sub-resolution
         // so the caller rounds correctly (0 under nearest, the smallest positive
         // under Ceiling). Sufficient condition: e^v < 2^(k+1) <= 10^-w, i.e.
         // -(k+1)·log10(2) >= w  (log10(2) ≈ 30103/100000).
         if k < -1 {
-            let neg = (-(k + 1)) as u128;
-            if neg.saturating_mul(30103) >= (w as u128).saturating_mul(100_000) {
+            let underflow_depth = (-(k + 1)) as u128;
+            if underflow_depth.saturating_mul(30103)
+                >= (working_scale as u128).saturating_mul(100_000)
+            {
                 return Some(lit::<S>(1));
             }
         }
@@ -1548,11 +1581,11 @@ use crate::support::rounding::RoundingMode;
         // peak — a genuinely unrepresentable result. (`k < 0` is the
         // underflow direction, handled by the short-circuits above and
         // below — never out of range.)
-        if k >= 0 && exp_peak_bits_model::<S>(w, k) >= <S as BigInt>::BITS as u64 {
+        if k >= 0 && exp_peak_bits_model::<S>(working_scale, k) >= <S as BigInt>::BITS as u64 {
             return None;
         }
         let abs_k_u128 = if k < 0 { -k } else { k } as u128;
-        let extra: u32 = if abs_k_u128 == 0 {
+        let extra_digits: u32 = if abs_k_u128 == 0 {
             0
         } else {
             // Saturating for the same upper-bound reason as the peak model;
@@ -1564,41 +1597,43 @@ use crate::support::rounding::RoundingMode;
 
         // `k < 0` internal-peak clamp. The `k >= 0` gate above does not cover
         // the negative-`k` band, yet the squaring chain's peak grows with
-        // `w_ext = w + extra` REGARDLESS of `k`'s sign: every squaring forms
+        // `extended_working_scale = working_scale + extra_digits` REGARDLESS
+        // of `k`'s sign: every squaring forms
         // the full symmetric product `sum²` (`wrapping_sqr_low_u128`) BEFORE
-        // its `÷10^w_ext`, and `sum` reaches up to `√2·10^w_ext`
+        // its `÷10^ext`, and `sum` reaches up to `√2·10^ext`
         // (`e^(ln2/2)`, `s` at the range-reduction band edge), so the peak
-        // intermediate reaches `2·10^(2·w_ext)`. For a deep-negative `k` the
-        // un-clamped `extra ≈ 1.25·|k|·log10(2) + 12` pushes that peak past
+        // intermediate reaches `2·10^(2·ext)`. For a deep-negative `k` the
+        // un-clamped `extra_digits ≈ 1.25·|k|·log10(2) + 12` pushes that peak past
         // `S`'s capacity and the low-bits square WRAPS — `S`'s sign bit sets
         // and a NEGATIVE "e^x" is handed back (the exp(-62.175)·10^184
-        // Int<24> instance: `k = -90`, `extra = 47`, `w_ext = 231`,
-        // `e^s·10^462 = 1.0219·2^1535`). Bound the peak and clamp `extra` so
+        // Int<24> instance: `k = -90`, `extra_digits = 47`, `ext = 231`,
+        // `e^s·10^462 = 1.0219·2^1535`). Bound the peak and clamp the extra so
         // it provably fits; the clamp only ENGAGES where the un-clamped path
         // is past the provable-fit line, so every cell that fits today keeps
         // its bit-identical path.
         //
         // Capacity bound (sufficient no-wrap condition): the chain's largest
-        // intermediate is `sum² < 2·10^(2·w_ext)·(1+ε)` with
-        // `ε ≤ 2^(n+1)·(T+2)·10^-w_ext ≪ 2^-30` (the chain's accumulated
+        // intermediate is `sum² < 2·10^(2·ext)·(1+ε)` with
+        // `ε ≤ 2^(n+1)·(T+2)·10^-ext ≪ 2^-30` (the chain's accumulated
         // relative error, see the precision floor below), and the signed `S`
         // holds magnitudes below `2^(BITS-1)`. So it suffices that
-        //   bits(2.0…·10^(2·w_ext)) ≤ 2·w_ext·log2(10) + 2  ≤  BITS − 2.
+        //   bits(2.0…·10^(2·ext)) ≤ 2·ext·log2(10) + 2  ≤  BITS − 2.
         // With the rational over-approximation log2(10) < 3322/1000 this is
         // implied by the integer condition
-        //   w_ext · 6644 ≤ (BITS − 4) · 1000,
-        // i.e. `w_ext ≤ W_EXT_CAP = (BITS − 4)·1000 / 6644` (floor). For
+        //   ext · 6644 ≤ (BITS − 4) · 1000,
+        // i.e. `ext ≤ W_EXT_CAP = (BITS − 4)·1000 / 6644` (floor). For
         // Int<24> (BITS = 1536): W_EXT_CAP = 230 — worst-case peak
         // `2·10^460 = 0.0166·2^1535` (fits), while the defect instance's
-        // `w_ext = 231` reaches `1.0219·2^1535` (wraps). Every other
-        // intermediate is strictly smaller: `|v_ext| ≤ (|k|+1)·ln2·10^w_ext`
-        // (bits ≈ log2|k| + w_ext·3.33 ≪ 2·w_ext·3.32), the `k·ln2` term is
-        // the same size, and each Taylor `term·s_red` product is bounded by
-        // `sum²`'s width.
+        // `ext = 231` reaches `1.0219·2^1535` (wraps). Every other
+        // intermediate is strictly smaller:
+        // `|extended_working_value| ≤ (|k|+1)·ln2·10^ext`
+        // (bits ≈ log2|k| + ext·3.33 ≪ 2·ext·3.32), the `k·ln2` term is
+        // the same size, and each Taylor `term·halved_arg` product is bounded
+        // by `sum²`'s width.
         //
         // Precision floor (the clamp must not degrade correctness): with the
-        // clamped `extra_c` the kernel's absolute error at the caller's scale
-        // `w`, in units of `10^-w`, is bounded by
+        // clamped `clamped_extra_digits` the kernel's absolute error at the
+        // caller's `working_scale`, in units of `10^-w`, is bounded by
         //   err ≤ [√2·(2^n·(T+2) + |k|/2) · 2^-|k| + 1] · 10^-extra_c + 0.5
         // where `n = squaring_levels(w + extra_c)` (each squaring doubles the
         // chain's relative error and adds a half-unit rounding), `T ≤ 1.2·n+4`
@@ -1617,78 +1652,80 @@ use crate::support::rounding::RoundingMode;
         // established instance (w = 184, |k| = 90): extra_c = 230 − 184 = 46,
         // n = squaring_levels(230) = 26, deficit = max(0, 36 − 90) = 0,
         // floor = 1 ≤ 46 — the clamp delivers with margin.
-        let extra: u32 = if k >= 0 {
-            extra
+        let extra_digits: u32 = if k >= 0 {
+            extra_digits
         } else {
             let w_ext_cap = ((<S as BigInt>::BITS as u64 - 4) * 1000 / 6644) as u32;
-            if (w as u64) + (extra as u64) <= w_ext_cap as u64 {
+            if (working_scale as u64) + (extra_digits as u64) <= w_ext_cap as u64 {
                 // Peak provably fits — the unchanged, bit-identical path.
-                extra
+                extra_digits
             } else {
-                let extra_c = w_ext_cap.saturating_sub(w);
-                let n_c = squaring_levels(w + extra_c) as u64;
+                let clamped_extra_digits = w_ext_cap.saturating_sub(working_scale);
+                let clamped_levels =
+                    squaring_levels(working_scale + clamped_extra_digits) as u64;
                 // `|k|` is far below u64 here (`Fits` bounds it to order
                 // BITS); the `min` only keeps the cast total.
                 let abs_k_u64 = abs_k_u128.min(u64::MAX as u128) as u64;
-                let deficit_bits = (n_c + 10).saturating_sub(abs_k_u64);
-                let floor_extra = (deficit_bits * 30103).div_ceil(100_000) as u32 + 1;
-                if extra_c < floor_extra {
+                let deficit_bits = (clamped_levels + 10).saturating_sub(abs_k_u64);
+                let min_extra_digits = (deficit_bits * 30103).div_ceil(100_000) as u32 + 1;
+                if clamped_extra_digits < min_extra_digits {
                     return None;
                 }
-                extra_c
+                clamped_extra_digits
             }
         };
 
-        let w_ext = w + extra;
-        let v_ext = if extra == 0 {
-            v_w
+        let extended_working_scale = working_scale + extra_digits;
+        let extended_working_value = if extra_digits == 0 {
+            working_value
         } else {
-            v_w * pow10::<S>(extra)
+            working_value * pow10::<S>(extra_digits)
         };
-        let one_w = one::<S>(w_ext);
-        let l2 = ln2::<S>(w_ext);
-        let s = v_ext - scale_by_k(l2, k);
+        let one_at_extended_scale = one::<S>(extended_working_scale);
+        let ln2_at_extended_scale = ln2::<S>(extended_working_scale);
+        let reduced_arg = extended_working_value - scale_by_k(ln2_at_extended_scale, k);
 
-        let n = squaring_levels(w_ext);
+        let levels = squaring_levels(extended_working_scale);
 
-        let s_red = s >> n;
-        let mut sum = one_w + s_red;
-        let mut term = s_red;
-        let mut iter: u128 = 2;
+        let halved_arg = reduced_arg >> levels;
+        let mut sum = one_at_extended_scale + halved_arg;
+        let mut term = halved_arg;
+        let mut term_index: u128 = 2;
         loop {
-            term = mul(term, s_red, w_ext) / lit::<S>(iter as i128);
+            term = mul(term, halved_arg, extended_working_scale)
+                / lit::<S>(term_index as i128);
             if term == S::ZERO {
                 break;
             }
             sum = sum + term;
-            iter += 1;
-            if iter > SERIES_CAP {
+            term_index += 1;
+            if term_index > SERIES_CAP {
                 break;
             }
         }
 
         let mut squared = sum;
         let mut i = 0;
-        while i < n {
+        while i < levels {
             // Dedicated low-half symmetric SQUARE through the limb-width
             // matcher (`wrapping_sqr_low_u128` → `int::policy::sqr_low`): the
             // u128-packed `sqr_low_limb` on even work widths (half the limbs),
             // bit-identical to the low-`BITS` of `x²`. The squaring sibling of
             // the Taylor `mul`'s `wrapping_mul_low_u128`; feeds the same divide.
-            squared = round_div_pow10(squared.wrapping_sqr_low_u128(), w_ext);
+            squared = round_div_pow10(squared.wrapping_sqr_low_u128(), extended_working_scale);
             i += 1;
         }
         let sum = squared;
 
-        let scaled_at_w_ext = if k >= 0 {
+        let exp_at_extended_scale = if k >= 0 {
             let shift = k as u32;
             if bit_length(sum) + shift >= <S as BigInt>::BITS {
                 return None;
             }
             sum << shift
         } else {
-            let neg_k = -k as u128;
-            if neg_k >= bit_length(sum) as u128 {
+            let right_shift_bits = -k as u128;
+            if right_shift_bits >= bit_length(sum) as u128 {
                 // Deep underflow: e^x (x < 0 here, since k < 0) is strictly
                 // positive but below the working resolution. Return the
                 // smallest positive working value (1 = 10^-w), NOT zero, so the
@@ -1699,12 +1736,12 @@ use crate::support::rounding::RoundingMode;
                 // — the hyperbolics call `exp_fixed` on |x| >= 0.
                 return Some(lit::<S>(1));
             }
-            sum >> (neg_k as u32)
+            sum >> (right_shift_bits as u32)
         };
-        let result = if extra == 0 {
-            scaled_at_w_ext
+        let exp_value = if extra_digits == 0 {
+            exp_at_extended_scale
         } else {
-            round_div_pow10(scaled_at_w_ext, extra)
+            round_div_pow10(exp_at_extended_scale, extra_digits)
         };
         // e^v > 0 for every finite v: a zero result here is genuine underflow
         // of `e^(negative)` below the working resolution, not a true zero.
@@ -1713,14 +1750,14 @@ use crate::support::rounding::RoundingMode;
         // correctly-rounded defect). Restricted to `k < 0`: for `k >= 0`,
         // `e^v >= 1`, so a 0 result would mean the working width overflowed,
         // and masking it as 1 would hide the defect rather than fix it.
-        if k < 0 && result == zero::<S>() {
+        if k < 0 && exp_value == zero::<S>() {
             Some(lit::<S>(1))
         } else {
-            Some(result)
+            Some(exp_value)
         }
     }
 
-    /// Narrows a `Wexp`-computed working value `v` back down to the tier's
+    /// Narrows a `Wexp`-computed `value` back down to the tier's
     /// own work integer `Dst`, panicking UNIFORMLY when it does not fit.
     ///
     /// The wide `exp` / hyperbolic compositions evaluate in the wider `Wexp`
@@ -1748,17 +1785,17 @@ use crate::support::rounding::RoundingMode;
     /// exact: a value needing `≥ Dst::BITS` significant bits cannot fit the
     /// signed `Dst`.
     #[inline]
-    pub(crate) fn resize_or_panic<Src: BigInt, Dst: BigInt>(v: Src) -> Dst {
-        if bit_length::<Src>(v.abs()) >= <Dst as BigInt>::BITS {
+    pub(crate) fn resize_or_panic<Src: BigInt, Dst: BigInt>(value: Src) -> Dst {
+        if bit_length::<Src>(value.abs()) >= <Dst as BigInt>::BITS {
             panic!("exp_generic: result out of range");
         }
-        <Src as BigInt>::resize_to::<Dst>(v)
+        <Src as BigInt>::resize_to::<Dst>(value)
     }
 
-    /// `(a · 10^w) / b`, rounded half-to-even (the generic sibling of
-    /// the per-tier `$core::div`).
+    /// `(numerator · 10^working_scale) / divisor`, rounded half-to-even (the
+    /// generic sibling of the per-tier `$core::div`).
     #[inline]
-    pub(crate) fn div<S: BigInt>(a: S, b: S, w: u32) -> S
+    pub(crate) fn div<S: BigInt>(numerator: S, divisor: S, working_scale: u32) -> S
     where
         S::Scratch: ComputeLimbs,
     {
@@ -1767,66 +1804,74 @@ use crate::support::rounding::RoundingMode;
         // the numerator product is the u128-packed truncated-low mul (the
         // macro `div`'s kernel) so routing through the policy costs no
         // multiply speed.
-        round_div(a.wrapping_mul_low_u128(pow10::<S>(w)), b)
+        round_div(numerator.wrapping_mul_low_u128(pow10::<S>(working_scale)), divisor)
     }
 
-    /// `sinh(|x|)` at working scale `w` for a non-negative working
-    /// value `av_w` (= `|x|·10^w`), computed entirely in `S`:
+    /// `sinh(|x|)` at `working_scale` for a non-negative
+    /// `abs_working_value` (= `|x|·10^w`), computed entirely in `S`:
     /// `(e^|x| − e^-|x|)/2`. The dominant `e^|x|` term is evaluated
     /// directly (`exp_fixed`) and the small `e^-|x|` via reciprocal, so
     /// the small term's relative error stays a small *absolute* error.
-    pub(crate) fn sinh_pos<S: BigInt>(av_w: S, w: u32) -> S
+    pub(crate) fn sinh_pos<S: BigInt>(abs_working_value: S, working_scale: u32) -> S
     where
         S::Scratch: ComputeLimbs,
     {
-        let ex = exp_fixed::<S>(av_w, w);
-        let enx = div(one::<S>(w), ex, w);
-        (ex - enx) >> 1
+        let exp_x = exp_fixed::<S>(abs_working_value, working_scale);
+        let exp_neg_x = div(one::<S>(working_scale), exp_x, working_scale);
+        (exp_x - exp_neg_x) >> 1
     }
 
-    /// `cosh(|x|) = (e^|x| + e^-|x|)/2` at working scale `w`. See
+    /// `cosh(|x|) = (e^|x| + e^-|x|)/2` at `working_scale`. See
     /// [`sinh_pos`].
-    pub(crate) fn cosh_pos<S: BigInt>(av_w: S, w: u32) -> S
+    pub(crate) fn cosh_pos<S: BigInt>(abs_working_value: S, working_scale: u32) -> S
     where
         S::Scratch: ComputeLimbs,
     {
-        let ex = exp_fixed::<S>(av_w, w);
-        let enx = div(one::<S>(w), ex, w);
-        (ex + enx) >> 1
+        let exp_x = exp_fixed::<S>(abs_working_value, working_scale);
+        let exp_neg_x = div(one::<S>(working_scale), exp_x, working_scale);
+        (exp_x + exp_neg_x) >> 1
     }
 
-    /// `tanh(|x|) = (e^|x| − e^-|x|)/(e^|x| + e^-|x|)` at working scale
-    /// `w`. See [`sinh_pos`].
-    pub(crate) fn tanh_pos<S: BigInt>(av_w: S, w: u32) -> S
+    /// `tanh(|x|) = (e^|x| − e^-|x|)/(e^|x| + e^-|x|)` at
+    /// `working_scale`. See [`sinh_pos`].
+    pub(crate) fn tanh_pos<S: BigInt>(abs_working_value: S, working_scale: u32) -> S
     where
         S::Scratch: ComputeLimbs,
     {
-        let one_w = one::<S>(w);
+        let one_at_working_scale = one::<S>(working_scale);
         // Past the all-nines saturation onset |x| ≳ ln(10)/2·w ≈ 1.1513·w,
         // tanh(|x|) rounds to 1 − 10^−w; return that directly.
-        let thr_x = (w as i128) * 1152 / 1000 + 2;
-        let saturated = one_w - lit::<S>(1);
+        let saturation_bound = (working_scale as i128) * 1152 / 1000 + 2;
+        let saturated = one_at_working_scale - lit::<S>(1);
         // `div_rem_exact` (not the `/` operator) — the narrow build's
         // blanket divide scratch is below this work width.
-        if div_rem_exact(av_w, one_w).0 > lit::<S>(thr_x) {
+        if div_rem_exact(abs_working_value, one_at_working_scale).0
+            > lit::<S>(saturation_bound)
+        {
             return saturated;
         }
-        // Below `thr_x` use the negative-exponent identity tanh(|x|) =
+        // Below `saturation_bound` use the negative-exponent identity tanh(|x|) =
         // (1 − m)/(1 + m), m = e^(−2|x|). Forming the dominant e^(+|x|) directly
         // overflows the work integer `S` once |x| ≳ (S::BITS·ln2 − w·ln10)/ln10,
         // which at high scale on a deep tier (w ≳ 0.67·S digits, e.g. D1232<924>)
-        // is BELOW `thr_x` — a panic GAP. `m` is tiny and is formed by `exp_fixed`
+        // is BELOW `saturation_bound` — a panic GAP. `exp_neg_2x` is tiny and is
+        // formed by `exp_fixed`
         // on the NEGATIVE argument −2|x| (its 2^k reassembly shifts DOWN, never
         // the overflowing up-shift), so e^(+|x|) is never formed; the identity is
         // the exact tanh. Mirrors `trig_series_2limb::tanh_with_raw` (the narrow
-        // path). `m == 0` (defensive: unreachable since `exp_fixed` on a negative argument
-        // returns >= 1 via the ArgRegime::Underflow short-circuit in
-        // `try_exp_fixed` -- retained as a belt-and-suspenders guard).
-        let m = exp_fixed::<S>(-(av_w + av_w), w);
-        if m == lit::<S>(0) {
+        // path). `exp_neg_2x == 0` (defensive: unreachable since `exp_fixed` on a
+        // negative argument returns >= 1 via the ArgRegime::Underflow
+        // short-circuit in `try_exp_fixed` -- retained as a belt-and-suspenders
+        // guard).
+        let exp_neg_2x =
+            exp_fixed::<S>(-(abs_working_value + abs_working_value), working_scale);
+        if exp_neg_2x == lit::<S>(0) {
             return saturated;
         }
-        div(one_w - m, one_w + m, w)
+        div(
+            one_at_working_scale - exp_neg_2x,
+            one_at_working_scale + exp_neg_2x,
+            working_scale)
     }
 
 #[cfg(test)]
@@ -1849,18 +1894,19 @@ mod tests {
     #[test]
     fn round_div_sided_reports_the_side_the_rounding_left_the_truth_on() {
         type I = Int<2>;
-        let d = |n: i128, m: i128| round_div_sided::<I>(lit::<I>(n), lit::<I>(m));
+        let sided = |numerator: i128, divisor: i128|
+            round_div_sided::<I>(lit::<I>(numerator), lit::<I>(divisor));
 
         // 7/3 = 2.333… — keeps q = 2, so the truth is above what came back.
-        assert_eq!(d(7, 3), (lit::<I>(2), Some(TailSign::Above)));
+        assert_eq!(sided(7, 3), (lit::<I>(2), Some(TailSign::Above)));
         // 8/3 = 2.667… — bumps to 3, a full unit past the truth.
-        assert_eq!(d(8, 3), (lit::<I>(3), Some(TailSign::Below)));
+        assert_eq!(sided(8, 3), (lit::<I>(3), Some(TailSign::Below)));
         // -7/3 — the same truncation as +7/3, opposite side.
-        assert_eq!(d(-7, 3), (lit::<I>(-2), Some(TailSign::Below)));
+        assert_eq!(sided(-7, 3), (lit::<I>(-2), Some(TailSign::Below)));
         // -8/3 — bumps to -3, past the truth, which is above it.
-        assert_eq!(d(-8, 3), (lit::<I>(-3), Some(TailSign::Above)));
+        assert_eq!(sided(-8, 3), (lit::<I>(-3), Some(TailSign::Above)));
         // Exact: no side to report.
-        assert_eq!(d(6, 3), (lit::<I>(2), None));
+        assert_eq!(sided(6, 3), (lit::<I>(2), None));
     }
 
     /// The tail-sign channel FIRES for the family that needs it, and reports
@@ -1888,10 +1934,10 @@ mod tests {
     #[test]
     fn log1p_fixed_tagged_reports_opposite_sides_at_the_two_signs() {
         type I = Int<2>;
-        let w: u32 = 12;
-        let t = pow10::<I>(8);
+        let working_scale: u32 = 12;
+        let argument = pow10::<I>(8);
 
-        let (pos, pos_tag) = log1p_fixed_tagged::<I>(t, w, GRANULARITY);
+        let (pos, pos_tag) = log1p_fixed_tagged::<I>(argument, working_scale, GRANULARITY);
         assert_eq!(pos, lit::<I>(2 * 49_997_500), "log1p(+1e-4) at w=12 is 2u");
         assert_eq!(
             pos_tag,
@@ -1899,7 +1945,7 @@ mod tests {
             "a truncated seed divide and a positive tail both put the truth ABOVE"
         );
 
-        let (neg, neg_tag) = log1p_fixed_tagged::<I>(-t, w, GRANULARITY);
+        let (neg, neg_tag) = log1p_fixed_tagged::<I>(-argument, working_scale, GRANULARITY);
         assert_eq!(neg, lit::<I>(-2 * 50_002_500), "log1p(-1e-4) at w=12 is 2u");
         assert_eq!(
             neg_tag,
@@ -1909,8 +1955,8 @@ mod tests {
 
         // The untagged wrapper is the tagged kernel with the tag dropped —
         // the value must not move.
-        assert_eq!(log1p_fixed::<I>(t, w), pos);
-        assert_eq!(log1p_fixed::<I>(-t, w), neg);
+        assert_eq!(log1p_fixed::<I>(argument, working_scale), pos);
+        assert_eq!(log1p_fixed::<I>(-argument, working_scale), neg);
     }
 
     /// The `k < 0` internal-peak wrap: a
@@ -1928,12 +1974,12 @@ mod tests {
     #[test]
     fn exp_fixed_k_negative_internal_peak_clamped_int24() {
         // v = -62.175 · 10^184 = -62175 · 10^181
-        let w: u32 = 184;
-        let v = lit::<Int<24>>(-62175) * pow10::<Int<24>>(181);
-        let r = try_exp_fixed::<Int<24>>(v, w)
+        let working_scale: u32 = 184;
+        let working_value = lit::<Int<24>>(-62175) * pow10::<Int<24>>(181);
+        let exp_value = try_exp_fixed::<Int<24>>(working_value, working_scale)
             .expect("in-range e^-62.175 at w=184 must not signal out-of-range");
         assert!(
-            r > zero::<Int<24>>(),
+            exp_value > zero::<Int<24>>(),
             "e^-62.175 must be strictly positive (a negative value is the wrap)"
         );
         // Tight oracle window: 9948110203481228920 · 10^138 < r·10^-184·10^184
@@ -1942,7 +1988,7 @@ mod tests {
         let lo = lit::<Int<24>>(9_948_110_203_481_228_920) * pow10::<Int<24>>(138);
         let hi = lit::<Int<24>>(9_948_110_203_481_228_921) * pow10::<Int<24>>(138);
         assert!(
-            r > lo && r < hi,
+            exp_value > lo && exp_value < hi,
             "e^-62.175 · 10^184 outside its 19-digit oracle window"
         );
     }
@@ -1960,13 +2006,13 @@ mod tests {
     #[cfg(any(feature = "d115", feature = "wide"))]
     #[test]
     fn exp_fixed_deep_negative_large_working_scale_int64() {
-        let w: u32 = 200;
-        let v = lit::<Int<64>>(-357) * pow10::<Int<64>>(w);
-        let r = exp_fixed::<Int<64>>(v, w);
+        let working_scale: u32 = 200;
+        let working_value = lit::<Int<64>>(-357) * pow10::<Int<64>>(working_scale);
+        let exp_value = exp_fixed::<Int<64>>(working_value, working_scale);
         // 357·log10(e) ≈ 155.057, so 10^44 < e^-357 · 10^200 < 10^45.
-        assert!(r > zero::<Int<64>>(), "e^-357 must stay strictly positive");
+        assert!(exp_value > zero::<Int<64>>(), "e^-357 must stay strictly positive");
         assert!(
-            r > pow10::<Int<64>>(44) && r < pow10::<Int<64>>(45),
+            exp_value > pow10::<Int<64>>(44) && exp_value < pow10::<Int<64>>(45),
             "e^-357 at working scale 200 out of its analytic bounds"
         );
     }
@@ -1998,19 +2044,22 @@ mod tests {
     #[test]
     fn log1p_fixed_tagged_fires_when_an_included_term_was_rounded() {
         type I = Int<2>;
-        let w: u32 = 12;
-        let one_w = one::<I>(w);
+        let working_scale: u32 = 12;
+        let one_at_working_scale = one::<I>(working_scale);
 
         // `u²` inexact + at least one term added: the two conditions that
         // together made the exactness gate refuse these arguments.
-        let refused_by_the_exactness_gate = |t: I| -> bool {
-            let (u, _side) = div_cached_sided::<I>(t, one_w + one_w + t, one_w);
-            let prod = u.wrapping_mul_low_u128(u);
-            let u2 = round_div_pow10::<I>(prod, w);
-            let u2_inexact = u2.wrapping_mul_low_u128(one_w) != prod;
-            let term = round_div_pow10::<I>(u.wrapping_mul_low_u128(u2), w);
-            let (first_contrib, _r) = div_rem_exact::<I>(term, lit::<I>(3));
-            u2_inexact && first_contrib != zero::<I>()
+        let refused_by_the_exactness_gate = |argument: I| -> bool {
+            let (u, _side) = div_cached_sided::<I>(
+                argument,
+                one_at_working_scale + one_at_working_scale + argument,
+                one_at_working_scale);
+            let product = u.wrapping_mul_low_u128(u);
+            let u2 = round_div_pow10::<I>(product, working_scale);
+            let u2_inexact = u2.wrapping_mul_low_u128(one_at_working_scale) != product;
+            let term = round_div_pow10::<I>(u.wrapping_mul_low_u128(u2), working_scale);
+            let (first_contribution, _remainder) = div_rem_exact::<I>(term, lit::<I>(3));
+            u2_inexact && first_contribution != zero::<I>()
         };
 
         let pos = lit::<I>(3) * pow10::<I>(8); // t = +3·10⁻⁴
@@ -2018,7 +2067,7 @@ mod tests {
             refused_by_the_exactness_gate(pos),
             "the positive argument must be one the exactness gate refused"
         );
-        let (pos_v, pos_tag) = log1p_fixed_tagged::<I>(pos, w, GRANULARITY);
+        let (pos_v, pos_tag) = log1p_fixed_tagged::<I>(pos, working_scale, GRANULARITY);
         assert_eq!(pos_v, lit::<I>(299_955_008), "log1p(3e-4) at w=12");
         assert_eq!(
             pos_tag,
@@ -2031,7 +2080,7 @@ mod tests {
             refused_by_the_exactness_gate(neg),
             "the negative argument must be one the exactness gate refused"
         );
-        let (neg_v, neg_tag) = log1p_fixed_tagged::<I>(neg, w, GRANULARITY);
+        let (neg_v, neg_tag) = log1p_fixed_tagged::<I>(neg, working_scale, GRANULARITY);
         assert_eq!(neg_v, lit::<I>(-400_080_020), "log1p(-4e-4) at w=12");
         assert_eq!(
             neg_tag,
@@ -2041,7 +2090,7 @@ mod tests {
 
         // The untagged wrapper is the tagged kernel with the tag dropped — the
         // value must not move on either argument.
-        assert_eq!(log1p_fixed::<I>(pos, w), pos_v);
-        assert_eq!(log1p_fixed::<I>(neg, w), neg_v);
+        assert_eq!(log1p_fixed::<I>(pos, working_scale), pos_v);
+        assert_eq!(log1p_fixed::<I>(neg, working_scale), neg_v);
     }
 }

--- a/src/algos/exp/exp_schoolbook.rs
+++ b/src/algos/exp/exp_schoolbook.rs
@@ -12,7 +12,8 @@
 //! 2. **Direct Maclaurin series**: compute
 //!    `exp(s) = 1 + s + s²/2! + s³/3! + …`
 //!    term-by-term, dividing each accumulated term by the loop counter
-//!    `i`, until the contribution rounds to zero at the working precision.
+//!    `term_index`, until the contribution rounds to zero at the working
+//!    precision.
 //!    No Smith/Brent argument-halving squarings — the loop runs to
 //!    convergence on the range-reduced argument directly.
 //! 3. **Reconstruct**: `exp(x) = 2^k · exp(s)`, applied as a bit-shift on
@@ -47,45 +48,46 @@ use crate::support::rounding::RoundingMode;
 pub(crate) const SCHOOLBOOK_GUARD: u32 = 30;
 
 /// `eˣ` via direct Maclaurin series on the 256-bit `Fixed` intermediate,
-/// returned at working scale `w`.
+/// returned at `working_scale`.
 ///
 /// Range-reduces `x = k·ln(2) + s` with `|s| ≤ ln(2)/2`, evaluates
-/// `exp(s) = Σ sⁱ/i!` term-by-term until terms vanish at scale `w`, then
-/// reconstructs `exp(x) = 2^k · exp(s)` by shifting the `Fixed` magnitude.
-/// No Smith squarings; the loop terminates by convergence on the
-/// range-reduced argument.
+/// `exp(s) = Σ sⁱ/i!` term-by-term until terms vanish at `working_scale`,
+/// then reconstructs `exp(x) = 2^k · exp(s)` by shifting the `Fixed`
+/// magnitude. No Smith squarings; the loop terminates by convergence on
+/// the range-reduced argument.
 ///
 /// # Panics
 ///
 /// Panics if the reconstructed value overflows a 256-bit `Fixed`.
-pub(crate) fn exp_schoolbook_fixed(v_w: Fixed, w: u32) -> Fixed {
-    let one_w = Fixed { negative: false, mag: Fixed::pow10(w) };
-    let ln2 = wide_ln2(w);
+pub(crate) fn exp_schoolbook_fixed(working_value: Fixed, working_scale: u32) -> Fixed {
+    let one_at_working_scale =
+        Fixed { negative: false, mag: Fixed::pow10(working_scale) };
+    let ln2 = wide_ln2(working_scale);
 
     // Range reduction: k = round(v / ln 2); s = v - k·ln(2), |s| <= ln(2)/2.
-    let k = v_w.div(ln2, w).round_to_nearest_int(w);
+    let k = working_value.div(ln2, working_scale).round_to_nearest_int(working_scale);
     let k_ln2 = if k >= 0 {
         ln2.mul_u128(k as u128)
     } else {
         ln2.mul_u128((-k) as u128).neg()
     };
-    let s = v_w.sub(k_ln2);
+    let reduced_arg = working_value.sub(k_ln2);
 
     // Direct Maclaurin series: exp(s) = 1 + s + s²/2! + s³/3! + …
     // term[i] = s^i / i!  is computed iteratively as  term[i] = term[i-1]*s/i.
-    let mut sum = one_w.add(s); // 1 + s (i=0 and i=1 terms)
-    let mut term = s; // term[1] = s
-    let mut i: u128 = 2;
+    let mut sum = one_at_working_scale.add(reduced_arg); // 1 + s (i=0 and i=1 terms)
+    let mut term = reduced_arg; // term[1] = s
+    let mut term_index: u128 = 2;
     loop {
-        term = term.mul(s, w).div_small(i);
+        term = term.mul(reduced_arg, working_scale).div_small(term_index);
         if term.is_zero() {
             break;
         }
         sum = sum.add(term);
-        i += 1;
+        term_index += 1;
         // Safety cap — at w=68 the loop needs ~110 iterations for |s|<=ln2/2.
         // 300 is far above any reachable working scale, so this is defensive.
-        if i > 300 {
+        if term_index > 300 {
             break;
         }
     }
@@ -124,15 +126,16 @@ pub(crate) fn exp_schoolbook<C: WideTrigCore, const SCALE: u32>(
     // line (`raw == 0` is pinned above) — so a zero working residual is a
     // sub-resolution artifact; the never-exact narrowing keeps Ceiling correct
     // on inputs whose deciding residual is below the work-int resolution.
-    C::round_to_storage_directed_never_exact(C::GUARD, SCALE, mode, &mut |guard| {
-        C::exp_fixed::<SCALE>(C::to_work_scaled(raw, guard), SCALE + guard)
+    C::round_to_storage_directed_never_exact(C::GUARD, SCALE, mode, &mut |guard_digits| {
+        C::exp_fixed::<SCALE>(C::to_work_scaled(raw, guard_digits), SCALE + guard_digits)
     })
 }
 
 /// `D38` schoolbook `eˣ` with explicit working digits and rounding mode.
 ///
 /// Accepts raw `Int<2>` storage at `scale`, evaluates in a `Fixed`
-/// intermediate at `w = scale + working_digits`, and rounds back to `scale`.
+/// intermediate at `working_scale = scale + working_digits`, and rounds
+/// back to `scale`.
 #[allow(dead_code)]
 pub(crate) fn exp_schoolbook_with(
     raw: Int<2>,
@@ -140,18 +143,18 @@ pub(crate) fn exp_schoolbook_with(
     working_digits: u32,
     mode: RoundingMode,
 ) -> Int<2> {
-    let raw_i = raw.as_i128();
-    if raw_i == 0 {
+    let raw_i128 = raw.as_i128();
+    if raw_i128 == 0 {
         return Int::<2>::from_i128(10_i128.pow(scale));
     }
-    let w = scale + working_digits;
-    let negative_input = raw_i < 0;
-    let v_w = Fixed::from_u128_mag(raw_i.unsigned_abs(), false)
+    let working_scale = scale + working_digits;
+    let negative_input = raw_i128 < 0;
+    let working_value = Fixed::from_u128_mag(raw_i128.unsigned_abs(), false)
         .mul_u128(10u128.pow(working_digits));
-    let v_w = if negative_input { v_w.neg() } else { v_w };
+    let working_value = if negative_input { working_value.neg() } else { working_value };
     Int::<2>::from_i128(
-        exp_schoolbook_fixed(v_w, w)
-            .round_to_i128_with(w, scale, mode)
+        exp_schoolbook_fixed(working_value, working_scale)
+            .round_to_i128_with(working_scale, scale, mode)
             .unwrap_or_else(|| {
                 crate::support::diagnostics::overflow_panic_with_scale(
                     "exp_schoolbook",
@@ -185,31 +188,31 @@ mod tests {
     ];
 
     #[track_caller]
-    fn check<const S: u32>(raw_i: i128, mode: RoundingMode) {
-        let raw = Int::<2>::from_i128(raw_i);
+    fn check<const S: u32>(raw_i128: i128, mode: RoundingMode) {
+        let raw = Int::<2>::from_i128(raw_i128);
         let got = exp_schoolbook_strict::<S>(raw, mode);
         let expected = exp_strict::<S>(raw, mode).expect("reference in range");
         assert_eq!(got, expected,
             "exp schoolbook D38<{}> raw={} mode={:?}: {:?} != {:?}",
-            S, raw_i, mode, got, expected);
+            S, raw_i128, mode, got, expected);
     }
 
     #[test]
     fn exp_schoolbook_matches_series_d38_s12() {
         // Boundary: zero, near-1, ln(2), small, large, negative.
-        for raw_i in [0_i128, 500_000_000_000, 1_000_000_000_000,
-                      -500_000_000_000, 2_000_000_000_000, 693_147_180_560,
-                      -1_000_000_000_000, 3_000_000_000_000, 100_000_000_000] {
-            for mode in MODES { check::<12>(raw_i, mode); }
+        for raw_i128 in [0_i128, 500_000_000_000, 1_000_000_000_000,
+                         -500_000_000_000, 2_000_000_000_000, 693_147_180_560,
+                         -1_000_000_000_000, 3_000_000_000_000, 100_000_000_000] {
+            for mode in MODES { check::<12>(raw_i128, mode); }
         }
     }
 
     #[test]
     fn exp_schoolbook_matches_series_d38_s19() {
         let one: i128 = 10_i128.pow(19);
-        for raw_i in [0, one / 2, one, -(one / 2), 2 * one, -one,
-                      one * 693_147_180 / 1_000_000_000] {
-            for mode in MODES { check::<19>(raw_i, mode); }
+        for raw_i128 in [0, one / 2, one, -(one / 2), 2 * one, -one,
+                         one * 693_147_180 / 1_000_000_000] {
+            for mode in MODES { check::<19>(raw_i128, mode); }
         }
     }
     #[cfg(any(feature = "d57", feature = "wide"))]
@@ -229,13 +232,13 @@ mod tests {
 
         #[test]
         fn exp_schoolbook_matches_routed() {
-            for &u in &INPUTS9 {
-                let r = raw9(u);
+            for &units in &INPUTS9 {
+                let raw = raw9(units);
                 for mode in MODES {
                     assert_eq!(
-                        crate::algos::exp::exp_schoolbook::exp_schoolbook::<Core, S>(r, mode),
-                        D::<Int<3>, S>(r).exp_strict_with(mode).0,
-                        "D57 exp schoolbook != routed at units={u} mode={mode:?}"
+                        crate::algos::exp::exp_schoolbook::exp_schoolbook::<Core, S>(raw, mode),
+                        D::<Int<3>, S>(raw).exp_strict_with(mode).0,
+                        "D57 exp schoolbook != routed at units={units} mode={mode:?}"
                     );
                 }
             }

--- a/src/algos/exp/exp_series_2limb.rs
+++ b/src/algos/exp/exp_series_2limb.rs
@@ -68,47 +68,49 @@ fn exp_result_int_digits(raw: i128, scale: u32) -> u32 {
     // and `10^scale·10^6` individually do. We want, exactly as before,
     //   `ceil(raw · 434295 / (10^scale · 10^6)) + 1`.
     // Compute it overflow-free by first dividing `raw` by `10^scale`
-    // (split into integer part `q` and remainder `r`), then forming the
-    // `·434295/10^6` product on the BOUNDED pieces:
+    // (split into `integer_part` and `fraction_remainder`), then forming
+    // the `·434295/10^6` product on the BOUNDED pieces:
     //
     //   raw·434295 / 10^scale = q·434295 + (r·434295)/10^scale
     //
     // where `q = ⌊x⌋`. The result int-digit count is past the 22-digit
-    // fast band once `q ≳ 50`, so capping `q` at 60 keeps `q·434295`
-    // inside u128 without ever mis-classifying an in-band cell — and the
-    // remainder term `r·434295 < 10^scale·434295` is divided back down by
-    // `10^scale`, never overflowing because `r < 10^scale ≤ 10^38` and
-    // `434295 < 10^6` give `r·434295 < 10^44`… which DOES overflow for
-    // large scale, so divide `r` toward the reduced scale first: drop the
-    // low digits of `r` that cannot affect the `/10^6` ceil. Keeping the
+    // fast band once the integer part is ≳ 50, so capping it at 60 keeps
+    // `q·434295` inside u128 without ever mis-classifying an in-band cell —
+    // and the remainder term `r·434295 < 10^scale·434295` is divided back
+    // down by `10^scale`, never overflowing because `r < 10^scale ≤ 10^38`
+    // and `434295 < 10^6` give `r·434295 < 10^44`… which DOES overflow for
+    // large scale, so divide the remainder toward the reduced scale first:
+    // drop the low digits that cannot affect the `/10^6` ceil. Keeping the
     // top 12 significant digits of the fraction (`10^6` precision ×6 guard)
     // is exact for the comparison; do it by reducing `r`/`10^scale` to
-    // `r6 = r·10^7 / 10^scale` (the fraction ×10^7, ≤ 10^7), all in u128.
-    let one_s = match 10u128.checked_pow(scale) {
-        Some(p) => p,
+    // `fraction_e7 = r·10^7 / 10^scale` (the fraction ×10^7, ≤ 10^7), all
+    // in u128.
+    let one_scaled = match 10u128.checked_pow(scale) {
+        Some(power) => power,
         // `scale > 38` cannot occur for an `i128`-storage tier; an
         // enormous scale means `x < 1`, single integer digit.
         None => return 1,
     };
-    let raw_u = raw as u128;
-    let q = raw_u / one_s; // integer part of x = ⌊raw / 10^scale⌋
-    let r = raw_u % one_s; // fractional remainder, r < 10^scale
-    // Past q = 50 the count certainly exceeds the 22-digit band; cap at 60
+    let raw_u128 = raw as u128;
+    let integer_part = raw_u128 / one_scaled; // ⌊raw / 10^scale⌋
+    let fraction_remainder = raw_u128 % one_scaled; // < 10^scale
+    // Past 50 the count certainly exceeds the 22-digit band; cap at 60
     // so q·434295 stays in u128 and never under-states an in-band cell.
-    let q_capped = q.min(60);
+    let integer_part_capped = integer_part.min(60);
     // Fraction of x scaled by 10^7 (one guard digit beyond the 10^6 in
-    // log10 e): r/10^scale ∈ [0,1) ⇒ r7 = ⌊r·10^7 / 10^scale⌋ ∈ [0, 10^7).
-    // Form it overflow-free: if scale ≤ 7, r·10^(7−scale); else r / 10^(scale−7).
-    let r7 = if scale <= 7 {
-        r * 10u128.pow(7 - scale)
+    // log10 e): r/10^scale ∈ [0,1) ⇒ fraction_e7 = ⌊r·10^7 / 10^scale⌋
+    // ∈ [0, 10^7). Form it overflow-free: if scale ≤ 7, r·10^(7−scale);
+    // else r / 10^(scale−7).
+    let fraction_e7 = if scale <= 7 {
+        fraction_remainder * 10u128.pow(7 - scale)
     } else {
-        r / 10u128.pow(scale - 7)
+        fraction_remainder / 10u128.pow(scale - 7)
     };
-    // x·10^7 ≈ q·10^7 + r7, then ·434295 / 10^6, ceil, +1.
-    // numerator = (q·10^7 + r7)·434295, all bounded (q ≤ 60, r7 < 10^7).
-    let x_e7 = q_capped * 10_000_000 + r7; // x · 10^7 (q capped)
-    let num = x_e7 * 434_295; // / 10^7 / 10^6 = / 10^13 gives x·log10 e
-    (num.div_ceil(10u128.pow(13)).min(u32::MAX as u128 - 1) as u32) + 1
+    // x·10^7 ≈ q·10^7 + fraction_e7, then ·434295 / 10^6, ceil, +1.
+    // numerator = (q·10^7 + fraction_e7)·434295, all bounded.
+    let x_e7 = integer_part_capped * 10_000_000 + fraction_e7; // x · 10^7 (capped)
+    let numerator = x_e7 * 434_295; // / 10^7 / 10^6 = / 10^13 gives x·log10 e
+    (numerator.div_ceil(10u128.pow(13)).min(u32::MAX as u128 - 1) as u32) + 1
 }
 
 /// Largest `e^x` integer-digit count the fast 256-bit `Fixed` path rounds
@@ -124,27 +126,27 @@ const FAST_MAX_RESULT_DIGITS: u32 = 22;
 /// storage value `raw` at `scale` — i.e. the result is NOT in the
 /// integer-regime where its many integer digits leave the `Fixed` too few
 /// guard digits to round correctly. Keyed on the result's integer-digit
-/// count against [`FAST_MAX_RESULT_DIGITS`]; `w` is unused (kept for the
-/// existing callers' signature) — the squaring/`2^k`-reassembly peak is
-/// computed in the full 512-bit product inside `Fixed::mul`, so it never
+/// count against [`FAST_MAX_RESULT_DIGITS`]; `working_scale` is unused (kept
+/// for the existing callers' signature) — the squaring/`2^k`-reassembly peak
+/// is computed in the full 512-bit product inside `Fixed::mul`, so it never
 /// overflows; only the rounded result's guard-digit budget bounds the fast
 /// path, and that is purely a function of the result magnitude.
 #[inline]
-fn narrow_fixed_fits(raw: i128, scale: u32, w: u32) -> bool {
-    let _ = w;
+fn narrow_fixed_fits(raw: i128, scale: u32, working_scale: u32) -> bool {
+    let _ = working_scale;
     exp_result_int_digits(raw, scale) <= FAST_MAX_RESULT_DIGITS
 }
 
-/// `e` raised to a working-scale value `v_w`, returned at the same
-/// working scale `w`.
+/// `e` raised to a `working_value`, returned at the same `working_scale`.
 ///
-/// Range-reduces `v = k·ln(2) + s` with `|s| ≤ ln(2)/2`, halves `s`
-/// `n` further times (`s_red = s / 2^n`), evaluates the Taylor
-/// series for `exp(s_red)` on the much smaller argument, then squares
-/// the result `n` times to recover `exp(s) = (exp(s_red))^(2^n)` —
-/// classic Brent–Salamin "argument reduction + squaring" trick. `n`
-/// is tuned so the Taylor cost (one mul + one div_small per term)
-/// trades evenly against the `n` post-squarings (one wide mul each).
+/// Range-reduces `v = k·ln(2) + s` with `|s| ≤ ln(2)/2`, halves the reduced
+/// argument `halvings` further times (`halved_arg = s / 2^n`), evaluates the
+/// Taylor series for `exp(halved_arg)` on the much smaller argument, then
+/// squares the result `halvings` times to recover
+/// `exp(s) = (exp(halved_arg))^(2^n)` — classic Brent–Salamin "argument
+/// reduction + squaring" trick. `halvings` is tuned so the Taylor cost (one
+/// mul + one div_small per term) trades evenly against the post-squarings
+/// (one wide mul each).
 ///
 /// At `w = 44` decimal digits (D38 SCALE 19 + STRICT_GUARD = 25) the
 /// naïve series wants ~25 iterations; halving with `n = 5` cuts that
@@ -157,10 +159,10 @@ fn narrow_fixed_fits(raw: i128, scale: u32, w: u32) -> bool {
 ///
 /// Panics if `2^k · exp(s)` cannot fit a 256-bit working value — i.e.
 /// the caller's result would overflow its representable range.
-pub(crate) fn exp_fixed(v_w: Fixed, w: u32) -> Fixed {
-    let one_w = Fixed {
+pub(crate) fn exp_fixed(working_value: Fixed, working_scale: u32) -> Fixed {
+    let one_at_working_scale = Fixed {
         negative: false,
-        mag: Fixed::pow10(w),
+        mag: Fixed::pow10(working_scale),
     };
     // Deep-underflow pre-gate — BEFORE the `k` range-reduction divide. For
     // a deep negative argument that divide (and the `k·ln 2` product after
@@ -177,59 +179,59 @@ pub(crate) fn exp_fixed(v_w: Fixed, w: u32) -> Fixed {
     // to zero), so every caller — exp's nearest-mode fast path (directed
     // modes route to the wider work integer before this kernel) and powf's
     // composition — sees the value it always did.
-    if v_w.negative && w >= 6 {
-        let thr = Fixed {
+    if working_value.negative && working_scale >= 6 {
+        let threshold = Fixed {
             negative: false,
-            mag: Fixed::pow10(w - 6),
+            mag: Fixed::pow10(working_scale - 6),
         }
-        .mul_u128(((w as u128) + 1) * 2_302_586);
-        if v_w.ge_mag(thr) {
+        .mul_u128(((working_scale as u128) + 1) * 2_302_586);
+        if working_value.ge_mag(threshold) {
             return Fixed::ZERO;
         }
     }
-    let ln2 = wide_ln2(w);
+    let ln2 = wide_ln2(working_scale);
 
     // k = round(v / ln 2); s = v - k·ln(2), |s| <= ln(2)/2.
-    let k = v_w.div(ln2, w).round_to_nearest_int(w);
+    let k = working_value.div(ln2, working_scale).round_to_nearest_int(working_scale);
     let k_ln2 = if k >= 0 {
         ln2.mul_u128(k as u128)
     } else {
         ln2.mul_u128((-k) as u128).neg()
     };
-    let s = v_w.sub(k_ln2);
+    let reduced_arg = working_value.sub(k_ln2);
 
     // Argument halvings: pick `n` such that `(n+1)² ≤ 3w+1` — the
     // standard tuning where one extra halving saves roughly two
     // Taylor iterations but costs one final squaring. For w ≤ 44
     // this lands at n ∈ {4, 5, 6}.
-    let p_bits = w.saturating_mul(3).saturating_add(1);
-    let mut n: u32 = 1;
-    while (n + 1) * (n + 1) <= p_bits {
-        n += 1;
+    let level_bound = working_scale.saturating_mul(3).saturating_add(1);
+    let mut halvings: u32 = 1;
+    while (halvings + 1) * (halvings + 1) <= level_bound {
+        halvings += 1;
     }
-    let s_red = s.shr(n);
+    let halved_arg = reduced_arg.shr(halvings);
 
     // Taylor series exp(s_red) = 1 + s_red + s_red²/2! + … on the
     // halved argument — `term` carries s_redⁱ/i!.
-    let mut sum = one_w.add(s_red);
-    let mut term = s_red;
-    let mut i: u128 = 2;
+    let mut sum = one_at_working_scale.add(halved_arg);
+    let mut term = halved_arg;
+    let mut term_index: u128 = 2;
     loop {
-        term = term.mul(s_red, w).div_small(i);
+        term = term.mul(halved_arg, working_scale).div_small(term_index);
         if term.is_zero() {
             break;
         }
         sum = sum.add(term);
-        i += 1;
-        if i > 400 {
+        term_index += 1;
+        if term_index > 400 {
             break;
         }
     }
 
-    // Undo the n halvings: exp(s) = (exp(s_red))^(2^n) — `n` repeated
-    // squarings.
-    for _ in 0..n {
-        sum = sum.mul(sum, w);
+    // Undo the halvings: exp(s) = (exp(halved_arg))^(2^n) — `halvings`
+    // repeated squarings.
+    for _ in 0..halvings {
+        sum = sum.mul(sum, working_scale);
     }
 
     // exp(v) = 2^k · exp(s).
@@ -276,17 +278,18 @@ fn exp_wide_narrow_raw(
 ) -> Option<i128> {
     use crate::algos::exp::exp_generic;
 
-    let w = scale + working_digits;
+    let working_scale = scale + working_digits;
     let negative_input = raw < 0;
-    let v_mag = WNarrow::from_i128(raw.unsigned_abs() as i128) * crate::consts::pow10::dispatch::<WNarrow>(working_digits);
-    let v_w = if negative_input { -v_mag } else { v_mag };
+    let abs_working_value = WNarrow::from_i128(raw.unsigned_abs() as i128)
+        * crate::consts::pow10::dispatch::<WNarrow>(working_digits);
+    let working_value = if negative_input { -abs_working_value } else { abs_working_value };
 
     // `try_exp_fixed`: a deep argument the generic kernel proves out of
     // range is this kernel's `None` (the policy dispatch wrapper applies
     // the default form's contractual panic; the `checked_` surface
     // propagates it), same as the post-narrowing fit check below.
-    let ex = exp_generic::try_exp_fixed::<WNarrow>(v_w, w)?;
-    narrow_round_mag(ex, working_digits, mode, true, false)
+    let exp_x = exp_generic::try_exp_fixed::<WNarrow>(working_value, working_scale)?;
+    narrow_round_mag(exp_x, working_digits, mode, true, false)
 }
 
 /// Whether the sub-storage residual of the non-negative working
@@ -298,26 +301,27 @@ fn exp_wide_narrow_raw(
 #[inline]
 fn wnarrow_residual_clear(mag: WNarrow, shift: u32, mode: RoundingMode) -> bool {
     let divisor = crate::consts::pow10::dispatch::<WNarrow>(shift);
-    let (_q, rem) = mag.div_rem(divisor);
+    let (_quotient, remainder) = mag.div_rem(divisor);
     let band = if shift >= 3 {
         crate::consts::pow10::dispatch::<WNarrow>(shift - 3)
     } else {
         WNarrow::ZERO
     };
-    let dist = if crate::support::rounding::is_nearest_mode(mode) {
+    let distance = if crate::support::rounding::is_nearest_mode(mode) {
         let half = divisor >> 1;
-        if rem < half { half - rem } else { rem - half }
+        if remainder < half { half - remainder } else { remainder - half }
     } else {
-        let comp = divisor - rem;
-        if rem < comp { rem } else { comp }
+        let complement = divisor - remainder;
+        if remainder < complement { remainder } else { complement }
     };
-    dist > band
+    distance > band
 }
 
-/// One `WZiv` exp probe at working scale `scale + g` (`WZiv` and
+/// One `WZiv` exp probe at working scale `scale + guard_digits` (`WZiv` and
 /// [`WNarrow`] are the same `Int<24>`).
-fn exp_ziv(raw: i128, scale: u32, g: u32) -> WZiv {
-    crate::algos::exp::exp_generic::exp_fixed::<WZiv>(narrow_ziv::lift(raw, g), scale + g)
+fn exp_ziv(raw: i128, scale: u32, guard_digits: u32) -> WZiv {
+    crate::algos::exp::exp_generic::exp_fixed::<WZiv>(
+        narrow_ziv::lift(raw, guard_digits), scale + guard_digits)
 }
 
 /// Strict-path integer-regime / directed `e^x` — the wide-[`WNarrow`]
@@ -327,18 +331,18 @@ fn exp_ziv(raw: i128, scale: u32, g: u32) -> WZiv {
 fn exp_wide_narrow_strict_raw(raw: i128, scale: u32, mode: RoundingMode) -> Option<i128> {
     use crate::algos::exp::exp_generic;
 
-    let w = scale + STRICT_GUARD;
+    let working_scale = scale + STRICT_GUARD;
     let negative_input = raw < 0;
-    let v_mag = WNarrow::from_i128(raw.unsigned_abs() as i128)
+    let abs_working_value = WNarrow::from_i128(raw.unsigned_abs() as i128)
         * crate::consts::pow10::dispatch::<WNarrow>(STRICT_GUARD);
-    let v_w = if negative_input { -v_mag } else { v_mag };
-    let ex = exp_generic::try_exp_fixed::<WNarrow>(v_w, w)?;
-    let base = narrow_round_mag(ex, STRICT_GUARD, mode, true, false);
-    if wnarrow_residual_clear(ex, STRICT_GUARD, mode) {
-        return base;
+    let working_value = if negative_input { -abs_working_value } else { abs_working_value };
+    let exp_x = exp_generic::try_exp_fixed::<WNarrow>(working_value, working_scale)?;
+    let single_shot = narrow_round_mag(exp_x, STRICT_GUARD, mode, true, false);
+    if wnarrow_residual_clear(exp_x, STRICT_GUARD, mode) {
+        return single_shot;
     }
-    narrow_ziv::walk_checked_never_exact(base, STRICT_GUARD, scale, mode, |g| {
-        exp_ziv(raw, scale, g)
+    narrow_ziv::walk_checked_never_exact(single_shot, STRICT_GUARD, scale, mode, |guard_digits| {
+        exp_ziv(raw, scale, guard_digits)
     })
 }
 
@@ -347,7 +351,7 @@ fn exp_wide_narrow_strict_raw(raw: i128, scale: u32, mode: RoundingMode) -> Opti
 /// argument) to a signed `i128` storage value at scale `w − shift` under
 /// `mode`. `never_exact` mirrors the wide directed path: a zero working
 /// residual is treated as a present positive sub-resolution fraction
-/// (bumps Ceiling, not Floor/Trunc). `result_neg` reapplies an odd
+/// (bumps Ceiling, not Floor/Trunc). `result_is_negative` reapplies an odd
 /// function's sign AFTER rounding the magnitude.
 ///
 /// Returns `None` when the rounded storage value does not fit the `i128`
@@ -364,80 +368,82 @@ fn narrow_round_mag(
     shift: u32,
     mode: RoundingMode,
     never_exact: bool,
-    result_neg: bool,
+    result_is_negative: bool,
 ) -> Option<i128> {
     use crate::support::rounding::{is_nearest_mode, should_bump};
     let divisor = crate::consts::pow10::dispatch::<WNarrow>(shift);
-    let (q, rem) = mag.div_rem(divisor);
-    let result_positive = !result_neg;
-    let bump = if rem != WNarrow::ZERO {
+    let (quotient, remainder) = mag.div_rem(divisor);
+    let result_is_positive = !result_is_negative;
+    let bump = if remainder != WNarrow::ZERO {
         if is_nearest_mode(mode) {
-            let comp = divisor - rem;
-            let cmp_r = rem.cmp(&comp);
-            should_bump(mode, cmp_r, q.bit(0), result_positive)
+            let complement = divisor - remainder;
+            let remainder_cmp = remainder.cmp(&complement);
+            should_bump(mode, remainder_cmp, quotient.bit(0), result_is_positive)
         } else {
             match mode {
-                RoundingMode::Ceiling => result_positive,
-                RoundingMode::Floor => !result_positive,
+                RoundingMode::Ceiling => result_is_positive,
+                RoundingMode::Floor => !result_is_positive,
                 _ => false, // Trunc
             }
         }
     } else if never_exact {
         // Present-and-positive sub-resolution residual.
         match mode {
-            RoundingMode::Ceiling => result_positive,
-            RoundingMode::Floor => !result_positive,
+            RoundingMode::Ceiling => result_is_positive,
+            RoundingMode::Floor => !result_is_positive,
             _ => false,
         }
     } else {
         false
     };
-    let q_mag = if bump { q + WNarrow::ONE } else { q };
+    let magnitude = if bump { quotient + WNarrow::ONE } else { quotient };
     // Result-type fit check (mirrors `Fixed::round_to_i128_with`): the
-    // non-negative quotient magnitude `q_mag` must fit the signed `i128`.
-    // A positive result fits iff `q_mag <= i128::MAX`; a negative result
-    // iff `q_mag <= 2^127` (= `|i128::MIN|`). Both are bounded by
+    // non-negative quotient `magnitude` must fit the signed `i128`.
+    // A positive result fits iff `magnitude <= i128::MAX`; a negative result
+    // iff `magnitude <= 2^127` (= `|i128::MIN|`). Both are bounded by
     // `bit_length <= 127`, with the single extra `2^127` value allowed
     // only for the negative side.
-    let bl = q_mag.bit_length();
-    if bl > 128 {
+    let magnitude_bits = magnitude.bit_length();
+    if magnitude_bits > 128 {
         return None;
     }
-    if bl == 128 {
+    if magnitude_bits == 128 {
         // The only 128-bit magnitude that fits is exactly `2^127`, and
         // only as a negative result (`i128::MIN`).
         let two_pow_127 = WNarrow::ONE << 127;
-        if !(result_neg && q_mag == two_pow_127) {
+        if !(result_is_negative && magnitude == two_pow_127) {
             return None;
         }
-    } else if bl == 127 && !result_neg {
-        // `2^126 <= q_mag < 2^127`: a positive result fits iff
-        // `q_mag <= i128::MAX = 2^127 - 1`. bit_length 127 already
-        // guarantees `q_mag < 2^127`, so it fits.
+    } else if magnitude_bits == 127 && !result_is_negative {
+        // `2^126 <= magnitude < 2^127`: a positive result fits iff
+        // `magnitude <= i128::MAX = 2^127 - 1`. bit_length 127 already
+        // guarantees `magnitude < 2^127`, so it fits.
     }
-    let signed = if result_neg { -q_mag } else { q_mag };
+    let signed = if result_is_negative { -magnitude } else { magnitude };
     Some(signed.to_i128())
 }
 
-/// `sinh(x)` / `cosh(x)` magnitude `(e^|x| ∓ e^-|x|)/2` at working scale
-/// `w`, computed in the wide [`WNarrow`] work integer. Returns the
-/// non-negative `sinh(|x|)` / `cosh(|x|)`; the odd-function sign is
+/// `sinh(x)` / `cosh(x)` magnitude `(e^|x| ∓ e^-|x|)/2` at
+/// `working_scale`, computed in the wide [`WNarrow`] work integer. Returns
+/// the non-negative `sinh(|x|)` / `cosh(|x|)`; the odd-function sign is
 /// reapplied by the caller via [`narrow_round_mag`].
 #[inline]
-fn hyper_pos_wide_narrow(av_w: WNarrow, w: u32, is_cosh: bool) -> WNarrow {
+fn hyper_pos_wide_narrow(
+    abs_working_value: WNarrow, working_scale: u32, is_cosh: bool) -> WNarrow {
     use crate::algos::exp::exp_generic;
-    let ex = exp_generic::exp_fixed::<WNarrow>(av_w, w);
-    let one_w = crate::consts::pow10::dispatch::<WNarrow>(w);
-    // `ex = e^|x|·10^w`. The reciprocal at the same scale is `e^-|x|·10^w
-    // = 10^(2w) / ex`. For the integer-regime |x| this is a tiny positive
-    // value (≪ 1 ULP-of-storage), formed in the wide integer to avoid the
-    // `Fixed` overflow.
-    let (enx, _r) = (one_w * one_w).div_rem(ex);
+    let exp_x = exp_generic::exp_fixed::<WNarrow>(abs_working_value, working_scale);
+    let one_at_working_scale = crate::consts::pow10::dispatch::<WNarrow>(working_scale);
+    // `exp_x = e^|x|·10^w`. The reciprocal at the same scale is
+    // `e^-|x|·10^w = 10^(2w) / exp_x`. For the integer-regime |x| this is a
+    // tiny positive value (≪ 1 ULP-of-storage), formed in the wide integer
+    // to avoid the `Fixed` overflow.
+    let (exp_neg_x, _remainder) =
+        (one_at_working_scale * one_at_working_scale).div_rem(exp_x);
     let two = WNarrow::from_i128(2);
     if is_cosh {
-        (ex + enx).div_rem(two).0
+        (exp_x + exp_neg_x).div_rem(two).0
     } else {
-        (ex - enx).div_rem(two).0
+        (exp_x - exp_neg_x).div_rem(two).0
     }
 }
 
@@ -450,11 +456,12 @@ pub(crate) fn sinh_wide_narrow_raw(
     working_digits: u32,
     mode: RoundingMode,
 ) -> i128 {
-    let w = scale + working_digits;
-    let neg = raw < 0;
-    let av = WNarrow::from_i128(raw.unsigned_abs() as i128) * crate::consts::pow10::dispatch::<WNarrow>(working_digits);
-    let sh = hyper_pos_wide_narrow(av, w, false);
-    narrow_round_mag(sh, working_digits, mode, true, neg).unwrap_or_else(|| {
+    let working_scale = scale + working_digits;
+    let is_negative = raw < 0;
+    let abs_working_value = WNarrow::from_i128(raw.unsigned_abs() as i128)
+        * crate::consts::pow10::dispatch::<WNarrow>(working_digits);
+    let sinh_magnitude = hyper_pos_wide_narrow(abs_working_value, working_scale, false);
+    narrow_round_mag(sinh_magnitude, working_digits, mode, true, is_negative).unwrap_or_else(|| {
         crate::support::diagnostics::overflow_panic_with_scale("D38::sinh", scale)
     })
 }
@@ -469,10 +476,11 @@ pub(crate) fn cosh_wide_narrow_raw(
     working_digits: u32,
     mode: RoundingMode,
 ) -> i128 {
-    let w = scale + working_digits;
-    let av = WNarrow::from_i128(raw.unsigned_abs() as i128) * crate::consts::pow10::dispatch::<WNarrow>(working_digits);
-    let ch = hyper_pos_wide_narrow(av, w, true);
-    narrow_round_mag(ch, working_digits, mode, true, false).unwrap_or_else(|| {
+    let working_scale = scale + working_digits;
+    let abs_working_value = WNarrow::from_i128(raw.unsigned_abs() as i128)
+        * crate::consts::pow10::dispatch::<WNarrow>(working_digits);
+    let cosh_magnitude = hyper_pos_wide_narrow(abs_working_value, working_scale, true);
+    narrow_round_mag(cosh_magnitude, working_digits, mode, true, false).unwrap_or_else(|| {
         crate::support::diagnostics::overflow_panic_with_scale("D38::cosh", scale)
     })
 }
@@ -482,8 +490,8 @@ pub(crate) fn cosh_wide_narrow_raw(
 /// `sinh(x)`/`cosh(x) ≈ e^|x|/2`, so the result's integer-digit count
 /// matches `e^|x|`'s — reuse the exp gate on `|raw|`.
 #[inline]
-pub(crate) fn hyper_needs_wide_narrow(raw: i128, scale: u32, w: u32) -> bool {
-    !narrow_fixed_fits(raw.unsigned_abs() as i128, scale, w)
+pub(crate) fn hyper_needs_wide_narrow(raw: i128, scale: u32, working_scale: u32) -> bool {
+    !narrow_fixed_fits(raw.unsigned_abs() as i128, scale, working_scale)
 }
 
 /// `e^x` with caller-chosen `working_digits` above the storage scale.
@@ -509,7 +517,7 @@ fn exp_with_raw(raw: i128, scale: u32, working_digits: u32, mode: RoundingMode) 
     if raw == 0 {
         return Some(10_i128.pow(scale)); // ONE for this scale
     }
-    let w = scale + working_digits;
+    let working_scale = scale + working_digits;
     // The wider `WNarrow` work integer is needed for the cells the fast
     // 256-bit `Fixed` path cannot round correctly:
     //  1. integer-regime — `e^x` carries so many integer digits the `Fixed`
@@ -522,13 +530,16 @@ fn exp_with_raw(raw: i128, scale: u32, working_digits: u32, mode: RoundingMode) 
     //     keeping it on the wide path costs nothing on the hot path.
     // Every other (NEAREST-mode, non-integer-regime) cell — the COMMON
     // narrow exp — stays on the fast path.
-    if !narrow_fixed_fits(raw, scale, w) || !crate::support::rounding::is_nearest_mode(mode) {
+    if !narrow_fixed_fits(raw, scale, working_scale)
+        || !crate::support::rounding::is_nearest_mode(mode)
+    {
         return exp_wide_narrow_raw(raw, scale, working_digits, mode);
     }
     let negative_input = raw < 0;
-    let v_w = Fixed::from_u128_mag(raw.unsigned_abs(), false).mul_u128(10u128.pow(working_digits));
-    let v_w = if negative_input { v_w.neg() } else { v_w };
-    exp_fixed(v_w, w).round_to_i128_with(w, scale, mode)
+    let working_value =
+        Fixed::from_u128_mag(raw.unsigned_abs(), false).mul_u128(10u128.pow(working_digits));
+    let working_value = if negative_input { working_value.neg() } else { working_value };
+    exp_fixed(working_value, working_scale).round_to_i128_with(working_scale, scale, mode)
 }
 
 /// Strict variant — const-folded `working_digits = STRICT_GUARD`.
@@ -545,27 +556,30 @@ fn exp_strict_raw<const SCALE: u32>(raw: i128, mode: RoundingMode) -> Option<i12
     if raw == 0 {
         return Some(10_i128.pow(SCALE));
     }
-    let w = SCALE + STRICT_GUARD;
+    let working_scale = SCALE + STRICT_GUARD;
     // See [`exp_with_raw`]: the integer-regime cells and ALL directed modes
     // route through the wider `WNarrow` work integer; every other
     // NEAREST-mode common cell stays on the fast `Fixed` path. Both
     // terminals are near-tie protected (clear-of-tie single shot, Ziv
     // walker behind it).
-    if !narrow_fixed_fits(raw, SCALE, w) || !crate::support::rounding::is_nearest_mode(mode) {
+    if !narrow_fixed_fits(raw, SCALE, working_scale)
+        || !crate::support::rounding::is_nearest_mode(mode)
+    {
         return exp_wide_narrow_strict_raw(raw, SCALE, mode);
     }
     let negative_input = raw < 0;
-    let v_w = Fixed::from_u128_mag(raw.unsigned_abs(), false).mul_u128(10u128.pow(STRICT_GUARD));
-    let v_w = if negative_input { v_w.neg() } else { v_w };
-    let v = exp_fixed(v_w, w);
-    match v.round_to_i128_clear_of_tie(w, SCALE, mode) {
-        Some(r) => r,
+    let working_value =
+        Fixed::from_u128_mag(raw.unsigned_abs(), false).mul_u128(10u128.pow(STRICT_GUARD));
+    let working_value = if negative_input { working_value.neg() } else { working_value };
+    let exp_working_value = exp_fixed(working_value, working_scale);
+    match exp_working_value.round_to_i128_clear_of_tie(working_scale, SCALE, mode) {
+        Some(rounded) => rounded,
         None => narrow_ziv::walk_checked_never_exact(
-            v.round_to_i128_with(w, SCALE, mode),
+            exp_working_value.round_to_i128_with(working_scale, SCALE, mode),
             STRICT_GUARD,
             SCALE,
             mode,
-            |g| exp_ziv(raw, SCALE, g),
+            |guard_digits| exp_ziv(raw, SCALE, guard_digits),
         ),
     }
 }
@@ -590,68 +604,70 @@ fn exp_strict_raw<const SCALE: u32>(raw: i128, mode: RoundingMode) -> Option<i12
 /// wide-tier `exp2_exact_pow`.
 #[inline]
 fn exp2_exact_pin(raw: i128, scale: u32, mode: RoundingMode) -> ExactPin<i128> {
-    let one_s = match 10i128.checked_pow(scale) {
-        Some(v) => v,
+    let one_scaled = match 10i128.checked_pow(scale) {
+        Some(value) => value,
         None => return ExactPin::Defer,
     };
-    if raw % one_s != 0 {
+    if raw % one_scaled != 0 {
         return ExactPin::Defer;
     }
-    let k = raw / one_s;
-    if k == 0 {
-        return ExactPin::Value(one_s);
+    let exponent = raw / one_scaled;
+    if exponent == 0 {
+        return ExactPin::Value(one_scaled);
     }
-    let kk = k.unsigned_abs();
-    if k > 0 {
+    let abs_exponent = exponent.unsigned_abs();
+    if exponent > 0 {
         // 2^k · 10^scale — exact integer when representable; the ladder's
         // overflow is the out-of-range proof.
-        let mut v: i128 = one_s;
-        for _ in 0..kk {
-            v = match v.checked_mul(2) {
-                Some(d) => d,
+        let mut power: i128 = one_scaled;
+        for _ in 0..abs_exponent {
+            power = match power.checked_mul(2) {
+                Some(doubled) => doubled,
                 None => return ExactPin::OutOfRange,
             };
         }
-        ExactPin::Value(v)
-    } else if kk <= scale as u128 {
+        ExactPin::Value(power)
+    } else if abs_exponent <= scale as u128 {
         // 2^-|k| = 5^|k| · 10^(scale − |k|) — exact, no rounding. These
         // checked steps cannot fail for any real scale (the value is
         // `<= 10^scale`); kept checked-and-deferring for totality.
-        let mut v = match 10i128.checked_pow(scale - kk as u32) {
-            Some(d) => d,
+        let mut power = match 10i128.checked_pow(scale - abs_exponent as u32) {
+            Some(value) => value,
             None => return ExactPin::Defer,
         };
-        for _ in 0..kk {
-            v = match v.checked_mul(5) {
-                Some(d) => d,
+        for _ in 0..abs_exponent {
+            power = match power.checked_mul(5) {
+                Some(next_power) => next_power,
                 None => return ExactPin::Defer,
             };
         }
-        ExactPin::Value(v)
+        ExactPin::Value(power)
     } else {
         // |k| > scale: `2^k · 10^scale = 5^scale / 2^(|k|−scale)` is a
         // proper dyadic fraction in `(0, 1)` storage units. Round it
         // exactly under `mode` (`exp2(-1) = 0.5` is the half-to-even tie
         // → 0; `exp2(-146)` is a sub-resolution positive → Ceiling → 1).
-        let num = match 5u128.checked_pow(scale) {
-            Some(d) => d, // 5^38 < 2^89, fits u128
+        let numerator = match 5u128.checked_pow(scale) {
+            Some(value) => value, // 5^38 < 2^89, fits u128
             None => return ExactPin::Defer,
         };
-        let p = kk as u32 - scale; // shift amount, ≥ 1
-        ExactPin::Value(round_pow2_fraction(num, p, mode))
+        let shift = abs_exponent as u32 - scale; // shift amount, ≥ 1
+        ExactPin::Value(round_pow2_fraction(numerator, shift, mode))
     }
 }
 
-/// Correctly-rounded storage value of the dyadic fraction `num / 2^p`
-/// (`num > 0`, `p ≥ 1`) — a strictly-positive result in `[0, num/2]`.
+/// Correctly-rounded storage value of the dyadic fraction
+/// `numerator / 2^shift` (`numerator > 0`, `shift ≥ 1`) — a
+/// strictly-positive result in `[0, numerator/2]`.
 ///
-/// `q = num >> p`, remainder `r = num & (2^p − 1)`; the half-way divisor
-/// is `2^p`, so the tie compares `2·r` against `2^p`. When `p ≥ 128`
-/// the quotient is `0` and the whole of `num` is the (sub-half) residual
-/// — a tiny positive value that only `Ceiling` rounds up.
+/// `quotient = numerator >> shift`, `remainder = numerator & (2^shift − 1)`;
+/// the half-way divisor is `2^shift`, so the tie compares `2·r` against
+/// `2^shift`. When `shift ≥ 128` the quotient is `0` and the whole of
+/// `numerator` is the (sub-half) residual — a tiny positive value that only
+/// `Ceiling` rounds up.
 #[inline]
-fn round_pow2_fraction(num: u128, p: u32, mode: RoundingMode) -> i128 {
-    if p >= 128 {
+fn round_pow2_fraction(numerator: u128, shift: u32, mode: RoundingMode) -> i128 {
+    if shift >= 128 {
         // num < 2^128 ≤ 2^p, so q = 0 and r = num > 0 but < 2^(p-1)
         // (half), i.e. a sub-resolution positive residual.
         let bump = crate::support::rounding::should_bump(
@@ -662,16 +678,16 @@ fn round_pow2_fraction(num: u128, p: u32, mode: RoundingMode) -> i128 {
         );
         return i128::from(bump);
     }
-    let q = (num >> p) as i128;
-    let r = num & ((1u128 << p) - 1);
-    if r == 0 {
-        return q;
+    let quotient = (numerator >> shift) as i128;
+    let remainder = numerator & ((1u128 << shift) - 1);
+    if remainder == 0 {
+        return quotient;
     }
-    let half = 1u128 << (p - 1);
-    let cmp_r = r.cmp(&half);
-    let q_is_odd = (q & 1) == 1;
-    let bump = crate::support::rounding::should_bump(mode, cmp_r, q_is_odd, true);
-    q + i128::from(bump)
+    let half = 1u128 << (shift - 1);
+    let remainder_cmp = remainder.cmp(&half);
+    let quotient_is_odd = (quotient & 1) == 1;
+    let bump = crate::support::rounding::should_bump(mode, remainder_cmp, quotient_is_odd, true);
+    quotient + i128::from(bump)
 }
 
 /// `2^x = exp(x · ln 2)` on the `Fixed` intermediate. Used by
@@ -718,12 +734,14 @@ fn exp2_with_raw(raw: i128, scale: u32, working_digits: u32, mode: RoundingMode)
     if exp2_result_int_digits(abs_raw, scale) > FAST_MAX_RESULT_DIGITS {
         return exp2_wide_narrow_raw(raw, scale, working_digits, mode);
     }
-    let w = scale + working_digits;
+    let working_scale = scale + working_digits;
     let negative_input = raw < 0;
-    let v_w = Fixed::from_u128_mag(raw.unsigned_abs(), false).mul_u128(10u128.pow(working_digits));
-    let v_w = if negative_input { v_w.neg() } else { v_w };
-    let arg_w = v_w.mul(wide_ln2(w), w);
-    exp_fixed(arg_w, w).round_to_i128_with(w, scale, mode)
+    let working_value =
+        Fixed::from_u128_mag(raw.unsigned_abs(), false).mul_u128(10u128.pow(working_digits));
+    let working_value = if negative_input { working_value.neg() } else { working_value };
+    let arg_at_working_scale = working_value.mul(wide_ln2(working_scale), working_scale);
+    exp_fixed(arg_at_working_scale, working_scale)
+        .round_to_i128_with(working_scale, scale, mode)
 }
 
 /// Integer-digit count of `2^x` for the non-negative storage magnitude
@@ -735,52 +753,52 @@ fn exp2_with_raw(raw: i128, scale: u32, working_digits: u32, mode: RoundingMode)
 /// overflow-free `q`/`r` split so no intermediate exceeds `u128`.
 #[inline]
 fn exp2_result_int_digits(abs_raw: u128, scale: u32) -> u32 {
-    let one_s = match 10u128.checked_pow(scale) {
-        Some(p) => p,
+    let one_scaled = match 10u128.checked_pow(scale) {
+        Some(power) => power,
         None => return 1,
     };
-    let q = abs_raw / one_s; // integer part of |x|
-    let r = abs_raw % one_s; // fractional remainder, r < 10^scale
-    let q_capped = q.min(180); // past here the count far exceeds the band
-    let r7 = if scale <= 7 {
-        r * 10u128.pow(7 - scale)
+    let integer_part = abs_raw / one_scaled; // integer part of |x|
+    let fraction_remainder = abs_raw % one_scaled; // < 10^scale
+    let integer_part_capped = integer_part.min(180); // past here the count far exceeds the band
+    let fraction_e7 = if scale <= 7 {
+        fraction_remainder * 10u128.pow(7 - scale)
     } else {
-        r / 10u128.pow(scale - 7)
+        fraction_remainder / 10u128.pow(scale - 7)
     };
-    let x_e7 = q_capped * 10_000_000 + r7; // |x| · 10^7 (q capped)
-    let num = x_e7 * 301_030; // / 10^7 / 10^6 = / 10^13 gives |x|·log10 2
-    (num.div_ceil(10u128.pow(13)).min(u32::MAX as u128 - 1) as u32) + 1
+    let x_e7 = integer_part_capped * 10_000_000 + fraction_e7; // |x| · 10^7 (capped)
+    let numerator = x_e7 * 301_030; // / 10^7 / 10^6 = / 10^13 gives |x|·log10 2
+    (numerator.div_ceil(10u128.pow(13)).min(u32::MAX as u128 - 1) as u32) + 1
 }
 
 /// LOWER bound on the integer-digit count of `2^x` for the non-negative
 /// storage magnitude `abs_raw` at `scale` — the floor counterpart of the
 /// (deliberately over-stating) [`exp2_result_int_digits`]. Every rounding
-/// here errs DOWN: the fraction `r7` is floored, `301_029/10^6` under-
-/// approximates `log10 2`, and the final division is floored — so the
+/// here errs DOWN: the fraction `fraction_e7` is floored, `301_029/10^6`
+/// under-approximates `log10 2`, and the final division is floored — so the
 /// returned count never exceeds the true `⌊x·log10 2⌋ + 1`. That is the
 /// safe direction for the [`exp2_wide_narrow_raw`] overflow gate: a cell
 /// it fires on is PROVABLY out of range, never a representable one.
 ///
-/// The `q` cap matches the sibling's: at `q ≥ 180` the count is already
-/// ≈ 55 — past the 40-digit `i128` ceiling at EVERY scale — so capping
-/// keeps `x_e7 · 301_029` inside `u128` without weakening the gate.
+/// The integer-part cap matches the sibling's: at `q ≥ 180` the count is
+/// already ≈ 55 — past the 40-digit `i128` ceiling at EVERY scale — so
+/// capping keeps `x_e7 · 301_029` inside `u128` without weakening the gate.
 #[inline]
 fn exp2_result_int_digits_floor(abs_raw: u128, scale: u32) -> u32 {
-    let one_s = match 10u128.checked_pow(scale) {
-        Some(p) => p,
+    let one_scaled = match 10u128.checked_pow(scale) {
+        Some(power) => power,
         None => return 1,
     };
-    let q = abs_raw / one_s; // integer part of |x|
-    let r = abs_raw % one_s; // fractional remainder, r < 10^scale
-    let q_capped = q.min(180);
-    let r7 = if scale <= 7 {
-        r * 10u128.pow(7 - scale)
+    let integer_part = abs_raw / one_scaled; // integer part of |x|
+    let fraction_remainder = abs_raw % one_scaled; // < 10^scale
+    let integer_part_capped = integer_part.min(180);
+    let fraction_e7 = if scale <= 7 {
+        fraction_remainder * 10u128.pow(7 - scale)
     } else {
-        r / 10u128.pow(scale - 7)
+        fraction_remainder / 10u128.pow(scale - 7)
     };
-    let x_e7 = q_capped * 10_000_000 + r7; // ≤ |x| · 10^7
-    let num = x_e7 * 301_029; // / 10^13 under-states |x|·log10 2
-    ((num / 10u128.pow(13)).min(u32::MAX as u128 - 1) as u32) + 1
+    let x_e7 = integer_part_capped * 10_000_000 + fraction_e7; // ≤ |x| · 10^7
+    let numerator = x_e7 * 301_029; // / 10^13 under-states |x|·log10 2
+    ((numerator / 10u128.pow(13)).min(u32::MAX as u128 - 1) as u32) + 1
 }
 
 /// Integer-regime / large-result `2^x` for the narrow tier, evaluated in the
@@ -797,13 +815,14 @@ fn exp2_wide_narrow_raw(
     working_digits: u32,
     mode: RoundingMode,
 ) -> Option<i128> {
-    let (ex, guard) = exp2_wide_narrow_eval(raw, scale, working_digits)?;
-    narrow_round_mag(ex, guard, mode, true, false)
+    let (exp_x, lifted_guard_digits) = exp2_wide_narrow_eval(raw, scale, working_digits)?;
+    narrow_round_mag(exp_x, lifted_guard_digits, mode, true, false)
 }
 
-/// The [`exp2_wide_narrow_raw`] evaluation: the `(value · 10^(scale +
-/// guard), guard)` pair before the narrowing terminal, shared by the
-/// approx single shot and the strict near-tie protected terminal.
+/// The [`exp2_wide_narrow_raw`] evaluation: the
+/// `(value · 10^(scale + lifted_guard_digits), lifted_guard_digits)` pair
+/// before the narrowing terminal, shared by the approx single shot and the
+/// strict near-tie protected terminal.
 fn exp2_wide_narrow_eval(
     raw: i128,
     scale: u32,
@@ -811,7 +830,7 @@ fn exp2_wide_narrow_eval(
 ) -> Option<(WNarrow, u32)> {
     use crate::algos::exp::exp_generic;
 
-    let neg = raw < 0;
+    let is_negative = raw < 0;
     let abs_raw = raw.unsigned_abs();
     // Storage overflow gate — BEFORE any working-scale arithmetic. The
     // `k_lift` lift below grows the working scale `w` with the result's
@@ -840,41 +859,46 @@ fn exp2_wide_narrow_eval(
     // lifting by `int_digits(2^|x|)` would re-inflate `w` without bound for
     // a deep-underflow argument (the mirror of the overflow band above),
     // with zero precision benefit: the `2^k` reassembly shifts DOWN.
-    let k_lift = if neg { 0 } else { exp2_result_int_digits(abs_raw, scale) };
-    let guard = working_digits + k_lift;
-    let w = scale + guard;
-    // x · ln 2 at scale `w`, formed in the wide work integer:
+    let k_lift = if is_negative { 0 } else { exp2_result_int_digits(abs_raw, scale) };
+    let lifted_guard_digits = working_digits + k_lift;
+    let working_scale = scale + lifted_guard_digits;
+    // x · ln 2 at the working scale, formed in the wide work integer:
     //   x_w = x·10^w = abs_raw·10^guard ;  ln2_w = ln 2·10^w ;
     //   (x_w · ln2_w) / 10^w = x·ln 2 · 10^w.
-    let x_w =
-        WNarrow::from_i128(abs_raw as i128) * crate::consts::pow10::dispatch::<WNarrow>(guard);
-    let ln2_w = crate::consts::ln2_by_working_scale::<WNarrow>(w, RoundingMode::HalfToEven);
-    let prod = x_w * ln2_w;
-    let arg_mag = if w <= 38 {
-        crate::algos::support::mg_divide::div_wide_pow10::<WNarrow>(prod, w, RoundingMode::HalfToEven)
+    let x_working_value = WNarrow::from_i128(abs_raw as i128)
+        * crate::consts::pow10::dispatch::<WNarrow>(lifted_guard_digits);
+    let ln2_at_working_scale =
+        crate::consts::ln2_by_working_scale::<WNarrow>(working_scale, RoundingMode::HalfToEven);
+    let product = x_working_value * ln2_at_working_scale;
+    let exp_arg_magnitude = if working_scale <= 38 {
+        crate::algos::support::mg_divide::div_wide_pow10::<WNarrow>(
+            product, working_scale, RoundingMode::HalfToEven)
     } else {
         crate::algos::support::mg_divide::div_wide_pow10_chain::<WNarrow>(
-            prod,
-            w,
+            product,
+            working_scale,
             RoundingMode::HalfToEven,
         )
     };
-    let arg = if neg { -arg_mag } else { arg_mag };
+    let exp_arg = if is_negative { -exp_arg_magnitude } else { exp_arg_magnitude };
     // `try_exp_fixed`: see [`exp_wide_narrow_raw`] — an out-of-range
     // verdict from the generic kernel propagates as this kernel's `None`.
-    let ex = exp_generic::try_exp_fixed::<WNarrow>(arg, w)?;
-    Some((ex, guard))
+    let exp_x = exp_generic::try_exp_fixed::<WNarrow>(exp_arg, working_scale)?;
+    Some((exp_x, lifted_guard_digits))
 }
 
-/// One `WZiv` `exp(x·ln 2)` probe at working scale `scale + g`. No
-/// `k_lift` is applied at the probe — the walker's escalation cap
+/// One `WZiv` `exp(x·ln 2)` probe at working scale `scale + guard_digits`.
+/// No `k_lift` is applied at the probe — the walker's escalation cap
 /// already subtracts the result's integer-digit count, so the probe
 /// keeps its guard digits without an explicit lift.
-fn exp2_ziv(raw: i128, scale: u32, g: u32) -> WZiv {
+fn exp2_ziv(raw: i128, scale: u32, guard_digits: u32) -> WZiv {
     use crate::algos::exp::exp_generic as eg;
-    let w = scale + g;
-    let arg = eg::mul::<WZiv>(narrow_ziv::lift(raw, g), narrow_ziv::ln2_w(w), w);
-    eg::exp_fixed::<WZiv>(arg, w)
+    let working_scale = scale + guard_digits;
+    let exp_arg = eg::mul::<WZiv>(
+        narrow_ziv::lift(raw, guard_digits),
+        narrow_ziv::ln2_w(working_scale),
+        working_scale);
+    eg::exp_fixed::<WZiv>(exp_arg, working_scale)
 }
 
 /// `None` = result out of storage range (see [`exp2_with`]). The strict
@@ -900,29 +924,30 @@ fn exp2_strict_raw(raw: i128, scale: u32, mode: RoundingMode) -> Option<i128> {
     let abs_raw = raw.unsigned_abs();
     if exp2_result_int_digits(abs_raw, scale) > FAST_MAX_RESULT_DIGITS {
         // Integer-regime: the lifted wide single shot, near-tie protected.
-        let (ex, guard) = exp2_wide_narrow_eval(raw, scale, STRICT_GUARD)?;
-        let base = narrow_round_mag(ex, guard, mode, true, false);
-        if wnarrow_residual_clear(ex, guard, mode) {
-            return base;
+        let (exp_x, lifted_guard_digits) = exp2_wide_narrow_eval(raw, scale, STRICT_GUARD)?;
+        let single_shot = narrow_round_mag(exp_x, lifted_guard_digits, mode, true, false);
+        if wnarrow_residual_clear(exp_x, lifted_guard_digits, mode) {
+            return single_shot;
         }
-        return narrow_ziv::walk_checked_never_exact(base, STRICT_GUARD, scale, mode, |g| {
-            exp2_ziv(raw, scale, g)
-        });
+        return narrow_ziv::walk_checked_never_exact(
+            single_shot, STRICT_GUARD, scale, mode, |guard_digits| {
+                exp2_ziv(raw, scale, guard_digits)
+            });
     }
-    let w = scale + STRICT_GUARD;
+    let working_scale = scale + STRICT_GUARD;
     let negative_input = raw < 0;
-    let v_w = Fixed::from_u128_mag(abs_raw, false).mul_u128(10u128.pow(STRICT_GUARD));
-    let v_w = if negative_input { v_w.neg() } else { v_w };
-    let arg_w = v_w.mul(wide_ln2(w), w);
-    let v = exp_fixed(arg_w, w);
-    match v.round_to_i128_clear_of_tie(w, scale, mode) {
-        Some(r) => r,
+    let working_value = Fixed::from_u128_mag(abs_raw, false).mul_u128(10u128.pow(STRICT_GUARD));
+    let working_value = if negative_input { working_value.neg() } else { working_value };
+    let arg_at_working_scale = working_value.mul(wide_ln2(working_scale), working_scale);
+    let exp_working_value = exp_fixed(arg_at_working_scale, working_scale);
+    match exp_working_value.round_to_i128_clear_of_tie(working_scale, scale, mode) {
+        Some(rounded) => rounded,
         None => narrow_ziv::walk_checked_never_exact(
-            v.round_to_i128_with(w, scale, mode),
+            exp_working_value.round_to_i128_with(working_scale, scale, mode),
             STRICT_GUARD,
             scale,
             mode,
-            |g| exp2_ziv(raw, scale, g),
+            |guard_digits| exp2_ziv(raw, scale, guard_digits),
         ),
     }
 }
@@ -965,9 +990,9 @@ mod deep_underflow_directed {
         // const-generic SCALE forces a literal per scale; same band, same
         // predicate (result magnitude strictly below the storage LSB).
         let cells: [(u32, fn(RoundingMode) -> Option<i128>); 3] = [
-            (17, |m| exp_strict_raw::<17>(raw_at(17), m)),
-            (18, |m| exp_strict_raw::<18>(raw_at(18), m)),
-            (19, |m| exp_strict_raw::<19>(raw_at(19), m)),
+            (17, |mode| exp_strict_raw::<17>(raw_at(17), mode)),
+            (18, |mode| exp_strict_raw::<18>(raw_at(18), mode)),
+            (19, |mode| exp_strict_raw::<19>(raw_at(19), mode)),
         ];
         for (scale, run) in cells {
             for mode in ALL_MODES {
@@ -1001,12 +1026,13 @@ mod fast_path_validity {
         if raw == 0 {
             return Some(10_i128.pow(scale));
         }
-        let w = scale + STRICT_GUARD;
+        let working_scale = scale + STRICT_GUARD;
         let negative_input = raw < 0;
-        let v_w =
+        let working_value =
             Fixed::from_u128_mag(raw.unsigned_abs(), false).mul_u128(10u128.pow(STRICT_GUARD));
-        let v_w = if negative_input { v_w.neg() } else { v_w };
-        std::panic::catch_unwind(|| exp_fixed(v_w, w).round_to_i128_with(w, scale, mode))
+        let working_value = if negative_input { working_value.neg() } else { working_value };
+        std::panic::catch_unwind(|| exp_fixed(working_value, working_scale)
+            .round_to_i128_with(working_scale, scale, mode))
             .unwrap_or(None)
     }
 
@@ -1022,8 +1048,9 @@ mod fast_path_validity {
     /// Mirror the production gate exactly: `true` ⇒ this cell stays on the
     /// fast path (so fast MUST equal wide). Directed modes always route wide.
     fn gate_keeps_fast(raw: i128, scale: u32, mode: RoundingMode) -> bool {
-        let w = scale + STRICT_GUARD;
-        narrow_fixed_fits(raw, scale, w) && crate::support::rounding::is_nearest_mode(mode)
+        let working_scale = scale + STRICT_GUARD;
+        narrow_fixed_fits(raw, scale, working_scale)
+            && crate::support::rounding::is_nearest_mode(mode)
     }
 
     // For EVERY D38 cell the production gate routes to the fast path,
@@ -1036,17 +1063,17 @@ mod fast_path_validity {
         std::panic::set_hook(Box::new(|_| {}));
         let mut checked = 0u64;
         for scale in 0u32..=38 {
-            let one_s = 10f64.powi(scale as i32);
-            let mut x10 = 1u64;
-            while x10 <= 1000 {
-                let x = x10 as f64 / 10.0;
+            let one_scaled = 10f64.powi(scale as i32);
+            let mut x_tenths = 1u64;
+            while x_tenths <= 1000 {
+                let x_value = x_tenths as f64 / 10.0;
                 for sign in [1i128, -1] {
-                    let raw_f = sign as f64 * x * one_s;
-                    if raw_f.abs() >= (i128::MAX as f64) {
-                        x10 += 1;
+                    let raw_float = sign as f64 * x_value * one_scaled;
+                    if raw_float.abs() >= (i128::MAX as f64) {
+                        x_tenths += 1;
                         continue;
                     }
-                    let raw = raw_f as i128;
+                    let raw = raw_float as i128;
                     if raw == 0 {
                         continue;
                     }
@@ -1057,7 +1084,7 @@ mod fast_path_validity {
                         let wide = match std::panic::catch_unwind(|| {
                             exp_wide_narrow_raw(raw, scale, STRICT_GUARD, mode)
                         }) {
-                            Ok(Some(v)) => v,
+                            Ok(Some(value)) => value,
                             // Wide reference itself overflows i128 — the
                             // narrow tier cannot represent the result; both
                             // paths report out of range, not a fast-vs-wide
@@ -1073,7 +1100,7 @@ mod fast_path_validity {
                         checked += 1;
                     }
                 }
-                x10 += 1;
+                x_tenths += 1;
             }
         }
         assert!(checked > 100_000, "too few cells checked: {checked}");
@@ -1130,25 +1157,34 @@ mod fast_path_validity {
     fn exp2_integer_regime_matches_golden_floor() {
         const S9: u32 = 9;
         let raw = 93_013_986_656_i128; // 93.013986656 at scale 9
-        let gfloor: i128 = 9_999_999_994_134_964_658_924_521_484_307_802_708;
+        let golden_floor: i128 = 9_999_999_994_134_964_658_924_521_484_307_802_708;
         for &mode in &MODES {
             let got = exp2_with_raw(raw, S9, STRICT_GUARD, mode);
             let want = if matches!(mode, RoundingMode::Ceiling) {
-                gfloor + 1
+                golden_floor + 1
             } else {
-                gfloor
+                golden_floor
             };
             assert_eq!(got, Some(want), "exp2(93.013986656) s9 mode={mode:?}");
         }
         // Integer-regime inputs whose result still fits i128 at scale 9:
         // 2^x·10^9 < i128::MAX ≈ 1.7·10^38 ⇒ x ≲ 97. (2^100·10^9 ≈ 1.3·10^39
         // overflows and correctly panics, so keep the sweep below that.)
-        for &r in &[50_000_000_000_i128, 70_000_000_000, 90_000_000_000] {
-            let he = exp2_with_raw(r, S9, STRICT_GUARD, RoundingMode::HalfToEven).expect("in range");
-            let fl = exp2_with_raw(r, S9, STRICT_GUARD, RoundingMode::Floor).expect("in range");
-            let ce = exp2_with_raw(r, S9, STRICT_GUARD, RoundingMode::Ceiling).expect("in range");
-            assert!(fl <= he && he <= ce, "exp2 rounding order violated at raw={r}");
-            assert!(ce - fl <= 1, "exp2 floor/ceil differ by >1 at raw={r}");
+        for &sweep_raw in &[50_000_000_000_i128, 70_000_000_000, 90_000_000_000] {
+            let half_even = exp2_with_raw(sweep_raw, S9, STRICT_GUARD, RoundingMode::HalfToEven)
+                .expect("in range");
+            let floor = exp2_with_raw(sweep_raw, S9, STRICT_GUARD, RoundingMode::Floor)
+                .expect("in range");
+            let ceiling = exp2_with_raw(sweep_raw, S9, STRICT_GUARD, RoundingMode::Ceiling)
+                .expect("in range");
+            assert!(
+                floor <= half_even && half_even <= ceiling,
+                "exp2 rounding order violated at raw={sweep_raw}"
+            );
+            assert!(
+                ceiling - floor <= 1,
+                "exp2 floor/ceil differ by >1 at raw={sweep_raw}"
+            );
         }
     }
 }

--- a/src/algos/exp/exp_tang.rs
+++ b/src/algos/exp/exp_tang.rs
@@ -40,21 +40,22 @@ use crate::int::types::compute_limbs::ComputeLimbs;
 use crate::int::types::traits::BigInt;
 use crate::support::rounding::RoundingMode;
 
-/// Tang-style `e^v_w` on an already-lifted working value `v_w` (`= x ·
-/// 10^w`), returned at working scale `w`. Generic over the tier `C` and
-/// the table size `M`.
+/// Tang-style `e^v` on an already-lifted `working_value` (`= x ·
+/// 10^w`), returned at the same `working_scale`. Generic over the tier `C`
+/// and the table size `M`.
 ///
 /// `INTERNAL_EXTRA` selects the large-`k` mitigation. For `k > 0` the final
 /// `2^k` reassembly (a LEFT shift) amplifies the reduction residual by
 /// `2^k ≈ 10^(k·log10 2)` decimal digits, so a fixed narrow guard cannot
 /// cover an unbounded `k`. When `true` the whole reduction runs at an
-/// extended working scale `w + extra` (`extra = ceil(k·log10 2) + 12`, sized
-/// for `k > 0` only) and the result is narrowed back to `w`
-/// round-to-nearest; when `false` the body runs at the caller-supplied `w`
-/// (the caller absorbs the `extra` lift in its own guard, or the band's `k`
-/// is small enough not to need it). For `k ≤ 0` the reassembly is an
-/// error-shrinking RIGHT shift, so no lift is taken (`extra = 0`) — see the
-/// body comment. This is the shared surface the trig hyperbolic kernels reuse.
+/// `extended_working_scale = working_scale + extra_digits`
+/// (`extra_digits = ceil(k·log10 2) + 12`, sized for `k > 0` only) and the
+/// result is narrowed back to `working_scale` round-to-nearest; when `false`
+/// the body runs at the caller-supplied `working_scale` (the caller absorbs
+/// the `extra_digits` lift in its own guard, or the band's `k` is small
+/// enough not to need it). For `k ≤ 0` the reassembly is an error-shrinking
+/// RIGHT shift, so no lift is taken (`extra_digits = 0`) — see the body
+/// comment. This is the shared surface the trig hyperbolic kernels reuse.
 #[must_use]
 pub(crate) fn tang_exp_fixed<
     C: WideTrigCore,
@@ -62,8 +63,8 @@ pub(crate) fn tang_exp_fixed<
     const INTERNAL_EXTRA: bool,
     const SCALE: u32,
 >(
-    v_w: C::W,
-    w: u32,
+    working_value: C::W,
+    working_scale: u32,
 ) -> C::W
 where
     <C::W as BigInt>::Scratch: ComputeLimbs,
@@ -74,7 +75,8 @@ where
     // rounding mode + the per-scale const-fold). One Tang `exp` kernel — the
     // wide compositions call `tang_exp_fixed_g` directly at their `Wagm` work
     // width.
-    tang_exp_fixed_g::<C::W, M, INTERNAL_EXTRA>(v_w, w, |ww| C::ln2::<SCALE>(ww))
+    tang_exp_fixed_g::<C::W, M, INTERNAL_EXTRA>(
+        working_value, working_scale, |at_scale| C::ln2::<SCALE>(at_scale))
 }
 
 /// Width-generic core of [`tang_exp_fixed`] — the Tang `exp` body over any
@@ -89,54 +91,57 @@ where
 /// hyperbolics) call this directly at their `Wagm` work width.
 #[must_use]
 pub(crate) fn tang_exp_fixed_g<S: BigInt, const M: u32, const INTERNAL_EXTRA: bool>(
-    v_w: S,
-    w: u32,
+    working_value: S,
+    working_scale: u32,
     ln2: impl Fn(u32) -> S,
 ) -> S
 where
     S::Scratch: ComputeLimbs,
 {
-    // Stage 0 (INTERNAL_EXTRA only): size an extended working scale
-    // `w_ext = w + extra` from `|k|` so the `2^k` reassembly does not
-    // amplify the reduction residual past the storage LSB. Matches the
+    // Stage 0 (INTERNAL_EXTRA only): size an `extended_working_scale
+    // = working_scale + extra_digits` from `|k|` so the `2^k` reassembly does
+    // not amplify the reduction residual past the storage LSB. Matches the
     // dynamic-margin reduction the generic `exp_fixed` uses (Muller,
     // *Elementary Functions* 3rd ed., §11.1). `k` is scale-invariant, so
-    // reuse the value computed at `w` below.
+    // reuse the value computed at `working_scale` below.
     let k = {
-        let one_w = eg::one::<S>(w);
-        eg::round_to_nearest_int::<S>(eg::div_cached::<S>(v_w, ln2(w), one_w), w)
+        let one_at_working_scale = eg::one::<S>(working_scale);
+        eg::round_to_nearest_int::<S>(
+            eg::div_cached::<S>(working_value, ln2(working_scale), one_at_working_scale),
+            working_scale)
     };
 
-    let (w_ext, v_ext, extra) = if INTERNAL_EXTRA {
+    let (extended_working_scale, extended_working_value, extra_digits) = if INTERNAL_EXTRA {
         // Size the extended scale from `k` only for `k > 0`: the `2^k`
         // reassembly amplifies the residual only on the LEFT shift. For `k < 0`
         // (underflow) the reassembly is an error-shrinking RIGHT shift, so the
-        // base scale already suffices — and inflating `w_ext` there would drive
-        // the table-entry product `slot_hi · 10^w_ext` (≈ `2·w_ext·log2(10)`
-        // bits) past the work integer `S`, silently wrapping `exp(c_j)`. (Same
-        // asymmetry the `EXTERNAL_EXTRA` wrapper applies.)
-        let extra: u32 = if k <= 0 {
+        // base scale already suffices — and inflating the extended scale there
+        // would drive the table-entry product `slot_hi · 10^ext` (≈
+        // `2·ext·log2(10)` bits) past the work integer `S`, silently wrapping
+        // `exp(c_j)`. (Same asymmetry the `EXTERNAL_EXTRA` wrapper applies.)
+        let extra_digits: u32 = if k <= 0 {
             0
         } else {
             let digits = (k as u128 * 30103).div_ceil(100_000) as u32;
             digits + 12
         };
-        let v_ext = if extra == 0 {
-            v_w
+        let extended_working_value = if extra_digits == 0 {
+            working_value
         } else {
-            v_w * eg::pow10::<S>(extra)
+            working_value * eg::pow10::<S>(extra_digits)
         };
-        (w + extra, v_ext, extra)
+        (working_scale + extra_digits, extended_working_value, extra_digits)
     } else {
-        (w, v_w, 0)
+        (working_scale, working_value, 0)
     };
 
-    // Overflow gate (up front, before any `w_ext`-scale work). The body runs at
-    // the extended scale `w_ext` — `one_w = 10^w_ext` and the `2^k` reassembly
-    // `exp_s << k` — so a result too large to represent needs `w_ext` digits
-    // (`≈ w_ext·log2(10)` bits) PLUS the `k`-bit shift to exceed `S`. Without
-    // this gate the `10^w_ext` literal alone silently WRAPS once it passes `S`'s
-    // width (e.g. exp2(1005) = e^696.7: `w_ext ≈ 372` ⇒ ~1236 bits > Wagm's
+    // Overflow gate (up front, before any extended-scale work). The body runs
+    // at `extended_working_scale` — `one_at_extended_scale = 10^ext` and the
+    // `2^k` reassembly `exp_reduced_arg << k` — so a result too large to
+    // represent needs `ext` digits (`≈ ext·log2(10)` bits) PLUS the `k`-bit
+    // shift to exceed `S`. Without this gate the `10^ext` literal alone
+    // silently WRAPS once it passes `S`'s
+    // width (e.g. exp2(1005) = e^696.7: `ext ≈ 372` ⇒ ~1236 bits > Wagm's
     // 1024 ⇒ garbage), and the result came back as 0 instead of panicking. A
     // fixed-width decimal has no infinity: PANIC, uniform across debug AND
     // release (the strict-transcendental overflow contract). In-range results
@@ -144,63 +149,70 @@ where
     // representable cell. digits→bits: `log2(10) ≈ 3322/1000`.
     {
         let peak_bits =
-            (w_ext as u64) * 3322 / 1000 + if k >= 0 { k as u64 } else { 0 };
+            (extended_working_scale as u64) * 3322 / 1000 + if k >= 0 { k as u64 } else { 0 };
         if peak_bits >= <S as BigInt>::BITS as u64 {
             panic!("tang_exp_fixed: result out of range");
         }
     }
 
-    let one_w = eg::one::<S>(w_ext);
-    let pow10_w = one_w;
-    let l2 = ln2(w_ext);
+    let one_at_extended_scale = eg::one::<S>(extended_working_scale);
+    let pow10_at_extended_scale = one_at_extended_scale;
+    let ln2_at_extended_scale = ln2(extended_working_scale);
 
     // Stage 1: v = k·ln 2 + s, |s| ≤ ln 2 / 2.
-    let k_l2 = if k >= 0 {
-        l2 * eg::lit::<S>(k)
+    let k_ln2 = if k >= 0 {
+        ln2_at_extended_scale * eg::lit::<S>(k)
     } else {
-        -(l2 * eg::lit::<S>(-k))
+        -(ln2_at_extended_scale * eg::lit::<S>(-k))
     };
-    let s = v_ext - k_l2;
+    let reduced_arg = extended_working_value - k_ln2;
 
     // Stage 2: s = j_signed · (ln 2 / M) + δ, |δ| ≤ ln 2 / (2M).
-    let j_signed =
-        eg::round_to_nearest_int::<S>(eg::div_cached::<S>(s * eg::lit::<S>(M as i128), l2, pow10_w), w_ext);
-    let cj_signed_w = if j_signed >= 0 {
-        (l2 * eg::lit::<S>(j_signed)) / eg::lit::<S>(M as i128)
+    let table_index_signed = eg::round_to_nearest_int::<S>(
+        eg::div_cached::<S>(
+            reduced_arg * eg::lit::<S>(M as i128),
+            ln2_at_extended_scale,
+            pow10_at_extended_scale),
+        extended_working_scale);
+    let table_point = if table_index_signed >= 0 {
+        (ln2_at_extended_scale * eg::lit::<S>(table_index_signed)) / eg::lit::<S>(M as i128)
     } else {
-        -((l2 * eg::lit::<S>(-j_signed)) / eg::lit::<S>(M as i128))
+        -((ln2_at_extended_scale * eg::lit::<S>(-table_index_signed))
+            / eg::lit::<S>(M as i128))
     };
-    let delta = s - cj_signed_w;
-    let (j_idx, k_adj) = if j_signed >= 0 {
-        (j_signed as u32, 0i128)
+    let delta = reduced_arg - table_point;
+    let (table_index, k_adj) = if table_index_signed >= 0 {
+        (table_index_signed as u32, 0i128)
     } else {
-        ((j_signed + M as i128) as u32, -1i128)
+        ((table_index_signed + M as i128) as u32, -1i128)
     };
-    debug_assert!(j_idx < M, "tang_exp_fixed: table index out of range");
+    debug_assert!(table_index < M, "tang_exp_fixed: table index out of range");
 
     // Taylor on δ.
-    let mut sum = one_w + delta;
+    let mut sum = one_at_extended_scale + delta;
     let mut term = delta;
-    let mut n: u128 = 2;
+    let mut term_index: u128 = 2;
     loop {
-        term = eg::mul::<S>(term, delta, w_ext) / eg::lit::<S>(n as i128);
+        term = eg::mul::<S>(term, delta, extended_working_scale)
+            / eg::lit::<S>(term_index as i128);
         if term == eg::zero::<S>() {
             break;
         }
         sum = sum + term;
-        n += 1;
-        if n > 200 {
+        term_index += 1;
+        if term_index > 200 {
             break;
         }
     }
 
-    let exp_cj = exp_table_entry_baked::<S>(w_ext, j_idx as usize, M, pow10_w);
-    let exp_s = eg::mul::<S>(exp_cj, sum, w_ext);
+    let exp_table_value = exp_table_entry_baked::<S>(
+        extended_working_scale, table_index as usize, M, pow10_at_extended_scale);
+    let exp_reduced_arg = eg::mul::<S>(exp_table_value, sum, extended_working_scale);
 
     let k_total = k + k_adj;
-    let scaled_at_w_ext = if k_total >= 0 {
+    let exp_at_extended_scale = if k_total >= 0 {
         let shift = k_total as u32;
-        // The `2^k` reassembly `exp_s << shift` wraps past `S`'s width once the
+        // The `2^k` reassembly `exp_reduced_arg << shift` wraps past `S`'s width once the
         // result is too large to represent — a genuinely out-of-range exp. A
         // fixed-width decimal has no infinity, so PANIC, uniform across debug
         // AND release (the strict-transcendental overflow contract). This was a
@@ -209,16 +221,16 @@ where
         // panicking, while `exp2(200)` (overflow that still fits `S`, panicking
         // later at the storage narrow) was correct: a tier/scale-INVARIANT
         // violation the full-surface golden surfaced.
-        if eg::bit_length::<S>(exp_s) + shift >= <S as BigInt>::BITS {
+        if eg::bit_length::<S>(exp_reduced_arg) + shift >= <S as BigInt>::BITS {
             panic!("tang_exp_fixed: result out of range");
         }
-        exp_s << shift
+        exp_reduced_arg << shift
     } else {
-        let neg_k = (-k_total) as u32;
-        if neg_k as u128 >= eg::bit_length::<S>(exp_s) as u128 {
+        let right_shift_bits = (-k_total) as u32;
+        if right_shift_bits as u128 >= eg::bit_length::<S>(exp_reduced_arg) as u128 {
             // Deep underflow: `e^v` (`v < 0` here, since `k_total < 0`) is
             // strictly positive but below the working resolution. Return the
-            // smallest positive working value (`1 = 10^-w_ext`), NOT a bare
+            // smallest positive working value (`1 = 10^-ext`), NOT a bare
             // zero, so the caller's directed narrowing keeps the sign —
             // Ceiling rounds UP to one storage ULP while Floor / Trunc /
             // nearest still give 0. A bare zero loses positivity and rounds
@@ -226,7 +238,7 @@ where
             // matches `exp_generic::try_exp_fixed`'s deep-underflow return.
             eg::lit::<S>(1)
         } else {
-            exp_s >> neg_k
+            exp_reduced_arg >> right_shift_bits
         }
     };
 
@@ -236,24 +248,24 @@ where
     // narrowing keeps the sign (Ceiling → 1 ULP). Mirrors the `exp_generic`
     // catch-all; restricted to `k_total < 0`, the only regime where
     // underflow to 0 is physical.
-    let scaled_at_w_ext = if k_total < 0 && scaled_at_w_ext == eg::zero::<S>() {
+    let exp_at_extended_scale = if k_total < 0 && exp_at_extended_scale == eg::zero::<S>() {
         eg::lit::<S>(1)
     } else {
-        scaled_at_w_ext
+        exp_at_extended_scale
     };
 
-    if !INTERNAL_EXTRA || extra == 0 {
-        scaled_at_w_ext
+    if !INTERNAL_EXTRA || extra_digits == 0 {
+        exp_at_extended_scale
     } else {
-        // Narrow the extended-scale result back to `w` round-to-nearest
-        // (ties up via the `+ half` bias). `extra` is bounded so
-        // `10^extra` stays well inside the working width.
-        let p = eg::pow10::<S>(extra);
-        let half = p / eg::lit::<S>(2);
-        if scaled_at_w_ext >= eg::zero::<S>() {
-            (scaled_at_w_ext + half) / p
+        // Narrow the extended-scale result back to `working_scale`
+        // round-to-nearest (ties up via the `+ half` bias). `extra_digits` is
+        // bounded so `10^extra_digits` stays well inside the working width.
+        let extra_pow10 = eg::pow10::<S>(extra_digits);
+        let half = extra_pow10 / eg::lit::<S>(2);
+        if exp_at_extended_scale >= eg::zero::<S>() {
+            (exp_at_extended_scale + half) / extra_pow10
         } else {
-            -((-scaled_at_w_ext + half) / p)
+            -((-exp_at_extended_scale + half) / extra_pow10)
         }
     }
 }
@@ -268,10 +280,10 @@ where
 /// - `DIRECTED` — route the final narrowing through the directed-rounding
 ///   Ziv escalation (`true`), else narrow once with
 ///   `round_to_storage_with` (`false`).
-/// - `EXTERNAL_EXTRA` — compute the large-`|k|` working-scale lift `extra`
-///   in this wrapper and fold it into the directed base guard (the D115
-///   shape; requires `DIRECTED`).
-/// - `INTERNAL_EXTRA` — let [`tang_exp_fixed`] do the `extra` lift +
+/// - `EXTERNAL_EXTRA` — compute the large-`|k|` working-scale lift
+///   `extra_digits` in this wrapper and fold it into the directed base guard
+///   (the D115 shape; requires `DIRECTED`).
+/// - `INTERNAL_EXTRA` — let [`tang_exp_fixed`] do the `extra_digits` lift +
 ///   narrow-back internally (the D153 shape).
 #[inline]
 #[must_use]
@@ -303,32 +315,38 @@ where
         // and can sit a sub-resolution residual below the work-int's
         // resolution — `exp(-10^-S)` just under `1.0` at MAX scale) fall
         // through to the never-exact Ziv path below.
-        let w = SCALE + GUARD;
-        let v_w = C::to_work_scaled(raw, GUARD);
-        let result = tang_exp_fixed::<C, M, INTERNAL_EXTRA, SCALE>(v_w, w);
-        return C::round_to_storage_with(result, w, SCALE, mode);
+        let working_scale = SCALE + GUARD;
+        let working_value = C::to_work_scaled(raw, GUARD);
+        let exp_working_value =
+            tang_exp_fixed::<C, M, INTERNAL_EXTRA, SCALE>(working_value, working_scale);
+        return C::round_to_storage_with(exp_working_value, working_scale, SCALE, mode);
     }
 
-    let base_guard = if EXTERNAL_EXTRA {
+    let base_guard_digits = if EXTERNAL_EXTRA {
         // The final reassembly is `exp_s << k` for `k ≥ 0` and `exp_s >> |k|`
         // for `k < 0`. Only the LEFT shift (`k ≥ 0`) amplifies the
         // working-scale rounding error by `2^k` (≈ `|k|·log10 2` digits), so
-        // only there must the base guard widen by `extra` to keep the
+        // only there must the base guard widen by `extra_digits` to keep the
         // post-shift residual inside the guard. For `k < 0` (the underflow
         // direction — `e^(large negative)`) the reassembly is a RIGHT shift
         // that shrinks the value and its absolute error, so the base `GUARD`
         // already covers it with vast margin; inflating the guard there is not
-        // only needless but HARMFUL — it drives the working scale `w = SCALE +
-        // base_guard` high enough that the Tang table-entry product
-        // (`exp_table_entry_baked`'s `slot_hi · 10^w`, ≈ `2·w·log2(10)` bits)
-        // overflows the work integer `S`, silently wrapping the `exp(c_j)`
+        // only needless but HARMFUL — it drives the working scale
+        // `SCALE + base_guard_digits` high enough that the Tang table-entry
+        // product (`exp_table_entry_baked`'s `slot_hi · 10^w`, ≈ `2·w·log2(10)`
+        // bits) overflows the work integer `S`, silently wrapping the `exp(c_j)`
         // factor (the deep-underflow misround at the wide tiers' max scale).
-        // So size `extra` from `k` only when `k > 0`.
-        let w = SCALE + GUARD;
-        let one_w = C::one(w);
-        let v_w_probe = C::to_work_scaled(raw, GUARD);
-        let k = C::round_to_nearest_int(C::div_cached(v_w_probe, C::ln2::<SCALE>(w), one_w), w);
-        let extra: u32 = if k <= 0 {
+        // So size `extra_digits` from `k` only when `k > 0`.
+        let working_scale = SCALE + GUARD;
+        let one_at_working_scale = C::one(working_scale);
+        let working_value_probe = C::to_work_scaled(raw, GUARD);
+        let k = C::round_to_nearest_int(
+            C::div_cached(
+                working_value_probe,
+                C::ln2::<SCALE>(working_scale),
+                one_at_working_scale),
+            working_scale);
+        let extra_digits: u32 = if k <= 0 {
             0
         } else {
             let abs_k = k as u128;
@@ -336,7 +354,7 @@ where
             let capped = digits.min((C::w_bits() / 4) as u128) as u32;
             capped + 12 + (capped >> 2)
         };
-        GUARD + extra
+        GUARD + extra_digits
     } else {
         GUARD
     };
@@ -350,8 +368,9 @@ where
     // artifact, and Ceiling must still round up (Floor / Trunc keep the floor)
     // on inputs whose deciding residual is below the work-int resolution
     // (`exp(-10^-S)` just under `1.0`).
-    C::round_to_storage_directed_never_exact(base_guard, SCALE, mode, &mut |guard| {
-        tang_exp_fixed::<C, M, INTERNAL_EXTRA, SCALE>(C::to_work_scaled(raw, guard), SCALE + guard)
+    C::round_to_storage_directed_never_exact(base_guard_digits, SCALE, mode, &mut |guard_digits| {
+        tang_exp_fixed::<C, M, INTERNAL_EXTRA, SCALE>(
+            C::to_work_scaled(raw, guard_digits), SCALE + guard_digits)
     })
 }
 
@@ -388,13 +407,16 @@ mod tests {
         // from below the overflow boundary (~−33) up to the storage edge
         // (max |x| ≈ 57.9 at D76<75>).
         let args = ["-20.0", "-33.5", "-34.37", "-40.0", "-45.123", "-50.25", "-55.0", "-57.5"];
-        for s in args {
-            let a76: D76<75> = s.parse().unwrap();
-            let a307: D307<75> = s.parse().unwrap();
-            for m in MODES {
-                let got = a76.exp_strict_with(m).to_string();
-                let want = a307.exp_strict_with(m).to_string();
-                assert_eq!(got, want, "exp({s}) D76<75> vs D307<75> oracle, mode {m:?}");
+        for arg_text in args {
+            let d76_value: D76<75> = arg_text.parse().unwrap();
+            let d307_value: D307<75> = arg_text.parse().unwrap();
+            for mode in MODES {
+                let got = d76_value.exp_strict_with(mode).to_string();
+                let want = d307_value.exp_strict_with(mode).to_string();
+                assert_eq!(
+                    got, want,
+                    "exp({arg_text}) D76<75> vs D307<75> oracle, mode {mode:?}"
+                );
             }
         }
     }
@@ -432,12 +454,12 @@ mod powf_deep_underflow_regression {
 
     /// `"0.00…01"` — one storage ULP at `scale` (the smallest positive).
     fn one_ulp_str(scale: usize) -> String {
-        let mut s = String::from("0.");
+        let mut text = String::from("0.");
         for _ in 0..scale - 1 {
-            s.push('0');
+            text.push('0');
         }
-        s.push('1');
-        s
+        text.push('1');
+        text
     }
 
     #[cfg(any(feature = "d57", feature = "wide"))]
@@ -451,10 +473,10 @@ mod powf_deep_underflow_regression {
                 let exp: D57<$s> = "-200".parse().unwrap();
                 let zero: D57<$s> = "0".parse().unwrap();
                 let one_ulp: D57<$s> = one_ulp_str($s).parse().unwrap();
-                for m in DOWN_MODES {
+                for mode in DOWN_MODES {
                     assert_eq!(
-                        base.powf_strict_with(exp, m), zero,
-                        "D57<{}> powf(2,-200) {m:?} must round the sub-resolution positive to 0", $s
+                        base.powf_strict_with(exp, mode), zero,
+                        "D57<{}> powf(2,-200) {mode:?} must round the sub-resolution positive to 0", $s
                     );
                 }
                 assert_eq!(
@@ -477,10 +499,10 @@ mod powf_deep_underflow_regression {
                 let exp: D76<$s> = "-200".parse().unwrap();
                 let zero: D76<$s> = "0".parse().unwrap();
                 let one_ulp: D76<$s> = one_ulp_str($s).parse().unwrap();
-                for m in DOWN_MODES {
+                for mode in DOWN_MODES {
                     assert_eq!(
-                        base.powf_strict_with(exp, m), zero,
-                        "D76<{}> powf(2,-200) {m:?} must round the sub-resolution positive to 0", $s
+                        base.powf_strict_with(exp, mode), zero,
+                        "D76<{}> powf(2,-200) {mode:?} must round the sub-resolution positive to 0", $s
                     );
                 }
                 assert_eq!(

--- a/src/algos/expm1/expm1_generic.rs
+++ b/src/algos/expm1/expm1_generic.rs
@@ -32,9 +32,9 @@ use crate::int::types::traits::BigInt;
 /// `(N, SCALE)` cell.
 pub(crate) const DIRECT_BAND: i128 = 1;
 
-/// Argument-magnitude regime of `expm1(v)` for a working-scale `v_w` at scale
-/// `w` in the work integer `S`, decided from the BIT LENGTH alone — before any
-/// division, exactly as `exp_generic::ArgRegime` is.
+/// Argument-magnitude regime of `expm1(v)` for a `working_value` at
+/// `working_scale` in the work integer `S`, decided from the BIT LENGTH alone —
+/// before any division, exactly as `exp_generic::ArgRegime` is.
 ///
 /// The bounds are the `exp` classifier's, re-derived for `e^v - 1`; the two
 /// functions differ by exactly `1`, which never moves an overflow threshold.
@@ -51,39 +51,39 @@ pub(crate) enum Regime {
     MinusOne,
 }
 
-/// Classifies `v_w` per [`Regime`].
+/// Classifies `working_value` per [`Regime`].
 ///
 /// Derivation (both bounds SUFFICIENT, never fired by a representable cell),
-/// with `bl = bit_length(v_w)` and `|v| >= 2^(bl-1) / 10^w`:
+/// with `bit_len = bit_length(working_value)` and `|v| >= 2^(bit_len-1) / 10^w`:
 ///
 /// * **Overflow** (`v > 0`): the result needs `e^v * 10^w < 2^BITS`, i.e.
 ///   `v < BITS*ln2 - w*ln10`. With
 ///   `R = floor(BITS*6932/10000) + 1 - floor(w*23025/10000) >= BITS*ln2 - w*ln10`
 ///   the result provably overflows `S` once
-///   `bl >= ceil(w*33220/10000) + bits(R) + 2`.
+///   `bit_len >= ceil(w*33220/10000) + bits(R) + 2`.
 /// * **MinusOne** (`v < 0`): `e^v < 10^-(w+1)` — strictly below the working
 ///   resolution — once `|v| >= (w+1)*ln10`. With
 ///   `U = floor((w+1)*23026/10000) + 1 >= (w+1)*ln10` the same bit-length
-///   argument gives `bl >= ceil(w*33220/10000) + bits(U) + 2`.
-pub(crate) fn regime<S: BigInt>(v_w: S, w: u32) -> Regime {
-    if v_w == S::ZERO {
+///   argument gives `bit_len >= ceil(w*33220/10000) + bits(U) + 2`.
+pub(crate) fn regime<S: BigInt>(working_value: S, working_scale: u32) -> Regime {
+    if working_value == S::ZERO {
         return Regime::Fits;
     }
-    let bl = eg::bit_length::<S>(v_w) as u64;
+    let bit_len = eg::bit_length::<S>(working_value) as u64;
     // ceil(w * log2 10), over-approximated (33220/10000 >= log2 10).
-    let w_bits = ((w as u64) * 33220).div_ceil(10000);
+    let working_scale_bits = ((working_scale as u64) * 33220).div_ceil(10000);
     // bits(x) = floor(log2 x) + 1, so 2^bits(x) >= x.
     let bits_of = |x: u64| 64 - x.leading_zeros() as u64;
-    if v_w > S::ZERO {
+    if working_value > S::ZERO {
         let bits_ln2 = (<S as BigInt>::BITS as u64) * 6932 / 10000 + 1;
-        let w_ln10 = (w as u64) * 23025 / 10000;
-        let r = bits_ln2.saturating_sub(w_ln10).max(1);
-        if bl >= w_bits + bits_of(r) + 2 {
+        let scale_ln10 = (working_scale as u64) * 23025 / 10000;
+        let overflow_arg_bound = bits_ln2.saturating_sub(scale_ln10).max(1);
+        if bit_len >= working_scale_bits + bits_of(overflow_arg_bound) + 2 {
             return Regime::Overflow;
         }
     } else {
-        let u = ((w as u64) + 1) * 23026 / 10000 + 1;
-        if bl >= w_bits + bits_of(u) + 2 {
+        let minus_one_arg_bound = ((working_scale as u64) + 1) * 23026 / 10000 + 1;
+        if bit_len >= working_scale_bits + bits_of(minus_one_arg_bound) + 2 {
             return Regime::MinusOne;
         }
     }
@@ -111,23 +111,24 @@ pub(crate) fn regime<S: BigInt>(v_w: S, w: u32) -> Regime {
 /// `Some(1)` (the smallest POSITIVE working value rather than `0`, so directed
 /// rounding keeps the sign) — the same rule, reflected about `-1`.
 #[inline]
-pub(crate) fn just_above_minus_one<S: BigInt>(w: u32) -> S {
-    eg::lit::<S>(1) - eg::one::<S>(w)
+pub(crate) fn just_above_minus_one<S: BigInt>(working_scale: u32) -> S {
+    eg::lit::<S>(1) - eg::one::<S>(working_scale)
 }
 
-/// `ceil(|v|)` as a `u128`, for a working-scale `v_w` at scale `w`.
+/// `ceil(|v|)` as a `u128`, for a `working_value` at `working_scale`.
 ///
 /// Bounded by [`Regime::Fits`] to order `S::BITS * ln 2`, far inside `u128`.
-pub(crate) fn ceil_abs_int<S: BigInt>(v_w: S, w: u32) -> u128
+pub(crate) fn ceil_abs_int<S: BigInt>(working_value: S, working_scale: u32) -> u128
 where
     S::Scratch: ComputeLimbs,
 {
-    let (q, r) = eg::div_rem_exact(v_w.abs(), eg::pow10::<S>(w));
-    let n = <S as BigInt>::to_i128(q).unsigned_abs();
-    if r == S::ZERO {
-        n
+    let (quotient, remainder) =
+        eg::div_rem_exact(working_value.abs(), eg::pow10::<S>(working_scale));
+    let integer_part = <S as BigInt>::to_i128(quotient).unsigned_abs();
+    if remainder == S::ZERO {
+        integer_part
     } else {
-        n.saturating_add(1)
+        integer_part.saturating_add(1)
     }
 }
 
@@ -169,18 +170,19 @@ pub(crate) fn extra_digits<S: BigInt>(int_digits: u32) -> u32 {
     capped + 12 + (capped >> 2)
 }
 
-/// Argument-reduction depth for the halving/doubling core at working scale
-/// `w_ext`: the largest `n >= 1` with `(n+1)^2 <= 3*w_ext + 1` (so
-/// `n ~ sqrt(3*w_ext)`) — the same balance point `exp_fixed`'s
-/// `squaring_levels` strikes between reduction depth and Taylor term count.
+/// Argument-reduction depth for the halving/doubling core at
+/// `extended_working_scale`: the largest `n >= 1` with
+/// `(n+1)^2 <= 3*extended_working_scale + 1` (so `n ~ sqrt(3*ext)`) — the
+/// same balance point `exp_fixed`'s `squaring_levels` strikes between
+/// reduction depth and Taylor term count.
 #[inline]
-pub(crate) fn halving_levels(w_ext: u32) -> u32 {
-    let p_bits = w_ext.saturating_mul(3).saturating_add(1);
-    let mut n: u32 = 1;
-    while (n + 1) * (n + 1) <= p_bits {
-        n += 1;
+pub(crate) fn halving_levels(extended_working_scale: u32) -> u32 {
+    let level_bound = extended_working_scale.saturating_mul(3).saturating_add(1);
+    let mut levels: u32 = 1;
+    while (levels + 1) * (levels + 1) <= level_bound {
+        levels += 1;
     }
-    n
+    levels
 }
 
 /// Extra halvings needed to bring `|v|` into the [`DIRECT_BAND`]:
@@ -195,10 +197,10 @@ pub(crate) fn band_levels(ceil_abs: u128) -> u32 {
     }
 }
 
-/// `w * log2 10`, over-approximated (3322/1000 >= log2 10).
+/// `working_scale * log2 10`, over-approximated (3322/1000 >= log2 10).
 #[inline]
-pub(crate) fn scale_bits(w: u32) -> u64 {
-    (w as u64) * 3322 / 1000
+pub(crate) fn scale_bits(working_scale: u32) -> u64 {
+    (working_scale as u64) * 3322 / 1000
 }
 
 /// Whether a modelled internal peak of `peak` bits fits the work integer `S`

--- a/src/algos/expm1/expm1_halving.rs
+++ b/src/algos/expm1/expm1_halving.rs
@@ -53,19 +53,20 @@
 //! The classic reduction keeps every squaring on `sum ~ P` (because
 //! `|s| <= ln2/2`) and applies the `2^k` growth ONCE at the end. This kernel
 //! carries the growth through the recurrence, so its last product is
-//! `~ e^v * P^2` rather than `~ P^2`: it needs up to `w_ext*log2(10)` MORE bits
-//! of work integer for large positive `v`. That is the trade — no `ln 2`, no
+//! `~ e^v * P^2` rather than `~ P^2`: it needs up to
+//! `extended_working_scale*log2(10)` MORE bits of work integer for large
+//! positive `v`. That is the trade — no `ln 2`, no
 //! divide, no reduction cancellation, in exchange for a taller peak on the
 //! positive side. `expm1_reduced` is the other side of it.
 //!
 //! # Validity
 //!
-//! * `v <= 0`: `2*w_ext*log2(10) + 1 + 64 < BITS`.
-//! * `v > 0`: `2*w_ext*log2(10) + ceil(|v|*log2 e) + 64 < BITS`.
+//! * `v <= 0`: `2*extended_working_scale*log2(10) + 1 + 64 < BITS`.
+//! * `v > 0`: `2*extended_working_scale*log2(10) + ceil(|v|*log2 e) + 64 < BITS`.
 //! * The halving depth is bounded by the caller's guard: the shift injects one
 //!   working unit which the chain amplifies by `2^n`, so correct rounding needs
-//!   `2^n < 1/2 * 10^guard`. The `n_digits` lift below covers it internally, so
-//!   the wall is on the work integer, not the guard.
+//!   `2^n < 1/2 * 10^guard`. The `chain_digits` lift below covers it
+//!   internally, so the wall is on the work integer, not the guard.
 
 #![allow(dead_code)]
 
@@ -74,88 +75,93 @@ use crate::algos::exp::exp_generic as eg;
 use crate::int::types::compute_limbs::ComputeLimbs;
 use crate::int::types::traits::BigInt;
 
-/// The halving + doubling core: `expm1(s)` at working scale `w`, reducing by
-/// `n` binary halvings and climbing back with `n` applications of
-/// `E <- E*(E + 2)`.
+/// The halving + doubling core: `expm1(s)` at `working_scale`, reducing by
+/// `doublings` binary halvings and climbing back with `doublings`
+/// applications of `E <- E*(E + 2)`.
 ///
 /// Shared with [`super::expm1_reduced`] (which supplies an already
-/// `k*ln 2`-reduced `s` and its own `n`), so the recurrence has ONE body.
+/// `k*ln 2`-reduced `reduced_arg` and its own `doublings`), so the recurrence
+/// has ONE body.
 ///
-/// `n` is capped at `bit_length(s) - 1` so the shift can never take the
-/// argument to zero — a zero `u` would return 0 for a genuinely non-zero `s`.
-/// The cap binds only for sub-resolution arguments, which the strict wrapper's
-/// near-min pin owns anyway. The shift semantics are `exp_fixed`'s `s >> n`
-/// (arithmetic for negative values); its one working unit of truncation is
-/// what the callers' guard lift provisions against the `2^n` amplification.
-pub(crate) fn expm1_doubling_core<S: BigInt>(s: S, w: u32, n: u32) -> S
+/// `doublings` is capped at `bit_length(reduced_arg) - 1` so the shift can
+/// never take the argument to zero — a zero `halved_arg` would return 0 for a
+/// genuinely non-zero `reduced_arg`. The cap binds only for sub-resolution
+/// arguments, which the strict wrapper's near-min pin owns anyway. The shift
+/// semantics are `exp_fixed`'s `s >> n` (arithmetic for negative values); its
+/// one working unit of truncation is what the callers' guard lift provisions
+/// against the `2^n` amplification.
+pub(crate) fn expm1_doubling_core<S: BigInt>(
+    reduced_arg: S, working_scale: u32, doublings: u32) -> S
 where
     S::Scratch: ComputeLimbs,
 {
-    let n = n.min(eg::bit_length::<S>(s).saturating_sub(1));
-    let u = s >> n;
-    let mut e = eg::expm1_fixed::<S>(u, w);
-    let two_p = eg::one::<S>(w) + eg::one::<S>(w);
+    let doublings = doublings.min(eg::bit_length::<S>(reduced_arg).saturating_sub(1));
+    let halved_arg = reduced_arg >> doublings;
+    let mut expm1_value = eg::expm1_fixed::<S>(halved_arg, working_scale);
+    let two_scaled = eg::one::<S>(working_scale) + eg::one::<S>(working_scale);
     let mut i = 0;
-    while i < n {
-        e = eg::mul::<S>(e, e + two_p, w);
+    while i < doublings {
+        expm1_value = eg::mul::<S>(expm1_value, expm1_value + two_scaled, working_scale);
         i += 1;
     }
-    e
+    expm1_value
 }
 
-/// `expm1(v)` for a working-scale value `v_w` at scale `w`, by halving +
-/// doubling. `None` = cannot be produced in `S` at this `w` (the
+/// `expm1(v)` for a `working_value` at `working_scale`, by halving +
+/// doubling. `None` = cannot be produced in `S` at this `working_scale` (the
 /// `try_exp_fixed` contract: detect once, the policy wrapper applies the
 /// overflow policy).
-pub(crate) fn expm1_halving_fixed<S: BigInt>(v_w: S, w: u32) -> Option<S>
+pub(crate) fn expm1_halving_fixed<S: BigInt>(working_value: S, working_scale: u32) -> Option<S>
 where
     S::Scratch: ComputeLimbs,
 {
-    if v_w == S::ZERO {
+    if working_value == S::ZERO {
         return Some(S::ZERO);
     }
-    match sup::regime::<S>(v_w, w) {
+    match sup::regime::<S>(working_value, working_scale) {
         sup::Regime::Overflow => return None,
-        sup::Regime::MinusOne => return Some(sup::just_above_minus_one::<S>(w)),
+        sup::Regime::MinusOne => return Some(sup::just_above_minus_one::<S>(working_scale)),
         sup::Regime::Fits => {}
     }
 
-    let c = sup::ceil_abs_int::<S>(v_w, w);
-    let positive = v_w > S::ZERO;
+    let ceil_abs = sup::ceil_abs_int::<S>(working_value, working_scale);
+    let is_positive = working_value > S::ZERO;
 
     // Guard lift. Two independent factors, each converted to decimal digits:
     //   * the chain's `2^n` amplification of the shift truncation and of every
     //     level's half-unit rounding  -> ceil(n*log10 2) digits;
     //   * the result's own growth `e^v` (positive arguments only — the
     //     recurrence contracts for v <= 0) -> ceil(|v|*log10 e) digits.
-    // `n` is estimated at `w` and used at `w_ext`; `halving_levels` grows like
-    // sqrt(w), so the drift over the lift is under one level, covered by the
-    // flat slack.
-    let n_est = sup::band_levels(c) + sup::halving_levels(w);
-    let n_digits = ((n_est as u64) * 30_103).div_ceil(100_000) as u32;
-    let growth = if positive { sup::result_int_digits(c) } else { 0 };
-    let extra = n_digits + growth + 4;
+    // The level count is estimated at `working_scale` and used at
+    // `extended_working_scale`; `halving_levels` grows like sqrt(w), so the
+    // drift over the lift is under one level, covered by the flat slack.
+    let levels_estimate = sup::band_levels(ceil_abs) + sup::halving_levels(working_scale);
+    let chain_digits = ((levels_estimate as u64) * 30_103).div_ceil(100_000) as u32;
+    let growth = if is_positive { sup::result_int_digits(ceil_abs) } else { 0 };
+    let extra_digits = chain_digits + growth + 4;
 
-    let w_ext = w.checked_add(extra)?;
+    let extended_working_scale = working_scale.checked_add(extra_digits)?;
     // Peak: the last doubling forms `E_{n-1} * (E_{n-1} + 2P)` with
     // `|E_{n-1}| ~ e^{v/2} * P`, i.e. a product of `~ e^v * P^2`.
-    let peak = 2 * sup::scale_bits(w_ext) + if positive { sup::result_bits(c) } else { 1 };
+    let peak = 2 * sup::scale_bits(extended_working_scale)
+        + if is_positive { sup::result_bits(ceil_abs) } else { 1 };
     if !sup::peak_fits::<S>(peak) {
         return None;
     }
 
-    let v_ext = if extra == 0 {
-        v_w
+    let extended_working_value = if extra_digits == 0 {
+        working_value
     } else {
-        v_w * eg::pow10::<S>(extra)
+        working_value * eg::pow10::<S>(extra_digits)
     };
-    let n = sup::band_levels(c) + sup::halving_levels(w_ext);
-    let e = expm1_doubling_core::<S>(v_ext, w_ext, n);
+    let levels = sup::band_levels(ceil_abs) + sup::halving_levels(extended_working_scale);
+    let expm1_extended =
+        expm1_doubling_core::<S>(extended_working_value, extended_working_scale, levels);
 
-    let r = if extra == 0 {
-        e
+    let expm1_value = if extra_digits == 0 {
+        expm1_extended
     } else {
-        eg::round_div_pow10::<S>(e, extra)
+        eg::round_div_pow10::<S>(expm1_extended, extra_digits)
     };
-    Some(r)
+    Some(expm1_value)
 }

--- a/src/algos/expm1/expm1_reduced.rs
+++ b/src/algos/expm1/expm1_reduced.rs
@@ -67,12 +67,13 @@
 //! ```
 //!
 //! so correct rounding needs `guard > k*log10 2 + log10|k|` — i.e. the guard
-//! must absorb the result's integer-digit count. That is exactly the `extra`
-//! lift `exp_fixed` provisions, mirrored here.
+//! must absorb the result's integer-digit count. That is exactly the
+//! `extra_digits` lift `exp_fixed` provisions, mirrored here.
 //!
 //! # Validity
 //!
-//! * `max(2*w_ext*log2(10), w_ext*log2(10) + |k|) + 64 < BITS` — the `exp_fixed`
+//! * writing `ext` for `extended_working_scale`,
+//!   `max(2*ext*log2(10), ext*log2(10) + |k|) + 64 < BITS` — the `exp_fixed`
 //!   wall verbatim (the squaring peak, and the `<< k` reassembly peak).
 //! * `|k| < BITS`, guaranteed by the [`super::expm1_generic::Regime`] pre-gate.
 //!
@@ -89,85 +90,94 @@ use crate::int::types::compute_limbs::ComputeLimbs;
 use crate::int::types::traits::BigInt;
 use crate::support::rounding::RoundingMode;
 
-/// `expm1(v)` for a working-scale value `v_w` at scale `w`, by `k*ln 2`
-/// reduction. `None` = cannot be produced in `S` at this `w` (the
+/// `expm1(v)` for a `working_value` at `working_scale`, by `k*ln 2`
+/// reduction. `None` = cannot be produced in `S` at this `working_scale` (the
 /// `try_exp_fixed` contract).
-pub(crate) fn expm1_reduced_fixed<S: BigInt>(v_w: S, w: u32) -> Option<S>
+pub(crate) fn expm1_reduced_fixed<S: BigInt>(working_value: S, working_scale: u32) -> Option<S>
 where
     S::Scratch: ComputeLimbs,
 {
-    if v_w == S::ZERO {
+    if working_value == S::ZERO {
         return Some(S::ZERO);
     }
-    match sup::regime::<S>(v_w, w) {
+    match sup::regime::<S>(working_value, working_scale) {
         sup::Regime::Overflow => return None,
-        sup::Regime::MinusOne => return Some(sup::just_above_minus_one::<S>(w)),
+        sup::Regime::MinusOne => return Some(sup::just_above_minus_one::<S>(working_scale)),
         sup::Regime::Fits => {}
     }
 
     // The range-reduction quotient, at the caller's scale. `Regime::Fits`
     // bounds `|v|` so this quotient stays well inside `i128`.
-    let one_w = eg::one::<S>(w);
-    let l2_w = crate::consts::ln2_by_working_scale::<S>(w, RoundingMode::HalfToEven);
-    let k = eg::round_to_nearest_int(eg::div_cached::<S>(v_w, l2_w, one_w), w);
+    let one_at_working_scale = eg::one::<S>(working_scale);
+    let ln2_at_working_scale =
+        crate::consts::ln2_by_working_scale::<S>(working_scale, RoundingMode::HalfToEven);
+    let k = eg::round_to_nearest_int(
+        eg::div_cached::<S>(working_value, ln2_at_working_scale, one_at_working_scale),
+        working_scale);
 
     // Guard lift, `exp_fixed`'s shape: `ceil(|k|*log10 2)` digits for the
     // reduction error `2^k*(|k|/2 + 1)`, plus the flat slack that also covers
     // the doubling chain's `2^n`.
     let abs_k = k.unsigned_abs();
     let k_digits = abs_k.saturating_mul(30_103).div_ceil(100_000).min(u32::MAX as u128) as u32;
-    let extra = sup::extra_digits::<S>(k_digits);
+    let extra_digits = sup::extra_digits::<S>(k_digits);
 
-    let w_ext = w.checked_add(extra)?;
+    let extended_working_scale = working_scale.checked_add(extra_digits)?;
     // Peak, exactly `exp_fixed`'s two terms: the symmetric doubling product
-    // spans `2*w_ext` digits, and the `<< k` reassembly lifts a `w_ext`-digit
-    // value by `|k|` bits.
-    let sqr_bits = 2 * sup::scale_bits(w_ext);
-    let reasm_bits = sup::scale_bits(w_ext).saturating_add(abs_k.min(u64::MAX as u128) as u64);
-    if !sup::peak_fits::<S>(sqr_bits.max(reasm_bits)) {
+    // spans twice the extended scale's digits, and the `<< k` reassembly lifts
+    // an extended-scale value by `|k|` bits.
+    let squaring_bits = 2 * sup::scale_bits(extended_working_scale);
+    let reassembly_bits = sup::scale_bits(extended_working_scale)
+        .saturating_add(abs_k.min(u64::MAX as u128) as u64);
+    if !sup::peak_fits::<S>(squaring_bits.max(reassembly_bits)) {
         return None;
     }
 
-    let v_ext = if extra == 0 {
-        v_w
+    let extended_working_value = if extra_digits == 0 {
+        working_value
     } else {
-        v_w * eg::pow10::<S>(extra)
+        working_value * eg::pow10::<S>(extra_digits)
     };
-    let l2 = crate::consts::ln2_by_working_scale::<S>(w_ext, RoundingMode::HalfToEven);
-    let s = v_ext - eg::scale_by_k::<S>(l2, k);
+    let ln2_at_extended_scale =
+        crate::consts::ln2_by_working_scale::<S>(extended_working_scale, RoundingMode::HalfToEven);
+    let reduced_arg = extended_working_value - eg::scale_by_k::<S>(ln2_at_extended_scale, k);
 
     // `|s| <= ln2/2`, so the doubling core only needs the precision-driven
     // depth (no band levels).
-    let e = expm1_doubling_core::<S>(s, w_ext, sup::halving_levels(w_ext));
+    let expm1_of_reduced_arg = expm1_doubling_core::<S>(
+        reduced_arg,
+        extended_working_scale,
+        sup::halving_levels(extended_working_scale));
 
-    let p = eg::one::<S>(w_ext);
-    let lifted = p + e; // exact: `e^s * 10^w_ext`, every bit of `e` kept
-    let r_ext = if k >= 0 {
+    let one_at_extended_scale = eg::one::<S>(extended_working_scale);
+    // exact: `e^s * 10^ext`, every bit of the reduced expm1 kept
+    let lifted = one_at_extended_scale + expm1_of_reduced_arg;
+    let reassembled = if k >= 0 {
         let shift = k as u32;
         // The reassembly must not wrap: `wrapping` arithmetic below it would
         // truncate a genuinely out-of-range result into a small wrong value.
         if eg::bit_length::<S>(lifted) + shift >= <S as BigInt>::BITS {
             return None;
         }
-        (lifted << shift) - p
+        (lifted << shift) - one_at_extended_scale
     } else {
-        let m = abs_k;
-        if m >= eg::bit_length::<S>(lifted) as u128 {
+        let shift_bits = abs_k;
+        if shift_bits >= eg::bit_length::<S>(lifted) as u128 {
             // `2^k * e^s` is below the working resolution: `expm1(v)` sits
             // strictly between `-1` and `-1 + 10^-w`. Return the value one
             // working unit above `-1`, never a bare `-P` — see
             // `expm1_generic::just_above_minus_one`.
-            return Some(sup::just_above_minus_one::<S>(w));
+            return Some(sup::just_above_minus_one::<S>(working_scale));
         }
         // One half-to-even rounded shift (<= 1/2 working unit), not a
         // truncating `>>`.
-        eg::round_div::<S>(lifted, S::ONE << (m as u32)) - p
+        eg::round_div::<S>(lifted, S::ONE << (shift_bits as u32)) - one_at_extended_scale
     };
 
-    let r = if extra == 0 {
-        r_ext
+    let expm1_value = if extra_digits == 0 {
+        reassembled
     } else {
-        eg::round_div_pow10::<S>(r_ext, extra)
+        eg::round_div_pow10::<S>(reassembled, extra_digits)
     };
-    Some(r)
+    Some(expm1_value)
 }

--- a/src/algos/expm1/expm1_series.rs
+++ b/src/algos/expm1/expm1_series.rs
@@ -46,19 +46,19 @@ use crate::int::types::compute_limbs::ComputeLimbs;
 use crate::int::types::traits::BigInt;
 use crate::support::rounding::RoundingMode;
 
-/// `expm1(v)` for a working-scale value `v_w` at scale `w`, by the direct
+/// `expm1(v)` for a `working_value` at `working_scale`, by the direct
 /// series.
 ///
-/// `None` means the value cannot be produced in `S` at this `w`: either the
-/// argument is outside the series' band (the caller must route to a reducing
-/// candidate) or the internal product would wrap the work integer. The
+/// `None` means the value cannot be produced in `S` at this `working_scale`:
+/// either the argument is outside the series' band (the caller must route to a
+/// reducing candidate) or the internal product would wrap the work integer. The
 /// `Option` is the `try_exp_fixed` contract — detect once here, let the policy
 /// wrapper apply the overflow policy.
-pub(crate) fn expm1_series_fixed<S: BigInt>(v_w: S, w: u32) -> Option<S>
+pub(crate) fn expm1_series_fixed<S: BigInt>(working_value: S, working_scale: u32) -> Option<S>
 where
     S::Scratch: ComputeLimbs,
 {
-    expm1_series_fixed_tagged::<S>(v_w, w).0
+    expm1_series_fixed_tagged::<S>(working_value, working_scale).0
 }
 
 /// [`expm1_series_fixed`] with the sign of the series tail alongside it —
@@ -75,37 +75,37 @@ where
 /// computed remainder. `None` makes the walker behave exactly as before, so
 /// both keep the treatment they had.
 pub(crate) fn expm1_series_fixed_tagged<S: BigInt>(
-    v_w: S,
-    w: u32,
+    working_value: S,
+    working_scale: u32,
 ) -> (Option<S>, Option<eg::TailSign>)
 where
     S::Scratch: ComputeLimbs,
 {
-    if v_w == S::ZERO {
+    if working_value == S::ZERO {
         // expm1(0) = 0 exactly — the ONLY exact case (for algebraic x != 0,
         // e^x is transcendental by Lindemann-Weierstrass, so e^x - 1 never
         // lands on a storage grid line).
         return (Some(S::ZERO), None);
     }
-    match sup::regime::<S>(v_w, w) {
+    match sup::regime::<S>(working_value, working_scale) {
         sup::Regime::Overflow => return (None, None),
         sup::Regime::MinusOne => {
-            return (Some(sup::just_above_minus_one::<S>(w)), None);
+            return (Some(sup::just_above_minus_one::<S>(working_scale)), None);
         }
         sup::Regime::Fits => {}
     }
     // Band gate: |v| <= DIRECT_BAND. Tested on the working-scale integer so no
     // division is needed on the hot path.
-    if v_w.abs() > eg::lit::<S>(sup::DIRECT_BAND) * eg::one::<S>(w) {
+    if working_value.abs() > eg::lit::<S>(sup::DIRECT_BAND) * eg::one::<S>(working_scale) {
         return (None, None);
     }
     // Peak: |term| <= 10^w and |s| <= 10^w, so the `term * s` product before
     // the `/10^w` spans at most `2w` digits.
-    if !sup::peak_fits::<S>(2 * sup::scale_bits(w)) {
+    if !sup::peak_fits::<S>(2 * sup::scale_bits(working_scale)) {
         return (None, None);
     }
-    let (v, tail) = eg::expm1_fixed_tagged::<S>(v_w, w);
-    (Some(v), tail)
+    let (expm1_value, tail_sign) = eg::expm1_fixed_tagged::<S>(working_value, working_scale);
+    (Some(expm1_value), tail_sign)
 }
 
 /// `expm1(x)` at storage `St`, computed in the work integer `S` and correctly
@@ -129,7 +129,7 @@ where
 /// handed to [`wtc::round_to_storage_tail_signed_g`], which is the only place
 /// that can act on it.
 ///
-/// This subsumes the old near-zero post-adjust, which tested `result == raw`
+/// This subsumes the old near-zero post-adjust, which tested `rounded == raw`
 /// and so reached only the ONE grid point where the value lands on its own
 /// linear term. Deeper partial sums land on the grid too whenever the
 /// argument's coefficients make `x^j/j!` terminate — `x = -3e-152` reaches the
@@ -155,26 +155,26 @@ where
 #[must_use]
 pub(crate) fn expm1_series_g<St: BigInt + Copy, S: BigInt, const SCALE: u32>(
     raw: St,
-    base_guard: u32,
-    st_max: St,
-    st_min: St,
+    base_guard_digits: u32,
+    storage_max: St,
+    storage_min: St,
     mode: RoundingMode,
 ) -> St
 where
     S::Scratch: ComputeLimbs,
 {
     wtc::round_to_storage_tail_signed_g::<St, S>(
-        base_guard,
+        base_guard_digits,
         SCALE,
         mode,
-        st_max,
-        st_min,
-        |guard| {
-            let (v, tail) = expm1_series_fixed_tagged::<S>(
-                wtc::to_work_scaled_g::<St, S>(raw, guard),
-                SCALE + guard,
+        storage_max,
+        storage_min,
+        |guard_digits| {
+            let (expm1_value, tail_sign) = expm1_series_fixed_tagged::<S>(
+                wtc::to_work_scaled_g::<St, S>(raw, guard_digits),
+                SCALE + guard_digits,
             );
-            (super::checked(v, "expm1_strict", SCALE), tail)
+            (super::checked(expm1_value, "expm1_strict", SCALE), tail_sign)
         },
     )
 }
@@ -194,21 +194,22 @@ where
 pub(crate) fn expm1_series_approx_g<St: BigInt + Copy, S: BigInt, const SCALE: u32>(
     raw: St,
     working_digits: u32,
-    st_max: St,
-    st_min: St,
+    storage_max: St,
+    storage_min: St,
     mode: RoundingMode,
 ) -> St
 where
     S::Scratch: ComputeLimbs,
 {
-    let w = SCALE + working_digits;
-    let r = super::checked(
-        expm1_series_fixed::<S>(wtc::to_work_scaled_g::<St, S>(raw, working_digits), w),
+    let working_scale = SCALE + working_digits;
+    let working_value = super::checked(
+        expm1_series_fixed::<S>(wtc::to_work_scaled_g::<St, S>(raw, working_digits), working_scale),
         "expm1_approx",
         SCALE,
     );
-    let out = wtc::round_to_storage_with_g::<St, S>(r, w, SCALE, mode, st_max, st_min);
-    super::adjust_near_zero::<St>(out, raw, mode)
+    let rounded = wtc::round_to_storage_with_g::<St, S>(
+        working_value, working_scale, SCALE, mode, storage_max, storage_min);
+    super::adjust_near_zero::<St>(rounded, raw, mode)
 }
 
 /// Tier-generic entry to [`expm1_series_g`] — sources the work integer `C::W`,

--- a/src/algos/expm1/expm1_with_exp.rs
+++ b/src/algos/expm1/expm1_with_exp.rs
@@ -71,15 +71,15 @@ use crate::int::types::compute_limbs::ComputeLimbs;
 use crate::int::types::traits::BigInt;
 use crate::support::rounding::RoundingMode;
 
-/// `expm1(v)` for a working-scale value `v_w` at scale `w`, as
-/// `exp_fixed(v_w, w) - 10^w`. `None` propagates `try_exp_fixed`'s
-/// out-of-range verdict (the "detect once, the wrapper applies the policy"
-/// contract).
-pub(crate) fn expm1_with_exp_fixed<S: BigInt>(v_w: S, w: u32) -> Option<S>
+/// `expm1(v)` for a `working_value` at `working_scale`, as
+/// `exp_fixed(working_value, working_scale) - 10^w`. `None` propagates
+/// `try_exp_fixed`'s out-of-range verdict (the "detect once, the wrapper
+/// applies the policy" contract).
+pub(crate) fn expm1_with_exp_fixed<S: BigInt>(working_value: S, working_scale: u32) -> Option<S>
 where
     S::Scratch: ComputeLimbs,
 {
-    if v_w == S::ZERO {
+    if working_value == S::ZERO {
         // expm1(0) = 0 exactly — the only exact case.
         return Some(S::ZERO);
     }
@@ -90,8 +90,8 @@ where
     // representative the negative tail requires
     // (`expm1_generic::just_above_minus_one`), so the deep band is correct here
     // for free.
-    let e = eg::try_exp_fixed::<S>(v_w, w)?;
-    Some(e - eg::one::<S>(w))
+    let exp_value = eg::try_exp_fixed::<S>(working_value, working_scale)?;
+    Some(exp_value - eg::one::<S>(working_scale))
 }
 
 /// `expm1(x)` at storage `St`, computed in the work integer `S` and correctly
@@ -121,29 +121,31 @@ where
 #[must_use]
 pub(crate) fn expm1_with_exp_g<St: BigInt + Copy, S: BigInt, const SCALE: u32>(
     raw: St,
-    base_guard: u32,
-    st_max: St,
-    st_min: St,
+    base_guard_digits: u32,
+    storage_max: St,
+    storage_min: St,
     mode: RoundingMode,
 ) -> St
 where
     S::Scratch: ComputeLimbs,
 {
-    let r = wtc::round_to_storage_directed_g::<St, S>(
-        base_guard,
+    let rounded = wtc::round_to_storage_directed_g::<St, S>(
+        base_guard_digits,
         SCALE,
         mode,
-        st_max,
-        st_min,
-        |guard| {
+        storage_max,
+        storage_min,
+        |guard_digits| {
             super::checked(
-                expm1_with_exp_fixed::<S>(wtc::to_work_scaled_g::<St, S>(raw, guard), SCALE + guard),
+                expm1_with_exp_fixed::<S>(
+                    wtc::to_work_scaled_g::<St, S>(raw, guard_digits),
+                    SCALE + guard_digits),
                 "expm1_strict",
                 SCALE,
             )
         },
     );
-    super::adjust_near_zero::<St>(r, raw, mode)
+    super::adjust_near_zero::<St>(rounded, raw, mode)
 }
 
 /// The `_approx` sibling of [`expm1_with_exp_g`]: a SINGLE shot at the caller's
@@ -158,21 +160,23 @@ where
 pub(crate) fn expm1_with_exp_approx_g<St: BigInt + Copy, S: BigInt, const SCALE: u32>(
     raw: St,
     working_digits: u32,
-    st_max: St,
-    st_min: St,
+    storage_max: St,
+    storage_min: St,
     mode: RoundingMode,
 ) -> St
 where
     S::Scratch: ComputeLimbs,
 {
-    let w = SCALE + working_digits;
-    let r = super::checked(
-        expm1_with_exp_fixed::<S>(wtc::to_work_scaled_g::<St, S>(raw, working_digits), w),
+    let working_scale = SCALE + working_digits;
+    let working_value = super::checked(
+        expm1_with_exp_fixed::<S>(
+            wtc::to_work_scaled_g::<St, S>(raw, working_digits), working_scale),
         "expm1_approx",
         SCALE,
     );
-    let out = wtc::round_to_storage_with_g::<St, S>(r, w, SCALE, mode, st_max, st_min);
-    super::adjust_near_zero::<St>(out, raw, mode)
+    let rounded = wtc::round_to_storage_with_g::<St, S>(
+        working_value, working_scale, SCALE, mode, storage_max, storage_min);
+    super::adjust_near_zero::<St>(rounded, raw, mode)
 }
 
 /// Tier-generic entry to [`expm1_with_exp_g`] at the tier's widest work integer

--- a/src/algos/expm1/mod.rs
+++ b/src/algos/expm1/mod.rs
@@ -15,7 +15,7 @@
 //! working-scale signature
 //!
 //! ```text
-//! fn expm1_<variant>_fixed<S: BigInt>(v_w: S, w: u32) -> Option<S>
+//! fn expm1_<variant>_fixed<S: BigInt>(working_value: S, working_scale: u32) -> Option<S>
 //! ```
 //!
 //! — the working-scale `expm1`, `None` = out of range, mirroring
@@ -69,8 +69,8 @@ use crate::support::rounding::RoundingMode;
 /// working scale; a fixed-width decimal has no infinity, so the contract is a
 /// PANIC, uniform across every tier and scale and in both debug and release.
 #[inline]
-pub(crate) fn checked<S>(v: Option<S>, method: &str, scale: u32) -> S {
-    v.unwrap_or_else(|| crate::support::diagnostics::overflow_panic_with_scale(method, scale))
+pub(crate) fn checked<S>(value: Option<S>, method: &str, scale: u32) -> S {
+    value.unwrap_or_else(|| crate::support::diagnostics::overflow_panic_with_scale(method, scale))
 }
 
 /// Directed-rounding post-adjust for the sub-resolution band near `x = 0` —
@@ -95,7 +95,7 @@ pub(crate) fn checked<S>(v: Option<S>, method: &str, scale: u32) -> S {
 /// true value is strictly above it.
 ///
 /// Because `expm1(x) > x`, a CORRECT upward result can never equal `x`, so
-/// `result == raw` is unambiguously the sub-resolution undershoot — step UP one
+/// `rounded == raw` is unambiguously the sub-resolution undershoot — step UP one
 /// LSB. `expm1(0) = 0` is exact and excluded; nearest modes (the fraction is
 /// `0⁺`, so they round to `x` anyway) and `Floor` (`x` IS the correct floor)
 /// are already right. `Ceiling` steps up for both signs; `Trunc` (toward zero)
@@ -107,7 +107,7 @@ pub(crate) fn checked<S>(v: Option<S>, method: &str, scale: u32) -> S {
 ///
 /// # Scope — the STRICT series path no longer uses this
 ///
-/// Testing `result == raw` reaches only the ONE grid point where the value
+/// Testing `rounded == raw` reaches only the ONE grid point where the value
 /// lands on its own linear term. The value lands on DEEPER partial sums just
 /// as often, whenever the argument makes `x^j/j!` terminate — `x = -3e-152`
 /// reaches the 3rd, `x = -3e-86` the 5th — and this test is blind to every one
@@ -124,23 +124,23 @@ pub(crate) fn checked<S>(v: Option<S>, method: &str, scale: u32) -> S {
 /// * [`expm1_with_exp_g`](super::expm1_with_exp::expm1_with_exp_g), where it is
 ///   a provable no-op — the policy routes `|x| > 1` there, and
 ///   `expm1(x) - x = x²/2 + ...` exceeds half an ULP by orders of magnitude
-///   across that whole region, so `result == raw` never holds. It is left in
+///   across that whole region, so `rounded == raw` never holds. It is left in
 ///   place rather than removed so that path stays byte-for-byte unchanged.
 #[inline]
-pub(crate) fn adjust_near_zero<St: BigInt>(result: St, raw: St, mode: RoundingMode) -> St {
+pub(crate) fn adjust_near_zero<St: BigInt>(rounded: St, raw: St, mode: RoundingMode) -> St {
     if crate::support::rounding::is_nearest_mode(mode) {
-        return result;
+        return rounded;
     }
     if raw == <St as BigInt>::ZERO {
-        return result; // expm1(0) = 0 is exact
+        return rounded; // expm1(0) = 0 is exact
     }
-    if result != raw {
-        return result; // only the sub-resolution linear-term undershoot
+    if rounded != raw {
+        return rounded; // only the sub-resolution linear-term undershoot
     }
     match mode {
-        RoundingMode::Ceiling => result + <St as BigInt>::ONE,
-        RoundingMode::Trunc if raw < <St as BigInt>::ZERO => result + <St as BigInt>::ONE,
-        _ => result,
+        RoundingMode::Ceiling => rounded + <St as BigInt>::ONE,
+        RoundingMode::Trunc if raw < <St as BigInt>::ZERO => rounded + <St as BigInt>::ONE,
+        _ => rounded,
     }
 }
 
@@ -216,11 +216,11 @@ mod candidate_agreement_tests {
         eg::lit::<S>(units) * eg::pow10::<S>(exp10)
     }
 
-    fn close(a: S, b: S, what: &str) {
-        let d = a - b;
-        let d = if d < S::ZERO { -d } else { d };
+    fn close(lhs: S, rhs: S, what: &str) {
+        let difference = lhs - rhs;
+        let difference = if difference < S::ZERO { -difference } else { difference };
         assert!(
-            d <= eg::lit::<S>(TOL),
+            difference <= eg::lit::<S>(TOL),
             "{what}: candidates disagree by more than the smoke tolerance"
         );
     }
@@ -237,21 +237,21 @@ mod candidate_agreement_tests {
             (5i128, W - 1, "0.5"),
             (-5i128, W - 1, "-0.5"),
         ] {
-            let v = at(units, exp10);
-            let base = expm1_with_exp_fixed::<S>(v, W).expect("via_exp in range");
+            let working_value = at(units, exp10);
+            let baseline = expm1_with_exp_fixed::<S>(working_value, W).expect("via_exp in range");
             close(
-                expm1_series_fixed::<S>(v, W).expect("series in band"),
-                base,
+                expm1_series_fixed::<S>(working_value, W).expect("series in band"),
+                baseline,
                 name,
             );
             close(
-                expm1_halving_fixed::<S>(v, W).expect("halving in range"),
-                base,
+                expm1_halving_fixed::<S>(working_value, W).expect("halving in range"),
+                baseline,
                 name,
             );
             close(
-                expm1_reduced_fixed::<S>(v, W).expect("reduced in range"),
-                base,
+                expm1_reduced_fixed::<S>(working_value, W).expect("reduced in range"),
+                baseline,
                 name,
             );
         }
@@ -268,16 +268,16 @@ mod candidate_agreement_tests {
             (12i128, W, "12"),
             (-12i128, W, "-12"),
         ] {
-            let v = at(units, exp10);
-            let base = expm1_with_exp_fixed::<S>(v, W).expect("via_exp in range");
+            let working_value = at(units, exp10);
+            let baseline = expm1_with_exp_fixed::<S>(working_value, W).expect("via_exp in range");
             close(
-                expm1_halving_fixed::<S>(v, W).expect("halving in range"),
-                base,
+                expm1_halving_fixed::<S>(working_value, W).expect("halving in range"),
+                baseline,
                 name,
             );
             close(
-                expm1_reduced_fixed::<S>(v, W).expect("reduced in range"),
-                base,
+                expm1_reduced_fixed::<S>(working_value, W).expect("reduced in range"),
+                baseline,
                 name,
             );
         }
@@ -307,12 +307,12 @@ mod candidate_agreement_tests {
         // deep (`e^-500 ~ 1e-218`, far under `10^-60`) but sits one bit under
         // that threshold, so `expm1_series_fixed` declines it as out-of-BAND
         // instead — correct behaviour, wrong test.
-        let v = at(-2000, W);
+        let working_value = at(-2000, W);
         for (got, name) in [
-            (expm1_series_fixed::<S>(v, W), "series"),
-            (expm1_halving_fixed::<S>(v, W), "halving"),
-            (expm1_reduced_fixed::<S>(v, W), "reduced"),
-            (expm1_with_exp_fixed::<S>(v, W), "via_exp"),
+            (expm1_series_fixed::<S>(working_value, W), "series"),
+            (expm1_halving_fixed::<S>(working_value, W), "halving"),
+            (expm1_reduced_fixed::<S>(working_value, W), "reduced"),
+            (expm1_with_exp_fixed::<S>(working_value, W), "via_exp"),
         ] {
             assert_eq!(got, Some(want), "{name}: deep-negative representative");
         }

--- a/src/algos/hypot/hypot_pythagoras.rs
+++ b/src/algos/hypot/hypot_pythagoras.rs
@@ -3,8 +3,8 @@
 
 //! `hypot_pythagoras` -- decimal hypotenuse via the int-tier hypot.
 //!
-//! For two `D<Int<N>, SCALE>` values with raw storages `a` and `b`, the
-//! hypotenuse raw storage is `round(sqrt(a^2 + b^2))` -- both operands
+//! For two `D<Int<N>, SCALE>` values with raw storages `lhs` and `rhs`, the
+//! hypotenuse raw storage is `round(sqrt(lhs^2 + rhs^2))` -- both operands
 //! carry the same `10^SCALE` factor, so it divides out of the root and no
 //! rescale is needed (contrast [`crate::algos::sqrt`], which forms
 //! `raw * 10^SCALE`). Decimal hypot is therefore *exactly* integer hypot on
@@ -13,7 +13,7 @@
 //! This kernel dispatches DOWN to the integer-tier hypot
 //! ([`crate::int::policy::hypot::dispatch`]) instead of re-implementing the
 //! radicand-and-root arithmetic: clean layering, single source of truth.
-//! The int tier forms `a^2 + b^2` in a limb scratch buffer, takes the floor
+//! The int tier forms `lhs^2 + rhs^2` in a limb scratch buffer, takes the floor
 //! root via the int slice `isqrt`, and applies the round step; it returns
 //! [`None`] on true overflow, which this layer maps back to [`None`] for
 //! the policy's out-of-range panic. The old inversion (calling the decimal
@@ -32,17 +32,17 @@ use crate::int::types::compute_limbs::{ComputeLimbs, Limbs};
 use crate::int::types::Int;
 use crate::support::rounding::RoundingMode;
 
-/// `round(sqrt(a^2 + b^2))` on the raw storages, dispatched DOWN to the
+/// `round(sqrt(lhs^2 + rhs^2))` on the raw storages, dispatched DOWN to the
 /// integer-tier hypot. `N` is the storage limb count backing
 /// `D<Int<N>, SCALE>`. Returns [`None`] on true overflow (the rounded root
 /// does not fit `Int<N>`).
 #[inline]
 #[must_use]
-pub(crate) fn hypot_pythagoras<const N: usize>(a: Int<N>, b: Int<N>, mode: RoundingMode) -> Option<Int<N>>
+pub(crate) fn hypot_pythagoras<const N: usize>(lhs: Int<N>, rhs: Int<N>, mode: RoundingMode) -> Option<Int<N>>
 where
     Limbs<N>: ComputeLimbs,
 {
-    crate::int::policy::hypot::dispatch::<N>(a, b, mode)
+    crate::int::policy::hypot::dispatch::<N>(lhs, rhs, mode)
 }
 
 #[cfg(test)]
@@ -62,37 +62,37 @@ mod tests {
 
     #[test]
     fn hypot_pythagoras_pythagorean_3_4_5_all_modes() {
-        let a = Int::<2>::from_i64(3);
-        let b = Int::<2>::from_i64(4);
+        let lhs = Int::<2>::from_i64(3);
+        let rhs = Int::<2>::from_i64(4);
         let expected = Int::<2>::from_i64(5);
         for mode in ALL_MODES {
-            assert_eq!(hypot_pythagoras::<2>(a, b, mode), Some(expected), "mode {mode:?}");
+            assert_eq!(hypot_pythagoras::<2>(lhs, rhs, mode), Some(expected), "mode {mode:?}");
         }
     }
 
     #[test]
     fn hypot_pythagoras_non_perfect_1_1() {
-        let a = Int::<2>::from_i64(1);
-        let b = Int::<2>::from_i64(1);
-        assert_eq!(hypot_pythagoras::<2>(a, b, RoundingMode::Trunc).unwrap().as_i128(), 1);
-        assert_eq!(hypot_pythagoras::<2>(a, b, RoundingMode::Ceiling).unwrap().as_i128(), 2);
-        assert_eq!(hypot_pythagoras::<2>(a, b, RoundingMode::HalfToEven).unwrap().as_i128(), 1);
+        let lhs = Int::<2>::from_i64(1);
+        let rhs = Int::<2>::from_i64(1);
+        assert_eq!(hypot_pythagoras::<2>(lhs, rhs, RoundingMode::Trunc).unwrap().as_i128(), 1);
+        assert_eq!(hypot_pythagoras::<2>(lhs, rhs, RoundingMode::Ceiling).unwrap().as_i128(), 2);
+        assert_eq!(hypot_pythagoras::<2>(lhs, rhs, RoundingMode::HalfToEven).unwrap().as_i128(), 1);
     }
 
     #[test]
     fn hypot_pythagoras_zero_zero() {
-        let z = Int::<2>::from_i64(0);
+        let zero = Int::<2>::from_i64(0);
         for mode in ALL_MODES {
-            assert_eq!(hypot_pythagoras::<2>(z, z, mode), Some(z), "mode {mode:?}");
+            assert_eq!(hypot_pythagoras::<2>(zero, zero, mode), Some(zero), "mode {mode:?}");
         }
     }
 
     #[test]
     fn hypot_pythagoras_zero_x_equals_abs_x() {
-        let z = Int::<2>::from_i64(0);
+        let zero = Int::<2>::from_i64(0);
         let x = Int::<2>::from_i64(42);
         for mode in ALL_MODES {
-            assert_eq!(hypot_pythagoras::<2>(z, x, mode), Some(x), "mode {mode:?}");
+            assert_eq!(hypot_pythagoras::<2>(zero, x, mode), Some(x), "mode {mode:?}");
         }
     }
 }

--- a/src/algos/hypot/mod.rs
+++ b/src/algos/hypot/mod.rs
@@ -3,18 +3,18 @@
 
 //! Hypotenuse algorithm family.
 //!
-//! `hypot` computes `sqrt(a² + b²)` by routing the root **down** through
+//! `hypot` computes `sqrt(lhs² + rhs²)` by routing the root **down** through
 //! the integer layer, exactly as the raw-storage root kernels in
-//! [`crate::algos::sqrt`] do: it forms the radicand `a² + b²` in a wider
+//! [`crate::algos::sqrt`] do: it forms the radicand `lhs² + rhs²` in a wider
 //! work integer and takes the floor root via
 //! [`crate::int::types::traits::BigInt::isqrt`], then a single round step
 //! — it does **not** call the decimal `sqrt` surface on the tier's own
 //! value. The single variant serves every `(N, SCALE)` cell; the per-cell
 //! selection lives in [`crate::policy::hypot`].
 //!
-//! - [`hypot_pythagoras`] — `round(sqrt(a² + b²))` over a work width `W` that
-//!   covers `a² + b²`. Generic over the storage and work widths `(S, W)`;
-//!   the rounding step is identical to
+//! - [`hypot_pythagoras`] — `round(sqrt(lhs² + rhs²))` over a work width `W`
+//!   that covers `lhs² + rhs²`. Generic over the storage and work widths
+//!   `(S, W)`; the rounding step is identical to
 //!   [`crate::algos::sqrt::sqrt_newton`].
 //!
 //! [`hypot_pythagoras`]: crate::algos::hypot::hypot_pythagoras::hypot_pythagoras

--- a/src/algos/ln/ln_schoolbook.rs
+++ b/src/algos/ln/ln_schoolbook.rs
@@ -47,56 +47,63 @@ use crate::support::rounding::{RoundingMode, is_nearest_mode};
 pub(crate) const SCHOOLBOOK_GUARD: u32 = 30;
 
 /// `ln(x)` via the atanh series on the 256-bit `Fixed` intermediate,
-/// returned at working scale `w`.
+/// returned at `working_scale`.
 ///
 /// Splits `x = 2^k · m` with `m ∈ [1, 2)`, evaluates
 /// `ln(m) = 2·artanh((m−1)/(m+1))` term-by-term until terms vanish, then
 /// returns `k·ln(2) + ln(m)`.  No Newton correction steps.
-pub(crate) fn ln_schoolbook_fixed(v_w: Fixed, w: u32) -> Fixed {
-    let one_w = Fixed { negative: false, mag: Fixed::pow10(w) };
-    let two_w = one_w.double();
+pub(crate) fn ln_schoolbook_fixed(working_value: Fixed, working_scale: u32) -> Fixed {
+    let one_at_working_scale = Fixed { negative: false, mag: Fixed::pow10(working_scale) };
+    let two_at_working_scale = one_at_working_scale.double();
 
-    // Exponent split: find k such that 2^k <= v < 2^(k+1); m_w = v / 2^k.
-    let mut k: i32 = v_w.bit_length() as i32 - one_w.bit_length() as i32;
-    let m_w = loop {
-        let m = if k >= 0 { v_w.shr(k as u32) } else { v_w.shl((-k) as u32) };
-        if m.ge_mag(two_w) {
+    // Exponent split: find k such that 2^k <= v < 2^(k+1); mantissa_w = v / 2^k.
+    let mut k: i32 =
+        working_value.bit_length() as i32 - one_at_working_scale.bit_length() as i32;
+    let mantissa_w = loop {
+        let candidate_mantissa = if k >= 0 {
+            working_value.shr(k as u32)
+        } else {
+            working_value.shl((-k) as u32)
+        };
+        if candidate_mantissa.ge_mag(two_at_working_scale) {
             k += 1;
-        } else if !m.ge_mag(one_w) {
+        } else if !candidate_mantissa.ge_mag(one_at_working_scale) {
             k -= 1;
         } else {
-            break m;
+            break candidate_mantissa;
         }
     };
 
     // t = (m - 1) / (m + 1) ∈ [0, 1/3); artanh(t) = t + t³/3 + t⁵/5 + …
-    let t = m_w.sub(one_w).div(m_w.add(one_w), w);
-    let t2 = t.mul(t, w);
-    let mut sum = t;
-    let mut term = t;
-    let mut j: u128 = 1;
+    let atanh_arg = mantissa_w
+        .sub(one_at_working_scale)
+        .div(mantissa_w.add(one_at_working_scale), working_scale);
+    let atanh_arg_sq = atanh_arg.mul(atanh_arg, working_scale);
+    let mut sum = atanh_arg;
+    let mut term = atanh_arg;
+    let mut term_index: u128 = 1;
     loop {
-        term = term.mul(t2, w);
-        let contrib = term.div_small(2 * j + 1);
-        if contrib.is_zero() {
+        term = term.mul(atanh_arg_sq, working_scale);
+        let contribution = term.div_small(2 * term_index + 1);
+        if contribution.is_zero() {
             break;
         }
-        sum = sum.add(contrib);
-        j += 1;
+        sum = sum.add(contribution);
+        term_index += 1;
         // Defensive cap — convergence for t<=1/3 at w=68 needs <80 steps.
-        if j > 300 {
+        if term_index > 300 {
             break;
         }
     }
-    let ln_m = sum.double();
+    let ln_mantissa = sum.double();
 
-    let ln2 = wide_ln2(w);
+    let ln2 = wide_ln2(working_scale);
     let k_ln2 = if k >= 0 {
         ln2.mul_u128(k as u128)
     } else {
         ln2.mul_u128((-k) as u128).neg()
     };
-    k_ln2.add(ln_m)
+    k_ln2.add(ln_mantissa)
 }
 
 // ── Wide tier — generic over the tier core `C: WideTrigCore` ─────────
@@ -119,8 +126,8 @@ pub(crate) fn ln_schoolbook<C: WideTrigCore, const SCALE: u32>(
     if raw <= C::storage_zero() {
         panic!("wide-tier ln schoolbook: argument must be positive");
     }
-    C::round_to_storage_directed(C::GUARD, SCALE, mode, &mut |guard| {
-        C::ln_fixed::<SCALE>(C::to_work_scaled(raw, guard), SCALE + guard)
+    C::round_to_storage_directed(C::GUARD, SCALE, mode, &mut |guard_digits| {
+        C::ln_fixed::<SCALE>(C::to_work_scaled(raw, guard_digits), SCALE + guard_digits)
     })
 }
 
@@ -132,24 +139,24 @@ pub(crate) fn ln_schoolbook_with(
     working_digits: u32,
     mode: RoundingMode,
 ) -> Int<2> {
-    let raw_i = raw.as_i128();
-    assert!(raw_i > 0, "ln_schoolbook: argument must be positive");
-    let one_bits: i128 = 10_i128.pow(scale);
-    if raw_i == one_bits {
+    let raw_i128 = raw.as_i128();
+    assert!(raw_i128 > 0, "ln_schoolbook: argument must be positive");
+    let one_scaled: i128 = 10_i128.pow(scale);
+    if raw_i128 == one_scaled {
         return Int::<2>::ZERO;
     }
     // Linear band fast-path: same as ln_series_2limb for nearest modes.
-    let delta = raw_i - one_bits;
+    let delta = raw_i128 - one_scaled;
     let ln1p_band: i128 = 10_i128.pow(scale.saturating_sub((scale + 1) >> 1));
     if delta.abs() <= ln1p_band && is_nearest_mode(mode) {
         return Int::<2>::from_i128(delta);
     }
-    let w = scale + working_digits;
-    let v_w = Fixed::from_u128_mag(raw_i as u128, false)
+    let working_scale = scale + working_digits;
+    let working_value = Fixed::from_u128_mag(raw_i128 as u128, false)
         .mul_u128(10u128.pow(working_digits));
     Int::<2>::from_i128(
-        ln_schoolbook_fixed(v_w, w)
-            .round_to_i128_with(w, scale, mode)
+        ln_schoolbook_fixed(working_value, working_scale)
+            .round_to_i128_with(working_scale, scale, mode)
             .unwrap_or_else(|| {
                 crate::support::diagnostics::overflow_panic_with_scale(
                     "ln_schoolbook",
@@ -183,30 +190,30 @@ mod tests {
     ];
 
     #[track_caller]
-    fn check<const S: u32>(raw_i: i128, mode: RoundingMode) {
-        let raw = Int::<2>::from_i128(raw_i);
+    fn check<const S: u32>(raw_i128: i128, mode: RoundingMode) {
+        let raw = Int::<2>::from_i128(raw_i128);
         let got = ln_schoolbook_strict::<S>(raw, mode);
         let expected = ln_strict::<S>(raw, mode).expect("reference in range");
         assert_eq!(got, expected,
             "ln schoolbook D38<{}> raw={} mode={:?}: {:?} != {:?}",
-            S, raw_i, mode, got, expected);
+            S, raw_i128, mode, got, expected);
     }
 
     #[test]
     fn ln_schoolbook_matches_series_d38_s12() {
         // Boundary: 1.0 (ln=0), 2, 0.5, e, 10, 3, near-1.
-        for raw_i in [1_000_000_000_000_i128, 2_000_000_000_000, 500_000_000_000,
-                      1_000_000_000, 10_000_000_000_000, 2_718_281_828_459,
-                      1_100_000_000_000, 3_000_000_000_000, 100_000_000_000] {
-            for mode in MODES { check::<12>(raw_i, mode); }
+        for raw_i128 in [1_000_000_000_000_i128, 2_000_000_000_000, 500_000_000_000,
+                         1_000_000_000, 10_000_000_000_000, 2_718_281_828_459,
+                         1_100_000_000_000, 3_000_000_000_000, 100_000_000_000] {
+            for mode in MODES { check::<12>(raw_i128, mode); }
         }
     }
 
     #[test]
     fn ln_schoolbook_matches_series_d38_s19() {
         let one: i128 = 10_i128.pow(19);
-        for raw_i in [one, 2 * one, one / 2, 10 * one, 3 * one, one + one / 10] {
-            for mode in MODES { check::<19>(raw_i, mode); }
+        for raw_i128 in [one, 2 * one, one / 2, 10 * one, 3 * one, one + one / 10] {
+            for mode in MODES { check::<19>(raw_i128, mode); }
         }
     }
     #[cfg(any(feature = "d57", feature = "wide"))]
@@ -227,13 +234,13 @@ mod tests {
 
         #[test]
         fn ln_schoolbook_matches_routed() {
-            for &u in &INPUTS9 {
-                let r = raw9(u);
+            for &units in &INPUTS9 {
+                let raw = raw9(units);
                 for mode in MODES {
                     assert_eq!(
-                        crate::algos::ln::ln_schoolbook::ln_schoolbook::<Core, S>(r, mode),
-                        D::<Int<3>, S>(r).ln_strict_with(mode).0,
-                        "D57 ln schoolbook != routed at units={u} mode={mode:?}"
+                        crate::algos::ln::ln_schoolbook::ln_schoolbook::<Core, S>(raw, mode),
+                        D::<Int<3>, S>(raw).ln_strict_with(mode).0,
+                        "D57 ln schoolbook != routed at units={units} mode={mode:?}"
                     );
                 }
             }

--- a/src/algos/ln/ln_series_2limb.rs
+++ b/src/algos/ln/ln_series_2limb.rs
@@ -74,10 +74,13 @@ fn fixed_from_int256(raw: Int<4>) -> Fixed {
 /// at `w = SCALE + STRICT_GUARD`, capped at `38 + 30 = 68`, so every
 /// strict call site is comfortably inside the bound. A debug-assert
 /// documents the invariant for any future caller.
-pub(crate) fn wide_ln2(w: u32) -> Fixed {
-    debug_assert!(w <= 75, "wide_ln2: working scale {w} exceeds Fixed capacity");
+pub(crate) fn wide_ln2(working_scale: u32) -> Fixed {
+    debug_assert!(
+        working_scale <= 75,
+        "wide_ln2: working scale {working_scale} exceeds Fixed capacity"
+    );
     fixed_from_int256(crate::consts::ln2_const_n::<4>(
-        w,
+        working_scale,
         crate::support::rounding::RoundingMode::HalfToEven,
     ))
 }
@@ -86,72 +89,78 @@ pub(crate) fn wide_ln2(w: u32) -> Fixed {
 /// the 75-digit reference and rescaled **down** to `w`.
 ///
 /// Caller-side precondition: `w <= 75`. See [`wide_ln2`].
-pub(crate) fn wide_ln10(w: u32) -> Fixed {
-    debug_assert!(w <= 75, "wide_ln10: working scale {w} exceeds Fixed capacity");
+pub(crate) fn wide_ln10(working_scale: u32) -> Fixed {
+    debug_assert!(
+        working_scale <= 75,
+        "wide_ln10: working scale {working_scale} exceeds Fixed capacity"
+    );
     fixed_from_int256(crate::consts::ln10_const_n::<4>(
-        w,
+        working_scale,
         crate::support::rounding::RoundingMode::HalfToEven,
     ))
 }
 
-/// Natural logarithm of a positive working-scale value `v_w`, returned
-/// at the same working scale `w`.
+/// Natural logarithm of a positive `working_value`, returned at the same
+/// `working_scale`.
 ///
 /// Range-reduces `v = 2^k · m` with `m ∈ [1,2)` — the mantissa is
-/// recomputed exactly from `v_w` once `k` is known — then evaluates
-/// `ln(m) = 2·artanh((m-1)/(m+1))` (`t ∈ [0,1/3]`, fast convergence)
-/// and returns `k·ln(2) + ln(m)`.
-pub(crate) fn ln_fixed(v_w: Fixed, w: u32) -> Fixed {
-    let one_w = Fixed {
+/// recomputed exactly from `working_value` once `k` is known — then
+/// evaluates `ln(m) = 2·artanh((m-1)/(m+1))` (`t ∈ [0,1/3]`, fast
+/// convergence) and returns `k·ln(2) + ln(m)`.
+pub(crate) fn ln_fixed(working_value: Fixed, working_scale: u32) -> Fixed {
+    let one_at_working_scale = Fixed {
         negative: false,
-        mag: Fixed::pow10(w),
+        mag: Fixed::pow10(working_scale),
     };
-    let two_w = one_w.double();
+    let two_at_working_scale = one_at_working_scale.double();
 
-    // Range reduction: find k with v ∈ [2^k, 2^(k+1)); m_w = v_w / 2^k.
-    let mut k: i32 = v_w.bit_length() as i32 - one_w.bit_length() as i32;
-    let m_w = loop {
-        let m = if k >= 0 {
-            v_w.shr(k as u32)
+    // Range reduction: find k with v ∈ [2^k, 2^(k+1)); mantissa_w = v / 2^k.
+    let mut k: i32 =
+        working_value.bit_length() as i32 - one_at_working_scale.bit_length() as i32;
+    let mantissa_w = loop {
+        let candidate_mantissa = if k >= 0 {
+            working_value.shr(k as u32)
         } else {
-            v_w.shl((-k) as u32)
+            working_value.shl((-k) as u32)
         };
-        if m.ge_mag(two_w) {
+        if candidate_mantissa.ge_mag(two_at_working_scale) {
             k += 1;
-        } else if !m.ge_mag(one_w) {
+        } else if !candidate_mantissa.ge_mag(one_at_working_scale) {
             k -= 1;
         } else {
-            break m;
+            break candidate_mantissa;
         }
     };
 
     // t = (m - 1) / (m + 1) ∈ [0, 1/3]; artanh(t) = t + t³/3 + t⁵/5 + …
-    let t = m_w.sub(one_w).div(m_w.add(one_w), w);
-    let t2 = t.mul(t, w);
-    let mut sum = t;
-    let mut term = t;
-    let mut j: u128 = 1;
+    let atanh_arg = mantissa_w
+        .sub(one_at_working_scale)
+        .div(mantissa_w.add(one_at_working_scale), working_scale);
+    let atanh_arg_sq = atanh_arg.mul(atanh_arg, working_scale);
+    let mut sum = atanh_arg;
+    let mut term = atanh_arg;
+    let mut term_index: u128 = 1;
     loop {
-        term = term.mul(t2, w);
-        let contrib = term.div_small(2 * j + 1);
-        if contrib.is_zero() {
+        term = term.mul(atanh_arg_sq, working_scale);
+        let contribution = term.div_small(2 * term_index + 1);
+        if contribution.is_zero() {
             break;
         }
-        sum = sum.add(contrib);
-        j += 1;
-        if j > 400 {
+        sum = sum.add(contribution);
+        term_index += 1;
+        if term_index > 400 {
             break;
         }
     }
-    let ln_m = sum.double();
+    let ln_mantissa = sum.double();
 
-    let ln2 = wide_ln2(w);
+    let ln2 = wide_ln2(working_scale);
     let k_ln2 = if k >= 0 {
         ln2.mul_u128(k as u128)
     } else {
         ln2.mul_u128((-k) as u128).neg()
     };
-    k_ln2.add(ln_m)
+    k_ln2.add(ln_mantissa)
 }
 
 /// D38 natural log with explicit `working_digits` and rounding mode.
@@ -176,11 +185,11 @@ pub(crate) fn ln_with(
 #[inline]
 fn ln_with_raw(raw: i128, scale: u32, working_digits: u32, mode: RoundingMode) -> Option<i128> {
     assert!(raw > 0, "ln kernel: argument must be positive");
-    let one_bits: i128 = 10_i128.pow(scale);
-    if raw == one_bits {
+    let one_scaled: i128 = 10_i128.pow(scale);
+    if raw == one_scaled {
         return Some(0);
     }
-    let delta = raw - one_bits;
+    let delta = raw - one_scaled;
     let ln1p_band: i128 = 10_i128.pow(scale.saturating_sub(1) / 2);
     if delta.abs() <= ln1p_band && is_nearest_mode(mode) {
         // ln(1 + δ/10^S)·10^S = δ − δ²/(2·10^S) + … . The leading omitted term
@@ -195,9 +204,10 @@ fn ln_with_raw(raw: i128, scale: u32, working_digits: u32, mode: RoundingMode) -
         // of `δ`), so they fall through to the full working-scale kernel below.
         return Some(delta);
     }
-    let w = scale + working_digits;
-    let v_w = Fixed::from_u128_mag(raw as u128, false).mul_u128(10u128.pow(working_digits));
-    ln_fixed(v_w, w).round_to_i128_with(w, scale, mode)
+    let working_scale = scale + working_digits;
+    let working_value =
+        Fixed::from_u128_mag(raw as u128, false).mul_u128(10u128.pow(working_digits));
+    ln_fixed(working_value, working_scale).round_to_i128_with(working_scale, scale, mode)
 }
 
 /// Strict variant — fixed to `STRICT_GUARD` working digits. Equivalent
@@ -214,11 +224,11 @@ pub(crate) fn ln_strict<const SCALE: u32>(raw: Int<2>, mode: RoundingMode) -> Op
 #[inline]
 fn ln_strict_raw<const SCALE: u32>(raw: i128, mode: RoundingMode) -> Option<i128> {
     assert!(raw > 0, "ln kernel: argument must be positive");
-    let one_bits: i128 = 10_i128.pow(SCALE);
-    if raw == one_bits {
+    let one_scaled: i128 = 10_i128.pow(SCALE);
+    if raw == one_scaled {
         return Some(0);
     }
-    let delta = raw - one_bits;
+    let delta = raw - one_scaled;
     let ln1p_band: i128 = 10_i128.pow(SCALE.saturating_sub(1) / 2);
     if delta.abs() <= ln1p_band && is_nearest_mode(mode) {
         // See `ln_with_raw`: the band exponent ⌊(S−1)/2⌋ keeps the omitted
@@ -229,95 +239,101 @@ fn ln_strict_raw<const SCALE: u32>(raw: i128, mode: RoundingMode) -> Option<i128
         // fall through to the full kernel.
         return Some(delta);
     }
-    let w = SCALE + STRICT_GUARD;
-    let v_w = Fixed::from_u128_mag(raw as u128, false).mul_u128(10u128.pow(STRICT_GUARD));
-    let lv = ln_fixed(v_w, w);
-    match lv.round_to_i128_clear_of_tie(w, SCALE, mode) {
-        Some(r) => r,
+    let working_scale = SCALE + STRICT_GUARD;
+    let working_value =
+        Fixed::from_u128_mag(raw as u128, false).mul_u128(10u128.pow(STRICT_GUARD));
+    let ln_working_value = ln_fixed(working_value, working_scale);
+    match ln_working_value.round_to_i128_clear_of_tie(working_scale, SCALE, mode) {
+        Some(rounded) => rounded,
         // Near-tie: the directed deep-near-1 family (`ln(1 ± k·10^-S)`
         // leaves the `δ²/2` deviation below the fixed working scale once
         // `δ² < 2·10^(S−30)`) and any nearest near-half — escalate. The
         // walker resolves every constructible member (deviation depth
         // ≤ 2·38 = 76 ≪ the `WZiv` reach).
         None => narrow_ziv::walk_checked(
-            lv.round_to_i128_with(w, SCALE, mode),
+            ln_working_value.round_to_i128_with(working_scale, SCALE, mode),
             STRICT_GUARD,
             SCALE,
             mode,
-            |g| ln_ziv(raw, SCALE, g),
+            |guard_digits| ln_ziv(raw, SCALE, guard_digits),
         ),
     }
 }
 
-/// One `WZiv` ln probe at working scale `scale + g`.
-fn ln_ziv(raw: i128, scale: u32, g: u32) -> WZiv {
-    let w = scale + g;
-    eg::ln_fixed::<WZiv>(narrow_ziv::lift(raw, g), w, narrow_ziv::ln2_w(w))
+/// One `WZiv` ln probe at working scale `scale + guard_digits`.
+fn ln_ziv(raw: i128, scale: u32, guard_digits: u32) -> WZiv {
+    let working_scale = scale + guard_digits;
+    eg::ln_fixed::<WZiv>(
+        narrow_ziv::lift(raw, guard_digits), working_scale,
+        narrow_ziv::ln2_w(working_scale))
 }
 
-/// One `WZiv` `ln(x)/ln(b)` ratio probe at working scale `scale + g`.
-/// `b_num2` selects the base: positive = the storage `b_raw` (general
-/// log), `-2` / `-10` = the constant bases (log2 / log10, whose scaled
-/// storage form can overflow `i128` at the maximal scale).
-fn log_ratio_ziv(x_raw: i128, b_sel: i128, scale: u32, g: u32) -> WZiv {
-    let w = scale + g;
-    let ln2 = narrow_ziv::ln2_w(w);
-    let lx = eg::ln_fixed::<WZiv>(narrow_ziv::lift(x_raw, g), w, ln2);
-    let lb = match b_sel {
+/// One `WZiv` `ln(x)/ln(b)` ratio probe at working scale
+/// `scale + guard_digits`. `base_selector` selects the base: positive =
+/// the storage `base_raw` (general log), `-2` / `-10` = the constant bases
+/// (log2 / log10, whose scaled storage form can overflow `i128` at the
+/// maximal scale).
+fn log_ratio_ziv(x_raw: i128, base_selector: i128, scale: u32, guard_digits: u32) -> WZiv {
+    let working_scale = scale + guard_digits;
+    let ln2 = narrow_ziv::ln2_w(working_scale);
+    let ln_x = eg::ln_fixed::<WZiv>(narrow_ziv::lift(x_raw, guard_digits), working_scale, ln2);
+    let ln_base = match base_selector {
         -2 => ln2,
-        -10 => narrow_ziv::ln10_w(w),
-        b_raw => eg::ln_fixed::<WZiv>(narrow_ziv::lift(b_raw, g), w, ln2),
+        -10 => narrow_ziv::ln10_w(working_scale),
+        base_raw => eg::ln_fixed::<WZiv>(
+            narrow_ziv::lift(base_raw, guard_digits), working_scale, ln2),
     };
-    eg::div::<WZiv>(lx, lb, w)
+    eg::div::<WZiv>(ln_x, ln_base, working_scale)
 }
 
 /// Greatest common divisor (Euclid) on `u128`.
-pub(crate) fn gcd_u128(mut a: u128, mut b: u128) -> u128 {
-    while b != 0 {
-        let t = a % b;
-        a = b;
-        b = t;
+pub(crate) fn gcd_u128(mut lhs: u128, mut rhs: u128) -> u128 {
+    while rhs != 0 {
+        let remainder = lhs % rhs;
+        lhs = rhs;
+        rhs = remainder;
     }
-    a
+    lhs
 }
 
-/// `base^e` in [`WZiv`], `None` when the result would exceed the bounded
-/// bit budget (1500 bits — inside `Int<24>`'s 1536 with sign headroom).
-/// Square-and-multiply; the bit-length pre-check bounds every
+/// `base^exponent` in [`WZiv`], `None` when the result would exceed the
+/// bounded bit budget (1500 bits — inside `Int<24>`'s 1536 with sign
+/// headroom). Square-and-multiply; the bit-length pre-check bounds every
 /// intermediate, so no step can overflow.
-pub(crate) fn pow_bounded(base: u128, e: u128) -> Option<WZiv> {
+pub(crate) fn pow_bounded(base: u128, exponent: u128) -> Option<WZiv> {
     if base == 0 {
         return None; // domain-asserted positive inputs; 0 never verifies
     }
-    let bl = (128 - base.leading_zeros()) as u128;
-    // Saturating: `e` can be as large as `10^scale` (an irreducible
+    let base_bits = (128 - base.leading_zeros()) as u128;
+    // Saturating: `exponent` can be as large as `10^scale` (an irreducible
     // candidate denominator), so the budget product must not wrap.
-    if bl.saturating_mul(e) > 1500 {
+    if base_bits.saturating_mul(exponent) > 1500 {
         return None;
     }
-    let mut acc = WZiv::from_i128(1);
-    let mut b = WZiv::from_u128(base);
-    let mut k = e;
-    while k > 0 {
-        if k & 1 == 1 {
-            acc = acc * b;
+    let mut accumulator = WZiv::from_i128(1);
+    let mut base_power = WZiv::from_u128(base);
+    let mut remaining_exponent = exponent;
+    while remaining_exponent > 0 {
+        if remaining_exponent & 1 == 1 {
+            accumulator = accumulator * base_power;
         }
-        k >>= 1;
-        if k > 0 {
-            b = b * b;
+        remaining_exponent >>= 1;
+        if remaining_exponent > 0 {
+            base_power = base_power * base_power;
         }
     }
-    Some(acc)
+    Some(accumulator)
 }
 
 /// Exact rational-power pin for the strict log near-tie terminal.
 ///
-/// `num2` is the boundary CANDIDATE in half-ULPs at `scale` (the working
+/// `half_ulp_numerator` is the boundary CANDIDATE in half-ULPs at `scale` (the working
 /// ratio doubled and rounded to the nearest integer): even = a grid
 /// candidate (a directed near-grid tie, e.g. `log_4(8) = 3/2` on the
 /// scale-19 grid), odd = a half candidate (a nearest near-half tie, e.g.
-/// `log_4(32) = 5/2` at scale 0). Verifies `log_(bn/bd)(xn/xd) ==
-/// num2/(2·10^scale)` EXACTLY via the integer identity `x^q == b^p`
+/// `log_4(32) = 5/2` at scale 0). Verifies
+/// `log_(base_num/base_den)(x_num/x_den) ==
+/// half_ulp_numerator/(2·10^scale)` EXACTLY via the integer identity `x^q == b^p`
 /// (`p/q` = the candidate in lowest terms; `pow_bounded` caps the
 /// verification at sizes [`WZiv`] holds — an unverifiable candidate
 /// defers to the walker). On a verified exact value the result is
@@ -327,63 +343,72 @@ pub(crate) fn pow_bounded(base: u128, e: u128) -> Option<WZiv> {
 /// residual at any finite scale is kernel noise around the boundary,
 /// which no escalation can settle.
 fn log_rational_pow_pin(
-    xn: u128,
-    xd: u128,
-    bn: u128,
-    bd: u128,
+    x_num: u128,
+    x_den: u128,
+    base_num: u128,
+    base_den: u128,
     scale: u32,
-    num2: i128,
+    half_ulp_numerator: i128,
     mode: RoundingMode,
 ) -> Option<i128> {
-    if num2 == 0 {
+    if half_ulp_numerator == 0 {
         return None; // r = 0 ⇔ x == 1, pinned upstream
     }
-    let den: u128 = 2 * 10u128.pow(scale);
-    let neg = num2 < 0;
-    let num = num2.unsigned_abs();
-    let g = gcd_u128(num, den);
-    let p = num / g;
-    let q = den / g;
+    let half_ulp_denominator: u128 = 2 * 10u128.pow(scale);
+    let is_negative = half_ulp_numerator < 0;
+    let abs_numerator = half_ulp_numerator.unsigned_abs();
+    let common_divisor = gcd_u128(abs_numerator, half_ulp_denominator);
+    let reduced_num = abs_numerator / common_divisor;
+    let reduced_den = half_ulp_denominator / common_divisor;
     // log_b(x) = ±p/q ⇔ x^q == b^(±p): for the negative sign the base
     // fraction inverts.
-    let (tn, td) = if neg { (bd, bn) } else { (bn, bd) };
-    let lx_n = pow_bounded(xn, q)?;
-    let lx_d = pow_bounded(xd, q)?;
-    let rb_n = pow_bounded(tn, p)?;
-    let rb_d = pow_bounded(td, p)?;
-    if lx_n != rb_n || lx_d != rb_d {
+    let (target_num, target_den) = if is_negative {
+        (base_den, base_num)
+    } else {
+        (base_num, base_den)
+    };
+    let x_pow_num = pow_bounded(x_num, reduced_den)?;
+    let x_pow_den = pow_bounded(x_den, reduced_den)?;
+    let base_pow_num = pow_bounded(target_num, reduced_num)?;
+    let base_pow_den = pow_bounded(target_den, reduced_num)?;
+    if x_pow_num != base_pow_num || x_pow_den != base_pow_den {
         return None;
     }
-    // Exact value num2/(2·10^scale): fold the half-ULP form to storage.
-    let q_mag = num / 2;
-    if num & 1 == 0 {
-        return Some(if neg { -(q_mag as i128) } else { q_mag as i128 });
+    // Exact value half_ulp_numerator/(2·10^scale): fold the half-ULP form
+    // to storage.
+    let result_magnitude = abs_numerator / 2;
+    if abs_numerator & 1 == 0 {
+        return Some(if is_negative {
+            -(result_magnitude as i128)
+        } else {
+            result_magnitude as i128
+        });
     }
-    // Exactly on the half between q_mag and q_mag + 1 (magnitude side):
-    // the mode's tie rule, by exact integer arithmetic.
+    // Exactly on the half between result_magnitude and result_magnitude + 1
+    // (magnitude side): the mode's tie rule, by exact integer arithmetic.
     let bump = crate::support::rounding::should_bump(
         mode,
         core::cmp::Ordering::Equal,
-        q_mag & 1 == 1,
-        !neg,
+        result_magnitude & 1 == 1,
+        !is_negative,
     );
-    let m = (q_mag + u128::from(bump)) as i128;
-    Some(if neg { -m } else { m })
+    let bumped_magnitude = (result_magnitude + u128::from(bump)) as i128;
+    Some(if is_negative { -bumped_magnitude } else { bumped_magnitude })
 }
 
-/// Reduces `a / b` to lowest terms.
-pub(crate) fn reduce_fraction(a: u128, b: u128) -> (u128, u128) {
-    let g = gcd_u128(a, b);
-    (a / g, b / g)
+/// Reduces `numerator / denominator` to lowest terms.
+pub(crate) fn reduce_fraction(numerator: u128, denominator: u128) -> (u128, u128) {
+    let common_divisor = gcd_u128(numerator, denominator);
+    (numerator / common_divisor, denominator / common_divisor)
 }
 
 // ── log / log2 / log10 kernels (D38, Fixed fallback) ──────────────
 
 /// Exact-integer-logarithm pin for the D38 log family.
 ///
-/// Returns `Some(k · 10^scale)` (the exact storage representation of the
-/// integer `k`) when `value == base^k` exactly at the storage scale, i.e.
-/// when the true `log_base(value)` is the exact integer `k`. Off this
+/// Returns `Some(exponent · 10^scale)` (the exact storage representation
+/// of the integer `exponent`) when `value == base^k` exactly at the storage
+/// scale, i.e. when the true `log_base(value)` is that exact integer. Off this
 /// allow-list the logarithm is irrational (Lindemann–Weierstrass), so the
 /// residual is genuinely non-zero and the caller's working-scale kernel
 /// runs. Pinning the exact points stops the `ln(value)/ln(base)` round-off
@@ -397,15 +422,15 @@ pub(crate) fn reduce_fraction(a: u128, b: u128) -> (u128, u128) {
 /// scaled `base · 10^scale` avoids overflowing `i128` when forming
 /// `10^(scale+1)` at the maximal scale (the D38 max-scale ln panic).
 ///
-/// The candidate `k` is derived by the caller from the nearest-rounded
-/// result. All arithmetic is `i128`; an intermediate that overflows
-/// `i128` cannot be a representable exact power, so the check returns
-/// `None`.
+/// The candidate `exponent` is derived by the caller from the
+/// nearest-rounded result. All arithmetic is `i128`; an intermediate that
+/// overflows `i128` cannot be a representable exact power, so the check
+/// returns `None`.
 #[inline]
-fn log_exact_int_pin(value_raw: i128, base_int: i128, scale: u32, k: i128) -> Option<i128> {
-    let one_s = 10i128.checked_pow(scale)?;
-    if k == 0 {
-        return (value_raw == one_s).then_some(0);
+fn log_exact_int_pin(value_raw: i128, base_int: i128, scale: u32, exponent: i128) -> Option<i128> {
+    let one_scaled = 10i128.checked_pow(scale)?;
+    if exponent == 0 {
+        return (value_raw == one_scaled).then_some(0);
     }
     // A non-integer base (only the near-1 ill-conditioning probes hit
     // this) raised to an integer `k` is not an integer matching `value`
@@ -413,46 +438,46 @@ fn log_exact_int_pin(value_raw: i128, base_int: i128, scale: u32, k: i128) -> Op
     if base_int == 0 {
         return None;
     }
-    let kk = k.unsigned_abs();
-    let exact = if k > 0 {
+    let abs_exponent = exponent.unsigned_abs();
+    let exact = if exponent > 0 {
         // value == base^|k|: compare `base_int^|k|` against the integer
         // part of `value`, requiring `value` to be that exact integer.
-        if value_raw % one_s != 0 {
+        if value_raw % one_scaled != 0 {
             return None;
         }
-        let value_int = value_raw / one_s;
-        let mut pow: i128 = 1;
-        let mut ok = true;
-        for _ in 0..kk {
-            match pow.checked_mul(base_int) {
-                Some(p) => pow = p,
+        let value_int = value_raw / one_scaled;
+        let mut power: i128 = 1;
+        let mut fits = true;
+        for _ in 0..abs_exponent {
+            match power.checked_mul(base_int) {
+                Some(next_power) => power = next_power,
                 None => {
-                    ok = false;
+                    fits = false;
                     break;
                 }
             }
         }
-        ok && pow == value_int
+        fits && power == value_int
     } else {
         // value == 1 / base^|k|: `value · base^|k| == 1` exactly, i.e.
         // `value_raw · base_int^|k| == 10^scale`. Drive `value_raw` up by
         // `base_int` each step (staying bounded near `10^scale`) and
         // require exact divisibility is not needed — multiplication is
-        // exact integer; the product must hit `one_s` precisely.
-        let mut cur = value_raw;
-        let mut ok = true;
-        for _ in 0..kk {
-            match cur.checked_mul(base_int) {
-                Some(p) => cur = p,
+        // exact integer; the product must hit `one_scaled` precisely.
+        let mut product = value_raw;
+        let mut fits = true;
+        for _ in 0..abs_exponent {
+            match product.checked_mul(base_int) {
+                Some(next_product) => product = next_product,
                 None => {
-                    ok = false;
+                    fits = false;
                     break;
                 }
             }
         }
-        ok && cur == one_s
+        fits && product == one_scaled
     };
-    if exact { k.checked_mul(one_s) } else { None }
+    if exact { exponent.checked_mul(one_scaled) } else { None }
 }
 
 /// `log_base(v) = ln(v) / ln(base)`, both carried in the `Fixed` wide.
@@ -488,30 +513,30 @@ fn log_with_raw(
 ) -> Option<i128> {
     assert!(raw > 0, "D38::log: argument must be positive");
     assert!(base_raw > 0, "D38::log: base must be positive");
-    let w = scale + working_digits;
-    let pow = 10u128.pow(working_digits);
-    let v_w = Fixed::from_u128_mag(raw as u128, false).mul_u128(pow);
-    let b_w = Fixed::from_u128_mag(base_raw as u128, false).mul_u128(pow);
-    let ln_b = ln_fixed(b_w, w);
+    let working_scale = scale + working_digits;
+    let guard_pow = 10u128.pow(working_digits);
+    let working_value = Fixed::from_u128_mag(raw as u128, false).mul_u128(guard_pow);
+    let base_working_value = Fixed::from_u128_mag(base_raw as u128, false).mul_u128(guard_pow);
+    let ln_b = ln_fixed(base_working_value, working_scale);
     assert!(
         !ln_b.is_zero(),
         "D38::log: base must not equal 1 (ln(1) is zero)"
     );
-    let ratio = ln_fixed(v_w, w).div(ln_b, w);
+    let ratio = ln_fixed(working_value, working_scale).div(ln_b, working_scale);
     // Exact-power pin: `value == base^k` ⇒ result is exactly `k`.
     // Reduce the storage `base_raw` to its integer base (`base_raw /
     // 10^scale`) here, without forming `base · 10^scale`, so the pin's
     // integer-domain check never carries (and never overflows) the
     // scale factor — `0` flags a non-integer base (no exact pin).
-    let k = ratio.round_to_nearest_int(w);
+    let exponent_candidate = ratio.round_to_nearest_int(working_scale);
     let base_int = match 10i128.checked_pow(scale) {
-        Some(one_s) if base_raw % one_s == 0 => base_raw / one_s,
+        Some(one_scaled) if base_raw % one_scaled == 0 => base_raw / one_scaled,
         _ => 0,
     };
-    if let Some(pinned) = log_exact_int_pin(raw, base_int, scale, k) {
+    if let Some(pinned) = log_exact_int_pin(raw, base_int, scale, exponent_candidate) {
         return Some(pinned);
     }
-    ratio.round_to_i128_with(w, scale, mode)
+    ratio.round_to_i128_with(working_scale, scale, mode)
 }
 
 /// Const-folded strict variant of [`log_with`] with the near-tie
@@ -531,49 +556,50 @@ pub(crate) fn log_strict<const SCALE: u32>(raw: Int<2>, base_raw: Int<2>, mode: 
 fn log_strict_raw(raw: i128, base_raw: i128, scale: u32, mode: RoundingMode) -> Option<i128> {
     assert!(raw > 0, "D38::log: argument must be positive");
     assert!(base_raw > 0, "D38::log: base must be positive");
-    let w = scale + STRICT_GUARD;
-    let pow = 10u128.pow(STRICT_GUARD);
-    let v_w = Fixed::from_u128_mag(raw as u128, false).mul_u128(pow);
-    let b_w = Fixed::from_u128_mag(base_raw as u128, false).mul_u128(pow);
-    let ln_b = ln_fixed(b_w, w);
+    let working_scale = scale + STRICT_GUARD;
+    let guard_pow = 10u128.pow(STRICT_GUARD);
+    let working_value = Fixed::from_u128_mag(raw as u128, false).mul_u128(guard_pow);
+    let base_working_value = Fixed::from_u128_mag(base_raw as u128, false).mul_u128(guard_pow);
+    let ln_b = ln_fixed(base_working_value, working_scale);
     assert!(
         !ln_b.is_zero(),
         "D38::log: base must not equal 1 (ln(1) is zero)"
     );
-    let ratio = ln_fixed(v_w, w).div(ln_b, w);
+    let ratio = ln_fixed(working_value, working_scale).div(ln_b, working_scale);
     // Exact-power pin (see `log_with_raw`).
-    let k = ratio.round_to_nearest_int(w);
+    let exponent_candidate = ratio.round_to_nearest_int(working_scale);
     let base_int = match 10i128.checked_pow(scale) {
-        Some(one_s) if base_raw % one_s == 0 => base_raw / one_s,
+        Some(one_scaled) if base_raw % one_scaled == 0 => base_raw / one_scaled,
         _ => 0,
     };
-    if let Some(pinned) = log_exact_int_pin(raw, base_int, scale, k) {
+    if let Some(pinned) = log_exact_int_pin(raw, base_int, scale, exponent_candidate) {
         return Some(pinned);
     }
-    match ratio.round_to_i128_clear_of_tie(w, scale, mode) {
-        Some(r) => r,
+    match ratio.round_to_i128_clear_of_tie(working_scale, scale, mode) {
+        Some(rounded) => rounded,
         None => {
             // Near a boundary: try the exact rational-power pin before
             // walking (an exact rational log never resolves by escalation
             // — the residual at every depth is kernel noise around the
             // boundary).
-            if let Some(num2) = ratio.double().round_to_i128_with(w, scale, RoundingMode::HalfToEven)
+            if let Some(half_ulp_numerator) =
+                ratio.double().round_to_i128_with(working_scale, scale, RoundingMode::HalfToEven)
             {
-                let one_s = 10u128.pow(scale);
-                let (xn, xd) = reduce_fraction(raw as u128, one_s);
-                let (bn, bd) = reduce_fraction(base_raw as u128, one_s);
-                if let Some(pinned) =
-                    log_rational_pow_pin(xn, xd, bn, bd, scale, num2, mode)
+                let one_scaled = 10u128.pow(scale);
+                let (x_num, x_den) = reduce_fraction(raw as u128, one_scaled);
+                let (base_num, base_den) = reduce_fraction(base_raw as u128, one_scaled);
+                if let Some(pinned) = log_rational_pow_pin(
+                    x_num, x_den, base_num, base_den, scale, half_ulp_numerator, mode)
                 {
                     return Some(pinned);
                 }
             }
             narrow_ziv::walk_checked(
-                ratio.round_to_i128_with(w, scale, mode),
+                ratio.round_to_i128_with(working_scale, scale, mode),
                 STRICT_GUARD,
                 scale,
                 mode,
-                |g| log_ratio_ziv(raw, base_raw, scale, g),
+                |guard_digits| log_ratio_ziv(raw, base_raw, scale, guard_digits),
             )
         }
     }
@@ -590,15 +616,17 @@ pub(crate) fn log2_with(raw: Int<2>, scale: u32, working_digits: u32, mode: Roun
 #[inline]
 fn log2_with_raw(raw: i128, scale: u32, working_digits: u32, mode: RoundingMode) -> Option<i128> {
     assert!(raw > 0, "D38::log2: argument must be positive");
-    let w = scale + working_digits;
-    let v_w = Fixed::from_u128_mag(raw as u128, false).mul_u128(10u128.pow(working_digits));
-    let ratio = ln_fixed(v_w, w).div(wide_ln2(w), w);
+    let working_scale = scale + working_digits;
+    let working_value =
+        Fixed::from_u128_mag(raw as u128, false).mul_u128(10u128.pow(working_digits));
+    let ratio =
+        ln_fixed(working_value, working_scale).div(wide_ln2(working_scale), working_scale);
     // Exact-power pin: `value == 2^k` ⇒ result is exactly `k`.
-    let k = ratio.round_to_nearest_int(w);
-    if let Some(pinned) = log_exact_int_pin(raw, 2, scale, k) {
+    let exponent_candidate = ratio.round_to_nearest_int(working_scale);
+    if let Some(pinned) = log_exact_int_pin(raw, 2, scale, exponent_candidate) {
         return Some(pinned);
     }
-    ratio.round_to_i128_with(w, scale, mode)
+    ratio.round_to_i128_with(working_scale, scale, mode)
 }
 
 /// `None` = result out of storage range. The strict terminal is
@@ -614,21 +642,23 @@ pub(crate) fn log2_strict<const SCALE: u32>(raw: Int<2>, mode: RoundingMode) -> 
 /// `i128` core of [`log2_strict`].
 fn log2_strict_raw(raw: i128, scale: u32, mode: RoundingMode) -> Option<i128> {
     assert!(raw > 0, "D38::log2: argument must be positive");
-    let w = scale + STRICT_GUARD;
-    let v_w = Fixed::from_u128_mag(raw as u128, false).mul_u128(10u128.pow(STRICT_GUARD));
-    let ratio = ln_fixed(v_w, w).div(wide_ln2(w), w);
-    let k = ratio.round_to_nearest_int(w);
-    if let Some(pinned) = log_exact_int_pin(raw, 2, scale, k) {
+    let working_scale = scale + STRICT_GUARD;
+    let working_value =
+        Fixed::from_u128_mag(raw as u128, false).mul_u128(10u128.pow(STRICT_GUARD));
+    let ratio =
+        ln_fixed(working_value, working_scale).div(wide_ln2(working_scale), working_scale);
+    let exponent_candidate = ratio.round_to_nearest_int(working_scale);
+    if let Some(pinned) = log_exact_int_pin(raw, 2, scale, exponent_candidate) {
         return Some(pinned);
     }
-    match ratio.round_to_i128_clear_of_tie(w, scale, mode) {
-        Some(r) => r,
+    match ratio.round_to_i128_clear_of_tie(working_scale, scale, mode) {
+        Some(rounded) => rounded,
         None => narrow_ziv::walk_checked(
-            ratio.round_to_i128_with(w, scale, mode),
+            ratio.round_to_i128_with(working_scale, scale, mode),
             STRICT_GUARD,
             scale,
             mode,
-            |g| log_ratio_ziv(raw, -2, scale, g),
+            |guard_digits| log_ratio_ziv(raw, -2, scale, guard_digits),
         ),
     }
 }
@@ -644,15 +674,17 @@ pub(crate) fn log10_with(raw: Int<2>, scale: u32, working_digits: u32, mode: Rou
 #[inline]
 fn log10_with_raw(raw: i128, scale: u32, working_digits: u32, mode: RoundingMode) -> Option<i128> {
     assert!(raw > 0, "D38::log10: argument must be positive");
-    let w = scale + working_digits;
-    let v_w = Fixed::from_u128_mag(raw as u128, false).mul_u128(10u128.pow(working_digits));
-    let ratio = ln_fixed(v_w, w).div(wide_ln10(w), w);
+    let working_scale = scale + working_digits;
+    let working_value =
+        Fixed::from_u128_mag(raw as u128, false).mul_u128(10u128.pow(working_digits));
+    let ratio =
+        ln_fixed(working_value, working_scale).div(wide_ln10(working_scale), working_scale);
     // Exact-power pin: `value == 10^k` ⇒ result is exactly `k`.
-    let k = ratio.round_to_nearest_int(w);
-    if let Some(pinned) = log_exact_int_pin(raw, 10, scale, k) {
+    let exponent_candidate = ratio.round_to_nearest_int(working_scale);
+    if let Some(pinned) = log_exact_int_pin(raw, 10, scale, exponent_candidate) {
         return Some(pinned);
     }
-    ratio.round_to_i128_with(w, scale, mode)
+    ratio.round_to_i128_with(working_scale, scale, mode)
 }
 
 /// `None` = result out of storage range. Near-tie protected like
@@ -667,21 +699,23 @@ pub(crate) fn log10_strict<const SCALE: u32>(raw: Int<2>, mode: RoundingMode) ->
 /// `i128` core of [`log10_strict`].
 fn log10_strict_raw(raw: i128, scale: u32, mode: RoundingMode) -> Option<i128> {
     assert!(raw > 0, "D38::log10: argument must be positive");
-    let w = scale + STRICT_GUARD;
-    let v_w = Fixed::from_u128_mag(raw as u128, false).mul_u128(10u128.pow(STRICT_GUARD));
-    let ratio = ln_fixed(v_w, w).div(wide_ln10(w), w);
-    let k = ratio.round_to_nearest_int(w);
-    if let Some(pinned) = log_exact_int_pin(raw, 10, scale, k) {
+    let working_scale = scale + STRICT_GUARD;
+    let working_value =
+        Fixed::from_u128_mag(raw as u128, false).mul_u128(10u128.pow(STRICT_GUARD));
+    let ratio =
+        ln_fixed(working_value, working_scale).div(wide_ln10(working_scale), working_scale);
+    let exponent_candidate = ratio.round_to_nearest_int(working_scale);
+    if let Some(pinned) = log_exact_int_pin(raw, 10, scale, exponent_candidate) {
         return Some(pinned);
     }
-    match ratio.round_to_i128_clear_of_tie(w, scale, mode) {
-        Some(r) => r,
+    match ratio.round_to_i128_clear_of_tie(working_scale, scale, mode) {
+        Some(rounded) => rounded,
         None => narrow_ziv::walk_checked(
-            ratio.round_to_i128_with(w, scale, mode),
+            ratio.round_to_i128_with(working_scale, scale, mode),
             STRICT_GUARD,
             scale,
             mode,
-            |g| log_ratio_ziv(raw, -10, scale, g),
+            |guard_digits| log_ratio_ziv(raw, -10, scale, guard_digits),
         ),
     }
 }
@@ -702,29 +736,29 @@ mod near_tie_pins {
         // partial + the strictly-negative tail (narrow_tie_derive.py).
         let raw = Int::<2>::from_i128(10_i128.pow(38) + 1);
         assert_eq!(
-            ln_strict::<38>(raw, RoundingMode::Floor).map(|v| v.as_i128()),
+            ln_strict::<38>(raw, RoundingMode::Floor).map(|value| value.as_i128()),
             Some(0),
             "ln Floor"
         );
         assert_eq!(
-            ln_strict::<38>(raw, RoundingMode::Trunc).map(|v| v.as_i128()),
+            ln_strict::<38>(raw, RoundingMode::Trunc).map(|value| value.as_i128()),
             Some(0),
             "ln Trunc"
         );
         assert_eq!(
-            ln_strict::<38>(raw, RoundingMode::Ceiling).map(|v| v.as_i128()),
+            ln_strict::<38>(raw, RoundingMode::Ceiling).map(|value| value.as_i128()),
             Some(1),
             "ln Ceiling"
         );
         // below 1: ln(1 − 1e-38) = −δ − δ²/2: strictly below −δ.
         let raw_lo = Int::<2>::from_i128(10_i128.pow(38) - 1);
         assert_eq!(
-            ln_strict::<38>(raw_lo, RoundingMode::Floor).map(|v| v.as_i128()),
+            ln_strict::<38>(raw_lo, RoundingMode::Floor).map(|value| value.as_i128()),
             Some(-2),
             "ln(1−ulp) Floor"
         );
         assert_eq!(
-            ln_strict::<38>(raw_lo, RoundingMode::Trunc).map(|v| v.as_i128()),
+            ln_strict::<38>(raw_lo, RoundingMode::Trunc).map(|value| value.as_i128()),
             Some(-1),
             "ln(1−ulp) Trunc"
         );
@@ -736,34 +770,35 @@ mod near_tie_pins {
         // resolution <=> delta^2 < 2*10^(S-30)... in working units at w:
         // dev_working = delta^2/(2*10^S)*10^30 < 1 <=> delta^2 < 2*10^(S-30)
         let mut bad = 0u32;
-        for s in 31u32..=38 {
-            let one: i128 = 10_i128.pow(s);
-            let max_d = ((2.0 * 10f64.powi(s as i32 - 30)).sqrt() as i128).max(1);
-            let mut d: i128 = 1;
-            while d <= max_d {
-                let raw = Int::<2>::from_i128(one + d);
-                let fl = ln_strict_dyn(s, raw, RoundingMode::Floor);
-                let ce = ln_strict_dyn(s, raw, RoundingMode::Ceiling);
-                if fl != Some(d - 1) || ce != Some(d) {
-                    println!("LIVE ln(1+{d}ulp) S={s}: Floor={fl:?} (want {}), Ceil={ce:?} (want {d})", d-1);
+        for scale in 31u32..=38 {
+            let one: i128 = 10_i128.pow(scale);
+            let max_offset =
+                ((2.0 * 10f64.powi(scale as i32 - 30)).sqrt() as i128).max(1);
+            let mut ulp_offset: i128 = 1;
+            while ulp_offset <= max_offset {
+                let raw = Int::<2>::from_i128(one + ulp_offset);
+                let above_floor = ln_strict_dyn(scale, raw, RoundingMode::Floor);
+                let above_ceiling = ln_strict_dyn(scale, raw, RoundingMode::Ceiling);
+                if above_floor != Some(ulp_offset - 1) || above_ceiling != Some(ulp_offset) {
+                    println!("LIVE ln(1+{ulp_offset}ulp) S={scale}: Floor={above_floor:?} (want {}), Ceil={above_ceiling:?} (want {ulp_offset})", ulp_offset-1);
                     bad += 1;
                 }
-                let raw_lo = Int::<2>::from_i128(one - d);
-                let fl2 = ln_strict_dyn(s, raw_lo, RoundingMode::Floor);
-                let tr2 = ln_strict_dyn(s, raw_lo, RoundingMode::Trunc);
-                if fl2 != Some(-d - 1) || tr2 != Some(-d) {
-                    println!("LIVE ln(1-{d}ulp) S={s}: Floor={fl2:?} (want {}), Trunc={tr2:?} (want {})", -d-1, -d);
+                let raw_lo = Int::<2>::from_i128(one - ulp_offset);
+                let below_floor = ln_strict_dyn(scale, raw_lo, RoundingMode::Floor);
+                let below_trunc = ln_strict_dyn(scale, raw_lo, RoundingMode::Trunc);
+                if below_floor != Some(-ulp_offset - 1) || below_trunc != Some(-ulp_offset) {
+                    println!("LIVE ln(1-{ulp_offset}ulp) S={scale}: Floor={below_floor:?} (want {}), Trunc={below_trunc:?} (want {})", -ulp_offset-1, -ulp_offset);
                     bad += 1;
                 }
-                d = if d < 20 { d + 1 } else { d + d / 3 };
+                ulp_offset = if ulp_offset < 20 { ulp_offset + 1 } else { ulp_offset + ulp_offset / 3 };
             }
         }
         assert_eq!(bad, 0, "ln deep directed band has live misrounds");
     }
 
-    fn ln_strict_dyn(s: u32, raw: Int<2>, mode: RoundingMode) -> Option<i128> {
+    fn ln_strict_dyn(scale: u32, raw: Int<2>, mode: RoundingMode) -> Option<i128> {
         // The STRICT path (const-scale): the fixed near-tie terminal.
-        let v = match s {
+        let strict_result = match scale {
             31 => ln_strict::<31>(raw, mode),
             32 => ln_strict::<32>(raw, mode),
             33 => ln_strict::<33>(raw, mode),
@@ -774,7 +809,7 @@ mod near_tie_pins {
             38 => ln_strict::<38>(raw, mode),
             _ => unreachable!(),
         };
-        v.map(|v| v.as_i128())
+        strict_result.map(|value| value.as_i128())
     }
 
     #[test]
@@ -784,15 +819,15 @@ mod near_tie_pins {
         // log(0.1096614350149675660535769418, 0.0182017066872921546105935121)
         // at D38<37> (the golden log.golden:18 panic). The saturating
         // budget must DEFER (walker), never wrap.
-        let xr: i128 = 1096614350149675660535769418_i128 * 1_000_000_000;
-        let br: i128 = 182017066872921546105935121_i128 * 1_000_000_000;
+        let x_raw: i128 = 1096614350149675660535769418_i128 * 1_000_000_000;
+        let base_raw: i128 = 182017066872921546105935121_i128 * 1_000_000_000;
         for mode in [
             RoundingMode::HalfToEven,
             RoundingMode::Floor,
             RoundingMode::Ceiling,
         ] {
-            let r = log_strict_raw(xr, br, 37, mode);
-            assert!(r.is_some(), "log fractional-base s37 mode={mode:?}");
+            let log_result = log_strict_raw(x_raw, base_raw, 37, mode);
+            assert!(log_result.is_some(), "log fractional-base s37 mode={mode:?}");
         }
     }
 
@@ -803,8 +838,8 @@ mod near_tie_pins {
         // the ln(8)/ln(4) single shot lands a hair off the grid line and
         // the directed modes stepped 1 LSB off the exact power.
         let one19 = 10_i128.pow(19);
-        let x = Int::<2>::from_i128(8 * one19);
-        let b = Int::<2>::from_i128(4 * one19);
+        let x_storage = Int::<2>::from_i128(8 * one19);
+        let base_storage = Int::<2>::from_i128(4 * one19);
         for mode in [
             RoundingMode::HalfToEven,
             RoundingMode::HalfAwayFromZero,
@@ -814,7 +849,7 @@ mod near_tie_pins {
             RoundingMode::Trunc,
         ] {
             assert_eq!(
-                log_strict_raw(x.as_i128(), b.as_i128(), 19, mode),
+                log_strict_raw(x_storage.as_i128(), base_storage.as_i128(), 19, mode),
                 Some(15 * one19 / 10),
                 "log_4(8) mode={mode:?}"
             );
@@ -828,33 +863,37 @@ mod near_tie_pins {
         // only exact integer arithmetic can certify (the working-scale
         // residual is kernel noise around the half). HalfToEven → 2
         // (even), HalfAwayFromZero → 3, HalfTowardZero → 2.
-        let x = Int::<2>::from_i128(32);
-        let b = Int::<2>::from_i128(4);
+        let x_storage = Int::<2>::from_i128(32);
+        let base_storage = Int::<2>::from_i128(4);
         assert_eq!(
-            log_strict_raw(x.as_i128(), b.as_i128(), 0, RoundingMode::HalfToEven),
+            log_strict_raw(x_storage.as_i128(), base_storage.as_i128(), 0, RoundingMode::HalfToEven),
             Some(2),
             "log_4(32) HalfToEven"
         );
         assert_eq!(
-            log_strict_raw(x.as_i128(), b.as_i128(), 0, RoundingMode::HalfAwayFromZero),
+            log_strict_raw(
+                x_storage.as_i128(), base_storage.as_i128(), 0, RoundingMode::HalfAwayFromZero),
             Some(3),
             "log_4(32) HalfAwayFromZero"
         );
         assert_eq!(
-            log_strict_raw(x.as_i128(), b.as_i128(), 0, RoundingMode::HalfTowardZero),
+            log_strict_raw(
+                x_storage.as_i128(), base_storage.as_i128(), 0, RoundingMode::HalfTowardZero),
             Some(2),
             "log_4(32) HalfTowardZero"
         );
         // log_16(8) = 3/4 (8⁴ = 16³): a half-tie at SCALE 1 (7.5 tenths).
-        let x8 = Int::<2>::from_i128(80);
-        let b16 = Int::<2>::from_i128(160);
+        let x8_storage = Int::<2>::from_i128(80);
+        let base16_storage = Int::<2>::from_i128(160);
         assert_eq!(
-            log_strict_raw(x8.as_i128(), b16.as_i128(), 1, RoundingMode::HalfToEven),
+            log_strict_raw(
+                x8_storage.as_i128(), base16_storage.as_i128(), 1, RoundingMode::HalfToEven),
             Some(8),
             "log_16(8) s1 HalfToEven"
         );
         assert_eq!(
-            log_strict_raw(x8.as_i128(), b16.as_i128(), 1, RoundingMode::HalfTowardZero),
+            log_strict_raw(
+                x8_storage.as_i128(), base16_storage.as_i128(), 1, RoundingMode::HalfTowardZero),
             Some(7),
             "log_16(8) s1 HalfTowardZero"
         );

--- a/src/algos/ln/ln_tang.rs
+++ b/src/algos/ln/ln_tang.rs
@@ -67,8 +67,8 @@ const M: u32 = 128;
 /// so a fixed lift suffices.
 pub(crate) const EXTERNAL_EXTRA_DIGITS: u32 = 12;
 
-/// Tang-style `ln(v)` for a working-scale value `v_w` (`= x · 10^w`),
-/// returned at the same working scale `w`. Generic over the tier `C`,
+/// Tang-style `ln(v)` for a `working_value` (`= x · 10^w`),
+/// returned at the same `working_scale`. Generic over the tier `C`,
 /// the artanh-series iteration cap `CAP` (a safety net; the loop
 /// terminates on a zero term far sooner), and the `INTERNAL_EXTRA`
 /// directed-mode boundary-precision flag.
@@ -81,7 +81,7 @@ pub(crate) const EXTERNAL_EXTRA_DIGITS: u32 = 12;
 ///
 /// ## Accuracy — the artanh truncation bias
 ///
-/// The artanh series is truncated when `contrib = term / (2j+1)`
+/// The artanh series is truncated when `contribution = term / (2j+1)`
 /// underflows to zero in the work integer. The omitted tail
 /// `T = sum_{k>=J} t^(2k+3)/(2k+3)` carries the **sign of `t`** and a
 /// magnitude bounded by ~1 working-ULP (the largest still-representable
@@ -118,8 +118,8 @@ pub(crate) fn tang_ln_fixed<
     const INTERNAL_EXTRA: bool,
     const SCALE: u32,
 >(
-    v_w: C::W,
-    w: u32,
+    working_value: C::W,
+    working_scale: u32,
 ) -> C::W
 where
     <C::W as BigInt>::Scratch: ComputeLimbs,
@@ -130,7 +130,8 @@ where
     // feature-flagged default rounding mode AND the per-scale const-fold).
     // One Tang `ln` kernel — the wide compositions call `tang_ln_fixed_g`
     // directly at their `Wagm` work width.
-    tang_ln_fixed_g::<C::W, CAP, INTERNAL_EXTRA>(v_w, w, |ww| C::ln2::<SCALE>(ww))
+    tang_ln_fixed_g::<C::W, CAP, INTERNAL_EXTRA>(
+        working_value, working_scale, |at_scale| C::ln2::<SCALE>(at_scale))
 }
 
 /// Width-generic core of [`tang_ln_fixed`] — the Tang `ln` body over any
@@ -146,72 +147,82 @@ where
 /// directly at their `Wagm` work width.
 #[inline]
 pub(crate) fn tang_ln_fixed_g<S: BigInt, const CAP: u128, const INTERNAL_EXTRA: bool>(
-    v_w: S,
-    w: u32,
+    working_value: S,
+    working_scale: u32,
     ln2: impl Fn(u32) -> S,
 ) -> S
 where
     S::Scratch: ComputeLimbs,
 {
     // Stage 0 (INTERNAL_EXTRA only): widen the internal working scale
-    // by `extra = EXTERNAL_EXTRA_DIGITS` so the artanh-series
+    // by `extra_digits = EXTERNAL_EXTRA_DIGITS` so the artanh-series
     // truncation bias (one-sided, ≈ 1 working-ULP) sits 12 decimal
     // digits below the caller's working ULP. The input is re-lifted
-    // from `w` to `w_ext` by multiplying by `10^extra`.
-    let (w_ext, v_ext, extra): (u32, S, u32) = if INTERNAL_EXTRA {
-        let extra = EXTERNAL_EXTRA_DIGITS;
-        let v_ext = v_w * eg::pow10::<S>(extra);
-        (w + extra, v_ext, extra)
-    } else {
-        (w, v_w, 0)
-    };
+    // from `working_scale` to `extended_working_scale` by multiplying
+    // by `10^extra_digits`.
+    let (extended_working_scale, extended_working_value, extra_digits): (u32, S, u32) =
+        if INTERNAL_EXTRA {
+            let extra_digits = EXTERNAL_EXTRA_DIGITS;
+            let extended_working_value = working_value * eg::pow10::<S>(extra_digits);
+            (working_scale + extra_digits, extended_working_value, extra_digits)
+        } else {
+            (working_scale, working_value, 0)
+        };
 
-    let one_w = eg::one::<S>(w_ext);
-    let pow10_w = one_w;
-    let two_w = one_w + one_w;
+    let one_at_extended_scale = eg::one::<S>(extended_working_scale);
+    let pow10_at_extended_scale = one_at_extended_scale;
+    let two_at_extended_scale = one_at_extended_scale + one_at_extended_scale;
 
     // Stage 1: v = 2^k · m, m ∈ [1, 2). k from bit-shifts.
-    let mut k: i32 = eg::bit_length::<S>(v_ext) as i32 - eg::bit_length::<S>(one_w) as i32;
-    let m_w = loop {
-        let m = if k >= 0 {
-            v_ext >> (k as u32)
+    let mut k: i32 = eg::bit_length::<S>(extended_working_value) as i32
+        - eg::bit_length::<S>(one_at_extended_scale) as i32;
+    let mantissa_w = loop {
+        let candidate_mantissa = if k >= 0 {
+            extended_working_value >> (k as u32)
         } else {
-            v_ext << ((-k) as u32)
+            extended_working_value << ((-k) as u32)
         };
-        if m >= two_w {
+        if candidate_mantissa >= two_at_extended_scale {
             k += 1;
-        } else if m < one_w {
+        } else if candidate_mantissa < one_at_extended_scale {
             k -= 1;
         } else {
-            break m;
+            break candidate_mantissa;
         }
     };
 
     // Stage 2: pick i. Boundary `m = 1` short-circuits: ln(m) = 0, so
     // ln(v) = k · ln(2).
-    let result_at_w_ext = if m_w == one_w {
+    let ln_at_extended_scale = if mantissa_w == one_at_extended_scale {
         // k·ln2 as an n-by-1-word product (`scale_by_k`, O(limbs)) — the
         // same value the previous full-width `ln2 * lit(k)` schoolbook
         // multiply produced (|k| < BITS, and k·ln2 at scale w_ext fits the
         // rung by construction, so the product never wraps), at a fraction
         // of the cost. Matches `exp_generic::ln_fixed`'s shape.
-        eg::scale_by_k::<S>(ln2(w_ext), k as i128)
+        eg::scale_by_k::<S>(ln2(extended_working_scale), k as i128)
     } else {
         // i ∈ [0, M); when m = 2 exactly (rare boundary post-rounding),
         // clamp to M-1 so the table lookup stays in range, then the
         // residual t handles the remaining tiny piece.
-        let i_raw = ((m_w - one_w) * eg::lit::<S>(M as i128)) / one_w;
-        let i_i128 = BigInt::to_i128(i_raw);
-        let i_idx = if i_i128 >= M as i128 {
+        let table_index_raw = ((mantissa_w - one_at_extended_scale)
+            * eg::lit::<S>(M as i128))
+            / one_at_extended_scale;
+        let table_index_i128 = BigInt::to_i128(table_index_raw);
+        let table_index = if table_index_i128 >= M as i128 {
             (M - 1) as usize
         } else {
-            i_i128 as usize
+            table_index_i128 as usize
         };
 
-        let f_i = one_w + (one_w * eg::lit::<S>(i_idx as i128)) / eg::lit::<S>(M as i128);
+        let table_boundary = one_at_extended_scale
+            + (one_at_extended_scale * eg::lit::<S>(table_index as i128))
+                / eg::lit::<S>(M as i128);
 
         // Stage 3: t = (m - f_i) / (m + f_i). |t| < 1/(2M + 1).
-        let t = eg::div_cached::<S>(m_w - f_i, m_w + f_i, pow10_w);
+        let atanh_arg = eg::div_cached::<S>(
+            mantissa_w - table_boundary,
+            mantissa_w + table_boundary,
+            pow10_at_extended_scale);
 
         // Artanh series: 2 · (t + t³/3 + t⁵/5 + ...).
         //
@@ -248,72 +259,78 @@ where
         // that needs the two roundings to beat the accumulated truncation.
         //
         // Note `INTERNAL_EXTRA` is `true` at D462 ONLY (`policy::ln`); the other
-        // nine wide tiers run natively at `w` with no outward magnitude bump, so
+        // nine wide tiers run natively at `working_scale` with no outward bump, so
         // they depend on exactly the argument above. See
         // `below_one_directed_modes_straddle` at the foot of this file.
-        let t2 = eg::mul::<S>(t, t, w_ext);
-        let mut sum = t;
-        let mut term = t;
-        let mut j: u128 = 1;
+        let atanh_arg_sq = eg::mul::<S>(atanh_arg, atanh_arg, extended_working_scale);
+        let mut sum = atanh_arg;
+        let mut term = atanh_arg;
+        let mut term_index: u128 = 1;
         loop {
-            term = eg::mul::<S>(term, t2, w_ext);
-            let contrib = term / eg::lit::<S>((2 * j + 1) as i128);
-            if contrib == eg::zero::<S>() {
+            term = eg::mul::<S>(term, atanh_arg_sq, extended_working_scale);
+            let contribution = term / eg::lit::<S>((2 * term_index + 1) as i128);
+            if contribution == eg::zero::<S>() {
                 break;
             }
-            sum = sum + contrib;
-            j += 1;
-            if j > CAP {
+            sum = sum + contribution;
+            term_index += 1;
+            if term_index > CAP {
                 break;
             }
         }
-        let ln_m = sum + sum + ln_table_entry_baked::<S>(w_ext, i_idx, pow10_w);
+        let ln_mantissa = sum
+            + sum
+            + ln_table_entry_baked::<S>(
+                extended_working_scale, table_index, pow10_at_extended_scale);
 
         // Final: ln(v) = k · ln(2) + ln(m). k·ln2 via the one-word
-        // `scale_by_k` product (see the `m == one_w` arm above).
-        eg::scale_by_k::<S>(ln2(w_ext), k as i128) + ln_m
+        // `scale_by_k` product (see the `mantissa_w == one_at_extended_scale`
+        // arm above).
+        eg::scale_by_k::<S>(ln2(extended_working_scale), k as i128) + ln_mantissa
     };
 
-    if !INTERNAL_EXTRA || extra == 0 {
-        result_at_w_ext
+    if !INTERNAL_EXTRA || extra_digits == 0 {
+        ln_at_extended_scale
     } else {
-        // Truncate toward zero from scale `w_ext` to scale `w`, then
-        // bump the magnitude by 1 LSB-at-`w` IF any digits were
-        // discarded (`r_mag != 0`). The bump signals to the outer
-        // directed rounder "sub-w-scale residual present, same sign as
-        // the value" — preserving the residual sign at scale `w` even
-        // when truncation alone would round the residual to exactly
-        // zero. The `+1` is at most one ULP-at-`w`, i.e. `10^-guard`
+        // Truncate toward zero from `extended_working_scale` to
+        // `working_scale`, then
+        // bump the magnitude by 1 LSB-at-`working_scale` IF any digits
+        // were discarded (`r_mag != 0`). The bump signals to the outer
+        // directed rounder "sub-working-scale residual present, same sign
+        // as the value" — preserving the residual sign at `working_scale`
+        // even when truncation alone would round the residual to exactly
+        // zero. The `+1` is at most one ULP-at-`working_scale`, i.e. `10^-guard`
         // storage ULPs (well below half a storage ULP), so nearest
         // stays correctly rounded.
         //
         // Sign-preservation argument: the discarded digits
-        // `result_at_w_ext mod p` share the sign of `result_at_w_ext`
-        // (Rust integer truncation toward zero), so the bumped
-        // magnitude `q + 1` straddles the true value on the "outside"
-        // (in magnitude), which is exactly what a directed rounder
-        // needs to decide whether to bump under each mode.
-        let p = eg::pow10::<S>(extra);
-        let (q_signed, has_residue) = if result_at_w_ext >= eg::zero::<S>() {
-            let q = result_at_w_ext / p;
-            let has = result_at_w_ext - q * p != eg::zero::<S>();
-            (q, has)
+        // `ln_at_extended_scale mod extra_pow10` share the sign of
+        // `ln_at_extended_scale` (Rust integer truncation toward zero),
+        // so the bumped magnitude `truncated + 1` straddles the true
+        // value on the "outside" (in magnitude), which is exactly what a
+        // directed rounder needs to decide whether to bump under each mode.
+        let extra_pow10 = eg::pow10::<S>(extra_digits);
+        let (truncated, has_residue) = if ln_at_extended_scale >= eg::zero::<S>() {
+            let quotient = ln_at_extended_scale / extra_pow10;
+            let has_discarded =
+                ln_at_extended_scale - quotient * extra_pow10 != eg::zero::<S>();
+            (quotient, has_discarded)
         } else {
-            let abs_v = -result_at_w_ext;
-            let q = abs_v / p;
-            let has = abs_v - q * p != eg::zero::<S>();
-            (-q, has)
+            let abs_value = -ln_at_extended_scale;
+            let quotient = abs_value / extra_pow10;
+            let has_discarded = abs_value - quotient * extra_pow10 != eg::zero::<S>();
+            (-quotient, has_discarded)
         };
         if has_residue {
-            // Bump magnitude by 1 LSB-at-`w` so the outer rounder sees
-            // a nonzero residual with the value's sign.
-            if q_signed >= eg::zero::<S>() {
-                q_signed + eg::lit::<S>(1)
+            // Bump magnitude by 1 LSB-at-`working_scale` so the outer
+            // rounder sees a nonzero residual with the value's sign.
+            if truncated >= eg::zero::<S>() {
+                truncated + eg::lit::<S>(1)
             } else {
-                q_signed - eg::lit::<S>(1)
+                truncated - eg::lit::<S>(1)
             }
         } else {
-            q_signed
+            truncated
         }
     }
 }
@@ -368,20 +385,20 @@ where
     // `ln 2` at the RUNG work integer `Wk`, const-folded at the base working
     // scale `SCALE + GUARD` (the hot path) — the rung sibling of the per-tier
     // `C::ln2::<SCALE>` (value-identical; only the const-fold seam differs).
-    let ln2 = |ww: u32| -> Wk {
-        if ww == SCALE + GUARD {
+    let ln2 = |at_scale: u32| -> Wk {
+        if at_scale == SCALE + GUARD {
             crate::consts::ln2_by_scale::<Wk>(SCALE + GUARD, DEFAULT_ROUNDING_MODE)
         } else {
-            crate::consts::ln2_by_working_scale::<Wk>(ww, DEFAULT_ROUNDING_MODE)
+            crate::consts::ln2_by_working_scale::<Wk>(at_scale, DEFAULT_ROUNDING_MODE)
         }
     };
     // The tier-width `ln 2` for the fall-up recompute (identical closure
     // shape at `C::W` - the `ln_tang` alias's own).
-    let ln2_w = |ww: u32| -> C::W {
-        if ww == SCALE + GUARD {
+    let ln2_tier_width = |at_scale: u32| -> C::W {
+        if at_scale == SCALE + GUARD {
             crate::consts::ln2_by_scale::<C::W>(SCALE + GUARD, DEFAULT_ROUNDING_MODE)
         } else {
-            crate::consts::ln2_by_working_scale::<C::W>(ww, DEFAULT_ROUNDING_MODE)
+            crate::consts::ln2_by_working_scale::<C::W>(at_scale, DEFAULT_ROUNDING_MODE)
         }
     };
     if DIRECTED {
@@ -390,7 +407,8 @@ where
         // land on the wrong side. Route through the shared Ziv escalation.
         //
         // `INTERNAL_EXTRA` buries the ~1-working-ULP artanh truncation bias
-        // below the storage ULP (it runs the body at `w + EXTERNAL_EXTRA_DIGITS`,
+        // below the storage ULP (it runs the body at
+        // `working_scale + EXTERNAL_EXTRA_DIGITS`,
         // ~5× the cost). That bias only flips a directed result NEAR x = 1,
         // where ln(x) ≈ x−1 is tiny and the deciding residual sits at the
         // precision boundary (the loss region is ε ~ 10^(−SCALE/2)); for x away
@@ -399,58 +417,62 @@ where
         // for near-1 inputs (`|x − 1| < 10^(−SCALE/4)`, comfortably covering the
         // loss region with margin) — every other input takes the fast
         // native-width path. `adjust_ln_near_one` (below) is itself value-gated
-        // (`result == δ`), so the truly-unreachable ε case is handled regardless.
-        let use_extra = INTERNAL_EXTRA && {
+        // (`rounded == δ`), so the truly-unreachable ε case is handled regardless.
+        let use_extra_digits = INTERNAL_EXTRA && {
             let one = C::storage_one(SCALE);
-            let diff = if raw >= one { raw - one } else { one - raw };
+            let distance_from_one = if raw >= one { raw - one } else { one - raw };
             // near 1 iff |x − 1| < ~10^(−SCALE/4), tested on the bit-length so
             // the threshold is a compile-time const and the check is O(limbs)
             // (no per-call `pow`): `bit_length(10^k) ≈ k·log2(10)`, and ×3 is a
             // conservative `log2(10)`. Covers the ε ~ 10^(−SCALE/2) loss region
             // with wide margin; excludes ordinary operands (e.g. x = 1.5).
-            diff.bit_length() < (SCALE - SCALE / 4) * 3
+            distance_from_one.bit_length() < (SCALE - SCALE / 4) * 3
         };
         // Two-width fall-up: an unresolved-at-rung-cap near-tie reruns the
         // walker at the tier work width `C::W` (the `ln_tang` alias's own
         // realisation, verbatim) - see
         // `wide_trig_core::round_to_storage_directed_widening_g`.
-        let r = if use_extra {
+        let rounded = if use_extra_digits {
             round_to_storage_directed_widening_g::<C::Storage, Wk, C::W>(
                 GUARD, SCALE, mode, C::storage_max(), C::storage_min(),
-                |guard| {
+                |guard_digits| {
                     tang_ln_fixed_g::<Wk, CAP, true>(
-                        to_work_scaled_g::<C::Storage, Wk>(raw, guard), SCALE + guard, ln2,
+                        to_work_scaled_g::<C::Storage, Wk>(raw, guard_digits),
+                        SCALE + guard_digits, ln2,
                     )
                 },
-                |guard| {
+                |guard_digits| {
                     tang_ln_fixed_g::<C::W, CAP, true>(
-                        to_work_scaled_g::<C::Storage, C::W>(raw, guard), SCALE + guard, ln2_w,
+                        to_work_scaled_g::<C::Storage, C::W>(raw, guard_digits),
+                        SCALE + guard_digits, ln2_tier_width,
                     )
                 },
             )
         } else {
             round_to_storage_directed_widening_g::<C::Storage, Wk, C::W>(
                 GUARD, SCALE, mode, C::storage_max(), C::storage_min(),
-                |guard| {
+                |guard_digits| {
                     tang_ln_fixed_g::<Wk, CAP, false>(
-                        to_work_scaled_g::<C::Storage, Wk>(raw, guard), SCALE + guard, ln2,
+                        to_work_scaled_g::<C::Storage, Wk>(raw, guard_digits),
+                        SCALE + guard_digits, ln2,
                     )
                 },
-                |guard| {
+                |guard_digits| {
                     tang_ln_fixed_g::<C::W, CAP, false>(
-                        to_work_scaled_g::<C::Storage, C::W>(raw, guard), SCALE + guard, ln2_w,
+                        to_work_scaled_g::<C::Storage, C::W>(raw, guard_digits),
+                        SCALE + guard_digits, ln2_tier_width,
                     )
                 },
             )
         };
-        crate::algos::support::wide_trig_core::adjust_ln_near_one::<C, SCALE>(r, raw, mode)
+        crate::algos::support::wide_trig_core::adjust_ln_near_one::<C, SCALE>(rounded, raw, mode)
     } else {
-        let w = SCALE + GUARD;
-        let r = tang_ln_fixed_g::<Wk, CAP, INTERNAL_EXTRA>(
-            to_work_scaled_g::<C::Storage, Wk>(raw, GUARD), w, ln2,
+        let working_scale = SCALE + GUARD;
+        let working_value = tang_ln_fixed_g::<Wk, CAP, INTERNAL_EXTRA>(
+            to_work_scaled_g::<C::Storage, Wk>(raw, GUARD), working_scale, ln2,
         );
         round_to_storage_with_g::<C::Storage, Wk>(
-            r, w, SCALE, mode, C::storage_max(), C::storage_min(),
+            working_value, working_scale, SCALE, mode, C::storage_max(), C::storage_min(),
         )
     }
 }
@@ -520,23 +542,24 @@ mod tests {
                 type St = crate::int::types::Int<$limbs>;
                 const S: u32 = $scale;
                 let one = crate::consts::pow10::dispatch::<St>(S);
-                for d in 1i128..=$depth {
-                    let raw = one - <St as BigInt>::from_i128(d);
-                    let at = |m| crate::D::<St, S>(raw).ln_strict_with(m).to_bits();
-                    let floor = at(RoundingMode::Floor);
-                    let ceiling = at(RoundingMode::Ceiling);
-                    let trunc = at(RoundingMode::Trunc);
+                for ulp_offset in 1i128..=$depth {
+                    let raw = one - <St as BigInt>::from_i128(ulp_offset);
+                    let ln_with_mode =
+                        |mode| crate::D::<St, S>(raw).ln_strict_with(mode).to_bits();
+                    let floor = ln_with_mode(RoundingMode::Floor);
+                    let ceiling = ln_with_mode(RoundingMode::Ceiling);
+                    let trunc = ln_with_mode(RoundingMode::Trunc);
                     assert_eq!(
                         ceiling - floor,
                         <St as BigInt>::ONE,
-                        "ln(1 - {d}ulp) at Int<{}><{}>: Ceiling and Floor must straddle \
+                        "ln(1 - {ulp_offset}ulp) at Int<{}><{}>: Ceiling and Floor must straddle \
                          a value that cannot lie on the grid",
                         $limbs,
                         S
                     );
                     assert_eq!(
                         trunc, ceiling,
-                        "ln(1 - {d}ulp) at Int<{}><{}>: Trunc must be the neighbour \
+                        "ln(1 - {ulp_offset}ulp) at Int<{}><{}>: Trunc must be the neighbour \
                          facing zero",
                         $limbs, S
                     );
@@ -566,17 +589,18 @@ mod tests {
     }
 
     /// The bbc-benched D462<231> ln(2.0) cell: the exact-power-of-two
-    /// operand takes the `m == one_w` short-circuit (`ln(v) = k·ln2`) and
+    /// operand takes the `mantissa_w == one_at_extended_scale`
+    /// short-circuit (`ln(v) = k·ln2`) and
     /// must produce the correctly-rounded 231-digit value — pins the
     /// `scale_by_k` k·ln2 product and the direct-injection constant fold
     /// against the prior full-multiply shapes.
     #[test]
     #[cfg(feature = "d462")]
     fn ln_d462_s231_power_of_two_short_circuit() {
-        let x: crate::D462<231> = "2.0".parse().unwrap();
-        let r = x.ln();
+        let value: crate::D462<231> = "2.0".parse().unwrap();
+        let ln_value = value.ln();
         let expect: crate::D462<231> = "0.693147180559945309417232121458176568075500134360255254120680009493393621969694715605863326996418687542001481020570685733685520235758130557032670751635075961930727570828371435190307038623891673471123350115364497955239120475172681575".parse().unwrap();
-        assert_eq!(r, expect);
+        assert_eq!(ln_value, expect);
     }
 
     /// The bbc-benched D115<0> ln(2) cell: SCALE = 0 now routes the Tang
@@ -585,8 +609,8 @@ mod tests {
     #[test]
     #[cfg(feature = "d115")]
     fn ln_d115_s0_routes_and_rounds() {
-        let x: crate::D115<0> = "2".parse().unwrap();
+        let value: crate::D115<0> = "2".parse().unwrap();
         let one: crate::D115<0> = "1".parse().unwrap();
-        assert_eq!(x.ln(), one);
+        assert_eq!(value.ln(), one);
     }
 }

--- a/src/algos/log/log_ln_divide.rs
+++ b/src/algos/log/log_ln_divide.rs
@@ -31,13 +31,14 @@ pub(crate) fn log_ln_divide_d18<const SCALE: u32>(
     base_raw: Int<1>,
     mode: RoundingMode,
 ) -> Int<1> {
-    let wide: crate::D<Int<2>, SCALE> = crate::D::<Int<1>, SCALE>(raw).into();
-    let wbase: crate::D<Int<2>, SCALE> = crate::D::<Int<1>, SCALE>(base_raw).into();
-    let result: crate::D<Int<1>, SCALE> =
-        ::core::convert::TryInto::try_into(wide.log_strict_with(wbase, mode)).unwrap_or_else(|_| {
-            crate::support::diagnostics::overflow_panic_with_scale("D18::log", SCALE)
-        });
-    result.0
+    let wide_value: crate::D<Int<2>, SCALE> = crate::D::<Int<1>, SCALE>(raw).into();
+    let wide_base: crate::D<Int<2>, SCALE> = crate::D::<Int<1>, SCALE>(base_raw).into();
+    let log_value: crate::D<Int<1>, SCALE> =
+        ::core::convert::TryInto::try_into(wide_value.log_strict_with(wide_base, mode))
+            .unwrap_or_else(|_| {
+                crate::support::diagnostics::overflow_panic_with_scale("D18::log", SCALE)
+            });
+    log_value.0
 }
 
 /// D18 approx `log(self, base)` with caller-chosen guard digits: widen to
@@ -49,14 +50,14 @@ pub(crate) fn log_ln_divide_d18_approx<const SCALE: u32>(
     working_digits: u32,
     mode: RoundingMode,
 ) -> Int<1> {
-    let wide: crate::D<Int<2>, SCALE> = crate::D::<Int<1>, SCALE>(raw).into();
-    let wbase: crate::D<Int<2>, SCALE> = crate::D::<Int<1>, SCALE>(base_raw).into();
-    let result: crate::D<Int<1>, SCALE> =
-        ::core::convert::TryInto::try_into(wide.log_approx_with(wbase, working_digits, mode))
-            .unwrap_or_else(|_| {
-                crate::support::diagnostics::overflow_panic_with_scale("D18::log", SCALE)
-            });
-    result.0
+    let wide_value: crate::D<Int<2>, SCALE> = crate::D::<Int<1>, SCALE>(raw).into();
+    let wide_base: crate::D<Int<2>, SCALE> = crate::D::<Int<1>, SCALE>(base_raw).into();
+    let log_value: crate::D<Int<1>, SCALE> = ::core::convert::TryInto::try_into(
+        wide_value.log_approx_with(wide_base, working_digits, mode))
+        .unwrap_or_else(|_| {
+            crate::support::diagnostics::overflow_panic_with_scale("D18::log", SCALE)
+        });
+    log_value.0
 }
 
 /// D38 strict `log(self, base)` via the `ln::ln_series_2limb` 256-bit log

--- a/src/algos/log/log_schoolbook.rs
+++ b/src/algos/log/log_schoolbook.rs
@@ -68,19 +68,19 @@ pub(crate) fn log_schoolbook<C: WideTrigCore, const SCALE: u32>(
     if raw_b == C::storage_one(SCALE) {
         panic!("wide-tier log schoolbook: base must not be 1");
     }
-    C::round_to_storage_directed(C::GUARD, SCALE, mode, &mut |guard| {
-        let w = SCALE + guard;
-        let ln_x = C::ln_fixed::<SCALE>(C::to_work_scaled(raw_x, guard), w);
-        let ln_b = C::ln_fixed::<SCALE>(C::to_work_scaled(raw_b, guard), w);
-        C::div(ln_x, ln_b, w)
+    C::round_to_storage_directed(C::GUARD, SCALE, mode, &mut |guard_digits| {
+        let working_scale = SCALE + guard_digits;
+        let ln_x = C::ln_fixed::<SCALE>(C::to_work_scaled(raw_x, guard_digits), working_scale);
+        let ln_b = C::ln_fixed::<SCALE>(C::to_work_scaled(raw_b, guard_digits), working_scale);
+        C::div(ln_x, ln_b, working_scale)
     })
 }
 
 /// `log_b(x)` via naive `ln(x)/ln(b)` on the 256-bit `Fixed` intermediate.
 ///
-/// Accepts raw `Int<2>` storage for `x` and `b` at `scale`, evaluates
-/// both natural logs at working scale `w = scale + working_digits`, divides,
-/// and rounds back to `scale`.
+/// Accepts raw `Int<2>` storage for `x` and `b` at `scale`, evaluates both
+/// natural logs at `working_scale = scale + working_digits`, divides, and
+/// rounds back to `scale`.
 ///
 /// # Panics
 ///
@@ -93,52 +93,52 @@ pub(crate) fn log_schoolbook_with(
     working_digits: u32,
     mode: RoundingMode,
 ) -> Int<2> {
-    let xi = raw_x.as_i128();
-    let bi = raw_b.as_i128();
-    assert!(xi > 0, "log_schoolbook: x must be positive");
-    assert!(bi > 0, "log_schoolbook: base must be positive");
-    let one_s = 10_i128.pow(scale);
-    assert!(bi != one_s, "log_schoolbook: base must not be 1");
+    let x_raw_i128 = raw_x.as_i128();
+    let b_raw_i128 = raw_b.as_i128();
+    assert!(x_raw_i128 > 0, "log_schoolbook: x must be positive");
+    assert!(b_raw_i128 > 0, "log_schoolbook: base must be positive");
+    let one_scaled = 10_i128.pow(scale);
+    assert!(b_raw_i128 != one_scaled, "log_schoolbook: base must not be 1");
 
     // Exact-integer pin: if x == b^k exactly, the result is the integer k.
     // Derived from the nearest-rounded ln ratio; skip for non-integer bases.
     // (Avoids the ln(x)/ln(b) round-off bumping a directed mode by 1 LSB
     // at exact powers.)
-    if xi % one_s == 0 && bi % one_s == 0 {
-        let x_int = xi / one_s;
-        let b_int = bi / one_s;
+    if x_raw_i128 % one_scaled == 0 && b_raw_i128 % one_scaled == 0 {
+        let x_int = x_raw_i128 / one_scaled;
+        let b_int = b_raw_i128 / one_scaled;
         if b_int >= 2 {
-            // Try k = 1, 2, … up to log2(i128::MAX) ~127
+            // Try exponent = 1, 2, … up to log2(i128::MAX) ~127
             let mut power: i128 = b_int;
-            let mut k: i128 = 1;
-            while power <= xi / one_s {
+            let mut exponent: i128 = 1;
+            while power <= x_raw_i128 / one_scaled {
                 if power == x_int {
-                    return Int::<2>::from_i128(k * one_s);
+                    return Int::<2>::from_i128(exponent * one_scaled);
                 }
                 match power.checked_mul(b_int) {
-                    Some(p) => power = p,
+                    Some(next_power) => power = next_power,
                     None => break,
                 }
-                k += 1;
+                exponent += 1;
             }
         }
     }
 
-    let w = scale + working_digits;
+    let working_scale = scale + working_digits;
     let guard_pow = 10u128.pow(working_digits);
 
-    // Lift both operands to working scale w.
-    let x_w = Fixed::from_u128_mag(xi as u128, false).mul_u128(guard_pow);
-    let b_w = Fixed::from_u128_mag(bi as u128, false).mul_u128(guard_pow);
+    // Lift both operands to working_scale.
+    let x_working_value = Fixed::from_u128_mag(x_raw_i128 as u128, false).mul_u128(guard_pow);
+    let b_working_value = Fixed::from_u128_mag(b_raw_i128 as u128, false).mul_u128(guard_pow);
 
-    // Compute ln(x) and ln(b) at working scale w via the schoolbook atanh kernel.
-    let ln_x = ln_schoolbook_fixed(x_w, w);
-    let ln_b = ln_schoolbook_fixed(b_w, w);
+    // Compute ln(x) and ln(b) at working_scale via the schoolbook atanh kernel.
+    let ln_x = ln_schoolbook_fixed(x_working_value, working_scale);
+    let ln_b = ln_schoolbook_fixed(b_working_value, working_scale);
 
     // log_b(x) = ln(x) / ln(b), rounded to storage scale.
     Int::<2>::from_i128(
-        ln_x.div(ln_b, w)
-            .round_to_i128_with(w, scale, mode)
+        ln_x.div(ln_b, working_scale)
+            .round_to_i128_with(working_scale, scale, mode)
             .unwrap_or_else(|| {
                 crate::support::diagnostics::overflow_panic_with_scale(
                     "log_schoolbook",
@@ -173,14 +173,14 @@ mod tests {
     ];
 
     #[track_caller]
-    fn check<const S: u32>(x: i128, b: i128, mode: RoundingMode) {
-        let rx = Int::<2>::from_i128(x);
-        let rb = Int::<2>::from_i128(b);
-        let got = log_schoolbook_strict::<S>(rx, rb, mode);
-        let expected = log_strict::<S>(rx, rb, mode).expect("reference in range");
+    fn check<const S: u32>(x_raw: i128, b_raw: i128, mode: RoundingMode) {
+        let x_storage = Int::<2>::from_i128(x_raw);
+        let b_storage = Int::<2>::from_i128(b_raw);
+        let got = log_schoolbook_strict::<S>(x_storage, b_storage, mode);
+        let expected = log_strict::<S>(x_storage, b_storage, mode).expect("reference in range");
         assert_eq!(got, expected,
             "log schoolbook D38<{}> x={} b={} mode={:?}: {:?} != {:?}",
-            S, x, b, mode, got, expected);
+            S, x_raw, b_raw, mode, got, expected);
     }
 
     #[test]
@@ -191,8 +191,8 @@ mod tests {
             (2*one, 2*one), (4*one, 2*one), (8*one, 2*one),
             (10*one, 10*one), (3*one, 2*one), (one+one/2, 2*one),
         ];
-        for (x, b) in cases {
-            for mode in MODES { check::<12>(x, b, mode); }
+        for (x_raw, b_raw) in cases {
+            for mode in MODES { check::<12>(x_raw, b_raw, mode); }
         }
     }
 
@@ -202,8 +202,8 @@ mod tests {
         let cases = [
             (2*one, 2*one), (4*one, 2*one), (3*one, 2*one), (10*one, 10*one),
         ];
-        for (x, b) in cases {
-            for mode in MODES { check::<19>(x, b, mode); }
+        for (x_raw, b_raw) in cases {
+            for mode in MODES { check::<19>(x_raw, b_raw, mode); }
         }
     }
     #[cfg(any(feature = "d57", feature = "wide"))]
@@ -227,14 +227,16 @@ mod tests {
 
         #[test]
         fn log_schoolbook_matches_routed() {
-            for &(x, b) in &CASES {
-                let rx = raw9(x);
-                let rb = raw9(b);
+            for &(x_units, base_units) in &CASES {
+                let x_storage = raw9(x_units);
+                let b_storage = raw9(base_units);
                 for mode in MODES {
                     assert_eq!(
-                        crate::algos::log::log_schoolbook::log_schoolbook::<Core, S>(rx, rb, mode),
-                        D::<Int<3>, S>(rx).log_strict_with(D::<Int<3>, S>(rb), mode).0,
-                        "D57 log schoolbook != routed at x={x} b={b} mode={mode:?}"
+                        crate::algos::log::log_schoolbook::log_schoolbook::<Core, S>(
+                            x_storage, b_storage, mode),
+                        D::<Int<3>, S>(x_storage)
+                            .log_strict_with(D::<Int<3>, S>(b_storage), mode).0,
+                        "D57 log schoolbook != routed at x={x_units} b={base_units} mode={mode:?}"
                     );
                 }
             }

--- a/src/algos/log1p/log1p_artanh.rs
+++ b/src/algos/log1p/log1p_artanh.rs
@@ -34,11 +34,11 @@ use crate::support::rounding::RoundingMode;
 ///
 /// Every width routes here through `policy::log1p`, which supplies the
 /// width's work integer `S`, its base guard, and its storage bounds.
-/// `recompute(guard)` is re-entered by the Ziv walker at successively
-/// deeper guards until the deciding digit resolves, so the result is
-/// within 0.5 ULP for every mode.
+/// `recompute(guard_digits)` is re-entered by the Ziv walker at
+/// successively deeper guards until the deciding digit resolves, so the
+/// result is within 0.5 ULP for every mode.
 ///
-/// `st_max` / `st_min` are the tier's storage bounds (`MAX`/`MIN` are
+/// `storage_max` / `storage_min` are the tier's storage bounds (`MAX`/`MIN` are
 /// inherent consts on `Int<N>`, not on [`BigInt`], so the caller
 /// supplies them — the same contract as
 /// [`wtc::round_to_storage_directed_g`]).
@@ -68,30 +68,30 @@ use crate::support::rounding::RoundingMode;
 #[must_use]
 pub(crate) fn log1p_artanh_g<St: BigInt + Copy, S: BigInt, const SCALE: u32>(
     raw: St,
-    base_guard: u32,
-    st_max: St,
-    st_min: St,
+    base_guard_digits: u32,
+    storage_max: St,
+    storage_min: St,
     mode: RoundingMode,
 ) -> St
 where
     S::Scratch: ComputeLimbs,
 {
     super::guard_domain::<St>(raw, SCALE);
-    let r = wtc::round_to_storage_tail_signed_g::<St, S>(
-        base_guard,
+    let rounded = wtc::round_to_storage_tail_signed_g::<St, S>(
+        base_guard_digits,
         SCALE,
         mode,
-        st_max,
-        st_min,
-        |guard| {
+        storage_max,
+        storage_min,
+        |guard_digits| {
             crate::algos::exp::exp_generic::log1p_fixed_tagged::<S>(
-                wtc::to_work_scaled_g::<St, S>(raw, guard),
-                SCALE + guard,
-                guard,
+                wtc::to_work_scaled_g::<St, S>(raw, guard_digits),
+                SCALE + guard_digits,
+                guard_digits,
             )
         },
     );
-    super::adjust_near_zero::<St, S, SCALE>(r, raw, mode)
+    super::adjust_near_zero::<St, S, SCALE>(rounded, raw, mode)
 }
 
 /// The `_approx` sibling of [`log1p_artanh_g`]: a SINGLE shot at the
@@ -106,21 +106,22 @@ where
 pub(crate) fn log1p_artanh_approx_g<St: BigInt + Copy, S: BigInt, const SCALE: u32>(
     raw: St,
     working_digits: u32,
-    st_max: St,
-    st_min: St,
+    storage_max: St,
+    storage_min: St,
     mode: RoundingMode,
 ) -> St
 where
     S::Scratch: ComputeLimbs,
 {
     super::guard_domain::<St>(raw, SCALE);
-    let w = SCALE + working_digits;
-    let r = crate::algos::exp::exp_generic::log1p_fixed::<S>(
+    let working_scale = SCALE + working_digits;
+    let working_value = crate::algos::exp::exp_generic::log1p_fixed::<S>(
         wtc::to_work_scaled_g::<St, S>(raw, working_digits),
-        w,
+        working_scale,
     );
-    let out = wtc::round_to_storage_with_g::<St, S>(r, w, SCALE, mode, st_max, st_min);
-    super::adjust_near_zero::<St, S, SCALE>(out, raw, mode)
+    let rounded = wtc::round_to_storage_with_g::<St, S>(
+        working_value, working_scale, SCALE, mode, storage_max, storage_min);
+    super::adjust_near_zero::<St, S, SCALE>(rounded, raw, mode)
 }
 
 /// Tier-generic entry to [`log1p_artanh_g`] — sources the work integer

--- a/src/algos/log1p/log1p_with_ln.rs
+++ b/src/algos/log1p/log1p_with_ln.rs
@@ -33,28 +33,30 @@ use crate::int::types::compute_limbs::ComputeLimbs;
 use crate::int::types::traits::BigInt;
 use crate::support::rounding::RoundingMode;
 
-/// `1 + t` at working scale `w = SCALE + guard`, exactly, in the work
-/// integer `S`.
+/// `1 + t` at `working_scale = SCALE + guard_digits`, exactly, in the
+/// work integer `S`.
 #[inline]
-fn one_plus_t_at_w<St: BigInt, S: BigInt>(raw: St, guard: u32, w: u32) -> S
+fn one_plus_t_at_w<St: BigInt, S: BigInt>(raw: St, guard_digits: u32, working_scale: u32) -> S
 where
     S::Scratch: ComputeLimbs,
 {
-    crate::algos::exp::exp_generic::one::<S>(w) + wtc::to_work_scaled_g::<St, S>(raw, guard)
+    crate::algos::exp::exp_generic::one::<S>(working_scale)
+        + wtc::to_work_scaled_g::<St, S>(raw, guard_digits)
 }
 
-/// `ln 2` at working scale `w`. Reads the const-scale table on the base
-/// guard (the hot path, where `w` is the monomorphisation's own
-/// `SCALE + base_guard`) and only falls to the runtime working-scale
-/// lookup on a Ziv escalation — the same split
+/// `ln 2` at `working_scale`. Reads the const-scale table on the base
+/// guard (the hot path, where `working_scale` is the monomorphisation's
+/// own `SCALE + base_guard_digits`) and only falls to the runtime
+/// working-scale lookup on a Ziv escalation — the same split
 /// [`wtc::ln_series_g`] makes.
 #[inline]
-fn ln2_at<S: BigInt>(w: u32, base_w: u32) -> S {
-    if w == base_w {
-        crate::consts::ln2_by_scale::<S>(w, crate::support::rounding::DEFAULT_ROUNDING_MODE)
+fn ln2_at<S: BigInt>(working_scale: u32, base_working_scale: u32) -> S {
+    if working_scale == base_working_scale {
+        crate::consts::ln2_by_scale::<S>(
+            working_scale, crate::support::rounding::DEFAULT_ROUNDING_MODE)
     } else {
         crate::consts::ln2_by_working_scale::<S>(
-            w,
+            working_scale,
             crate::support::rounding::DEFAULT_ROUNDING_MODE,
         )
     }
@@ -74,35 +76,35 @@ fn ln2_at<S: BigInt>(w: u32, base_w: u32) -> S {
 #[must_use]
 pub(crate) fn log1p_with_ln_g<St: BigInt + Copy, S: BigInt, const SCALE: u32>(
     raw: St,
-    base_guard: u32,
-    st_max: St,
-    st_min: St,
+    base_guard_digits: u32,
+    storage_max: St,
+    storage_min: St,
     mode: RoundingMode,
 ) -> St
 where
     S::Scratch: ComputeLimbs,
 {
     super::guard_domain::<St>(raw, SCALE);
-    let base_w = SCALE + base_guard;
-    let r = wtc::round_to_storage_directed_g::<St, S>(
-        base_guard,
+    let base_working_scale = SCALE + base_guard_digits;
+    let rounded = wtc::round_to_storage_directed_g::<St, S>(
+        base_guard_digits,
         SCALE,
         mode,
-        st_max,
-        st_min,
-        |guard| {
-            let w = SCALE + guard;
+        storage_max,
+        storage_min,
+        |guard_digits| {
+            let working_scale = SCALE + guard_digits;
             crate::algos::exp::exp_generic::ln_fixed::<S>(
-                one_plus_t_at_w::<St, S>(raw, guard, w),
-                w,
-                ln2_at::<S>(w, base_w),
+                one_plus_t_at_w::<St, S>(raw, guard_digits, working_scale),
+                working_scale,
+                ln2_at::<S>(working_scale, base_working_scale),
             )
         },
     );
     // The same analytic sub-resolution adjust the artanh kernel applies:
     // this composition runs the Series `ln` core directly, which (unlike
     // the Tang path) does not carry `adjust_ln_near_one` of its own.
-    super::adjust_near_zero::<St, S, SCALE>(r, raw, mode)
+    super::adjust_near_zero::<St, S, SCALE>(rounded, raw, mode)
 }
 
 /// The `_approx` sibling of [`log1p_with_ln_g`]: a SINGLE shot at the
@@ -116,22 +118,23 @@ where
 pub(crate) fn log1p_with_ln_approx_g<St: BigInt + Copy, S: BigInt, const SCALE: u32>(
     raw: St,
     working_digits: u32,
-    st_max: St,
-    st_min: St,
+    storage_max: St,
+    storage_min: St,
     mode: RoundingMode,
 ) -> St
 where
     S::Scratch: ComputeLimbs,
 {
     super::guard_domain::<St>(raw, SCALE);
-    let w = SCALE + working_digits;
-    let r = crate::algos::exp::exp_generic::ln_fixed::<S>(
-        one_plus_t_at_w::<St, S>(raw, working_digits, w),
-        w,
-        ln2_at::<S>(w, w),
+    let working_scale = SCALE + working_digits;
+    let working_value = crate::algos::exp::exp_generic::ln_fixed::<S>(
+        one_plus_t_at_w::<St, S>(raw, working_digits, working_scale),
+        working_scale,
+        ln2_at::<S>(working_scale, working_scale),
     );
-    let out = wtc::round_to_storage_with_g::<St, S>(r, w, SCALE, mode, st_max, st_min);
-    super::adjust_near_zero::<St, S, SCALE>(out, raw, mode)
+    let rounded = wtc::round_to_storage_with_g::<St, S>(
+        working_value, working_scale, SCALE, mode, storage_max, storage_min);
+    super::adjust_near_zero::<St, S, SCALE>(rounded, raw, mode)
 }
 
 /// Tier-generic entry to [`log1p_with_ln_g`] — sources the work integer

--- a/src/algos/log1p/mod.rs
+++ b/src/algos/log1p/mod.rs
@@ -54,7 +54,7 @@ use crate::support::rounding::RoundingMode;
 /// the parabola term is `Q = raw²/(2·10^SCALE)`.
 ///
 /// `log1p` shares BOTH of that adjust's grid points, not just the first.
-/// The tangent case (`result == raw`) is the original one: `log1p(t) < t`
+/// The tangent case (`rounded == raw`) is the original one: `log1p(t) < t`
 /// strictly, so a downward-directed result that landed on `t` is above
 /// the true value. The parabola case is the same `δ² ≡ 0 (mod 2·10^SCALE)`
 /// family `ln` hits near `x = 1` — read at `t` rather than at `x − 1`, it
@@ -66,7 +66,7 @@ use crate::support::rounding::RoundingMode;
 /// [`wide_trig_core::adjust_log_near_zero`]: crate::algos::support::wide_trig_core::adjust_log_near_zero
 #[inline]
 pub(crate) fn adjust_near_zero<St: BigInt, S: BigInt, const SCALE: u32>(
-    result: St,
+    rounded: St,
     raw: St,
     mode: RoundingMode,
 ) -> St
@@ -74,10 +74,10 @@ where
     S::Scratch: crate::int::types::compute_limbs::ComputeLimbs,
 {
     if crate::support::rounding::is_nearest_mode(mode) {
-        return result;
+        return rounded;
     }
     let one = crate::consts::pow10::dispatch::<St>(SCALE);
-    crate::algos::support::wide_trig_core::adjust_log_near_zero::<St, S>(result, raw, one, mode)
+    crate::algos::support::wide_trig_core::adjust_log_near_zero::<St, S>(rounded, raw, one, mode)
 }
 
 /// Panics unless `t > -1`, i.e. unless the raw storage value exceeds
@@ -149,25 +149,25 @@ mod crate_internal_tests {
             UNIT / 2,
             -UNIT / 2,
         ];
-        for &t in &TS {
+        for &t_raw in &TS {
             for &mode in &MODES {
-                let v = Int::<2>::from_i128(t);
+                let t_storage = Int::<2>::from_i128(t_raw);
                 assert_eq!(
                     log1p_artanh_g::<Int<2>, WZiv, 20>(
-                        v,
+                        t_storage,
                         GUARD,
                         Int::<2>::MAX,
                         Int::<2>::MIN,
                         mode
                     ),
                     log1p_with_ln_g::<Int<2>, WZiv, 20>(
-                        v,
+                        t_storage,
                         GUARD,
                         Int::<2>::MAX,
                         Int::<2>::MIN,
                         mode
                     ),
-                    "artanh != with_ln at t_raw={t} mode={mode:?}"
+                    "artanh != with_ln at t_raw={t_raw} mode={mode:?}"
                 );
             }
         }
@@ -181,18 +181,18 @@ mod crate_internal_tests {
     /// no-mode entry points actually use.
     #[test]
     fn log1p_default_mode_siblings_agree() {
-        let t = UNIT / 2;
+        let t_raw = UNIT / 2;
         assert_eq!(
-            d38s20(t).log1p_approx(45).to_bits().as_i128(),
-            d38s20(t)
+            d38s20(t_raw).log1p_approx(45).to_bits().as_i128(),
+            d38s20(t_raw)
                 .log1p_approx_with(45, crate::support::rounding::DEFAULT_ROUNDING_MODE)
                 .to_bits()
                 .as_i128(),
             "log1p_approx != log1p_approx_with(default mode)"
         );
         assert_eq!(
-            d38s20(t).log1p_strict().to_bits().as_i128(),
-            d38s20(t)
+            d38s20(t_raw).log1p_strict().to_bits().as_i128(),
+            d38s20(t_raw)
                 .log1p_strict_with(crate::support::rounding::DEFAULT_ROUNDING_MODE)
                 .to_bits()
                 .as_i128(),

--- a/src/algos/mul/mod.rs
+++ b/src/algos/mul/mod.rs
@@ -3,7 +3,7 @@
 
 //! Decimal multiplication algorithm family.
 //!
-//! One algorithm: [`mul_widen_divide`] — widens `a * b` to the next-up work
+//! One algorithm: [`mul_widen_divide`] — widens `lhs * rhs` to the next-up work
 //! width then divides the product by `10^SCALE` to return to the storage
 //! scale, with a value-gated fast path that skips the widen step when the
 //! product provably fits the storage width. The per-`(N, SCALE)` choice

--- a/src/algos/mul/mul_native.rs
+++ b/src/algos/mul/mul_native.rs
@@ -13,7 +13,7 @@
 //! Two specialised arms, selected on `N` at compile time (the unused arm is
 //! dead-code-eliminated per monomorphisation):
 //!
-//! * **`N == 1` (D18):** the product `a * b` always fits `i128` (two `i64`
+//! * **`N == 1` (D18):** the product `lhs * rhs` always fits `i128` (two `i64`
 //!   magnitudes), and `10^SCALE` (`SCALE <= 18`) always fits `u64`. The
 //!   rescale divide is therefore an `i128 / u64` schoolbook divide -- two
 //!   hardware `divq` instructions via
@@ -45,24 +45,24 @@ use crate::support::rounding::RoundingMode;
 
 /// Hardware-`i128` decimal multiply kernel for narrow storage (`N <= 2`).
 ///
-/// Computes `a * b / 10^SCALE` rounded under `mode`. Panics on storage
+/// Computes `lhs * rhs / 10^SCALE` rounded under `mode`. Panics on storage
 /// overflow in BOTH debug and release per the decimal default-operator
 /// contract.
 #[inline]
 #[must_use]
 pub(crate) fn mul_native<const N: usize, const SCALE: u32>(
-    a: Int<N>,
-    b: Int<N>,
+    lhs: Int<N>,
+    rhs: Int<N>,
     mode: RoundingMode,
 ) -> Int<N> {
     if N == 1 {
         // D18: product fits i128, 10^SCALE fits u64 (SCALE <= 18).
-        let n = a.as_i128() * b.as_i128();
+        let product = lhs.as_i128() * rhs.as_i128();
         let scaled: i128 = if SCALE == 0 {
-            n
+            product
         } else {
-            let m_mag: u64 = 10u64.pow(SCALE);
-            crate::macros::arithmetic::i128_divrem_by_u64_with_mode(n, m_mag, mode)
+            let pow10_scale: u64 = 10u64.pow(SCALE);
+            crate::macros::arithmetic::i128_divrem_by_u64_with_mode(product, pow10_scale, mode)
         };
         assert!(
             scaled >= i64::MIN as i128 && scaled <= i64::MAX as i128,
@@ -72,10 +72,10 @@ pub(crate) fn mul_native<const N: usize, const SCALE: u32>(
     }
 
     // N == 2 (D38): the shared i128 / 256-bit kernel.
-    let ai = a.as_i128();
-    let bi = b.as_i128();
-    match mul_div_pow10_with::<SCALE>(ai, bi, mode) {
-        Some(q) => Int::<N>::from_i128(q),
+    let lhs_raw = lhs.as_i128();
+    let rhs_raw = rhs.as_i128();
+    match mul_div_pow10_with::<SCALE>(lhs_raw, rhs_raw, mode) {
+        Some(product) => Int::<N>::from_i128(product),
         None => panic!("attempt to multiply with overflow"),
     }
 }
@@ -91,7 +91,7 @@ mod tests {
     #[test]
     fn mul_native_n1_matches_naive() {
         const S: u32 = 6;
-        let m = 10i128.pow(S);
+        let pow10_scale = 10i128.pow(S);
         let cases: &[(i64, i64)] = &[
             (0, 0),
             (1_000_000, 2_000_000),
@@ -102,18 +102,18 @@ mod tests {
             (999_999, 999_999),
             (i32::MAX as i64, 1_000_000),
         ];
-        for &(a, b) in cases {
-            let want = ((a as i128) * (b as i128)) / m;
-            let got = mul_native::<1, S>(Int::<1>::from_i64(a), Int::<1>::from_i64(b), MODE);
-            assert_eq!(got.to_i128(), want, "mul_native n1 ({a}, {b})");
+        for &(lhs, rhs) in cases {
+            let want = ((lhs as i128) * (rhs as i128)) / pow10_scale;
+            let got = mul_native::<1, S>(Int::<1>::from_i64(lhs), Int::<1>::from_i64(rhs), MODE);
+            assert_eq!(got.to_i128(), want, "mul_native n1 ({lhs}, {rhs})");
         }
     }
 
     #[test]
     fn mul_native_n2_matches_naive() {
         const S: u32 = 12;
-        let m = 10i128.pow(S);
-        // Operands chosen so a * b is an exact multiple of 10^12 (no tie /
+        let pow10_scale = 10i128.pow(S);
+        // Operands chosen so lhs * rhs is an exact multiple of 10^12 (no tie /
         // rounding ambiguity), letting the truncating reference stand.
         let cases: &[(i128, i128)] = &[
             (0, 0),
@@ -121,11 +121,12 @@ mod tests {
             (-1_000_000_000_000_i128, 2_000_000_000_000_i128),
             (5_000_000_000_000_i128, 4_000_000_000_000_i128),
         ];
-        for &(a, b) in cases {
-            assert_eq!((a * b) % m, 0, "test operands must be exact for ({a}, {b})");
-            let want = (a * b) / m;
-            let got = mul_native::<2, S>(Int::<2>::from_i128(a), Int::<2>::from_i128(b), MODE);
-            assert_eq!(got.to_i128(), want, "mul_native n2 ({a}, {b})");
+        for &(lhs, rhs) in cases {
+            assert_eq!((lhs * rhs) % pow10_scale, 0,
+                "test operands must be exact for ({lhs}, {rhs})");
+            let want = (lhs * rhs) / pow10_scale;
+            let got = mul_native::<2, S>(Int::<2>::from_i128(lhs), Int::<2>::from_i128(rhs), MODE);
+            assert_eq!(got.to_i128(), want, "mul_native n2 ({lhs}, {rhs})");
         }
     }
 }

--- a/src/algos/mul/mul_schoolbook.rs
+++ b/src/algos/mul/mul_schoolbook.rs
@@ -4,13 +4,13 @@
 //! `mul_schoolbook` -- naive schoolbook decimal multiplication reference,
 //! generic over the storage width `N` only.
 //!
-//! Computes `a * b` for two same-`SCALE` decimals stored as `Int<N>`.
-//! The logical product is `(a / 10^SCALE) * (b / 10^SCALE)`, whose raw
-//! storage value is `a * b / 10^SCALE`.
+//! Computes `lhs * rhs` for two same-`SCALE` decimals stored as `Int<N>`.
+//! The logical product is `(lhs / 10^SCALE) * (rhs / 10^SCALE)`, whose raw
+//! storage value is `lhs * rhs / 10^SCALE`.
 //!
 //! This is the naive reference algorithm — no leading-zero fast path:
 //!
-//! 1. Form the full magnitude product `|a| * |b|` (`2N` u64 limbs) in a
+//! 1. Form the full magnitude product `|lhs| * |rhs|` (`2N` u64 limbs) in a
 //!    [`ComputeLimbs::double_buffered_u64`] buffer via the int layer's slice
 //!    [`crate::int::algos::mul::mul_schoolbook::mul_schoolbook`].
 //! 2. Build `10^SCALE` in the same limb domain and divide the product by
@@ -36,12 +36,12 @@ use crate::support::rounding::{should_bump, RoundingMode};
 
 /// Significant limb length (highest non-zero limb index + 1, min 1).
 #[inline]
-fn sig_len(a: &[u64]) -> usize {
-    let mut l = a.len();
-    while l > 1 && a[l - 1] == 0 {
-        l -= 1;
+fn sig_len(limbs: &[u64]) -> usize {
+    let mut len = limbs.len();
+    while len > 1 && limbs[len - 1] == 0 {
+        len -= 1;
     }
-    l
+    len
 }
 
 /// Naive schoolbook decimal multiplication, generic over `N`. Requires
@@ -53,80 +53,83 @@ fn sig_len(a: &[u64]) -> usize {
 /// `SCALE == 0` returns the narrowed product unscaled.
 #[inline]
 pub(crate) fn mul_schoolbook<const N: usize, const SCALE: u32>(
-    a: Int<N>,
-    b: Int<N>,
+    lhs: Int<N>,
+    rhs: Int<N>,
     mode: RoundingMode,
 ) -> Int<N>
 where
     Limbs<N>: ComputeLimbs,
 {
-    let neg = a.is_negative() != b.is_negative();
-    let a_mag = *a.unsigned_abs().as_limbs();
-    let b_mag = *b.unsigned_abs().as_limbs();
-    let al = sig_len(&a_mag);
-    let bl = sig_len(&b_mag);
+    let is_negative = lhs.is_negative() != rhs.is_negative();
+    let lhs_mag = *lhs.unsigned_abs().as_limbs();
+    let rhs_mag = *rhs.unsigned_abs().as_limbs();
+    let lhs_len = sig_len(&lhs_mag);
+    let rhs_len = sig_len(&rhs_mag);
 
     // Full magnitude product in the work scratch (2N u64 limbs).
-    let mut prod_buf = Limbs::<N>::double_buffered_u64();
-    let prod = prod_buf.as_mut();
-    let plen = (al + bl).min(prod.len());
-    for slot in prod[..plen].iter_mut() {
+    let mut product_buf = Limbs::<N>::double_buffered_u64();
+    let product = product_buf.as_mut();
+    let product_len = (lhs_len + rhs_len).min(product.len());
+    for slot in product[..product_len].iter_mut() {
         *slot = 0;
     }
-    mul_slice(&a_mag[..al], &b_mag[..bl], &mut prod[..plen]);
+    mul_slice(&lhs_mag[..lhs_len], &rhs_mag[..rhs_len], &mut product[..product_len]);
 
     if SCALE == 0 {
-        let mut out = [0u64; N];
-        out.copy_from_slice(&prod[..N]);
-        return apply_sign::<N>(out, neg, "attempt to multiply with overflow");
+        let mut product_limbs = [0u64; N];
+        product_limbs.copy_from_slice(&product[..N]);
+        return apply_sign::<N>(product_limbs, is_negative, "attempt to multiply with overflow");
     }
 
     // Build 10^SCALE in a u64 limb buffer (iterative *10).
-    let mut div_buf = Limbs::<N>::double_buffered_u64();
-    let divisor = div_buf.as_mut();
+    let mut divisor_buf = Limbs::<N>::double_buffered_u64();
+    let divisor = divisor_buf.as_mut();
     divisor[0] = 1;
-    let mut dl = 1usize;
+    let mut divisor_len = 1usize;
     for _ in 0..SCALE {
         let mut carry: u64 = 0;
-        for limb in divisor[..dl].iter_mut() {
-            let p = (*limb as u128) * 10u128 + carry as u128;
-            *limb = p as u64;
-            carry = (p >> 64) as u64;
+        for limb in divisor[..divisor_len].iter_mut() {
+            let scaled_limb = (*limb as u128) * 10u128 + carry as u128;
+            *limb = scaled_limb as u64;
+            carry = (scaled_limb >> 64) as u64;
         }
         if carry != 0 {
-            divisor[dl] = carry;
-            dl += 1;
+            divisor[divisor_len] = carry;
+            divisor_len += 1;
         }
     }
 
-    // q = prod / divisor, r = prod % divisor (magnitudes, via int layer).
-    let ptop = sig_len(&prod[..plen]);
-    let mut quot_buf = Limbs::<N>::double_buffered_u64();
-    let quot = quot_buf.as_mut();
-    let mut rem_buf = Limbs::<N>::double_buffered_u64();
-    let rem = rem_buf.as_mut();
-    for slot in quot[..ptop].iter_mut() {
+    // quotient = product / divisor, remainder = product % divisor
+    // (magnitudes, via int layer).
+    let product_sig_len = sig_len(&product[..product_len]);
+    let mut quotient_buf = Limbs::<N>::double_buffered_u64();
+    let quotient = quotient_buf.as_mut();
+    let mut remainder_buf = Limbs::<N>::double_buffered_u64();
+    let remainder = remainder_buf.as_mut();
+    for slot in quotient[..product_sig_len].iter_mut() {
         *slot = 0;
     }
-    for slot in rem[..dl].iter_mut() {
+    for slot in remainder[..divisor_len].iter_mut() {
         *slot = 0;
     }
-    div_rem_mag_slice(&prod[..ptop], &divisor[..dl], &mut quot[..ptop], &mut rem[..dl]);
+    div_rem_mag_slice(&product[..product_sig_len], &divisor[..divisor_len],
+        &mut quotient[..product_sig_len], &mut remainder[..divisor_len]);
 
     // Round: compare remainder against divisor - remainder.
-    let rl = sig_len(&rem[..dl]);
-    let rem_nonzero = !(rl == 1 && rem[0] == 0);
-    if rem_nonzero {
-        // cmp_r = rem.cmp(divisor - rem), via comparing 2*rem to divisor.
-        let cmp_r = cmp_double_vs::<N>(&rem[..dl], &divisor[..dl]);
-        let q_is_odd = (quot[0] & 1) != 0;
-        if should_bump(mode, cmp_r, q_is_odd, !neg) {
-            // quot += 1
+    let remainder_len = sig_len(&remainder[..divisor_len]);
+    let remainder_nonzero = !(remainder_len == 1 && remainder[0] == 0);
+    if remainder_nonzero {
+        // remainder_cmp = remainder.cmp(divisor - remainder), via comparing
+        // 2*remainder to divisor.
+        let remainder_cmp = cmp_double_vs::<N>(&remainder[..divisor_len], &divisor[..divisor_len]);
+        let quotient_is_odd = (quotient[0] & 1) != 0;
+        if should_bump(mode, remainder_cmp, quotient_is_odd, !is_negative) {
+            // quotient += 1
             let mut carry: u64 = 1;
-            for limb in quot.iter_mut() {
-                let (s, c) = limb.overflowing_add(carry);
-                *limb = s;
-                if !c {
+            for limb in quotient.iter_mut() {
+                let (sum, overflowed) = limb.overflowing_add(carry);
+                *limb = sum;
+                if !overflowed {
                     carry = 0;
                     break;
                 }
@@ -135,42 +138,43 @@ where
         }
     }
 
-    let mut out = [0u64; N];
-    out.copy_from_slice(&quot[..N]);
-    apply_sign::<N>(out, neg, "attempt to multiply with overflow")
+    let mut quotient_limbs = [0u64; N];
+    quotient_limbs.copy_from_slice(&quotient[..N]);
+    apply_sign::<N>(quotient_limbs, is_negative, "attempt to multiply with overflow")
 }
 
-/// Compare `2*rem` against `divisor` (both little-endian magnitudes),
-/// returning the ordering of `rem` vs `divisor - rem`.
+/// Compare `2*remainder` against `divisor` (both little-endian magnitudes),
+/// returning the ordering of `remainder` vs `divisor - remainder`.
 #[inline]
-fn cmp_double_vs<const N: usize>(rem: &[u64], divisor: &[u64]) -> core::cmp::Ordering
+fn cmp_double_vs<const N: usize>(remainder: &[u64], divisor: &[u64]) -> core::cmp::Ordering
 where
     Limbs<N>: ComputeLimbs,
 {
-    // `2·rem` spans at most `rem.len() + 1` limbs, and `rem < divisor`, whose
+    // `2·remainder` spans at most `remainder.len() + 1` limbs, and
+    // `remainder < divisor`, whose
     // length is `≤ N + 1` (the `10^SCALE` divisor); the `single_buffered_u64`
     // buffer (`N + 2`) holds it exactly per-`N`.
-    let mut two_r_buf = Limbs::<N>::single_buffered_u64();
-    let two_r = two_r_buf.as_mut();
+    let mut double_remainder_buf = Limbs::<N>::single_buffered_u64();
+    let double_remainder = double_remainder_buf.as_mut();
     let mut carry: u64 = 0;
-    for (i, &r) in rem.iter().enumerate() {
-        let v = (r as u128) << 1 | carry as u128;
-        two_r[i] = v as u64;
-        carry = (v >> 64) as u64;
+    for (i, &limb) in remainder.iter().enumerate() {
+        let doubled = (limb as u128) << 1 | carry as u128;
+        double_remainder[i] = doubled as u64;
+        carry = (doubled >> 64) as u64;
     }
-    let mut len = rem.len();
+    let mut len = remainder.len();
     if carry != 0 {
-        two_r[len] = carry;
+        double_remainder[len] = carry;
         len += 1;
     }
-    // Compare two_r[..len] vs divisor (little-endian).
-    let dl = divisor.len();
-    let maxl = len.max(dl);
-    let mut k = maxl;
-    while k > 0 {
-        k -= 1;
-        let lhs = if k < len { two_r[k] } else { 0 };
-        let rhs = if k < dl { divisor[k] } else { 0 };
+    // Compare double_remainder[..len] vs divisor (little-endian).
+    let divisor_len = divisor.len();
+    let max_len = len.max(divisor_len);
+    let mut idx = max_len;
+    while idx > 0 {
+        idx -= 1;
+        let lhs = if idx < len { double_remainder[idx] } else { 0 };
+        let rhs = if idx < divisor_len { divisor[idx] } else { 0 };
         if lhs != rhs {
             return if lhs > rhs {
                 core::cmp::Ordering::Greater
@@ -182,21 +186,21 @@ where
     core::cmp::Ordering::Equal
 }
 
-/// Rebuild a signed `Int<N>` from magnitude limbs `out` and sign `neg`,
+/// Rebuild a signed `Int<N>` from `magnitude_limbs` and sign `is_negative`,
 /// panicking on overflow in BOTH debug and release (the decimal default
 /// operator never silently wraps a wrong number).
 #[inline]
-fn apply_sign<const N: usize>(out: [u64; N], neg: bool, msg: &str) -> Int<N> {
-    let mag = Int::<N>::from_limbs(out);
+fn apply_sign<const N: usize>(magnitude_limbs: [u64; N], is_negative: bool, msg: &str) -> Int<N> {
+    let magnitude = Int::<N>::from_limbs(magnitude_limbs);
     // `from_limbs` reinterprets bits as two's complement; if the top bit is
     // set the magnitude exceeds the signed range. The sole representable case
-    // is exactly Int<N>::MIN with neg.
-    if mag.is_negative() && !(neg && mag == Int::<N>::MIN) {
+    // is exactly Int<N>::MIN with is_negative.
+    if magnitude.is_negative() && !(is_negative && magnitude == Int::<N>::MIN) {
         panic!("{msg}");
     }
-    if neg {
-        mag.wrapping_neg()
+    if is_negative {
+        magnitude.wrapping_neg()
     } else {
-        mag
+        magnitude
     }
 }

--- a/src/algos/mul/mul_widen_divide.rs
+++ b/src/algos/mul/mul_widen_divide.rs
@@ -4,9 +4,9 @@
 //! `mul_widen_divide` -- decimal multiplication by the widen-then-divide
 //! method, generic over the storage width `N` only.
 //!
-//! Multiplies `a * b` for two same-`SCALE` decimals stored as `Int<N>`. The
-//! logical product is `(a / 10^SCALE) * (b / 10^SCALE)`, whose raw storage
-//! is `a * b / 10^SCALE`. The full product spans up to twice the storage
+//! Multiplies `lhs * rhs` for two same-`SCALE` decimals stored as `Int<N>`.
+//! The logical product is `(lhs / 10^SCALE) * (rhs / 10^SCALE)`, whose raw
+//! storage is `lhs * rhs / 10^SCALE`. The full product spans up to twice the storage
 //! width (`2N` limbs), so it is formed in a limb **scratch buffer** rather
 //! than a work *type* `Int<2N>` (which stable Rust cannot name from `N`).
 //!
@@ -16,7 +16,7 @@
 //! the storage limb count `N` alone and does the `2N`-wide work directly in
 //! a `ComputeLimbs::double_buffered_u64()` buffer:
 //!
-//! 1. form the magnitude product `|a| * |b|` (`2N` u64 limbs) via the int
+//! 1. form the magnitude product `|lhs| * |rhs|` (`2N` u64 limbs) via the int
 //!    layer's const-`N` policy dispatcher
 //!    [`crate::int::policy::mul::dispatch`], which routes even-`N` widths
 //!    to the u128-packed `mul_full_limb` kernel for maximum throughput;
@@ -30,7 +30,7 @@
 //!    the product sign.
 //!
 //! A leading-zero fast path keeps the narrow case cheap: when the
-//! unsigned-magnitude leading-zero count proves `a * b` fits `Int<N>`, the
+//! unsigned-magnitude leading-zero count proves `lhs * rhs` fits `Int<N>`, the
 //! product stays in `Int<N>` and the divide runs over its `(N + 1) / 2`
 //! u128 limbs.
 //!
@@ -43,16 +43,17 @@ use crate::int::types::Int;
 use crate::support::rounding::RoundingMode;
 
 /// Rebuild a signed `Int<N>` from a quotient magnitude held in u128 limbs
-/// `mag` (the low `(N + 1) / 2` of which carry the result) and sign `neg`.
+/// `magnitude` (the low `(N + 1) / 2` of which carry the result) and sign
+/// `is_negative`.
 /// Panics in BOTH debug and release if the magnitude exceeds `Int<N>`'s
 /// representable range — the decimal default operator never silently wraps a
 /// wrong number. (The explicit `wrapping_mul` / `checked_mul` etc. variants
 /// take their own `Int<N>` paths and do not reach this kernel.)
 #[inline]
-fn narrow_mag_to_int<const N: usize>(mag: &[u128], neg: bool, msg: &str) -> Int<N> {
+fn narrow_mag_to_int<const N: usize>(magnitude: &[u128], is_negative: bool, msg: &str) -> Int<N> {
     let u128_limbs = N.div_ceil(2);
     // Any set bit beyond the storage width is overflow.
-    let mut overflow = mag.iter().skip(u128_limbs).any(|&l| l != 0);
+    let mut overflow = magnitude.iter().skip(u128_limbs).any(|&limb| limb != 0);
     // For odd `N` the top counted u128 limb (`u128_limbs - 1`) is only
     // half-used — storage is `N` u64 limbs, so that limb carries one u64 and
     // its HIGH 64 bits sit beyond `Int<N>`. `skip(u128_limbs)` never reaches
@@ -60,36 +61,36 @@ fn narrow_mag_to_int<const N: usize>(mag: &[u128], neg: bool, msg: &str) -> Int<
     // so a product spilling into them would wrap silently; treat any set bit
     // there as overflow. (Even `N` uses every counted limb fully — no tail.)
     if (N & 1) == 1 {
-        if let Some(&top) = mag.get(u128_limbs - 1) {
+        if let Some(&top) = magnitude.get(u128_limbs - 1) {
             overflow |= (top >> 64) != 0;
         }
     }
     if !overflow {
         // Compare the in-range magnitude against |Int<N>::MAX| / |MIN|.
-        let limit = if neg {
+        let limit = if is_negative {
             Int::<N>::MIN.unsigned_abs()
         } else {
             Int::<N>::MAX.unsigned_abs()
         };
         let limit_limbs = *limit.as_limbs();
         // Reconstruct the result magnitude limbs (u64) for the compare.
-        let mut got = [0u64; N];
-        let pairs = (N / 2).min(u128_limbs).min(mag.len());
+        let mut magnitude_u64 = [0u64; N];
+        let pairs = (N / 2).min(u128_limbs).min(magnitude.len());
         let mut i = 0;
         while i < pairs {
-            got[2 * i] = mag[i] as u64;
-            got[2 * i + 1] = (mag[i] >> 64) as u64;
+            magnitude_u64[2 * i] = magnitude[i] as u64;
+            magnitude_u64[2 * i + 1] = (magnitude[i] >> 64) as u64;
             i += 1;
         }
-        if (N & 1) == 1 && i < u128_limbs && i < mag.len() {
-            got[2 * i] = mag[i] as u64;
+        if (N & 1) == 1 && i < u128_limbs && i < magnitude.len() {
+            magnitude_u64[2 * i] = magnitude[i] as u64;
         }
-        // got > limit ?  (little-endian magnitude compare)
-        let mut k = N;
-        while k > 0 {
-            k -= 1;
-            if got[k] != limit_limbs[k] {
-                overflow = got[k] > limit_limbs[k];
+        // magnitude_u64 > limit ?  (little-endian magnitude compare)
+        let mut idx = N;
+        while idx > 0 {
+            idx -= 1;
+            if magnitude_u64[idx] != limit_limbs[idx] {
+                overflow = magnitude_u64[idx] > limit_limbs[idx];
                 break;
             }
         }
@@ -97,14 +98,14 @@ fn narrow_mag_to_int<const N: usize>(mag: &[u128], neg: bool, msg: &str) -> Int<
     if overflow {
         panic!("{msg}");
     }
-    Int::<N>::from_mag_sign_u128(mag, neg)
+    Int::<N>::from_mag_sign_u128(magnitude, is_negative)
 }
 
 /// Widen-then-divide decimal multiplication kernel, generic over the
 /// storage limb count `N`. Requires `Limbs<N>: ComputeLimbs` for the `2N`-limb
 /// product scratch.
 ///
-/// A fast path skips the wide product when `a * b` provably fits `Int<N>`
+/// A fast path skips the wide product when `lhs * rhs` provably fits `Int<N>`
 /// (via leading-zero counts); otherwise the magnitude product is formed in
 /// the scratch buffer via [`crate::int::policy::mul::dispatch`] (which routes
 /// even-`N` widths to the u128-packed `mul_full_limb` kernel), divided by
@@ -113,79 +114,82 @@ fn narrow_mag_to_int<const N: usize>(mag: &[u128], neg: bool, msg: &str) -> Int<
 /// product unscaled.
 #[inline]
 pub(crate) fn mul_widen_divide<const N: usize, const SCALE: u32>(
-    a: Int<N>,
-    b: Int<N>,
+    lhs: Int<N>,
+    rhs: Int<N>,
     mode: RoundingMode,
 ) -> Int<N>
 where
     Limbs<N>: ComputeLimbs,
 {
-    let neg = a.is_negative() != b.is_negative();
-    let lz_a = a.unsigned_abs().leading_zeros();
-    let lz_b = b.unsigned_abs().leading_zeros();
+    let is_negative = lhs.is_negative() != rhs.is_negative();
+    let lhs_leading_zeros = lhs.unsigned_abs().leading_zeros();
+    let rhs_leading_zeros = rhs.unsigned_abs().leading_zeros();
 
-    if lz_a + lz_b > <Int<N>>::BITS {
-        // Fast path: |a * b| fits `Int<N>`. Divide its `(N + 1) / 2` u128
+    if lhs_leading_zeros + rhs_leading_zeros > <Int<N>>::BITS {
+        // Fast path: |lhs * rhs| fits `Int<N>`. Divide its `(N + 1) / 2` u128
         // limbs in place; the result certainly fits, so build directly.
-        let prod: Int<N> = a.wrapping_mul(b);
+        let product: Int<N> = lhs.wrapping_mul(rhs);
         if SCALE == 0 {
-            return prod;
+            return product;
         }
         let u128_limbs = N.div_ceil(2);
-        let mut mag = [0u128; N];
-        let _ = prod.mag_into_u128(&mut mag[..u128_limbs]);
+        let mut magnitude = [0u128; N];
+        let _ = product.mag_into_u128(&mut magnitude[..u128_limbs]);
         crate::algos::support::rescale::dispatch_mag(
-            &mut mag[..u128_limbs],
+            &mut magnitude[..u128_limbs],
             SCALE,
-            neg,
+            is_negative,
             mode,
             <Int<N>>::BITS,
         );
-        return Int::<N>::from_mag_sign_u128(&mag[..u128_limbs], neg);
+        return Int::<N>::from_mag_sign_u128(&magnitude[..u128_limbs], is_negative);
     }
 
-    // Slow path: form |a| * |b| (2N u64 limbs) in the work scratch via the
+    // Slow path: form |lhs| * |rhs| (2N u64 limbs) in the work scratch via the
     // int-layer const-N policy dispatcher -- routes even-N widths to the
     // u128-packed mul_full_limb kernel (the full-product sibling of
     // mul_low_limb); the dispatcher zeroes its own accumulator and writes
-    // 2*N u64 limbs into prod_buf.
-    let a_mag = *a.unsigned_abs().as_limbs();
-    let b_mag = *b.unsigned_abs().as_limbs();
+    // 2*N u64 limbs into product_buf.
+    let lhs_mag = *lhs.unsigned_abs().as_limbs();
+    let rhs_mag = *rhs.unsigned_abs().as_limbs();
 
-    let mut prod_buf = Limbs::<N>::double_buffered_u64();
-    crate::int::policy::mul::dispatch::<N>(&a_mag, &b_mag, prod_buf.as_mut());
-    let prod = prod_buf.as_ref();
+    let mut product_buf = Limbs::<N>::double_buffered_u64();
+    crate::int::policy::mul::dispatch::<N>(&lhs_mag, &rhs_mag, product_buf.as_mut());
+    let product = product_buf.as_ref();
 
     // Transcode the 2N-u64 product into N u128 limbs (2N u64 == N u128).
-    let mut mag = [0u128; N];
+    let mut magnitude = [0u128; N];
     for i in 0..N {
-        let lo = prod[2 * i] as u128;
-        let hi = *prod.get(2 * i + 1).unwrap_or(&0) as u128;
-        mag[i] = lo | (hi << 64);
+        let lo = product[2 * i] as u128;
+        let hi = *product.get(2 * i + 1).unwrap_or(&0) as u128;
+        magnitude[i] = lo | (hi << 64);
     }
 
     if SCALE == 0 {
-        return narrow_mag_to_int::<N>(&mag, neg, "attempt to multiply with overflow");
+        return narrow_mag_to_int::<N>(&magnitude, is_negative, "attempt to multiply with overflow");
     }
 
     // Magnitude-length-aware rescale (mirrors the typed door
     // `rescale::dispatch_wide_pow10`, task 9.24). A *representable* product is
     // far shorter than the full `2N`-limb buffer: the result must fit `Int<N>`,
-    // so `|a*b| <= 10^SCALE * |Int::<N>::MAX|` and the high u128 limbs of `mag`
-    // are zero. Every rescale kernel's cost scales with the SIGNIFICANT length,
-    // not the buffer width, so strip the leading-zero high limbs and size
+    // so `|lhs*rhs| <= 10^SCALE * |Int::<N>::MAX|` and the high u128 limbs of
+    // `magnitude` are zero. Every rescale kernel's cost scales with the
+    // SIGNIFICANT length, not the buffer width, so strip the leading-zero
+    // high limbs and size
     // `select` + the baked-Newton apply on the real length — otherwise the
     // wide-tier `÷10^SCALE` Newton runs at the full `2N` width regardless of the
     // operand magnitude. Bit-identical: the
     // quotient `<= ` the numerator, so the trimmed high limbs stay zero and
-    // `narrow_mag_to_int` reads the full `mag` unchanged.
-    let mut sig = mag.len();
-    while sig > 1 && mag[sig - 1] == 0 {
-        sig -= 1;
+    // `narrow_mag_to_int` reads the full `magnitude` unchanged.
+    let mut significant_limbs = magnitude.len();
+    while significant_limbs > 1 && magnitude[significant_limbs - 1] == 0 {
+        significant_limbs -= 1;
     }
-    let sig_bits = (sig as u32).saturating_mul(128).min((2 * N as u32) * 64);
-    crate::algos::support::rescale::dispatch_mag(&mut mag[..sig], SCALE, neg, mode, sig_bits);
-    narrow_mag_to_int::<N>(&mag, neg, "attempt to multiply with overflow")
+    let significant_bits =
+        (significant_limbs as u32).saturating_mul(128).min((2 * N as u32) * 64);
+    crate::algos::support::rescale::dispatch_mag(
+        &mut magnitude[..significant_limbs], SCALE, is_negative, mode, significant_bits);
+    narrow_mag_to_int::<N>(&magnitude, is_negative, "attempt to multiply with overflow")
 }
 
 #[cfg(test)]
@@ -194,14 +198,15 @@ mod overflow_tests {
     use crate::int::types::Int;
     use crate::support::rounding::RoundingMode;
 
-    /// `value * 10^k` as an `Int<3>` (the D57 raw storage of `value` at scale `k`).
-    fn at_scale(value: i128, k: u32) -> Int<3> {
-        let mut p = Int::<3>::from_i128(value);
+    /// `value * 10^scale` as an `Int<3>` (the D57 raw storage of `value` at
+    /// scale `scale`).
+    fn at_scale(value: i128, scale: u32) -> Int<3> {
+        let mut scaled = Int::<3>::from_i128(value);
         let ten = Int::<3>::from_i128(10);
-        for _ in 0..k {
-            p = p.wrapping_mul(ten);
+        for _ in 0..scale {
+            scaled = scaled.wrapping_mul(ten);
         }
-        p
+        scaled
     }
 
     /// D57 (`Int<3>`, the only odd-`N` wide tier): an out-of-range product must
@@ -216,15 +221,16 @@ mod overflow_tests {
         assert_eq!(got, at_scale(12, 56), "in-range D57<56> product must be exact");
 
         // Out-of-range at scale 56: 15 * 13 = 195 > MAX ≈ 31.4 → must panic.
-        let a = at_scale(15, 56);
-        let b = at_scale(13, 56);
-        let r = std::panic::catch_unwind(|| mul_widen_divide::<3, 56>(a, b, mode));
-        assert!(r.is_err(), "D57<56> 15*13=195 out of range must panic, not wrap");
+        let lhs = at_scale(15, 56);
+        let rhs = at_scale(13, 56);
+        let caught = std::panic::catch_unwind(|| mul_widen_divide::<3, 56>(lhs, rhs, mode));
+        assert!(caught.is_err(), "D57<56> 15*13=195 out of range must panic, not wrap");
 
         // Out-of-range at scale 0: -2.219...e57 * 3 overflows Int<3> (MAX ≈ 3.14e57).
-        let neg_big = Int::<3>::ZERO.wrapping_sub(at_scale(2_219_290_601, 48)); // ≈ -2.22e57, in range
+        let negative_big = Int::<3>::ZERO.wrapping_sub(at_scale(2_219_290_601, 48)); // ≈ -2.22e57, in range
         let three = Int::<3>::from_i128(3);
-        let r0 = std::panic::catch_unwind(|| mul_widen_divide::<3, 0>(neg_big, three, mode));
-        assert!(r0.is_err(), "D57<0> (-2.2e57)*3 overflow must panic, not wrap");
+        let caught_scale0 =
+            std::panic::catch_unwind(|| mul_widen_divide::<3, 0>(negative_big, three, mode));
+        assert!(caught_scale0.is_err(), "D57<0> (-2.2e57)*3 overflow must panic, not wrap");
     }
 }

--- a/src/algos/neg/neg_int_layer.rs
+++ b/src/algos/neg/neg_int_layer.rs
@@ -13,6 +13,6 @@ use crate::int::types::Int;
 /// `saturating_neg` / `overflowing_neg` variants carry the modular / `None`
 /// / clamp / flag policies). No rescaling needed — the scale is unchanged.
 #[inline]
-pub(crate) fn neg_int_layer<const N: usize>(a: Int<N>) -> Int<N> {
-    a.checked_neg().expect("attempt to negate with overflow")
+pub(crate) fn neg_int_layer<const N: usize>(value: Int<N>) -> Int<N> {
+    value.checked_neg().expect("attempt to negate with overflow")
 }

--- a/src/algos/pow/pow_schoolbook.rs
+++ b/src/algos/pow/pow_schoolbook.rs
@@ -11,7 +11,7 @@
 //!
 //! All three stages — `ln(x)`, the multiplication `y · ln(x)`, and
 //! `exp(…)` — are performed in the 256-bit `Fixed` guard-digit
-//! intermediate at `w = SCALE + SCHOOLBOOK_GUARD` working digits,
+//! intermediate at `working_scale = SCALE + SCHOOLBOOK_GUARD` working digits,
 //! using:
 //! - [`crate::algos::ln::ln_schoolbook::ln_schoolbook_fixed`] for the
 //!   natural log;
@@ -80,26 +80,29 @@ pub(crate) fn pow_schoolbook<C: WideTrigCore, const SCALE: u32>(
     // base/exponent, or a positive power out of range) defers to the
     // composition below. The wide schoolbook kernel has no other integer
     // fast path, so this is also the wide tiers' only exact-integer handling.
-    if let Some(v) = crate::algos::pow::powi_exact::powi_exact_pin::<C::Storage, SCALE>(
+    if let Some(value) = crate::algos::pow::powi_exact::powi_exact_pin::<C::Storage, SCALE>(
         base,
         exponent,
         C::storage_max(),
         mode,
     ) {
-        return v;
+        return value;
     }
-    C::round_to_storage_directed(C::GUARD, SCALE, mode, &mut |guard| {
-        let w = SCALE + guard;
-        let ln_base = C::ln_fixed::<SCALE>(C::to_work_scaled(base, guard), w);
-        let arg = C::mul(C::to_work_scaled(exponent, guard), ln_base, w);
-        C::exp_fixed::<SCALE>(arg, w)
+    C::round_to_storage_directed(C::GUARD, SCALE, mode, &mut |guard_digits| {
+        let working_scale = SCALE + guard_digits;
+        let ln_base =
+            C::ln_fixed::<SCALE>(C::to_work_scaled(base, guard_digits), working_scale);
+        let arg = C::mul(
+            C::to_work_scaled(exponent, guard_digits), ln_base, working_scale);
+        C::exp_fixed::<SCALE>(arg, working_scale)
     })
 }
 
 /// `x^y` via naive `exp(y · ln(x))` on the 256-bit `Fixed` intermediate.
 ///
-/// Accepts raw `Int<2>` storage for `base` and `exp` at `scale`, evaluates
-/// `exp(exp · ln(base))` at working scale `w = scale + working_digits`, and
+/// Accepts raw `Int<2>` storage for `base` and `exponent` at `scale`,
+/// evaluates `exp(exponent · ln(base))` at
+/// `working_scale = scale + working_digits`, and
 /// rounds the result back to `scale`.
 ///
 /// Returns `0` for a non-positive `base` (matching the production NaN-to-ZERO
@@ -112,38 +115,43 @@ pub(crate) fn pow_schoolbook_with(
     working_digits: u32,
     mode: RoundingMode,
 ) -> Int<2> {
-    let base_i = base.as_i128();
-    if base_i <= 0 {
+    let base_raw = base.as_i128();
+    if base_raw <= 0 {
         return Int::<2>::ZERO;
     }
-    let exp_i = exponent.as_i128();
-    let one_s: i128 = 10_i128.pow(scale);
+    let exponent_raw = exponent.as_i128();
+    let one_at_scale: i128 = 10_i128.pow(scale);
     // base^0 == 1.
-    if exp_i == 0 {
-        return Int::<2>::from_i128(one_s);
+    if exponent_raw == 0 {
+        return Int::<2>::from_i128(one_at_scale);
     }
 
-    let w = scale + working_digits;
+    let working_scale = scale + working_digits;
     let guard_pow = 10u128.pow(working_digits);
 
-    // Lift base to working scale w.
-    let base_w = Fixed::from_u128_mag(base_i as u128, false).mul_u128(guard_pow);
+    // Lift base to the working scale.
+    let base_working_value = Fixed::from_u128_mag(base_raw as u128, false).mul_u128(guard_pow);
 
-    // Compute ln(base) at working scale w.
-    let ln_base = ln_schoolbook_fixed(base_w, w);
+    // Compute ln(base) at the working scale.
+    let ln_base = ln_schoolbook_fixed(base_working_value, working_scale);
 
-    // Lift exponent to working scale w (preserving sign).
-    let negative_exp = exp_i < 0;
-    let exp_w = Fixed::from_u128_mag(exp_i.unsigned_abs(), false).mul_u128(guard_pow);
-    let exp_w = if negative_exp { exp_w.neg() } else { exp_w };
+    // Lift exponent to the working scale (preserving sign).
+    let exponent_is_negative = exponent_raw < 0;
+    let exponent_working_value =
+        Fixed::from_u128_mag(exponent_raw.unsigned_abs(), false).mul_u128(guard_pow);
+    let exponent_working_value = if exponent_is_negative {
+        exponent_working_value.neg()
+    } else {
+        exponent_working_value
+    };
 
-    // Multiply: arg = y · ln(base) at working scale w.
-    let arg = exp_w.mul(ln_base, w);
+    // Multiply: arg = y · ln(base) at the working scale.
+    let arg = exponent_working_value.mul(ln_base, working_scale);
 
     // exp(arg) and round to storage.
     Int::<2>::from_i128(
-        exp_schoolbook_fixed(arg, w)
-            .round_to_i128_with(w, scale, mode)
+        exp_schoolbook_fixed(arg, working_scale)
+            .round_to_i128_with(working_scale, scale, mode)
             .unwrap_or_else(|| {
                 crate::support::diagnostics::overflow_panic_with_scale(
                     "pow_schoolbook",
@@ -179,10 +187,10 @@ mod tests {
 
     #[track_caller]
     fn check<const S: u32>(base: i128, exp: i128, mode: RoundingMode) {
-        let rb = Int::<2>::from_i128(base);
-        let re = Int::<2>::from_i128(exp);
-        let got = pow_schoolbook_strict::<S>(rb, re, mode);
-        let expected = powf_strict::<S>(rb, re, mode).expect("reference in range");
+        let base_raw = Int::<2>::from_i128(base);
+        let exponent_raw = Int::<2>::from_i128(exp);
+        let got = pow_schoolbook_strict::<S>(base_raw, exponent_raw, mode);
+        let expected = powf_strict::<S>(base_raw, exponent_raw, mode).expect("reference in range");
         assert_eq!(got, expected,
             "pow schoolbook D38<{}> base={} exp={} mode={:?}: {:?} != {:?}",
             S, base, exp, mode, got, expected);
@@ -196,8 +204,8 @@ mod tests {
             (2*one, one/2), (2*one, 3*one/2), (3*one, one/2),
             (2*one, -(one/2)), (4*one, 3*one/4), (3*one/2, 5*one/2),
         ];
-        for (b, e) in cases {
-            for mode in MODES { check::<12>(b, e, mode); }
+        for (base, exponent) in cases {
+            for mode in MODES { check::<12>(base, exponent, mode); }
         }
     }
 
@@ -207,8 +215,8 @@ mod tests {
         let cases = [
             (2*one, one/2), (2*one, 3*one/2), (3*one, one/2),
         ];
-        for (b, e) in cases {
-            for mode in MODES { check::<19>(b, e, mode); }
+        for (base, exponent) in cases {
+            for mode in MODES { check::<19>(base, exponent, mode); }
         }
     }
     #[cfg(any(feature = "d57", feature = "wide"))]
@@ -234,14 +242,16 @@ mod tests {
 
         #[test]
         fn pow_schoolbook_matches_routed() {
-            for &(b, e) in &CASES {
-                let rb = raw9(b);
-                let re = raw9(e);
+            for &(base, exponent) in &CASES {
+                let base_raw = raw9(base);
+                let exponent_raw = raw9(exponent);
                 for mode in MODES {
                     assert_eq!(
-                        crate::algos::pow::pow_schoolbook::pow_schoolbook::<Core, S>(rb, re, mode),
-                        D::<Int<3>, S>(rb).powf_strict_with(D::<Int<3>, S>(re), mode).0,
-                        "D57 pow schoolbook != routed at base={b} exp={e} mode={mode:?}"
+                        crate::algos::pow::pow_schoolbook::pow_schoolbook::<Core, S>(
+                            base_raw, exponent_raw, mode),
+                        D::<Int<3>, S>(base_raw)
+                            .powf_strict_with(D::<Int<3>, S>(exponent_raw), mode).0,
+                        "D57 pow schoolbook != routed at base={base} exp={exponent} mode={mode:?}"
                     );
                 }
             }
@@ -264,15 +274,16 @@ mod tests {
                 (4, -3, 64),      // 0.015625
                 (5, -3, 125),     // 0.008
             ];
-            for (b, e, div) in cases {
-                let rb = Int::<3>::from_i128(b) * one3;
-                let re = Int::<3>::from_i128(e) * one3;
-                let want = Int::<3>::from_i128(one / div);
+            for (base, exponent, divisor) in cases {
+                let base_raw = Int::<3>::from_i128(base) * one3;
+                let exponent_raw = Int::<3>::from_i128(exponent) * one3;
+                let want = Int::<3>::from_i128(one / divisor);
                 for mode in MODES {
                     assert_eq!(
-                        crate::algos::pow::pow_schoolbook::pow_schoolbook::<Core, S>(rb, re, mode),
+                        crate::algos::pow::pow_schoolbook::pow_schoolbook::<Core, S>(
+                            base_raw, exponent_raw, mode),
                         want,
-                        "D57 {b}^{e} mode={mode:?}"
+                        "D57 {base}^{exponent} mode={mode:?}"
                     );
                 }
             }

--- a/src/algos/pow/powf_overflow_gate.rs
+++ b/src/algos/pow/powf_overflow_gate.rs
@@ -12,9 +12,9 @@
 //! The wide `powf` shell sizes its working lift from the result's
 //! integer-digit count (`k_lift = digits(e^{y·ln x})`). For a
 //! deep-overflow cell that count is in the hundreds, pushing the
-//! working scale `w = SCALE + GUARD + k_lift` past the work integer's
+//! `working_scale = SCALE + GUARD + k_lift` past the work integer's
 //! safe working-scale ceiling (`~W::BITS/8` decimal digits — the bound
-//! the Tang table reconstruction `slot_hi · 10^w` is sized for). Past
+//! the Tang table reconstruction `slot_hi · 10^working_scale` is sized for). Past
 //! that ceiling the `ln` kernel's table product silently WRAPS,
 //! returning a near-zero garbage `ln x`; the exp argument collapses,
 //! every downstream overflow gate sees a tiny in-range argument, and
@@ -33,8 +33,8 @@ use crate::int::types::traits::BigInt;
 /// the lifted composition.
 ///
 /// `arg_w` is the composition argument `y·ln x` as a working-scale
-/// value (`arg · 10^w`) in the work integer `S` — computed at the
-/// CANONICAL working scale `w = SCALE + GUARD`, which every tier's work
+/// value (`arg · 10^working_scale`) in the work integer `S` — computed at the
+/// CANONICAL `working_scale = SCALE + GUARD`, which every tier's work
 /// integer carries in-contract (the gate must run before any
 /// result-sized lift).
 ///
@@ -54,25 +54,27 @@ use crate::int::types::traits::BigInt;
 ///   scale stays inside the work integer's ceiling and the existing
 ///   storage-narrowing fit check raises the same contractual panic.
 ///
-/// `arg < 0` (`x^y < 1`) never overflows; `w < 6` (no real caller —
-/// every shell forms `w ≥ GUARD = 30`) skips the gate for totality.
+/// `arg < 0` (`x^y < 1`) never overflows; `working_scale < 6` (no real caller
+/// — every shell forms `working_scale ≥ GUARD = 30`) skips the gate for
+/// totality.
 #[inline]
 pub(crate) fn powf_overflow_gate_g<S: BigInt>(
     arg_w: S,
-    w: u32,
+    working_scale: u32,
     storage_bits: u32,
     scale: u32,
 ) -> bool {
-    if arg_w <= S::ZERO || w < 6 {
+    if arg_w <= S::ZERO || working_scale < 6 {
         return false;
     }
     // D = ⌊BITS·log10(2)⌋ + 1 (over-approximated), +1 margin digit.
-    let d = (storage_bits as u64) * 30_103 / 100_000 + 2;
-    // Every tier's max SCALE is below its digit count, so `d - scale`
-    // is positive; saturate for totality.
-    let digits_left = d.saturating_sub(scale as u64).max(1);
-    // thr = (D+1−scale)·2.302586 · 10^w = (digits_left·2_302_586) · 10^(w−6).
-    let thr = eg::lit::<S>((digits_left as u128 * 2_302_586) as i128)
-        * eg::pow10::<S>(w - 6);
-    arg_w >= thr
+    let storage_digits = (storage_bits as u64) * 30_103 / 100_000 + 2;
+    // Every tier's max SCALE is below its digit count, so `storage_digits -
+    // scale` is positive; saturate for totality.
+    let digits_left = storage_digits.saturating_sub(scale as u64).max(1);
+    // threshold = (D+1−scale)·2.302586 · 10^working_scale
+    //           = (digits_left·2_302_586) · 10^(working_scale−6).
+    let threshold = eg::lit::<S>((digits_left as u128 * 2_302_586) as i128)
+        * eg::pow10::<S>(working_scale - 6);
+    arg_w >= threshold
 }

--- a/src/algos/pow/powf_series_2limb.rs
+++ b/src/algos/pow/powf_series_2limb.rs
@@ -44,7 +44,7 @@ use crate::support::rounding::RoundingMode;
 pub(crate) const INT_FAST_PATH_THRESHOLD: i32 = 64;
 
 /// Analytic storage-overflow gate on the `exp(y·ln x)` composition's
-/// argument `arg = y·ln x` (a working-scale [`Fixed`] at scale `w`),
+/// argument `arg = y·ln x` (a [`Fixed`] at `working_scale`),
 /// run BEFORE [`exp_fixed`]. Returns `true` when the result
 /// `x^y = e^arg` provably cannot be stored: the kernel signals its
 /// out-of-range `None` (the policy dispatch wrapper applies the default
@@ -64,23 +64,24 @@ pub(crate) const INT_FAST_PATH_THRESHOLD: i32 = 64;
 /// assertion (loud but non-contractual), and an extreme one could wrap
 /// the `k` shift narrowing entirely.
 ///
-/// The threshold magnitude `(39−scale)·2_302_586 · 10^(w−6)` fits `U256`
-/// for every working scale this kernel serves (`w ≤ 68`); `w < 6` (no
-/// real caller) skips the gate and leaves the kernel assert as backstop.
+/// The threshold magnitude `(39−scale)·2_302_586 · 10^(working_scale−6)` fits
+/// `U256` for every working scale this kernel serves (`working_scale ≤ 68`);
+/// `working_scale < 6` (no real caller) skips the gate and leaves the kernel
+/// assert as backstop.
 #[inline]
-fn powf_overflow_gate(arg: Fixed, w: u32, scale: u32) -> bool {
-    if arg.negative || w < 6 {
+fn powf_overflow_gate(arg: Fixed, working_scale: u32, scale: u32) -> bool {
+    if arg.negative || working_scale < 6 {
         return false; // y·ln x < 0 ⇒ x^y < 1: never a storage overflow.
     }
-    let thr = Fixed {
+    let threshold = Fixed {
         negative: false,
-        mag: Fixed::pow10(w - 6),
+        mag: Fixed::pow10(working_scale - 6),
     }
     .mul_u128(((39 - scale) as u128) * 2_302_586);
-    arg.ge_mag(thr)
+    arg.ge_mag(threshold)
 }
 
-/// `(a · b) / 10^SCALE` rounded under `mode`, on `i128` storage. Returns
+/// `(lhs · rhs) / 10^SCALE` rounded under `mode`, on `i128` storage. Returns
 /// `None` when the rounded result does not fit `i128` — the signal
 /// [`powi_raw_checked`] uses to defer to the overflow-safe `exp(y·ln x)`
 /// composition rather than compute a partial power that has left the
@@ -94,61 +95,65 @@ fn powf_overflow_gate(arg: Fixed, w: u32, scale: u32) -> bool {
 /// shape paid the 256-bit `mul_widen_divide::<4, SCALE>` machinery
 /// unconditionally — the dominant cost of the bbc powf D18<0> cell.
 /// Value and rounding are engine-independent (the same correctly-rounded
-/// `(a·b)/10^SCALE`), so results are bit-identical.
+/// `(lhs·rhs)/10^SCALE`), so results are bit-identical.
 ///
 /// [`mul_div_pow10_with`]: crate::algos::support::mg_divide::mul_div_pow10_with
 #[inline]
-fn mul_div_scale_checked<const SCALE: u32>(a: i128, b: i128, mode: RoundingMode) -> Option<i128> {
-    crate::algos::support::mg_divide::mul_div_pow10_with::<SCALE>(a, b, mode)
+fn mul_div_scale_checked<const SCALE: u32>(
+    lhs: i128, rhs: i128, mode: RoundingMode) -> Option<i128> {
+    crate::algos::support::mg_divide::mul_div_pow10_with::<SCALE>(lhs, rhs, mode)
 }
 
 /// Integer-exponent square-and-multiply on raw `i128` storage at `SCALE`,
 /// returning `None` if any partial power `base^k` (`k ≤ |n|`) leaves the
 /// `i128` storage range. Uses `mul_widen_divide` directly (not the decimal
 /// `Mul` operator, which would re-enter the mul policy from inside an
-/// algorithm fn — the layering inversion). `one_s` is `10^SCALE`.
+/// algorithm fn — the layering inversion). `one_at_scale` is `10^SCALE`.
 ///
-/// Every intermediate (`acc`, `b`) is bounded by `base^|n|`, so a `None`
+/// Every intermediate (`accumulator`, `base_power`) is bounded by `base^|n|`,
+/// so a `None`
 /// means the full integer power `base^|n|` is itself out of range. The
 /// caller then routes to the composition, which panics on a genuinely
-/// out-of-range result (positive `n`) and computes the in-range reciprocal
-/// `base^-|n|` overflow-safely (negative `n`) — fixing the integer fast
-/// path's spurious panic on `powf(10, -2)` (`10² = 100` overflows storage
-/// while `1/100 = 0.01` is representable). When `Some`, the result is the
-/// exact integer power (or its reciprocal), bit-identical to before.
+/// out-of-range result (a positive `exponent`) and computes the in-range
+/// reciprocal `base^-|n|` overflow-safely (a negative `exponent`) — fixing the
+/// integer fast path's spurious panic on `powf(10, -2)` (`10² = 100` overflows
+/// storage while `1/100 = 0.01` is representable). When `Some`, the result is
+/// the exact integer power (or its reciprocal), bit-identical to before.
 ///
-/// For negative `n`, returns `one_s / base^|n|` via the decimal
+/// For a negative `exponent`, returns `one_at_scale / base^|n|` via the decimal
 /// `div_widen_scale` (a genuine downward cross-tier call to the int layer).
 #[inline]
-fn powi_raw_checked<const SCALE: u32>(base: i128, n: i32, mode: RoundingMode) -> Option<i128> {
-    let one_s: Int<2> = const { crate::consts::pow10::dispatch_int::<2>(SCALE) };
-    if n == 0 {
-        return Some(one_s.as_i128());
+fn powi_raw_checked<const SCALE: u32>(
+    base: i128, exponent: i32, mode: RoundingMode) -> Option<i128> {
+    let one_at_scale: Int<2> = const { crate::consts::pow10::dispatch_int::<2>(SCALE) };
+    if exponent == 0 {
+        return Some(one_at_scale.as_i128());
     }
-    let pos_n = n.unsigned_abs();
+    let abs_exponent = exponent.unsigned_abs();
     // Square-and-multiply; every partial product is range-checked so an
     // out-of-storage intermediate signals `None` instead of panicking.
-    let mut acc: i128 = one_s.as_i128();
-    let mut b: i128 = base;
-    let mut e = pos_n;
-    while e > 0 {
-        if e & 1 == 1 {
-            acc = mul_div_scale_checked::<SCALE>(acc, b, mode)?;
+    let mut accumulator: i128 = one_at_scale.as_i128();
+    let mut base_power: i128 = base;
+    let mut remaining_exponent = abs_exponent;
+    while remaining_exponent > 0 {
+        if remaining_exponent & 1 == 1 {
+            accumulator = mul_div_scale_checked::<SCALE>(accumulator, base_power, mode)?;
         }
-        e >>= 1;
-        if e > 0 {
-            b = mul_div_scale_checked::<SCALE>(b, b, mode)?;
+        remaining_exponent >>= 1;
+        if remaining_exponent > 0 {
+            base_power = mul_div_scale_checked::<SCALE>(base_power, base_power, mode)?;
         }
     }
-    if n > 0 {
-        Some(acc)
+    if exponent > 0 {
+        Some(accumulator)
     } else {
-        // Reciprocal: one_s / base^|n|. `acc = base^|n|` fits i128 here and
-        // `1/acc ≤ 1`, so the quotient certainly fits storage.
+        // Reciprocal: one_at_scale / base^|n|. `accumulator = base^|n|` fits
+        // i128 here and `1/accumulator ≤ 1`, so the quotient certainly fits
+        // storage.
         Some(
             crate::algos::div::div_widen_scale::div_widen_scale::<2>(
-                one_s,
-                Int::<2>::from_i128(acc),
+                one_at_scale,
+                Int::<2>::from_i128(accumulator),
                 const { crate::consts::pow10::dispatch_int::<2>(SCALE) },
                 mode,
             )
@@ -157,21 +162,21 @@ fn powi_raw_checked<const SCALE: u32>(base: i128, n: i32, mode: RoundingMode) ->
     }
 }
 
-/// Returns `Some(n)` if `exp_raw` (at `SCALE`) represents an exact
-/// integer value `n` that fits `i32` and `|n| <= INT_FAST_PATH_THRESHOLD`.
+/// Returns `Some(exponent)` if `exp_raw` (at `SCALE`) represents an exact
+/// integer value that fits `i32` with `|n| <= INT_FAST_PATH_THRESHOLD`.
 #[inline]
 fn exp_as_small_int<const SCALE: u32>(exp_raw: i128) -> Option<i32> {
-    let mult = const { crate::consts::pow10::dispatch_i128(SCALE) };
-    if exp_raw % mult != 0 {
+    let one_at_scale = const { crate::consts::pow10::dispatch_i128(SCALE) };
+    if exp_raw % one_at_scale != 0 {
         return None;
     }
-    let q = exp_raw / mult;
-    if !(i32::MIN as i128..=i32::MAX as i128).contains(&q) {
+    let quotient = exp_raw / one_at_scale;
+    if !(i32::MIN as i128..=i32::MAX as i128).contains(&quotient) {
         return None;
     }
-    let n = q as i32;
-    if n.unsigned_abs() <= INT_FAST_PATH_THRESHOLD as u32 {
-        Some(n)
+    let exponent = quotient as i32;
+    if exponent.unsigned_abs() <= INT_FAST_PATH_THRESHOLD as u32 {
+        Some(exponent)
     } else {
         None
     }
@@ -204,14 +209,14 @@ fn powf_with_raw<const SCALE: u32>(
     if base <= 0 {
         return Some(0);
     }
-    if let Some(n) = exp_as_small_int::<SCALE>(exp) {
-        if let Some(v) = powi_raw_checked::<SCALE>(base, n, mode) {
-            return Some(v);
+    if let Some(exponent) = exp_as_small_int::<SCALE>(exp) {
+        if let Some(value) = powi_raw_checked::<SCALE>(base, exponent, mode) {
+            return Some(value);
         }
         // `base^|n|` left the storage range. When the base is an exact
         // integer the result is still an exact rational — pin its
         // correctly-directed-rounded value (`10^SCALE / base^|n|` for a
-        // negative `n`) so a directed mode is not 1 LSB off, rather than
+        // negative `exponent`) so a directed mode is not 1 LSB off, rather than
         // defer to the to-nearest `exp(y·ln x)` composition. A fractional
         // base defers to the composition; a genuinely out-of-range positive
         // power is the pin's PROOF of overflow — signal the kernel's `None`
@@ -225,22 +230,28 @@ fn powf_with_raw<const SCALE: u32>(
             Int::<2>::MAX,
             mode,
         ) {
-            ExactPin::Value(v) => return Some(v.as_i128()),
+            ExactPin::Value(value) => return Some(value.as_i128()),
             ExactPin::OutOfRange => return None,
             ExactPin::Defer => {}
         }
     }
-    let w = SCALE + working_digits;
-    let pow = 10u128.pow(working_digits);
-    let ln_x = ln_fixed(Fixed::from_u128_mag(base as u128, false).mul_u128(pow), w);
-    let y_neg = exp < 0;
-    let y_w = Fixed::from_u128_mag(exp.unsigned_abs(), false).mul_u128(pow);
-    let y_w = if y_neg { y_w.neg() } else { y_w };
-    let arg = y_w.mul(ln_x, w);
-    if powf_overflow_gate(arg, w, SCALE) {
+    let working_scale = SCALE + working_digits;
+    let guard_pow = 10u128.pow(working_digits);
+    let ln_x = ln_fixed(
+        Fixed::from_u128_mag(base as u128, false).mul_u128(guard_pow), working_scale);
+    let exponent_is_negative = exp < 0;
+    let exponent_working_value =
+        Fixed::from_u128_mag(exp.unsigned_abs(), false).mul_u128(guard_pow);
+    let exponent_working_value = if exponent_is_negative {
+        exponent_working_value.neg()
+    } else {
+        exponent_working_value
+    };
+    let arg = exponent_working_value.mul(ln_x, working_scale);
+    if powf_overflow_gate(arg, working_scale, SCALE) {
         return None;
     }
-    exp_fixed(arg, w).round_to_i128_with(w, SCALE, mode)
+    exp_fixed(arg, working_scale).round_to_i128_with(working_scale, SCALE, mode)
 }
 
 /// Strict variant — const-folded `working_digits = STRICT_GUARD`.
@@ -258,14 +269,14 @@ fn powf_strict_raw<const SCALE: u32>(base: i128, exp: i128, mode: RoundingMode) 
     if base <= 0 {
         return Some(0);
     }
-    if let Some(n) = exp_as_small_int::<SCALE>(exp) {
-        if let Some(v) = powi_raw_checked::<SCALE>(base, n, mode) {
-            return Some(v);
+    if let Some(exponent) = exp_as_small_int::<SCALE>(exp) {
+        if let Some(value) = powi_raw_checked::<SCALE>(base, exponent, mode) {
+            return Some(value);
         }
         // `base^|n|` left the storage range. When the base is an exact
         // integer the result is still an exact rational — pin its
         // correctly-directed-rounded value (`10^SCALE / base^|n|` for a
-        // negative `n`) so a directed mode is not 1 LSB off, rather than
+        // negative `exponent`) so a directed mode is not 1 LSB off, rather than
         // defer to the to-nearest `exp(y·ln x)` composition. A fractional
         // base defers to the composition; a genuinely out-of-range positive
         // power is the pin's PROOF of overflow — signal the kernel's `None`
@@ -279,24 +290,30 @@ fn powf_strict_raw<const SCALE: u32>(base: i128, exp: i128, mode: RoundingMode) 
             Int::<2>::MAX,
             mode,
         ) {
-            ExactPin::Value(v) => return Some(v.as_i128()),
+            ExactPin::Value(value) => return Some(value.as_i128()),
             ExactPin::OutOfRange => return None,
             ExactPin::Defer => {}
         }
     }
-    let w = SCALE + STRICT_GUARD;
-    let pow = 10u128.pow(STRICT_GUARD);
-    let ln_x = ln_fixed(Fixed::from_u128_mag(base as u128, false).mul_u128(pow), w);
-    let y_neg = exp < 0;
-    let y_w = Fixed::from_u128_mag(exp.unsigned_abs(), false).mul_u128(pow);
-    let y_w = if y_neg { y_w.neg() } else { y_w };
-    let arg = y_w.mul(ln_x, w);
-    if powf_overflow_gate(arg, w, SCALE) {
+    let working_scale = SCALE + STRICT_GUARD;
+    let guard_pow = 10u128.pow(STRICT_GUARD);
+    let ln_x = ln_fixed(
+        Fixed::from_u128_mag(base as u128, false).mul_u128(guard_pow), working_scale);
+    let exponent_is_negative = exp < 0;
+    let exponent_working_value =
+        Fixed::from_u128_mag(exp.unsigned_abs(), false).mul_u128(guard_pow);
+    let exponent_working_value = if exponent_is_negative {
+        exponent_working_value.neg()
+    } else {
+        exponent_working_value
+    };
+    let arg = exponent_working_value.mul(ln_x, working_scale);
+    if powf_overflow_gate(arg, working_scale, SCALE) {
         return None;
     }
-    let v = exp_fixed(arg, w);
-    match v.round_to_i128_clear_of_tie(w, SCALE, mode) {
-        Some(r) => r,
+    let power_w = exp_fixed(arg, working_scale);
+    match power_w.round_to_i128_clear_of_tie(working_scale, SCALE, mode) {
+        Some(rounded) => rounded,
         // Near a boundary. The constructible family is the EXACT rational
         // power reached through the composition (`powf(4, 0.5) = 2`,
         // `powf(225, 0.5) = 15` — the composition's value lands a
@@ -310,39 +327,44 @@ fn powf_strict_raw<const SCALE: u32>(base: i128, exp: i128, mode: RoundingMode) 
         // candidates can verify; the walker resolves the genuinely
         // transcendental near-ties.
         None => {
-            if let Some(num2) =
-                v.double().round_to_i128_with(w, SCALE, RoundingMode::HalfToEven)
+            if let Some(half_ulp_numerator) = power_w
+                .double()
+                .round_to_i128_with(working_scale, SCALE, RoundingMode::HalfToEven)
             {
-                if let Some(pinned) = powf_rational_pin(base, exp, SCALE, num2) {
+                if let Some(pinned) = powf_rational_pin(base, exp, SCALE, half_ulp_numerator) {
                     return Some(pinned);
                 }
             }
             narrow_ziv::walk_checked(
-                v.round_to_i128_with(w, SCALE, mode),
+                power_w.round_to_i128_with(working_scale, SCALE, mode),
                 STRICT_GUARD,
                 SCALE,
                 mode,
-                |g| powf_ziv(base, exp, SCALE, g),
+                |guard_digits| powf_ziv(base, exp, SCALE, guard_digits),
             )
         }
     }
 }
 
-/// One `WZiv` `exp(y·ln x)` probe at working scale `scale + g`.
-fn powf_ziv(base: i128, exp: i128, scale: u32, g: u32) -> WZiv {
-    let w = scale + g;
-    let ln_x = eg::ln_fixed::<WZiv>(narrow_ziv::lift(base, g), w, narrow_ziv::ln2_w(w));
-    let arg = eg::mul::<WZiv>(narrow_ziv::lift(exp, g), ln_x, w);
-    eg::exp_fixed::<WZiv>(arg, w)
+/// One `WZiv` `exp(y·ln x)` probe at working scale `scale + guard_digits`.
+fn powf_ziv(base: i128, exp: i128, scale: u32, guard_digits: u32) -> WZiv {
+    let working_scale = scale + guard_digits;
+    let ln_x = eg::ln_fixed::<WZiv>(
+        narrow_ziv::lift(base, guard_digits), working_scale, narrow_ziv::ln2_w(working_scale));
+    let arg = eg::mul::<WZiv>(narrow_ziv::lift(exp, guard_digits), ln_x, working_scale);
+    eg::exp_fixed::<WZiv>(arg, working_scale)
 }
 
 /// Exact rational-power pin for the strict powf near-tie terminal — the
-/// powf sibling of `ln_series_2limb::log_rational_pow_pin`. `num2` is
+/// powf sibling of `ln_series_2limb::log_rational_pow_pin`.
+/// `half_ulp_numerator` is
 /// the boundary candidate in half-ULPs at `scale` (the working value
 /// doubled and nearest-rounded). With the exponent `y = p/q` (the input
-/// reduced — exact by construction) the claim `x^y == num2/(2·10^scale)`
+/// reduced — exact by construction) the claim
+/// `x^y == half_ulp_numerator/(2·10^scale)`
 /// is the integer identity `x^p == v^q` over the reduced fractions,
-/// verified with the bounded checked ladder. Only an EVEN `num2` (a grid
+/// verified with the bounded checked ladder. Only an EVEN
+/// `half_ulp_numerator` (a grid
 /// candidate) can verify — an exact-half powf value is impossible for
 /// on-grid `(x, y)`: `x^y = (2k+1)/(2·10^S)` forces `x = u^q` with
 /// `den(u^p) = 2^(S+1)·5^S`, whose 2-/5-adic exponents demand
@@ -350,33 +372,40 @@ fn powf_ziv(base: i128, exp: i128, scale: u32, g: u32) -> WZiv {
 /// cannot divide `10^S` — so the half-candidate arm is unreachable and
 /// simply returns `None`. A verified grid value is returned for every
 /// mode (it IS the exact result).
-fn powf_rational_pin(base: i128, exp: i128, scale: u32, num2: i128) -> Option<i128> {
+fn powf_rational_pin(
+    base: i128, exp: i128, scale: u32, half_ulp_numerator: i128) -> Option<i128> {
     use crate::algos::ln::ln_series_2limb::{gcd_u128, pow_bounded, reduce_fraction};
-    if num2 <= 0 || num2 & 1 == 1 || exp == 0 || base <= 0 {
+    if half_ulp_numerator <= 0 || half_ulp_numerator & 1 == 1 || exp == 0 || base <= 0 {
         // x > 0 ⇒ x^y > 0; half candidates can't verify (see above);
         // y == 0 is the exact-1 case the integer fast path already pins.
         return None;
     }
-    let one_s = 10u128.pow(scale);
+    let one_at_scale = 10u128.pow(scale);
     // y = p/q in lowest terms (sign split off).
-    let y_neg = exp < 0;
-    let g = gcd_u128(exp.unsigned_abs(), one_s);
-    let p = exp.unsigned_abs() / g;
-    let q = one_s / g;
+    let exponent_is_negative = exp < 0;
+    let common_divisor = gcd_u128(exp.unsigned_abs(), one_at_scale);
+    let reduced_num = exp.unsigned_abs() / common_divisor;
+    let reduced_den = one_at_scale / common_divisor;
     // x and the candidate v as reduced fractions.
-    let (xn, xd) = reduce_fraction(base as u128, one_s);
-    let (vn, vd) = reduce_fraction((num2 / 2) as u128, one_s);
-    // x^(±p/q) == v  ⇔  x^(±p) == v^q  ⇔ (positive y) xn^p == vn^q ∧
-    // xd^p == vd^q; (negative y) xd^p == vn^q ∧ xn^p == vd^q.
-    let (tn, td) = if y_neg { (xd, xn) } else { (xn, xd) };
-    let lx_n = pow_bounded(tn, p)?;
-    let lx_d = pow_bounded(td, p)?;
-    let rv_n = pow_bounded(vn, q)?;
-    let rv_d = pow_bounded(vd, q)?;
-    if lx_n != rv_n || lx_d != rv_d {
+    let (base_num, base_den) = reduce_fraction(base as u128, one_at_scale);
+    let (candidate_num, candidate_den) =
+        reduce_fraction((half_ulp_numerator / 2) as u128, one_at_scale);
+    // x^(±p/q) == v  ⇔  x^(±p) == v^q  ⇔ (positive y) base_num^p ==
+    // candidate_num^q ∧ base_den^p == candidate_den^q; (negative y)
+    // base_den^p == candidate_num^q ∧ base_num^p == candidate_den^q.
+    let (target_num, target_den) = if exponent_is_negative {
+        (base_den, base_num)
+    } else {
+        (base_num, base_den)
+    };
+    let base_pow_num = pow_bounded(target_num, reduced_num)?;
+    let base_pow_den = pow_bounded(target_den, reduced_num)?;
+    let candidate_pow_num = pow_bounded(candidate_num, reduced_den)?;
+    let candidate_pow_den = pow_bounded(candidate_den, reduced_den)?;
+    if base_pow_num != candidate_pow_num || base_pow_den != candidate_pow_den {
         return None;
     }
-    Some(num2 / 2)
+    Some(half_ulp_numerator / 2)
 }
 
 #[cfg(test)]

--- a/src/algos/pow/powi_exact.rs
+++ b/src/algos/pow/powi_exact.rs
@@ -60,7 +60,7 @@ pub(crate) fn powi_exact_pin<St: BigInt, const SCALE: u32>(
     mode: RoundingMode,
 ) -> Option<St> {
     match powi_exact_pin_checked::<St, SCALE>(base, exp, storage_max, mode) {
-        ExactPin::Value(v) => Some(v),
+        ExactPin::Value(value) => Some(value),
         ExactPin::OutOfRange => {
             crate::support::diagnostics::overflow_panic_with_scale("powf kernel", SCALE)
         }
@@ -91,37 +91,37 @@ pub(crate) fn powi_exact_pin_checked<St: BigInt, const SCALE: u32>(
     // `10^SCALE` — the raw value `1.0`, sourced from the baked table so it is
     // exact at every tier (`St::TEN.pow` would wrap; `pow10::dispatch` does
     // not).
-    let one_s = crate::consts::pow10::dispatch::<St>(SCALE);
+    let one_at_scale = crate::consts::pow10::dispatch::<St>(SCALE);
 
     // The exponent must be an exact integer `n` (`exp` an exact multiple of
     // `10^SCALE`) with `|n|` inside the integer fast-path threshold.
-    let (n_big, e_rem) = exp.div_rem(one_s);
-    if e_rem != St::ZERO {
+    let (exponent_big, exponent_remainder) = exp.div_rem(one_at_scale);
+    if exponent_remainder != St::ZERO {
         return ExactPin::Defer;
     }
-    let thresh =
+    let threshold =
         St::from_i128(crate::algos::pow::powf_series_2limb::INT_FAST_PATH_THRESHOLD as i128);
-    if n_big > thresh || n_big < St::ZERO - thresh {
+    if exponent_big > threshold || exponent_big < St::ZERO - threshold {
         return ExactPin::Defer;
     }
-    let n = n_big.to_i128() as i32;
+    let exponent = exponent_big.to_i128() as i32;
 
     // The base must be an exact positive integer `b >= 1`.
     if base <= St::ZERO {
         return ExactPin::Defer;
     }
-    let (bv, b_rem) = base.div_rem(one_s);
-    if b_rem != St::ZERO {
+    let (base_value, base_remainder) = base.div_rem(one_at_scale);
+    if base_remainder != St::ZERO {
         return ExactPin::Defer; // fractional base — defer to the composition
     }
 
     // `b^0 = 1` and `1^n = 1` are exactly `1.0` for every mode.
-    if n == 0 || bv == St::ONE {
-        return ExactPin::Value(one_s);
+    if exponent == 0 || base_value == St::ONE {
+        return ExactPin::Value(one_at_scale);
     }
-    let k = n.unsigned_abs();
+    let abs_exponent = exponent.unsigned_abs();
 
-    if n > 0 {
+    if exponent > 0 {
         // `b^n · 10^SCALE` — an exact integer when it fits the decimal range.
         // A `checked_pow` / `checked_mul` overflow, or a value past
         // `storage_max`, is PROOF the exact `b^n` exceeds the decimal range
@@ -132,31 +132,32 @@ pub(crate) fn powi_exact_pin_checked<St: BigInt, const SCALE: u32>(
         // approximation can directed-round (Floor / Trunc) back INSIDE the
         // range at an out-by-one boundary (the `exp2(127)` hair case:
         // `2^127` at scale 0 is `i128::MAX + 1`).
-        match bv
-            .checked_pow(k)
-            .and_then(|p| p.checked_mul(one_s))
-            .filter(|v| *v <= storage_max)
+        match base_value
+            .checked_pow(abs_exponent)
+            .and_then(|power| power.checked_mul(one_at_scale))
+            .filter(|value| *value <= storage_max)
         {
-            Some(v) => ExactPin::Value(v),
+            Some(value) => ExactPin::Value(value),
             None => ExactPin::OutOfRange,
         }
     } else {
         // `b^-k = 1 / b^k`, stored as `round(10^SCALE / b^k)` — a strictly
         // positive value in `(0, 1]`.
-        match bv.checked_pow(k) {
-            Some(d) => {
-                // `d = b^k` fits storage; round `10^SCALE / d` under `mode`.
-                let (q, r) = one_s.div_rem(d);
-                if r == St::ZERO {
-                    return ExactPin::Value(q); // exact — no rounding
+        match base_value.checked_pow(abs_exponent) {
+            Some(divisor) => {
+                // `divisor = b^k` fits storage; round `10^SCALE / divisor`
+                // under `mode`.
+                let (quotient, remainder) = one_at_scale.div_rem(divisor);
+                if remainder == St::ZERO {
+                    return ExactPin::Value(quotient); // exact — no rounding
                 }
                 // Half-comparison `2r vs d`, formed as `r vs d − r` to avoid
-                // overflowing `2r` (`r < d <= MAX`). `q` is the truncated
-                // quotient; the result is positive.
-                let cmp = r.cmp(&(d - r));
-                let q_is_odd = q.bit(0);
-                let bump = should_bump(mode, cmp, q_is_odd, true);
-                ExactPin::Value(if bump { q + St::ONE } else { q })
+                // overflowing `2r` (`r < d <= MAX`). The truncated `quotient`
+                // stands; the result is positive.
+                let remainder_cmp = remainder.cmp(&(divisor - remainder));
+                let quotient_is_odd = quotient.bit(0);
+                let bump = should_bump(mode, remainder_cmp, quotient_is_odd, true);
+                ExactPin::Value(if bump { quotient + St::ONE } else { quotient })
             }
             None => {
                 // `b^k` overflowed storage ⟹ `b^k > MAX >= 2·10^SCALE`
@@ -175,31 +176,31 @@ pub(crate) fn powi_exact_pin_checked<St: BigInt, const SCALE: u32>(
 /// `|n|` inside the integer fast-path threshold — the shared exponent gate of
 /// [`powi_exact_pin`] and the fractional-base chain.
 pub(crate) fn exp_as_small_int_raw<St: BigInt, const SCALE: u32>(exp: St) -> Option<i32> {
-    let one_s = crate::consts::pow10::dispatch::<St>(SCALE);
-    let (n_big, e_rem) = exp.div_rem(one_s);
-    if e_rem != St::ZERO {
+    let one_at_scale = crate::consts::pow10::dispatch::<St>(SCALE);
+    let (exponent_big, exponent_remainder) = exp.div_rem(one_at_scale);
+    if exponent_remainder != St::ZERO {
         return None;
     }
-    let thresh =
+    let threshold =
         St::from_i128(crate::algos::pow::powf_series_2limb::INT_FAST_PATH_THRESHOLD as i128);
-    if n_big > thresh || n_big < St::ZERO - thresh {
+    if exponent_big > threshold || exponent_big < St::ZERO - threshold {
         return None;
     }
-    Some(n_big.to_i128() as i32)
+    Some(exponent_big.to_i128() as i32)
 }
 
-/// `10^d` in `St`, or `None` past the width (checked ×10 loop — this is a
-/// cold pin path; `d` is bounded by `SCALE·(k+1)` in practice).
-fn checked_pow10<St: BigInt>(d: u32) -> Option<St> {
+/// `10^exponent` in `St`, or `None` past the width (checked ×10 loop — this is
+/// a cold pin path; `exponent` is bounded by `SCALE·(k+1)` in practice).
+fn checked_pow10<St: BigInt>(exponent: u32) -> Option<St> {
     let ten = St::from_i128(10);
-    let mut v = St::ONE;
-    for _ in 0..d {
-        v = v.checked_mul(ten)?;
+    let mut value = St::ONE;
+    for _ in 0..exponent {
+        value = value.checked_mul(ten)?;
     }
-    Some(v)
+    Some(value)
 }
 
-/// `floor(10^e / d)` with remainder, by STREAMING long division — the
+/// `floor(10^exponent / divisor)` with remainder, by STREAMING long division — the
 /// power-of-ten dividend is never materialised, so the reciprocal pin works
 /// at MAX_SCALE where `10^(SCALE+f·k)` itself exceeds the width.
 enum Pow10Div<St> {
@@ -208,38 +209,40 @@ enum Pow10Div<St> {
     /// The quotient exceeds the decimal range — PROOF of overflow (the
     /// quotient only grows as digits stream in).
     OutOfRange,
-    /// `d` is too close to the width for the digit step (`r·10` overflowed) —
-    /// not a proof of anything; the caller defers.
+    /// The `divisor` is too close to the width for the digit step (`r·10`
+    /// overflowed) — not a proof of anything; the caller defers.
     Wide,
 }
 
-fn div_pow10_small<St: BigInt>(e: u32, d: St, storage_max: St) -> Pow10Div<St> {
+fn div_pow10_small<St: BigInt>(exponent: u32, divisor: St, storage_max: St) -> Pow10Div<St> {
     let ten = St::from_i128(10);
-    let (mut q, mut r) = St::ONE.div_rem(d);
-    for _ in 0..e {
-        let r10 = match r.checked_mul(ten) {
-            Some(v) => v,
+    let (mut quotient, mut remainder) = St::ONE.div_rem(divisor);
+    for _ in 0..exponent {
+        let scaled_remainder = match remainder.checked_mul(ten) {
+            Some(value) => value,
             None => return Pow10Div::Wide,
         };
-        let (digit, rr) = r10.div_rem(d); // digit <= 9: r < d ⇒ r·10 < 10·d
-        q = match q.checked_mul(ten).and_then(|v| v.checked_add(digit)) {
-            Some(v) => v,
+        // digit <= 9: r < d ⇒ r·10 < 10·d
+        let (digit, next_remainder) = scaled_remainder.div_rem(divisor);
+        quotient = match quotient.checked_mul(ten).and_then(|value| value.checked_add(digit)) {
+            Some(value) => value,
             None => return Pow10Div::OutOfRange,
         };
-        if q > storage_max {
+        if quotient > storage_max {
             return Pow10Div::OutOfRange;
         }
-        r = rr;
+        remainder = next_remainder;
     }
-    Pow10Div::Q(q, r)
+    Pow10Div::Q(quotient, remainder)
 }
 
-/// Correctly-rounded `base^n` for a TERMINATING-DECIMAL base — the
+/// Correctly-rounded `base^exponent` for a TERMINATING-DECIMAL base — the
 /// fractional-base sibling of [`powi_exact_pin`], reached when that pin
 /// declines (non-integer base). The base is REDUCED to its significant
 /// digits first: `base = m / 10^f` with the trailing zeros of the raw
 /// stripped, so `m` is small for real literals (`2.5 -> m = 25, f = 1`) and
-/// `m^k` never touches a `2·SCALE` product. Then `base^n = m^k / 10^(f·k)`
+/// `m^k` never touches a `2·SCALE` product. Then
+/// `base^exponent = m^k / 10^(f·k)`
 /// (or its reciprocal) is placed on the `SCALE` grid by EXACT integer
 /// arithmetic — a shift when it terminates, a single half-compared rounding
 /// otherwise (ties included), at every scale.
@@ -250,58 +253,59 @@ fn div_pow10_small<St: BigInt>(e: u32, d: St, storage_max: St) -> Pow10Div<St> {
 /// (the proof is in hand), mirroring [`powi_exact_pin`].
 pub(crate) fn powi_terminating_pin<St: BigInt, const SCALE: u32>(
     base: St,
-    n: i32,
+    exponent: i32,
     storage_max: St,
     mode: RoundingMode,
 ) -> Option<St> {
-    debug_assert!(n != 0);
+    debug_assert!(exponent != 0);
     if base <= St::ZERO {
         return None;
     }
-    // Reduce: base raw = m · 10^z, m not divisible by 10; f = significant
-    // fraction length of the VALUE (f <= SCALE; f == 0 means integer base,
-    // which powi_exact_pin already owns but is handled here for totality).
+    // Reduce: base raw = m · 10^trailing_zeros, m not divisible by 10; f =
+    // significant fraction length of the VALUE (f <= SCALE; f == 0 means
+    // integer base, which powi_exact_pin already owns but is handled here for
+    // totality).
     let ten = St::from_i128(10);
     let mut m = base;
-    let mut z = 0u32;
+    let mut trailing_zeros = 0u32;
     loop {
-        let (q, r) = m.div_rem(ten);
-        if r != St::ZERO || z >= SCALE {
+        let (quotient, remainder) = m.div_rem(ten);
+        if remainder != St::ZERO || trailing_zeros >= SCALE {
             break;
         }
-        m = q;
-        z += 1;
+        m = quotient;
+        trailing_zeros += 1;
     }
-    let f = SCALE - z;
-    let k = n.unsigned_abs();
+    let f = SCALE - trailing_zeros;
+    let k = exponent.unsigned_abs();
     let mk = m.checked_pow(k)?; // base's significant digits ^ k — small for real literals
     let fk = f.checked_mul(k)?;
 
     // Round the exact rational `num_pow10 / den` (or `mk · 10^shift`) onto the
     // SCALE grid; `positive` results only (base > 0).
-    let place = |q: St, r: St, d: St| -> St {
-        if r == St::ZERO {
-            return q;
+    let place = |quotient: St, remainder: St, divisor: St| -> St {
+        if remainder == St::ZERO {
+            return quotient;
         }
-        let cmp = r.cmp(&(d - r));
-        let bump = should_bump(mode, cmp, q.bit(0), true);
+        let remainder_cmp = remainder.cmp(&(divisor - remainder));
+        let bump = should_bump(mode, remainder_cmp, quotient.bit(0), true);
         if bump {
-            q + St::ONE
+            quotient + St::ONE
         } else {
-            q
+            quotient
         }
     };
 
-    let v = if n > 0 {
+    let value = if exponent > 0 {
         // base^k = mk / 10^fk; at SCALE the raw is mk · 10^(SCALE - fk) when
         // that shift is non-negative (exact), else a single rounded division.
         if fk <= SCALE {
             mk.checked_mul(checked_pow10::<St>(SCALE - fk)?)?
         } else {
             match checked_pow10::<St>(fk - SCALE) {
-                Some(d) => {
-                    let (q, r) = mk.div_rem(d);
-                    place(q, r, d)
+                Some(divisor) => {
+                    let (quotient, remainder) = mk.div_rem(divisor);
+                    place(quotient, remainder, divisor)
                 }
                 None => {
                     // The divisor exceeds the width while mk fits: the result
@@ -322,14 +326,14 @@ pub(crate) fn powi_terminating_pin<St: BigInt, const SCALE: u32>(
         // non-terminating reciprocals alike (1.5^-1 = 0.666...). When the
         // power-of-ten numerator exceeds the width (MAX_SCALE cells), the
         // division streams digit-by-digit instead.
-        let e = SCALE.checked_add(fk)?;
-        match checked_pow10::<St>(e) {
-            Some(num) => {
-                let (q, r) = num.div_rem(mk);
-                place(q, r, mk)
+        let pow10_exponent = SCALE.checked_add(fk)?;
+        match checked_pow10::<St>(pow10_exponent) {
+            Some(numerator) => {
+                let (quotient, remainder) = numerator.div_rem(mk);
+                place(quotient, remainder, mk)
             }
-            None => match div_pow10_small::<St>(e, mk, storage_max) {
-                Pow10Div::Q(q, r) => place(q, r, mk),
+            None => match div_pow10_small::<St>(pow10_exponent, mk, storage_max) {
+                Pow10Div::Q(quotient, remainder) => place(quotient, remainder, mk),
                 Pow10Div::OutOfRange => crate::support::diagnostics::overflow_panic_with_scale(
                     "powf kernel",
                     SCALE,
@@ -338,12 +342,12 @@ pub(crate) fn powi_terminating_pin<St: BigInt, const SCALE: u32>(
             },
         }
     };
-    if v > storage_max {
+    if value > storage_max {
         // Exact arithmetic put the correctly-rounded result beyond the
         // decimal range — proof of overflow; the contract panics.
         crate::support::diagnostics::overflow_panic_with_scale("powf kernel", SCALE)
     }
-    Some(v)
+    Some(value)
 }
 
 #[cfg(test)]
@@ -353,9 +357,10 @@ mod tests {
 
     #[test]
     fn terminating_pin_exact_ties_and_reciprocals() {
-        let pin = |base: i128, n: i32, mode: RoundingMode| {
-            powi_terminating_pin::<Int<2>, 2>(Int::<2>::from_i128(base), n, Int::<2>::MAX, mode)
-                .map(|v| v.as_i128())
+        let pin = |base: i128, exponent: i32, mode: RoundingMode| {
+            powi_terminating_pin::<Int<2>, 2>(
+                Int::<2>::from_i128(base), exponent, Int::<2>::MAX, mode)
+                .map(|value| value.as_i128())
         };
         for mode in MODES {
             // 2.5^2 = 6.25 at scale 2 — exact at every mode.
@@ -370,9 +375,10 @@ mod tests {
         assert_eq!(pin(150, 3, RoundingMode::Ceiling), Some(338));
         // 0.5^-2 = 4 at MAX-scale-like cells: 10^(SCALE+2) exceeds i128, so
         // the reciprocal streams its long division (the gate4 residue).
-        let pin37 = |base: i128, n: i32, mode: RoundingMode| {
-            powi_terminating_pin::<Int<2>, 37>(Int::<2>::from_i128(base), n, Int::<2>::MAX, mode)
-                .map(|v| v.as_i128())
+        let pin37 = |base: i128, exponent: i32, mode: RoundingMode| {
+            powi_terminating_pin::<Int<2>, 37>(
+                Int::<2>::from_i128(base), exponent, Int::<2>::MAX, mode)
+                .map(|value| value.as_i128())
         };
         let half_raw = 5 * 10_i128.pow(36);
         for mode in MODES {
@@ -405,7 +411,7 @@ mod tests {
             Int::<2>::MAX,
             mode,
         )
-        .map(|v| v.as_i128())
+        .map(|value| value.as_i128())
     }
 
     /// Pin on integer `base`/`exp` values, scaled to `SC` internally.
@@ -442,14 +448,14 @@ mod tests {
 
     #[test]
     fn inexact_reciprocal_rounds_each_direction() {
-        // 1/3 = 0.333…3̅ at scale 37: q = floor(10^37 / 3), remainder 1 (< half),
-        // so the directed/nearest split is the LSB.
-        let q = 10_i128.pow(37) / 3; // 333…3 (37 threes)
+        // 1/3 = 0.333…3̅ at scale 37: quotient = floor(10^37 / 3), remainder 1
+        // (< half), so the directed/nearest split is the LSB.
+        let quotient = 10_i128.pow(37) / 3; // 333…3 (37 threes)
         // remainder 10^37 mod 3 == 1, strictly below half → round down except Ceiling.
-        assert_eq!(pin::<37>(3, -1, RoundingMode::Floor), Some(q));
-        assert_eq!(pin::<37>(3, -1, RoundingMode::Trunc), Some(q));
-        assert_eq!(pin::<37>(3, -1, RoundingMode::HalfToEven), Some(q));
-        assert_eq!(pin::<37>(3, -1, RoundingMode::Ceiling), Some(q + 1));
+        assert_eq!(pin::<37>(3, -1, RoundingMode::Floor), Some(quotient));
+        assert_eq!(pin::<37>(3, -1, RoundingMode::Trunc), Some(quotient));
+        assert_eq!(pin::<37>(3, -1, RoundingMode::HalfToEven), Some(quotient));
+        assert_eq!(pin::<37>(3, -1, RoundingMode::Ceiling), Some(quotient + 1));
     }
 
     #[test]

--- a/src/algos/rem/rem_int_layer.rs
+++ b/src/algos/rem/rem_int_layer.rs
@@ -18,10 +18,11 @@ use crate::int::types::Int;
 /// same-SCALE operands share the scale factor.
 ///
 /// A value-gated small-operand fast path runs FIRST: when both operand
-/// Two value-gated fast paths run FIRST. (1) When `|a| < |b|` the truncating
-/// remainder is the dividend itself (`a % b == a`), returned after one
+/// Two value-gated fast paths run FIRST. (1) When `|dividend| < |divisor|`
+/// the truncating remainder is the dividend itself
+/// (`dividend % divisor == dividend`), returned after one
 /// top-down magnitude compare — no divide, no scratch. This is the dominant
-/// decimal-`rem` benchmarked shape (`x % b` with `|x| < |b|`, e.g. `2.0 % 3.5`) and it
+/// decimal-`rem` benchmarked shape (`x % y` with `|x| < |y|`, e.g. `2.0 % 3.5`) and it
 /// catches the cases the u128 probe misses (a scaled divisor crossing the
 /// 128-bit line while the dividend stays smaller — D76 s38 onward).
 /// (2) When both operand magnitudes fit a single 128-bit word it takes a
@@ -55,7 +56,7 @@ use crate::int::types::Int;
 ///
 /// [`div_knuth_into`]: crate::int::algos::div::div_knuth::div_knuth_into
 #[inline]
-pub(crate) fn rem_int_layer<const N: usize>(a: Int<N>, b: Int<N>) -> Int<N>
+pub(crate) fn rem_int_layer<const N: usize>(dividend: Int<N>, divisor: Int<N>) -> Int<N>
 where
     Limbs<N>: ComputeLimbs,
 {
@@ -63,33 +64,34 @@ where
     // BOTH debug and release (the default operator never silently wraps to
     // `0`): detect it with cheap comparisons (no divide) and panic before
     // the divide wraps it.
-    if a == Int::<N>::MIN && b == -Int::<N>::ONE {
+    if dividend == Int::<N>::MIN && divisor == -Int::<N>::ONE {
         panic!("attempt to calculate the remainder with overflow");
     }
     assert!(
-        !b.is_zero(),
+        !divisor.is_zero(),
         "attempt to calculate the remainder with a divisor of zero"
     );
 
     // Truncating-toward-zero: the remainder carries the dividend's sign.
-    let neg_r = a.is_negative();
-    let a_abs = a.unsigned_abs();
-    let b_abs = b.unsigned_abs();
+    let remainder_is_negative = dividend.is_negative();
+    let dividend_abs = dividend.unsigned_abs();
+    let divisor_abs = divisor.unsigned_abs();
 
-    // Dividend-smaller short-circuit: when `|a| < |b|` the truncating
-    // remainder is the dividend itself (`a % b == a`), so return `a`
+    // Dividend-smaller short-circuit: when `|dividend| < |divisor|` the
+    // truncating remainder is the dividend itself
+    // (`dividend % divisor == dividend`), so return `dividend`
     // unchanged — no divide, no scratch, no shape classifier. This is one
     // top-down `N`-limb magnitude compare (`Uint::cmp`), correct for EVERY
     // `N` and operand value, and it catches the dominant decimal-`rem` shape
-    // the u128 fast path below MISSES: a balanced-magnitude `x % b` where the
+    // the u128 fast path below MISSES: a balanced-magnitude `x % y` where the
     // SCALED divisor crosses the 128-bit line (e.g. the benchmarked `2.0 % 3.5` cell
     // at D76 s38: `2·10^38` fits a u128 but `3.5·10^38` is 129 bits, so the
     // u128 probe fails and the operands fall into a full multi-limb Knuth
     // divmod whose `top < n` early-out the compare reaches first, for free).
-    // Bit-identical to the divmod (which also yields `rem == a` here), so it
+    // Bit-identical to the divmod (which also yields the dividend here), so it
     // only changes which path runs, never the result.
-    if a_abs < b_abs {
-        return a;
+    if dividend_abs < divisor_abs {
+        return dividend;
     }
 
     // Small-operand fast path (single-word, applied generically across
@@ -103,8 +105,8 @@ where
     // (the magnitude check guarantees the `u128` load is lossless), so valid
     // at every `N >= 3`. The MIN%-1 hazard cannot reach here (magnitudes are
     // unsigned, the divisor magnitude is `>= 1`).
-    let al = a_abs.as_limbs();
-    let bl = b_abs.as_limbs();
+    let dividend_limbs = dividend_abs.as_limbs();
+    let divisor_limbs = divisor_abs.as_limbs();
     // Probe whether both magnitudes fit one 128-bit word (every limb above
     // index 1 zero). Break on the FIRST set high limb so a full-width operand
     // pays only a couple of comparisons before falling through to the divmod
@@ -112,44 +114,44 @@ where
     let mut fits = true;
     let mut i = 2;
     while i < N {
-        if al[i] != 0 || bl[i] != 0 {
+        if dividend_limbs[i] != 0 || divisor_limbs[i] != 0 {
             fits = false;
             break;
         }
         i += 1;
     }
     if fits {
-        let a_hi = if N >= 2 { al[1] as u128 } else { 0 };
-        let b_hi = if N >= 2 { bl[1] as u128 } else { 0 };
-        let a_u = (al[0] as u128) | (a_hi << 64);
-        let b_u = (bl[0] as u128) | (b_hi << 64);
-        let r = a_u % b_u;
-        let mut rem = [0u64; N];
-        rem[0] = r as u64;
+        let dividend_hi = if N >= 2 { dividend_limbs[1] as u128 } else { 0 };
+        let divisor_hi = if N >= 2 { divisor_limbs[1] as u128 } else { 0 };
+        let dividend_u128 = (dividend_limbs[0] as u128) | (dividend_hi << 64);
+        let divisor_u128 = (divisor_limbs[0] as u128) | (divisor_hi << 64);
+        let remainder_u128 = dividend_u128 % divisor_u128;
+        let mut remainder_limbs = [0u64; N];
+        remainder_limbs[0] = remainder_u128 as u64;
         if N >= 2 {
-            rem[1] = (r >> 64) as u64;
+            remainder_limbs[1] = (remainder_u128 >> 64) as u64;
         }
-        return Int::<N>::from_mag_limbs(&rem, neg_r);
+        return Int::<N>::from_mag_limbs(&remainder_limbs, remainder_is_negative);
     }
 
-    divmod_mags::<N>(&a_abs, &b_abs, neg_r)
+    divmod_mags::<N>(&dividend_abs, &divisor_abs, remainder_is_negative)
 }
 
 /// The exact-scratch Knuth divmod remainder core. Operates on precomputed
-/// unsigned magnitudes (`a_abs`, `b_abs`) and the dividend sign (`neg_r`),
-/// so both [`rem_int_layer`] (fast-path miss) and
+/// unsigned magnitudes (`dividend_abs`, `divisor_abs`) and the dividend sign
+/// (`remainder_is_negative`), so both [`rem_int_layer`] (fast-path miss) and
 /// [`rem_int_layer_divmod`] (fast-path-free, for the microbench) share it.
 #[inline]
 fn divmod_mags<const N: usize>(
-    a_abs: &crate::int::types::Uint<N>,
-    b_abs: &crate::int::types::Uint<N>,
-    neg_r: bool,
+    dividend_abs: &crate::int::types::Uint<N>,
+    divisor_abs: &crate::int::types::Uint<N>,
+    remainder_is_negative: bool,
 ) -> Int<N>
 where
     Limbs<N>: ComputeLimbs,
 {
-    let mut quot = [0u64; N];
-    let mut rem = [0u64; N];
+    let mut quotient = [0u64; N];
+    let mut remainder = [0u64; N];
     // Exact per-`N` Knuth scratch: `single_buffered_u64` is `[u64; N + 2]`, covering
     // the normalised dividend `u` (`num.len() + 2`) and divisor `v`.
     let mut u = Limbs::<N>::single_buffered_u64();
@@ -159,7 +161,7 @@ where
     // `Int<N>`, so the wide `num ≥ 2·den` u128 shape IS reachable at wide
     // `N` — honor that verdict rather than collapse
     // it onto Knuth.
-    match select_for_limbs(a_abs.as_limbs(), b_abs.as_limbs()) {
+    match select_for_limbs(dividend_abs.as_limbs(), divisor_abs.as_limbs()) {
         Algorithm::KnuthU128Limb => {
             // Operands are ≤ `N` limbs (one family step below
             // `div_widen_scale`'s `2N` dividend): the engine's minima are
@@ -169,10 +171,10 @@ where
             let mut u128_u = Limbs::<N>::double_u128();
             let mut u128_v = Limbs::<N>::single_u128();
             div_knuth_u128_limb_into(
-                a_abs.as_limbs(),
-                b_abs.as_limbs(),
-                &mut quot,
-                &mut rem,
+                dividend_abs.as_limbs(),
+                divisor_abs.as_limbs(),
+                &mut quotient,
+                &mut remainder,
                 u.as_mut(),
                 v.as_mut(),
                 u128_u.as_mut(),
@@ -183,15 +185,15 @@ where
         | Algorithm::Knuth
         | Algorithm::BurnikelZieglerWithKnuth
         | Algorithm::Schoolbook => div_knuth_into(
-            a_abs.as_limbs(),
-            b_abs.as_limbs(),
-            &mut quot,
-            &mut rem,
+            dividend_abs.as_limbs(),
+            divisor_abs.as_limbs(),
+            &mut quotient,
+            &mut remainder,
             u.as_mut(),
             v.as_mut(),
         ),
     }
-    Int::<N>::from_mag_limbs(&rem, neg_r)
+    Int::<N>::from_mag_limbs(&remainder, remainder_is_negative)
 }
 
 /// The fast-path-FREE remainder: identical validation to [`rem_int_layer`]
@@ -200,21 +202,21 @@ where
 /// exposed only so the microbench can A/B the fast path's contribution
 /// against the divmod-only path it guards.
 #[inline]
-pub(crate) fn rem_int_layer_divmod<const N: usize>(a: Int<N>, b: Int<N>) -> Int<N>
+pub(crate) fn rem_int_layer_divmod<const N: usize>(dividend: Int<N>, divisor: Int<N>) -> Int<N>
 where
     Limbs<N>: ComputeLimbs,
 {
-    if a == Int::<N>::MIN && b == -Int::<N>::ONE {
+    if dividend == Int::<N>::MIN && divisor == -Int::<N>::ONE {
         panic!("attempt to calculate the remainder with overflow");
     }
     assert!(
-        !b.is_zero(),
+        !divisor.is_zero(),
         "attempt to calculate the remainder with a divisor of zero"
     );
-    let neg_r = a.is_negative();
-    let a_abs = a.unsigned_abs();
-    let b_abs = b.unsigned_abs();
-    divmod_mags::<N>(&a_abs, &b_abs, neg_r)
+    let remainder_is_negative = dividend.is_negative();
+    let dividend_abs = dividend.unsigned_abs();
+    let divisor_abs = divisor.unsigned_abs();
+    divmod_mags::<N>(&dividend_abs, &divisor_abs, remainder_is_negative)
 }
 
 #[cfg(test)]
@@ -242,36 +244,36 @@ mod tests {
             (i128::MAX, 3),
             (i128::MIN + 1, 7),
         ];
-        for &(a, b) in small {
-            let ia = Int::<3>::from_i128(a);
-            let ib = Int::<3>::from_i128(b);
+        for &(dividend, divisor) in small {
+            let dividend_int = Int::<3>::from_i128(dividend);
+            let divisor_int = Int::<3>::from_i128(divisor);
             assert_eq!(
-                rem_int_layer::<3>(ia, ib),
-                rem_int_layer_divmod::<3>(ia, ib),
-                "fast path ({a} % {b}) at N=3"
+                rem_int_layer::<3>(dividend_int, divisor_int),
+                rem_int_layer_divmod::<3>(dividend_int, divisor_int),
+                "fast path ({dividend} % {divisor}) at N=3"
             );
             // also a wide storage width
-            let ja = Int::<16>::from_i128(a);
-            let jb = Int::<16>::from_i128(b);
+            let dividend_wide = Int::<16>::from_i128(dividend);
+            let divisor_wide = Int::<16>::from_i128(divisor);
             assert_eq!(
-                rem_int_layer::<16>(ja, jb),
-                rem_int_layer_divmod::<16>(ja, jb),
-                "fast path ({a} % {b}) at N=16"
+                rem_int_layer::<16>(dividend_wide, divisor_wide),
+                rem_int_layer_divmod::<16>(dividend_wide, divisor_wide),
+                "fast path ({dividend} % {divisor}) at N=16"
             );
         }
 
         // Full-width operands (span all limbs) — the fall-through branch.
-        let mut a_lim = [0u64; 8];
-        let mut b_lim = [0u64; 8];
+        let mut dividend_limbs = [0u64; 8];
+        let mut divisor_limbs = [0u64; 8];
         for i in 0..8 {
-            a_lim[i] = 0x9E37_79B9_7F4A_7C15u64.wrapping_mul(i as u64 + 1);
-            b_lim[i] = 0xD1B5_4A32_D192_ED03u64.wrapping_mul(i as u64 + 3);
+            dividend_limbs[i] = 0x9E37_79B9_7F4A_7C15u64.wrapping_mul(i as u64 + 1);
+            divisor_limbs[i] = 0xD1B5_4A32_D192_ED03u64.wrapping_mul(i as u64 + 3);
         }
-        let ia = Int::<8>::from_mag_limbs(&a_lim, false);
-        let ib = Int::<8>::from_mag_limbs(&b_lim, true); // negative divisor
+        let dividend_int = Int::<8>::from_mag_limbs(&dividend_limbs, false);
+        let divisor_int = Int::<8>::from_mag_limbs(&divisor_limbs, true); // negative divisor
         assert_eq!(
-            rem_int_layer::<8>(ia, ib),
-            rem_int_layer_divmod::<8>(ia, ib),
+            rem_int_layer::<8>(dividend_int, divisor_int),
+            rem_int_layer_divmod::<8>(dividend_int, divisor_int),
             "full-width fall-through"
         );
     }
@@ -306,49 +308,52 @@ mod tests {
         let shapes: &[(usize, usize)] = &[(64, 24), (64, 32), (48, 24), (56, 28), (50, 24)];
         for (case, &(num_n, den_n)) in shapes.iter().enumerate() {
             for round in 0..8 {
-                let mut a_lim = [0u64; N];
-                let mut b_lim = [0u64; N];
-                for x in a_lim[..num_n].iter_mut() {
-                    *x = next();
+                let mut dividend_limbs = [0u64; N];
+                let mut divisor_limbs = [0u64; N];
+                for limb in dividend_limbs[..num_n].iter_mut() {
+                    *limb = next();
                 }
-                for x in b_lim[..den_n].iter_mut() {
-                    *x = next();
+                for limb in divisor_limbs[..den_n].iter_mut() {
+                    *limb = next();
                 }
                 // Keep the dividend magnitude in signed-positive range when
                 // it spans all N limbs, and pin both top limbs nonzero so
                 // the significant lengths are exactly (num_n, den_n).
                 if num_n == N {
-                    a_lim[N - 1] &= !(1u64 << 63);
+                    dividend_limbs[N - 1] &= !(1u64 << 63);
                 }
-                a_lim[num_n - 1] |= 1;
-                b_lim[den_n - 1] |= 1;
+                dividend_limbs[num_n - 1] |= 1;
+                divisor_limbs[den_n - 1] |= 1;
 
                 // The pair must provably route to the u128 engine — this is
                 // what makes the test exercise the new arm, not Knuth.
                 assert!(
-                    select_for_limbs(&a_lim, &b_lim) == Algorithm::KnuthU128Limb,
+                    select_for_limbs(&dividend_limbs, &divisor_limbs)
+                        == Algorithm::KnuthU128Limb,
                     "case {case}: ({num_n},{den_n}) sig limbs must route to KnuthU128Limb"
                 );
 
                 // Reference remainder: the base-2^64 Knuth engine on the
                 // same magnitudes (zeroed u/v, >= num.len()+2 / den.len()).
-                let mut quot = [0u64; N];
-                let mut rem = [0u64; N];
+                let mut quotient = [0u64; N];
+                let mut remainder = [0u64; N];
                 let mut u = [0u64; N + 2];
                 let mut v = [0u64; N + 2];
-                div_knuth_into(&a_lim, &b_lim, &mut quot, &mut rem, &mut u, &mut v);
+                div_knuth_into(
+                    &dividend_limbs, &divisor_limbs,
+                    &mut quotient, &mut remainder, &mut u, &mut v);
 
                 // All four sign combinations; the remainder carries the
                 // dividend's sign.
-                let a_neg = round & 1 == 1;
-                let b_neg = round & 2 == 2;
-                let ia = Int::<N>::from_mag_limbs(&a_lim, a_neg);
-                let ib = Int::<N>::from_mag_limbs(&b_lim, b_neg);
-                let expected = Int::<N>::from_mag_limbs(&rem, a_neg);
+                let dividend_is_negative = round & 1 == 1;
+                let divisor_is_negative = round & 2 == 2;
+                let dividend_int = Int::<N>::from_mag_limbs(&dividend_limbs, dividend_is_negative);
+                let divisor_int = Int::<N>::from_mag_limbs(&divisor_limbs, divisor_is_negative);
+                let expected = Int::<N>::from_mag_limbs(&remainder, dividend_is_negative);
                 assert_eq!(
-                    rem_int_layer::<N>(ia, ib),
+                    rem_int_layer::<N>(dividend_int, divisor_int),
                     expected,
-                    "case {case} round {round}: ({num_n},{den_n}) a_neg={a_neg} b_neg={b_neg}"
+                    "case {case} round {round}: ({num_n},{den_n}) a_neg={dividend_is_negative} b_neg={divisor_is_negative}"
                 );
             }
         }

--- a/src/algos/rem/rem_native.rs
+++ b/src/algos/rem/rem_native.rs
@@ -6,7 +6,8 @@
 //!
 //! Same-`SCALE` decimal remainder needs no rescaling: both operands carry the
 //! same `10^SCALE` factor, so the storage-level remainder IS the answer
-//! (`(a / 10^S) rem (b / 10^S) == (a rem b) / 10^S`). For narrow storage the
+//! (`(dividend / 10^S) rem (divisor / 10^S) == (dividend rem divisor) /
+//! 10^S`). For narrow storage the
 //! storage value fits a single hardware integer, so the remainder is a direct
 //! primitive `%`:
 //!
@@ -37,31 +38,31 @@ use crate::int::types::Int;
 
 /// Hardware-`%` decimal remainder for narrow storage (`N <= 2`).
 ///
-/// Computes `a % b` on the storage values. Panics on a zero divisor and on
-/// the `MIN % -ONE` overflow boundary in BOTH debug and release, matching the
-/// generic `rem_int_layer` default-operator contract.
+/// Computes `dividend % divisor` on the storage values. Panics on a zero
+/// divisor and on the `MIN % -ONE` overflow boundary in BOTH debug and
+/// release, matching the generic `rem_int_layer` default-operator contract.
 #[inline]
 #[must_use]
-pub(crate) fn rem_native<const N: usize>(a: Int<N>, b: Int<N>) -> Int<N> {
+pub(crate) fn rem_native<const N: usize>(dividend: Int<N>, divisor: Int<N>) -> Int<N> {
     assert!(
-        !b.is_zero(),
+        !divisor.is_zero(),
         "attempt to calculate the remainder with a divisor of zero"
     );
     if N == 1 {
-        let ai = a.to_i128() as i64;
-        let bi = b.to_i128() as i64;
-        if ai == i64::MIN && bi == -1 {
+        let dividend_raw = dividend.to_i128() as i64;
+        let divisor_raw = divisor.to_i128() as i64;
+        if dividend_raw == i64::MIN && divisor_raw == -1 {
             panic!("attempt to calculate the remainder with overflow");
         }
-        return Int::<N>::from_i128(ai.wrapping_rem(bi) as i128);
+        return Int::<N>::from_i128(dividend_raw.wrapping_rem(divisor_raw) as i128);
     }
     // N == 2 (D38): native i128 %.
-    let ai = a.to_i128();
-    let bi = b.to_i128();
-    if ai == i128::MIN && bi == -1 {
+    let dividend_raw = dividend.to_i128();
+    let divisor_raw = divisor.to_i128();
+    if dividend_raw == i128::MIN && divisor_raw == -1 {
         panic!("attempt to calculate the remainder with overflow");
     }
-    Int::<N>::from_i128(ai.wrapping_rem(bi))
+    Int::<N>::from_i128(dividend_raw.wrapping_rem(divisor_raw))
 }
 
 #[cfg(test)]
@@ -83,9 +84,13 @@ mod tests {
             (i64::MIN + 1, 2),
             (i64::MIN, 7),
         ];
-        for &(a, b) in cases {
-            let got = rem_native::<1>(Int::<1>::from_i64(a), Int::<1>::from_i64(b));
-            assert_eq!(got.to_i128() as i64, a % b, "rem_native n1 ({a}, {b})");
+        for &(dividend, divisor) in cases {
+            let got = rem_native::<1>(Int::<1>::from_i64(dividend), Int::<1>::from_i64(divisor));
+            assert_eq!(
+                got.to_i128() as i64,
+                dividend % divisor,
+                "rem_native n1 ({dividend}, {divisor})"
+            );
         }
     }
 
@@ -100,9 +105,13 @@ mod tests {
             (i128::MIN + 1, 3),
             (1_000_000_000_000_i128, 999_999_937),
         ];
-        for &(a, b) in cases {
-            let got = rem_native::<2>(Int::<2>::from_i128(a), Int::<2>::from_i128(b));
-            assert_eq!(got.to_i128(), a % b, "rem_native n2 ({a}, {b})");
+        for &(dividend, divisor) in cases {
+            let got = rem_native::<2>(Int::<2>::from_i128(dividend), Int::<2>::from_i128(divisor));
+            assert_eq!(
+                got.to_i128(),
+                dividend % divisor,
+                "rem_native n2 ({dividend}, {divisor})"
+            );
         }
     }
 }

--- a/src/algos/schoolbook_tests.rs
+++ b/src/algos/schoolbook_tests.rs
@@ -11,12 +11,12 @@ mod tests {
     use crate::int::types::Int;
     use crate::support::rounding::RoundingMode;
 
-    fn i1(v: i64) -> Int<1> {
-        Int::<1>::from_i64(v)
+    fn i1(value: i64) -> Int<1> {
+        Int::<1>::from_i64(value)
     }
 
-    fn i2(v: i128) -> Int<2> {
-        Int::<2>::from_i128(v)
+    fn i2(value: i128) -> Int<2> {
+        Int::<2>::from_i128(value)
     }
 
     // -- add_int_layer (Schoolbook = IntLayer for add) --
@@ -24,8 +24,8 @@ mod tests {
     #[test]
     fn add_schoolbook_identity_int1() {
         use crate::algos::add::add_int_layer::add_int_layer;
-        let a = i1(123456);
-        assert_eq!(add_int_layer::<1>(a, i1(0)), a);
+        let lhs = i1(123456);
+        assert_eq!(add_int_layer::<1>(lhs, i1(0)), lhs);
     }
 
     #[test]
@@ -45,8 +45,8 @@ mod tests {
     #[test]
     fn sub_schoolbook_identity_int1() {
         use crate::algos::sub::sub_int_layer::sub_int_layer;
-        let a = i1(99900);
-        assert_eq!(sub_int_layer::<1>(a, i1(0)), a);
+        let lhs = i1(99900);
+        assert_eq!(sub_int_layer::<1>(lhs, i1(0)), lhs);
     }
 
     #[test]
@@ -78,8 +78,8 @@ mod tests {
     #[test]
     fn neg_schoolbook_double_identity_int2() {
         use crate::algos::neg::neg_int_layer::neg_int_layer;
-        let v = i2(123_456_789_012);
-        assert_eq!(neg_int_layer::<2>(neg_int_layer::<2>(v)), v);
+        let value = i2(123_456_789_012);
+        assert_eq!(neg_int_layer::<2>(neg_int_layer::<2>(value)), value);
     }
 
     // -- rem_int_layer (Schoolbook = IntLayer for rem) --
@@ -105,9 +105,9 @@ mod tests {
     #[test]
     fn rem_schoolbook_int2() {
         use crate::algos::rem::rem_int_layer::rem_int_layer;
-        let a = i2(1_000_000_000_000_000_007);
-        let b = i2(1_000_000_000_000_000_000);
-        assert_eq!(rem_int_layer::<2>(a, b), i2(7));
+        let dividend = i2(1_000_000_000_000_000_007);
+        let divisor = i2(1_000_000_000_000_000_000);
+        assert_eq!(rem_int_layer::<2>(dividend, divisor), i2(7));
     }
 
     // -- mul_schoolbook --
@@ -115,15 +115,15 @@ mod tests {
     #[test]
     fn mul_schoolbook_basic_scale2() {
         use crate::algos::mul::mul_schoolbook::mul_schoolbook;
-        let r = mul_schoolbook::<1, 2>(i1(150), i1(200), RoundingMode::HalfToEven);
-        assert_eq!(r, i1(300));
+        let product = mul_schoolbook::<1, 2>(i1(150), i1(200), RoundingMode::HalfToEven);
+        assert_eq!(product, i1(300));
     }
 
     #[test]
     fn mul_schoolbook_neg_pos() {
         use crate::algos::mul::mul_schoolbook::mul_schoolbook;
-        let r = mul_schoolbook::<1, 2>(i1(-200), i1(300), RoundingMode::HalfToEven);
-        assert_eq!(r, i1(-600));
+        let product = mul_schoolbook::<1, 2>(i1(-200), i1(300), RoundingMode::HalfToEven);
+        assert_eq!(product, i1(-600));
     }
 
     #[test]
@@ -147,8 +147,8 @@ mod tests {
     #[test]
     fn mul_schoolbook_scale4_exact() {
         use crate::algos::mul::mul_schoolbook::mul_schoolbook;
-        let r = mul_schoolbook::<1, 4>(i1(12500), i1(40000), RoundingMode::HalfToEven);
-        assert_eq!(r, i1(50000));
+        let product = mul_schoolbook::<1, 4>(i1(12500), i1(40000), RoundingMode::HalfToEven);
+        assert_eq!(product, i1(50000));
     }
 
     #[test]
@@ -160,14 +160,14 @@ mod tests {
             (1_000_000, 2_000_000), (1_500_000, 3_000_000), (-1_000_000, 2_000_000),
             (1_234_567, 9_876_543), (999_999_999, 1),
         ];
-        for &(ra, rb) in cases {
-            let a = i2(ra);
-            let b = i2(rb);
+        for &(lhs_raw, rhs_raw) in cases {
+            let lhs = i2(lhs_raw);
+            let rhs = i2(rhs_raw);
             for mode in [RoundingMode::HalfToEven, RoundingMode::HalfAwayFromZero,
                 RoundingMode::Floor, RoundingMode::Ceiling, RoundingMode::Trunc, RoundingMode::HalfTowardZero] {
-                let sb = mul_schoolbook::<2, SCALE>(a, b, mode);
-                let wd = mul_widen_divide::<2, SCALE>(a, b, mode);
-                assert_eq!(sb, wd);
+                let schoolbook = mul_schoolbook::<2, SCALE>(lhs, rhs, mode);
+                let widen_divide = mul_widen_divide::<2, SCALE>(lhs, rhs, mode);
+                assert_eq!(schoolbook, widen_divide);
             }
         }
     }
@@ -177,48 +177,48 @@ mod tests {
     #[test]
     fn div_schoolbook_basic_scale2() {
         use crate::algos::div::div_schoolbook::div_schoolbook;
-        let r = div_schoolbook::<1>(i1(600), i1(200), i1(100), RoundingMode::HalfToEven);
-        assert_eq!(r, i1(300));
+        let quotient = div_schoolbook::<1>(i1(600), i1(200), i1(100), RoundingMode::HalfToEven);
+        assert_eq!(quotient, i1(300));
     }
 
     #[test]
     fn div_schoolbook_floor_truncation() {
         use crate::algos::div::div_schoolbook::div_schoolbook;
-        let r = div_schoolbook::<1>(i1(100), i1(300), i1(100), RoundingMode::Floor);
-        assert_eq!(r, i1(33));
+        let quotient = div_schoolbook::<1>(i1(100), i1(300), i1(100), RoundingMode::Floor);
+        assert_eq!(quotient, i1(33));
     }
 
     #[test]
     fn div_schoolbook_ceiling_rounding() {
         use crate::algos::div::div_schoolbook::div_schoolbook;
-        let r = div_schoolbook::<1>(i1(100), i1(300), i1(100), RoundingMode::Ceiling);
-        assert_eq!(r, i1(34));
+        let quotient = div_schoolbook::<1>(i1(100), i1(300), i1(100), RoundingMode::Ceiling);
+        assert_eq!(quotient, i1(34));
     }
 
     #[test]
     fn div_schoolbook_negative_dividend() {
         use crate::algos::div::div_schoolbook::div_schoolbook;
-        let r = div_schoolbook::<1>(i1(-600), i1(200), i1(100), RoundingMode::HalfToEven);
-        assert_eq!(r, i1(-300));
+        let quotient = div_schoolbook::<1>(i1(-600), i1(200), i1(100), RoundingMode::HalfToEven);
+        assert_eq!(quotient, i1(-300));
     }
 
     #[test]
     fn div_schoolbook_exact_half() {
         use crate::algos::div::div_schoolbook::div_schoolbook;
-        let r = div_schoolbook::<1>(i1(100), i1(200), i1(100), RoundingMode::HalfToEven);
-        assert_eq!(r, i1(50));
+        let quotient = div_schoolbook::<1>(i1(100), i1(200), i1(100), RoundingMode::HalfToEven);
+        assert_eq!(quotient, i1(50));
     }
 
     #[test]
     fn div_schoolbook_all_modes_one_third() {
         use crate::algos::div::div_schoolbook::div_schoolbook;
-        let (a, b, mult) = (i1(100), i1(300), i1(100));
-        assert_eq!(div_schoolbook::<1>(a, b, mult, RoundingMode::Floor), i1(33));
-        assert_eq!(div_schoolbook::<1>(a, b, mult, RoundingMode::Ceiling), i1(34));
-        assert_eq!(div_schoolbook::<1>(a, b, mult, RoundingMode::Trunc), i1(33));
-        assert_eq!(div_schoolbook::<1>(a, b, mult, RoundingMode::HalfTowardZero), i1(33));
-        assert_eq!(div_schoolbook::<1>(a, b, mult, RoundingMode::HalfToEven), i1(33));
-        assert_eq!(div_schoolbook::<1>(a, b, mult, RoundingMode::HalfAwayFromZero), i1(33));
+        let (dividend, divisor, multiplier) = (i1(100), i1(300), i1(100));
+        assert_eq!(div_schoolbook::<1>(dividend, divisor, multiplier, RoundingMode::Floor), i1(33));
+        assert_eq!(div_schoolbook::<1>(dividend, divisor, multiplier, RoundingMode::Ceiling), i1(34));
+        assert_eq!(div_schoolbook::<1>(dividend, divisor, multiplier, RoundingMode::Trunc), i1(33));
+        assert_eq!(div_schoolbook::<1>(dividend, divisor, multiplier, RoundingMode::HalfTowardZero), i1(33));
+        assert_eq!(div_schoolbook::<1>(dividend, divisor, multiplier, RoundingMode::HalfToEven), i1(33));
+        assert_eq!(div_schoolbook::<1>(dividend, divisor, multiplier, RoundingMode::HalfAwayFromZero), i1(33));
     }
 
     #[test]
@@ -226,19 +226,19 @@ mod tests {
         use crate::algos::div::div_schoolbook::div_schoolbook;
         use crate::algos::div::div_widen_scale::div_widen_scale;
         const SCALE: u32 = 6;
-        let mult = Int::<2>::TEN.pow(SCALE);
+        let multiplier = Int::<2>::TEN.pow(SCALE);
         let cases: &[(i128, i128)] = &[
             (2_000_000, 1_000_000), (1_000_000, 3_000_000), (7_000_000, 2_000_000),
             (-5_000_000, 2_000_000), (1_234_567, 9_876_543),
         ];
-        for &(ra, rb) in cases {
-            let a = i2(ra);
-            let b = i2(rb);
+        for &(dividend_raw, divisor_raw) in cases {
+            let dividend = i2(dividend_raw);
+            let divisor = i2(divisor_raw);
             for mode in [RoundingMode::HalfToEven, RoundingMode::HalfAwayFromZero,
                 RoundingMode::Floor, RoundingMode::Ceiling, RoundingMode::Trunc, RoundingMode::HalfTowardZero] {
-                let sb = div_schoolbook::<2>(a, b, mult, mode);
-                let wd = div_widen_scale::<2>(a, b, mult, mode);
-                assert_eq!(sb, wd);
+                let schoolbook = div_schoolbook::<2>(dividend, divisor, multiplier, mode);
+                let widen_scale = div_widen_scale::<2>(dividend, divisor, multiplier, mode);
+                assert_eq!(schoolbook, widen_scale);
             }
         }
     }
@@ -261,18 +261,19 @@ mod tests {
         use crate::algos::div::div_native::div_native;
         use crate::algos::div::div_widen_scale::div_widen_scale;
         const SCALE: u32 = 6;
-        let mult = Int::<1>::TEN.pow(SCALE);
+        let multiplier = Int::<1>::TEN.pow(SCALE);
         let cases: &[(i64, i64)] = &[
             (2_000_000, 1_000_000), (1_000_000, 3_000_000), (7_000_000, 2_000_000),
             (-5_000_000, 2_000_000), (1_234_567, 9_876_543), (-7, -13), (0, 5_000_000),
         ];
-        for &(ra, rb) in cases {
-            let a = i1(ra);
-            let b = i1(rb);
+        for &(dividend_raw, divisor_raw) in cases {
+            let dividend = i1(dividend_raw);
+            let divisor = i1(divisor_raw);
             for mode in ALL_MODES {
-                let nat = div_native::<1, SCALE>(a, b, mode);
-                let wd = div_widen_scale::<1>(a, b, mult, mode);
-                assert_eq!(nat, wd, "div N1 ({ra},{rb}) mode {mode:?}");
+                let native = div_native::<1, SCALE>(dividend, divisor, mode);
+                let widen_scale = div_widen_scale::<1>(dividend, divisor, multiplier, mode);
+                assert_eq!(native, widen_scale,
+                    "div N1 ({dividend_raw},{divisor_raw}) mode {mode:?}");
             }
         }
     }
@@ -288,21 +289,21 @@ mod tests {
             (-5_000_000, 2_000_000), (1_234_567, 9_876_543),
             (98_765_432_109_876_543, 12_345_678_901_234_567),
         ];
-        for &(ra, rb) in cases {
-            let a = i2(ra);
-            let b = i2(rb);
+        for &(dividend_raw, divisor_raw) in cases {
+            let dividend = i2(dividend_raw);
+            let divisor = i2(divisor_raw);
             for mode in ALL_MODES {
-                let mult6 = Int::<2>::TEN.pow(6);
+                let multiplier6 = Int::<2>::TEN.pow(6);
                 assert_eq!(
-                    div_native::<2, 6>(a, b, mode),
-                    div_widen_scale::<2>(a, b, mult6, mode),
-                    "div N2 s6 ({ra},{rb}) mode {mode:?}"
+                    div_native::<2, 6>(dividend, divisor, mode),
+                    div_widen_scale::<2>(dividend, divisor, multiplier6, mode),
+                    "div N2 s6 ({dividend_raw},{divisor_raw}) mode {mode:?}"
                 );
-                let mult22 = Int::<2>::TEN.pow(22);
+                let multiplier22 = Int::<2>::TEN.pow(22);
                 assert_eq!(
-                    div_native::<2, 22>(a, b, mode),
-                    div_widen_scale::<2>(a, b, mult22, mode),
-                    "div N2 s22 ({ra},{rb}) mode {mode:?}"
+                    div_native::<2, 22>(dividend, divisor, mode),
+                    div_widen_scale::<2>(dividend, divisor, multiplier22, mode),
+                    "div N2 s22 ({dividend_raw},{divisor_raw}) mode {mode:?}"
                 );
             }
         }

--- a/src/algos/sqrt/sqrt_native.rs
+++ b/src/algos/sqrt/sqrt_native.rs
@@ -16,7 +16,7 @@
 //! dominates the real arithmetic, so the slice `isqrt` is slow for those cells.
 //! This kernel instead runs Newton directly in a concrete `Int<W>` (whose
 //! width `W` the policy picks per `(N, SCALE)` cell to just cover
-//! `mag · 10^SCALE`), so each `n / x` is one Knuth divide on tight
+//! `mag · 10^SCALE`), so each `radicand / x` is one Knuth divide on tight
 //! operands with no build-max zeroing.
 //!
 //! # Newton seed via the shared seed leaf (std / no_std agnostic)
@@ -43,26 +43,26 @@ use crate::support::rounding::RoundingMode;
 
 /// `⌊√n⌋` over `Int<W>`, seeded via the shared seed leaf.
 ///
-/// Returns `⌊√n⌋` for `n > 0`. The seed comes from
+/// Returns `⌊√n⌋` for a positive `radicand`. The seed comes from
 /// [`crate::algo_x_support::seed::sqrt_seed`] — the `f64::sqrt` of the top
 /// 64 significant bits scaled back under `std`, the classical pure-integer
 /// `2^⌈bits/2⌉` under `no_std` — so it is a safe over-estimate at **any**
-/// work width `W` (no `f64::MAX` ceiling, unlike a direct `n.as_f64()`),
+/// work width `W` (no `f64::MAX` ceiling, unlike a direct `as_f64()`),
 /// and the std/no_std divergence stays inside the leaf. The
 /// monotone-decrease Newton loop then settles on `⌊√n⌋`.
 #[inline]
-fn isqrt_w_seeded<const W: usize>(n: Int<W>) -> Int<W> {
+fn isqrt_w_seeded<const W: usize>(radicand: Int<W>) -> Int<W> {
     // Build the over-estimate seed in the W-limb magnitude via the leaf.
-    let bits = n.bit_length();
-    let mag = n.unsigned_abs();
+    let bits = radicand.bit_length();
+    let magnitude = radicand.unsigned_abs();
     let mut seed_limbs = [0u64; W];
-    sqrt_seed(mag.as_limbs(), bits, &mut seed_limbs);
+    sqrt_seed(magnitude.as_limbs(), bits, &mut seed_limbs);
     let x0 = Int::<W>::from_mag_limbs(&seed_limbs, false);
     let x0 = if x0 <= Int::<W>::ZERO { Int::<W>::ONE } else { x0 };
     let two = Int::<W>::from_i128(2);
     let mut x = x0;
     loop {
-        let y = (x + n / x) / two;
+        let y = (x + radicand / x) / two;
         if y >= x {
             break x;
         }
@@ -93,15 +93,15 @@ pub(crate) fn sqrt_native<const N: usize, const W: usize>(
     // `pow10_scale` is `10^SCALE` in `Int<W>`, supplied pre-computed by the
     // caller so it folds at compile time (`const { Int::<W>::TEN.pow(SCALE) }`
     // in the dispatch) instead of running the int pow at runtime per call.
-    let n: Int<W> = widened * pow10_scale;
+    let radicand: Int<W> = widened * pow10_scale;
 
-    let q = isqrt_w_seeded::<W>(n);
+    let root = isqrt_w_seeded::<W>(radicand);
 
     // ── single round step (same logic as sqrt_newton). ──────────────
-    // diff = n - q²  (q² ≤ n, so diff ≥ 0).
-    let qsq = q * q;
-    let diff = n - qsq;
-    let halfway_round_up = diff > q;
+    // diff = radicand - root²  (root² ≤ radicand, so diff ≥ 0).
+    let root_sq = root * root;
+    let diff = radicand - root_sq;
+    let halfway_round_up = diff > root;
     let diff_nonzero = diff != zero;
     let bump = match mode {
         RoundingMode::HalfToEven
@@ -110,8 +110,8 @@ pub(crate) fn sqrt_native<const N: usize, const W: usize>(
         RoundingMode::Trunc | RoundingMode::Floor => false,
         RoundingMode::Ceiling => diff_nonzero,
     };
-    let q = if bump { q + one } else { q };
-    q.resize_to::<Int<N>>()
+    let root = if bump { root + one } else { root };
+    root.resize_to::<Int<N>>()
 }
 
 #[cfg(all(test, feature = "std"))]
@@ -140,12 +140,12 @@ mod tests {
     where
         crate::int::types::compute_limbs::Limbs<N>: crate::int::types::compute_limbs::ComputeLimbs,
     {
-        for &r in raws {
-            let raw = Int::<N>::from_i128(r);
+        for &raw_value in raws {
+            let raw = Int::<N>::from_i128(raw_value);
             for mode in ALL_MODES {
                 let got = sqrt_native::<N, W>(raw, Int::<W>::TEN.pow(scale), mode);
                 let want = sqrt_newton::<N>(raw, scale, mode);
-                assert_eq!(got, want, "N={N} W={W} scale={scale} raw={r} mode={mode:?}");
+                assert_eq!(got, want, "N={N} W={W} scale={scale} raw={raw_value} mode={mode:?}");
             }
         }
     }
@@ -216,13 +216,13 @@ mod tests {
     /// diverge / be release-mode UB).
     #[cfg(feature = "_wide-support")]
     fn near_max<const N: usize>() -> Int<N> {
-        let mut mag = [0u64; N];
-        for m in mag.iter_mut() {
-            *m = u64::MAX;
+        let mut magnitude = [0u64; N];
+        for limb in magnitude.iter_mut() {
+            *limb = u64::MAX;
         }
         // Clear the top bit so the value stays a positive magnitude.
-        mag[N - 1] = u64::MAX >> 1;
-        Int::<N>::from_mag_limbs(&mag, false)
+        magnitude[N - 1] = u64::MAX >> 1;
+        Int::<N>::from_mag_limbs(&magnitude, false)
     }
 
     // Spans D76..D307; the D307 cell's work width (Int<24>) needs x-wide+.
@@ -250,17 +250,17 @@ mod tests {
     #[test]
     fn sqrt_native_routed_2n_widths_near_max() {
         for mode in ALL_MODES {
-            for &s in &[0u32, 20, 28, 57] {
-                assert_eq!(sqrt_native::<3, 6>(near_max::<3>(), Int::<6>::TEN.pow(s), mode), sqrt_newton::<3>(near_max::<3>(), s, mode), "D57 W=6 s={s} mode {mode:?}");
+            for &scale in &[0u32, 20, 28, 57] {
+                assert_eq!(sqrt_native::<3, 6>(near_max::<3>(), Int::<6>::TEN.pow(scale), mode), sqrt_newton::<3>(near_max::<3>(), scale, mode), "D57 W=6 s={scale} mode {mode:?}");
             }
-            for &s in &[0u32, 20, 35, 76] {
-                assert_eq!(sqrt_native::<4, 8>(near_max::<4>(), Int::<8>::TEN.pow(s), mode), sqrt_newton::<4>(near_max::<4>(), s, mode), "D76 W=8 s={s} mode {mode:?}");
+            for &scale in &[0u32, 20, 35, 76] {
+                assert_eq!(sqrt_native::<4, 8>(near_max::<4>(), Int::<8>::TEN.pow(scale), mode), sqrt_newton::<4>(near_max::<4>(), scale, mode), "D76 W=8 s={scale} mode {mode:?}");
             }
-            for &s in &[0u32, 25, 57, 115] {
-                assert_eq!(sqrt_native::<6, 12>(near_max::<6>(), Int::<12>::TEN.pow(s), mode), sqrt_newton::<6>(near_max::<6>(), s, mode), "D115 W=12 s={s} mode {mode:?}");
+            for &scale in &[0u32, 25, 57, 115] {
+                assert_eq!(sqrt_native::<6, 12>(near_max::<6>(), Int::<12>::TEN.pow(scale), mode), sqrt_newton::<6>(near_max::<6>(), scale, mode), "D115 W=12 s={scale} mode {mode:?}");
             }
-            for &s in &[0u32, 25, 75, 153] {
-                assert_eq!(sqrt_native::<8, 16>(near_max::<8>(), Int::<16>::TEN.pow(s), mode), sqrt_newton::<8>(near_max::<8>(), s, mode), "D153 W=16 s={s} mode {mode:?}");
+            for &scale in &[0u32, 25, 75, 153] {
+                assert_eq!(sqrt_native::<8, 16>(near_max::<8>(), Int::<16>::TEN.pow(scale), mode), sqrt_newton::<8>(near_max::<8>(), scale, mode), "D153 W=16 s={scale} mode {mode:?}");
             }
         }
     }

--- a/src/algos/sqrt/sqrt_newton.rs
+++ b/src/algos/sqrt/sqrt_newton.rs
@@ -34,15 +34,15 @@ use crate::int::types::compute_limbs::{ComputeLimbs, Limbs};
 use crate::int::types::Int;
 use crate::support::rounding::RoundingMode;
 
-/// Significant limb length of `a` (index of the highest non-zero limb + 1),
-/// clamped to at least 1 so zero has length 1.
+/// Significant limb length of `limbs` (index of the highest non-zero limb
+/// + 1), clamped to at least 1 so zero has length 1.
 #[inline]
-fn sig_len(a: &[u64]) -> usize {
-    let mut l = a.len();
-    while l > 1 && a[l - 1] == 0 {
-        l -= 1;
+fn sig_len(limbs: &[u64]) -> usize {
+    let mut len = limbs.len();
+    while len > 1 && limbs[len - 1] == 0 {
+        len -= 1;
     }
-    l
+    len
 }
 
 /// Newton integer square-root kernel, computed in limbs.
@@ -60,46 +60,47 @@ where
         return Int::<N>::ZERO;
     }
 
-    // ── radicand n = |raw| · 10^scale, in limb scratch ──────────────────
-    let mut n_buf = Limbs::<N>::double_buffered_u64();
-    let n = n_buf.as_mut();
-    n[..N].copy_from_slice(raw.unsigned_abs().as_limbs());
-    let mut nl = sig_len(&n[..N]);
+    // ── radicand = |raw| · 10^scale, in limb scratch ────────────────────
+    let mut radicand_buf = Limbs::<N>::double_buffered_u64();
+    let radicand = radicand_buf.as_mut();
+    radicand[..N].copy_from_slice(raw.unsigned_abs().as_limbs());
+    let mut radicand_len = sig_len(&radicand[..N]);
     {
-        let mut tmp_buf = Limbs::<N>::double_buffered_u64();
-        let tmp = tmp_buf.as_mut();
+        let mut product_buf = Limbs::<N>::double_buffered_u64();
+        let product = product_buf.as_mut();
         for _ in 0..scale {
-            let out = nl + 1;
-            for t in tmp[..out].iter_mut() {
-                *t = 0;
+            let product_len = radicand_len + 1;
+            for limb in product[..product_len].iter_mut() {
+                *limb = 0;
             }
-            mul_slice(&n[..nl], &[10u64], &mut tmp[..out]);
-            n[..out].copy_from_slice(&tmp[..out]);
-            nl = sig_len(&n[..out]);
+            mul_slice(&radicand[..radicand_len], &[10u64], &mut product[..product_len]);
+            radicand[..product_len].copy_from_slice(&product[..product_len]);
+            radicand_len = sig_len(&radicand[..product_len]);
         }
     }
 
-    // ── q = floor(sqrt(n)) via the int slice kernel ─────────────────────
-    let mut q_buf = Limbs::<N>::double_buffered_u64();
-    let q = q_buf.as_mut();
-    isqrt_newton(&n[..nl], &mut q[..nl]);
-    let ql = sig_len(&q[..nl]);
+    // ── root = floor(sqrt(radicand)) via the int slice kernel ───────────
+    let mut root_buf = Limbs::<N>::double_buffered_u64();
+    let root = root_buf.as_mut();
+    isqrt_newton(&radicand[..radicand_len], &mut root[..radicand_len]);
+    let root_len = sig_len(&root[..radicand_len]);
 
-    // ── diff = n - q²  (q² ≤ n, so diff fits in nl limbs) ───────────────
-    let mut qsq_buf = Limbs::<N>::double_buffered_u64();
-    let qsq = qsq_buf.as_mut();
-    let qsq_cap = qsq.len();
-    mul_slice(&q[..ql], &q[..ql], &mut qsq[..(2 * ql).min(qsq_cap)]);
+    // ── diff = radicand - root²  (root² ≤ radicand, so diff fits in
+    //    radicand_len limbs) ──────────────────────────────────────────────
+    let mut root_sq_buf = Limbs::<N>::double_buffered_u64();
+    let root_sq = root_sq_buf.as_mut();
+    let root_sq_cap = root_sq.len();
+    mul_slice(&root[..root_len], &root[..root_len], &mut root_sq[..(2 * root_len).min(root_sq_cap)]);
     let mut diff_buf = Limbs::<N>::double_buffered_u64();
     let diff = diff_buf.as_mut();
-    diff[..nl].copy_from_slice(&n[..nl]);
-    sub_assign(&mut diff[..nl], &qsq[..nl]);
+    diff[..radicand_len].copy_from_slice(&radicand[..radicand_len]);
+    sub_assign(&mut diff[..radicand_len], &root_sq[..radicand_len]);
 
     // ── single round step (matches the BigInt-generic kernel exactly) ───
     // halfway_round_up: remainder past the lower root exceeds the root
-    // (diff > q); diff_nonzero: any remainder at all.
-    let halfway_round_up = cmp_cross(&diff[..nl], &q[..ql]) > 0;
-    let diff_nonzero = !is_zero(&diff[..nl]);
+    // (diff > root); diff_nonzero: any remainder at all.
+    let halfway_round_up = cmp_cross(&diff[..radicand_len], &root[..root_len]) > 0;
+    let diff_nonzero = !is_zero(&diff[..radicand_len]);
     let bump = match mode {
         RoundingMode::HalfToEven
         | RoundingMode::HalfAwayFromZero
@@ -108,12 +109,12 @@ where
         RoundingMode::Ceiling => diff_nonzero,
     };
     if bump {
-        // q += 1 (carry stays within ql+1 limbs).
+        // root += 1 (carry stays within root_len+1 limbs).
         let mut i = 0;
         loop {
-            let (v, c) = q[i].overflowing_add(1);
-            q[i] = v;
-            if !c {
+            let (sum, carry) = root[i].overflowing_add(1);
+            root[i] = sum;
+            if !carry {
                 break;
             }
             i += 1;
@@ -121,7 +122,7 @@ where
     }
 
     // ── narrow the root to Int<N> (positive; fits by construction) ──────
-    let mut out = [0u64; N];
-    out.copy_from_slice(&q[..N]);
-    Int::<N>::from_limbs(out)
+    let mut root_limbs = [0u64; N];
+    root_limbs.copy_from_slice(&root[..N]);
+    Int::<N>::from_limbs(root_limbs)
 }

--- a/src/algos/sqrt/sqrt_newton_with_table_seed.rs
+++ b/src/algos/sqrt/sqrt_newton_with_table_seed.rs
@@ -64,10 +64,10 @@ pub(crate) fn sqrt_newton_with_table_seed(raw: Int<3>, mode: RoundingMode) -> In
     // `const {}` forces the 10^SCALE multiplier to fold at compile time; a
     // bare `TEN.pow(SCALE)` runs the int pow square-and-multiply at runtime
     // (the exponent reaches the method as a plain `u32`) every call.
-    let n: Int<4> = raw.resize_to::<Int<4>>() * const { Int::<4>::TEN.pow(SCALE) };
-    let q: Int<4> = n.isqrt();
-    let diff: Int<4> = n - q * q;
-    let halfway_round_up = diff > q;
+    let radicand: Int<4> = raw.resize_to::<Int<4>>() * const { Int::<4>::TEN.pow(SCALE) };
+    let root: Int<4> = radicand.isqrt();
+    let diff: Int<4> = radicand - root * root;
+    let halfway_round_up = diff > root;
     let diff_nonzero = diff != Int::<4>::ZERO;
     let bump = match mode {
         RoundingMode::HalfToEven
@@ -76,6 +76,6 @@ pub(crate) fn sqrt_newton_with_table_seed(raw: Int<3>, mode: RoundingMode) -> In
         RoundingMode::Trunc | RoundingMode::Floor => false,
         RoundingMode::Ceiling => diff_nonzero,
     };
-    let q = if bump { q + Int::<4>::ONE } else { q };
-    q.resize_to::<Int<3>>()
+    let root = if bump { root + Int::<4>::ONE } else { root };
+    root.resize_to::<Int<3>>()
 }

--- a/src/algos/sub/sub_int_layer.rs
+++ b/src/algos/sub/sub_int_layer.rs
@@ -13,6 +13,6 @@ use crate::int::types::Int;
 /// modular / `None` / clamp / flag policies). No rescaling needed —
 /// same-SCALE operands share the scale factor.
 #[inline]
-pub(crate) fn sub_int_layer<const N: usize>(a: Int<N>, b: Int<N>) -> Int<N> {
-    a.checked_sub(b).expect("attempt to subtract with overflow")
+pub(crate) fn sub_int_layer<const N: usize>(lhs: Int<N>, rhs: Int<N>) -> Int<N> {
+    lhs.checked_sub(rhs).expect("attempt to subtract with overflow")
 }

--- a/src/algos/support/fixed.rs
+++ b/src/algos/support/fixed.rs
@@ -33,42 +33,42 @@ pub(crate) type U512 = [u128; 4];
 
 /// Full 128x128 -> 256 unsigned product, `(high, low)`.
 #[inline]
-const fn mul_128(a: u128, b: u128) -> (u128, u128) {
-    let (a_hi, a_lo) = (a >> 64, a & u64::MAX as u128);
-    let (b_hi, b_lo) = (b >> 64, b & u64::MAX as u128);
-    let (mid, carry1) = (a_lo * b_hi).overflowing_add(a_hi * b_lo);
-    let (low, carry2) = (a_lo * b_lo).overflowing_add(mid << 64);
-    let high = a_hi * b_hi + (mid >> 64) + ((carry1 as u128) << 64) + carry2 as u128;
+const fn mul_128(lhs: u128, rhs: u128) -> (u128, u128) {
+    let (lhs_hi, lhs_lo) = (lhs >> 64, lhs & u64::MAX as u128);
+    let (rhs_hi, rhs_lo) = (rhs >> 64, rhs & u64::MAX as u128);
+    let (mid, carry1) = (lhs_lo * rhs_hi).overflowing_add(lhs_hi * rhs_lo);
+    let (low, carry2) = (lhs_lo * rhs_lo).overflowing_add(mid << 64);
+    let high = lhs_hi * rhs_hi + (mid >> 64) + ((carry1 as u128) << 64) + carry2 as u128;
     (high, low)
 }
 
-/// `a + b` for 256-bit values; returns `(sum, carry_out)`.
+/// `lhs + rhs` for 256-bit values; returns `(sum, carry_out)`.
 #[inline]
-fn add_u256(a: U256, b: U256) -> (U256, bool) {
-    let (lo, c0) = a[0].overflowing_add(b[0]);
-    let (hi1, c1) = a[1].overflowing_add(b[1]);
-    let (hi, c2) = hi1.overflowing_add(u128::from(c0));
-    ([lo, hi], c1 || c2)
+fn add_u256(lhs: U256, rhs: U256) -> (U256, bool) {
+    let (lo, carry0) = lhs[0].overflowing_add(rhs[0]);
+    let (hi_partial, carry1) = lhs[1].overflowing_add(rhs[1]);
+    let (hi, carry2) = hi_partial.overflowing_add(u128::from(carry0));
+    ([lo, hi], carry1 || carry2)
 }
 
-/// `a - b` for 256-bit values; caller guarantees `a >= b`.
+/// `lhs - rhs` for 256-bit values; caller guarantees `lhs >= rhs`.
 #[inline]
-fn sub_u256(a: U256, b: U256) -> U256 {
-    let (lo, borrow) = a[0].overflowing_sub(b[0]);
-    let hi = a[1].wrapping_sub(b[1]).wrapping_sub(u128::from(borrow));
+fn sub_u256(lhs: U256, rhs: U256) -> U256 {
+    let (lo, borrow) = lhs[0].overflowing_sub(rhs[0]);
+    let hi = lhs[1].wrapping_sub(rhs[1]).wrapping_sub(u128::from(borrow));
     [lo, hi]
 }
 
-/// `a >= b` for 256-bit values.
+/// `lhs >= rhs` for 256-bit values.
 #[inline]
-fn ge_u256(a: U256, b: U256) -> bool {
-    a[1] > b[1] || (a[1] == b[1] && a[0] >= b[0])
+fn ge_u256(lhs: U256, rhs: U256) -> bool {
+    lhs[1] > rhs[1] || (lhs[1] == rhs[1] && lhs[0] >= rhs[0])
 }
 
-/// `a == 0` for a 256-bit value.
+/// `value == 0` for a 256-bit value.
 #[inline]
-fn is_zero_u256(a: U256) -> bool {
-    a[0] == 0 && a[1] == 0
+fn is_zero_u256(value: U256) -> bool {
+    value[0] == 0 && value[1] == 0
 }
 
 /// Full 256x128 -> 384 unsigned product, returned in U512 form
@@ -79,102 +79,102 @@ fn is_zero_u256(a: U256) -> bool {
 /// collapses to two because two of the partial products with the
 /// zero high limb are themselves zero.
 #[inline]
-fn mul_u256_by_u128(a: U256, b: u128) -> U512 {
-    let (p0_hi, p0_lo) = mul_128(a[0], b);
-    let (p1_hi, p1_lo) = mul_128(a[1], b);
-    let r0 = p0_lo;
-    let (r1, c1) = p0_hi.overflowing_add(p1_lo);
-    let r2 = p1_hi + u128::from(c1);
-    [r0, r1, r2, 0]
+fn mul_u256_by_u128(value: U256, multiplier: u128) -> U512 {
+    let (p0_hi, p0_lo) = mul_128(value[0], multiplier);
+    let (p1_hi, p1_lo) = mul_128(value[1], multiplier);
+    let limb0 = p0_lo;
+    let (limb1, carry1) = p0_hi.overflowing_add(p1_lo);
+    let limb2 = p1_hi + u128::from(carry1);
+    [limb0, limb1, limb2, 0]
 }
 
 /// Full 256x256 -> 512 unsigned product.
-pub(crate) fn mul_u256(a: U256, b: U256) -> U512 {
-    // a = a0 + a1·B, b = b0 + b1·B, B = 2^128.
-    let (p00_hi, p00_lo) = mul_128(a[0], b[0]);
-    let (p01_hi, p01_lo) = mul_128(a[0], b[1]);
-    let (p10_hi, p10_lo) = mul_128(a[1], b[0]);
-    let (p11_hi, p11_lo) = mul_128(a[1], b[1]);
+pub(crate) fn mul_u256(lhs: U256, rhs: U256) -> U512 {
+    // lhs = a0 + a1·B, rhs = b0 + b1·B, B = 2^128.
+    let (p00_hi, p00_lo) = mul_128(lhs[0], rhs[0]);
+    let (p01_hi, p01_lo) = mul_128(lhs[0], rhs[1]);
+    let (p10_hi, p10_lo) = mul_128(lhs[1], rhs[0]);
+    let (p11_hi, p11_lo) = mul_128(lhs[1], rhs[1]);
 
     // limb0 = p00_lo
-    let r0 = p00_lo;
+    let limb0 = p00_lo;
     // limb1 = p00_hi + p01_lo + p10_lo
-    let (s1, c1a) = p00_hi.overflowing_add(p01_lo);
-    let (r1, c1b) = s1.overflowing_add(p10_lo);
-    let carry1 = u128::from(c1a) + u128::from(c1b);
+    let (sum1, carry1a) = p00_hi.overflowing_add(p01_lo);
+    let (limb1, carry1b) = sum1.overflowing_add(p10_lo);
+    let carry1 = u128::from(carry1a) + u128::from(carry1b);
     // limb2 = p01_hi + p10_hi + p11_lo + carry1
-    let (s2, c2a) = p01_hi.overflowing_add(p10_hi);
-    let (s2b, c2b) = s2.overflowing_add(p11_lo);
-    let (r2, c2c) = s2b.overflowing_add(carry1);
-    let carry2 = u128::from(c2a) + u128::from(c2b) + u128::from(c2c);
+    let (sum2, carry2a) = p01_hi.overflowing_add(p10_hi);
+    let (sum2b, carry2b) = sum2.overflowing_add(p11_lo);
+    let (limb2, carry2c) = sum2b.overflowing_add(carry1);
+    let carry2 = u128::from(carry2a) + u128::from(carry2b) + u128::from(carry2c);
     // limb3 = p11_hi + carry2
-    let r3 = p11_hi + carry2;
-    [r0, r1, r2, r3]
+    let limb3 = p11_hi + carry2;
+    [limb0, limb1, limb2, limb3]
 }
 
 /// Bit length of a 512-bit value (`0` for zero, else `floor(log2)+1`).
 #[inline]
-fn bitlen_u512(n: U512) -> u32 {
-    if n[3] != 0 {
-        512 - n[3].leading_zeros()
-    } else if n[2] != 0 {
-        384 - n[2].leading_zeros()
-    } else if n[1] != 0 {
-        256 - n[1].leading_zeros()
+fn bitlen_u512(value: U512) -> u32 {
+    if value[3] != 0 {
+        512 - value[3].leading_zeros()
+    } else if value[2] != 0 {
+        384 - value[2].leading_zeros()
+    } else if value[1] != 0 {
+        256 - value[1].leading_zeros()
     } else {
-        128 - n[0].leading_zeros()
+        128 - value[0].leading_zeros()
     }
 }
 
-/// `n << shift` for a 512-bit value (`shift < 512`).
+/// `value << shift` for a 512-bit value (`shift < 512`).
 #[inline]
-fn shl_u512(n: U512, shift: u32) -> U512 {
+fn shl_u512(value: U512, shift: u32) -> U512 {
     if shift == 0 {
-        return n;
+        return value;
     }
-    let limb = (shift / 128) as usize;
-    let bit = shift % 128;
+    let limb_offset = (shift / 128) as usize;
+    let bit_offset = shift % 128;
     let mut out = [0u128; 4];
-    if bit == 0 {
-        for i in (limb..4).rev() {
-            out[i] = n[i - limb];
+    if bit_offset == 0 {
+        for i in (limb_offset..4).rev() {
+            out[i] = value[i - limb_offset];
         }
     } else {
-        for i in (limb..4).rev() {
-            let lo = n[i - limb] << bit;
-            let carry = if i - limb == 0 {
+        for i in (limb_offset..4).rev() {
+            let shifted_low = value[i - limb_offset] << bit_offset;
+            let carry = if i - limb_offset == 0 {
                 0
             } else {
-                n[i - limb - 1] >> (128 - bit)
+                value[i - limb_offset - 1] >> (128 - bit_offset)
             };
-            out[i] = lo | carry;
+            out[i] = shifted_low | carry;
         }
     }
     out
 }
 
-/// Quotient `num / d` for a 512-bit dividend and a divisor that fits
-/// in a single 64-bit word.
+/// Quotient `numerator / divisor` for a 512-bit dividend and a divisor
+/// that fits in a single 64-bit word.
 ///
 /// Schoolbook long division in base `2^64`: each step divides a
 /// 128-bit `(remainder, limb)` pair by the word divisor with one
 /// hardware division. Far cheaper than the general bit loop, and it
 /// covers every `10^scale` divisor for `scale <= 19` — the common
 /// decimal multiply path.
-fn div_u512_by_word(num: U512, d: u64) -> U512 {
-    let dd = u128::from(d);
+fn div_u512_by_word(numerator: U512, divisor: u64) -> U512 {
+    let divisor_u128 = u128::from(divisor);
     let mut limbs = [0u64; 8];
     for i in 0..4 {
-        limbs[i << 1] = num[i] as u64;
-        limbs[(i << 1) | 1] = (num[i] >> 64) as u64;
+        limbs[i << 1] = numerator[i] as u64;
+        limbs[(i << 1) | 1] = (numerator[i] >> 64) as u64;
     }
-    let mut rem: u128 = 0;
+    let mut remainder: u128 = 0;
     let mut i = 8;
     while i > 0 {
         i -= 1;
-        let cur = (rem << 64) | u128::from(limbs[i]);
-        limbs[i] = (cur / dd) as u64;
-        rem = cur % dd;
+        let current = (remainder << 64) | u128::from(limbs[i]);
+        limbs[i] = (current / divisor_u128) as u64;
+        remainder = current % divisor_u128;
     }
     let mut out = [0u128; 4];
     for i in 0..4 {
@@ -203,26 +203,26 @@ fn div_u512_by_word(num: U512, d: u64) -> U512 {
 /// embedded-constant rescales (`wide_pi`, `wide_ln2`, …) divide by
 /// `10^(75 - w)` which is also < 38 for any caller-relevant `w`.
 #[inline]
-fn div_u512_by_pow10(num: U512, w: u32) -> U256 {
-    if w == 0 {
-        return [num[0], num[1]];
+fn div_u512_by_pow10(numerator: U512, working_scale: u32) -> U256 {
+    if working_scale == 0 {
+        return [numerator[0], numerator[1]];
     }
-    if w <= 38 {
-        return div_u512_by_pow10_small(num, w as usize);
+    if working_scale <= 38 {
+        return div_u512_by_pow10_small(numerator, working_scale as usize);
     }
-    if w <= 76 {
+    if working_scale <= 76 {
         // Chained truncating divide: floor(num / 10^w) ==
         // floor(floor(num / 10^38) / 10^(w-38)) for integer w > 38.
         // The first pass shrinks the dividend by ~126 bits, leaving
         // at most ~386 bits — we keep the full 4 u128 limbs across
         // the chain to be safe.
-        let pass1 = div_u512_by_pow10_small_full(num, 38);
-        return div_u512_by_pow10_small(pass1, (w - 38) as usize);
+        let first_pass = div_u512_by_pow10_small_full(numerator, 38);
+        return div_u512_by_pow10_small(first_pass, (working_scale - 38) as usize);
     }
     // Fallback for w > 76 — not used by any caller in this module.
-    let scale = Fixed::pow10(w);
-    let q = div_u512_by_u256(num, scale);
-    [q[0], q[1]]
+    let divisor = Fixed::pow10(working_scale);
+    let quotient = div_u512_by_u256(numerator, divisor);
+    [quotient[0], quotient[1]]
 }
 
 /// Same as [`div_u512_by_pow10_small`] but returns all four u128
@@ -230,64 +230,73 @@ fn div_u512_by_pow10(num: U512, w: u32) -> U256 {
 /// the `w > 38` chain where the intermediate dividend may span more
 /// than 256 bits.
 #[inline]
-fn div_u512_by_pow10_small_full(num: U512, scale_idx: usize) -> U512 {
+fn div_u512_by_pow10_small_full(numerator: U512, scale_idx: usize) -> U512 {
     debug_assert!((1..=38).contains(&scale_idx));
-    let exp = crate::algos::support::mg_divide::POW10_U128[scale_idx];
-    let mut rem: u128 = 0;
-    let (q3, r3) = crate::algos::support::mg_divide::divmod_pow10_2word(rem, num[3], exp, scale_idx)
+    let pow10_divisor = crate::algos::support::mg_divide::POW10_U128[scale_idx];
+    let mut remainder: u128 = 0;
+    let (quotient3, remainder3) = crate::algos::support::mg_divide::divmod_pow10_2word(
+        remainder, numerator[3], pow10_divisor, scale_idx)
         .expect("div_u512_by_pow10_small_full: invariant violated");
-    rem = r3;
-    let (q2, r2) = crate::algos::support::mg_divide::divmod_pow10_2word(rem, num[2], exp, scale_idx)
+    remainder = remainder3;
+    let (quotient2, remainder2) = crate::algos::support::mg_divide::divmod_pow10_2word(
+        remainder, numerator[2], pow10_divisor, scale_idx)
         .expect("div_u512_by_pow10_small_full: invariant violated");
-    rem = r2;
-    let (q1, r1) = crate::algos::support::mg_divide::divmod_pow10_2word(rem, num[1], exp, scale_idx)
+    remainder = remainder2;
+    let (quotient1, remainder1) = crate::algos::support::mg_divide::divmod_pow10_2word(
+        remainder, numerator[1], pow10_divisor, scale_idx)
         .expect("div_u512_by_pow10_small_full: invariant violated");
-    rem = r1;
-    let (q0, _r0) = crate::algos::support::mg_divide::divmod_pow10_2word(rem, num[0], exp, scale_idx)
+    remainder = remainder1;
+    let (quotient0, _remainder0) = crate::algos::support::mg_divide::divmod_pow10_2word(
+        remainder, numerator[0], pow10_divisor, scale_idx)
         .expect("div_u512_by_pow10_small_full: invariant violated");
-    [q0, q1, q2, q3]
+    [quotient0, quotient1, quotient2, quotient3]
 }
 
 /// `num / 10^scale_idx` where `1 <= scale_idx <= 38`, returning the
 /// 256-bit quotient. The divisor fits a single u128 limb, so one MG
 /// 2-by-1 step per dividend u128 limb suffices.
 #[inline]
-fn div_u512_by_pow10_small(num: U512, scale_idx: usize) -> U256 {
+fn div_u512_by_pow10_small(numerator: U512, scale_idx: usize) -> U256 {
     debug_assert!((1..=38).contains(&scale_idx));
-    let exp = crate::algos::support::mg_divide::POW10_U128[scale_idx];
+    let pow10_divisor = crate::algos::support::mg_divide::POW10_U128[scale_idx];
     // Walk dividend top-down (most-significant limb first), tracking a
     // running remainder. Quotient limbs go bottom-up; the high two
     // quotient limbs are discarded (they're always 0 for the working-
     // scale invariants in this module — the radicand fits 256 bits
     // after the divide).
-    let mut rem: u128 = 0;
+    let mut remainder: u128 = 0;
     // limb 3 (highest)
-    let (q3, r3) = crate::algos::support::mg_divide::divmod_pow10_2word(rem, num[3], exp, scale_idx)
+    let (quotient3, remainder3) = crate::algos::support::mg_divide::divmod_pow10_2word(
+        remainder, numerator[3], pow10_divisor, scale_idx)
         .expect("div_u512_by_pow10: invariant rem < exp violated");
     debug_assert!(
-        q3 == 0,
+        quotient3 == 0,
         "div_u512_by_pow10: quotient overflows 256 bits — caller invariant violated"
     );
-    rem = r3;
+    remainder = remainder3;
     // limb 2
-    let (q2, r2) = crate::algos::support::mg_divide::divmod_pow10_2word(rem, num[2], exp, scale_idx)
+    let (quotient2, remainder2) = crate::algos::support::mg_divide::divmod_pow10_2word(
+        remainder, numerator[2], pow10_divisor, scale_idx)
         .expect("div_u512_by_pow10: invariant rem < exp violated");
     debug_assert!(
-        q2 == 0,
+        quotient2 == 0,
         "div_u512_by_pow10: quotient overflows 256 bits — caller invariant violated"
     );
-    rem = r2;
+    remainder = remainder2;
     // limb 1
-    let (out_hi, r1) = crate::algos::support::mg_divide::divmod_pow10_2word(rem, num[1], exp, scale_idx)
+    let (out_hi, remainder1) = crate::algos::support::mg_divide::divmod_pow10_2word(
+        remainder, numerator[1], pow10_divisor, scale_idx)
         .expect("div_u512_by_pow10: invariant rem < exp violated");
-    rem = r1;
+    remainder = remainder1;
     // limb 0
-    let (out_lo, _r0) = crate::algos::support::mg_divide::divmod_pow10_2word(rem, num[0], exp, scale_idx)
+    let (out_lo, _remainder0) = crate::algos::support::mg_divide::divmod_pow10_2word(
+        remainder, numerator[0], pow10_divisor, scale_idx)
         .expect("div_u512_by_pow10: invariant rem < exp violated");
     [out_lo, out_hi]
 }
 
-/// Quotient `num / d` where `num` is 512-bit and `d` is 256-bit.
+/// Quotient `numerator / divisor` where the numerator is 512-bit and the
+/// divisor 256-bit.
 ///
 /// Returned as `U512`; for every use in this crate the true quotient
 /// fits in 256 bits, but the wider return type keeps the routine
@@ -297,51 +306,52 @@ fn div_u512_by_pow10_small(num: U512, scale_idx: usize) -> U256 {
 /// numerator's actual bit length, not a fixed 512 — for the typical
 /// operands in this crate (products of moderate-magnitude decimals)
 /// that is a multiple-times reduction in iteration count.
-pub(crate) fn div_u512_by_u256(num: U512, d: U256) -> U512 {
-    debug_assert!(!(d[0] == 0 && d[1] == 0), "division by zero");
+pub(crate) fn div_u512_by_u256(numerator: U512, divisor: U256) -> U512 {
+    debug_assert!(!(divisor[0] == 0 && divisor[1] == 0), "division by zero");
     // Fast path: when both the dividend and divisor fit in a single
     // 128-bit word, the hardware divide is exact and far cheaper than
     // any bit loop. This covers the overwhelmingly common case of
     // moderate-magnitude decimal multiply/divide at small scales.
-    if num[1] == 0 && num[2] == 0 && num[3] == 0 && d[1] == 0 {
-        return [num[0] / d[0], 0, 0, 0];
+    if numerator[1] == 0 && numerator[2] == 0 && numerator[3] == 0 && divisor[1] == 0 {
+        return [numerator[0] / divisor[0], 0, 0, 0];
     }
     // Word-divisor path: a wide dividend divided by a divisor that
     // fits in 64 bits (every `10^scale` for `scale <= 19`).
-    if d[1] == 0 && d[0] <= u128::from(u64::MAX) {
-        return div_u512_by_word(num, d[0] as u64);
+    if divisor[1] == 0 && divisor[0] <= u128::from(u64::MAX) {
+        return div_u512_by_word(numerator, divisor[0] as u64);
     }
-    let bits = bitlen_u512(num);
+    let bits = bitlen_u512(numerator);
     if bits == 0 {
         return [0; 4];
     }
     // Pre-shift so the most-significant set bit sits at position 511,
     // then only `bits` shift-subtract steps are needed (the leading
     // `512 - bits` iterations of the naive loop are provably no-ops).
-    let mut num = shl_u512(num, 512 - bits);
-    let mut q: U512 = [0; 4];
-    let mut rem: U256 = [0, 0];
+    let mut numerator = shl_u512(numerator, 512 - bits);
+    let mut quotient: U512 = [0; 4];
+    let mut remainder: U256 = [0, 0];
     let mut i = bits;
     while i > 0 {
         i -= 1;
-        // Shift (rem, num) left by 1; the top bit of num enters rem.
-        let bit = (num[3] >> 127) & 1;
-        num[3] = (num[3] << 1) | (num[2] >> 127);
-        num[2] = (num[2] << 1) | (num[1] >> 127);
-        num[1] = (num[1] << 1) | (num[0] >> 127);
-        num[0] <<= 1;
-        rem[1] = (rem[1] << 1) | (rem[0] >> 127);
-        rem[0] = (rem[0] << 1) | bit;
-        q[3] = (q[3] << 1) | (q[2] >> 127);
-        q[2] = (q[2] << 1) | (q[1] >> 127);
-        q[1] = (q[1] << 1) | (q[0] >> 127);
-        q[0] <<= 1;
-        if ge_u256(rem, d) {
-            rem = sub_u256(rem, d);
-            q[0] |= 1;
+        // Shift (remainder, numerator) left by 1; the top bit enters the
+        // remainder.
+        let bit = (numerator[3] >> 127) & 1;
+        numerator[3] = (numerator[3] << 1) | (numerator[2] >> 127);
+        numerator[2] = (numerator[2] << 1) | (numerator[1] >> 127);
+        numerator[1] = (numerator[1] << 1) | (numerator[0] >> 127);
+        numerator[0] <<= 1;
+        remainder[1] = (remainder[1] << 1) | (remainder[0] >> 127);
+        remainder[0] = (remainder[0] << 1) | bit;
+        quotient[3] = (quotient[3] << 1) | (quotient[2] >> 127);
+        quotient[2] = (quotient[2] << 1) | (quotient[1] >> 127);
+        quotient[1] = (quotient[1] << 1) | (quotient[0] >> 127);
+        quotient[0] <<= 1;
+        if ge_u256(remainder, divisor) {
+            remainder = sub_u256(remainder, divisor);
+            quotient[0] |= 1;
         }
     }
-    q
+    quotient
 }
 
 /// A signed value held as a 256-bit magnitude interpreted at a fixed
@@ -432,19 +442,20 @@ impl Fixed {
             return self;
         }
         let shift = from_w - to_w;
-        let (q, _r) = divmod_u256_by_pow10(self.mag, Fixed::pow10(shift), shift);
+        let (quotient, _remainder) =
+            divmod_u256_by_pow10(self.mag, Fixed::pow10(shift), shift);
         Fixed {
-            negative: self.negative && !is_zero_u256(q),
-            mag: q,
+            negative: self.negative && !is_zero_u256(quotient),
+            mag: quotient,
         }
     }
 
-    /// Multiplies the magnitude by a small unsigned integer `k`. The
+    /// Multiplies the magnitude by a small unsigned `multiplier`. The
     /// caller guarantees the result stays below `2^256`.
-    pub(crate) fn mul_u128(self, k: u128) -> Fixed {
+    pub(crate) fn mul_u128(self, multiplier: u128) -> Fixed {
         // self.mag * k: (mag_lo + mag_hi*B) * k.
-        let (lo_hi, lo_lo) = mul_128(self.mag[0], k);
-        let (_hi_hi, hi_lo) = mul_128(self.mag[1], k);
+        let (lo_hi, lo_lo) = mul_128(self.mag[0], multiplier);
+        let (_hi_hi, hi_lo) = mul_128(self.mag[1], multiplier);
         let (mag1, _c) = hi_lo.overflowing_add(lo_hi);
         let mag = [lo_lo, mag1];
         Fixed {
@@ -491,18 +502,18 @@ impl Fixed {
         }
     }
 
-    /// `self << n` (magnitude shifted left). Caller guarantees no
-    /// significant bits are lost (`bit_length + n <= 256`).
-    pub(crate) fn shl(self, n: u32) -> Fixed {
-        if n == 0 {
+    /// `self << shift` (magnitude shifted left). Caller guarantees no
+    /// significant bits are lost (`bit_length + shift <= 256`).
+    pub(crate) fn shl(self, shift: u32) -> Fixed {
+        if shift == 0 {
             return self;
         }
-        let mag = if n >= 128 {
-            [0, self.mag[0] << (n - 128)]
+        let mag = if shift >= 128 {
+            [0, self.mag[0] << (shift - 128)]
         } else {
             [
-                self.mag[0] << n,
-                (self.mag[1] << n) | (self.mag[0] >> (128 - n)),
+                self.mag[0] << shift,
+                (self.mag[1] << shift) | (self.mag[0] >> (128 - shift)),
             ]
         };
         Fixed {
@@ -511,27 +522,27 @@ impl Fixed {
         }
     }
 
-    /// `self >> n` (magnitude shifted right, truncating).
-    pub(crate) fn shr(self, n: u32) -> Fixed {
-        if n == 0 {
+    /// `self >> shift` (magnitude shifted right, truncating).
+    pub(crate) fn shr(self, shift: u32) -> Fixed {
+        if shift == 0 {
             return self;
         }
         // A 256-bit magnitude shifted right by its full width (or more) is zero;
         // this also guards the per-limb shifts below, where `mag[1] >> (n - 128)`
         // would otherwise overflow the u128 once `n >= 256` (e.g. a deep-underflow
         // `exp(-222)` reassembling `2^k` with `k ≈ -320`).
-        if n >= 256 {
+        if shift >= 256 {
             return Fixed {
                 negative: false,
                 mag: [0, 0],
             };
         }
-        let mag = if n >= 128 {
-            [self.mag[1] >> (n - 128), 0]
+        let mag = if shift >= 128 {
+            [self.mag[1] >> (shift - 128), 0]
         } else {
             [
-                (self.mag[0] >> n) | (self.mag[1] << (128 - n)),
-                self.mag[1] >> n,
+                (self.mag[0] >> shift) | (self.mag[1] << (128 - shift)),
+                self.mag[1] >> shift,
             ]
         };
         Fixed {
@@ -593,8 +604,8 @@ impl Fixed {
     /// Multiplies two working-scale values: `(self * rhs) / 10^w`,
     /// truncating toward zero. Both magnitudes must be below `10^w *
     /// 2^128` so the 512-bit product divides back into 256 bits.
-    pub(crate) fn mul(self, rhs: Fixed, w: u32) -> Fixed {
-        let prod = mul_u256(self.mag, rhs.mag);
+    pub(crate) fn mul(self, rhs: Fixed, working_scale: u32) -> Fixed {
+        let product = mul_u256(self.mag, rhs.mag);
         // Specialised `pow10(w)` divisor path. The general
         // `div_u512_by_u256` falls back to a 256-iteration shift /
         // subtract bit loop once the divisor exceeds `u64::MAX`
@@ -603,17 +614,18 @@ impl Fixed {
         // which collapses one 2-limb step into a handful of u128
         // multiplies. Chain it across the 512-bit dividend in u128
         // limbs to avoid the bit loop entirely.
-        let q_mag = div_u512_by_pow10(prod, w);
+        let quotient_mag = div_u512_by_pow10(product, working_scale);
         Fixed {
-            negative: (self.negative ^ rhs.negative) && !(q_mag[0] == 0 && q_mag[1] == 0),
-            mag: q_mag,
+            negative: (self.negative ^ rhs.negative)
+                && !(quotient_mag[0] == 0 && quotient_mag[1] == 0),
+            mag: quotient_mag,
         }
     }
 
-    /// Divides by an unsigned `u128` quotient `n`, truncating toward
-    /// zero. `n` must be non-zero.
-    pub(crate) fn div_small(self, n: u128) -> Fixed {
-        debug_assert!(n != 0, "division by zero");
+    /// Divides by an unsigned `u128` `divisor`, truncating toward
+    /// zero. The divisor must be non-zero.
+    pub(crate) fn div_small(self, divisor: u128) -> Fixed {
+        debug_assert!(divisor != 0, "division by zero");
         // Fast path: divisor fits a single u64 — schoolbook base-2^64
         // long division costs four hardware u128/u64 divides (one per
         // 64-bit limb) instead of the 256-iteration bit loop below.
@@ -621,9 +633,9 @@ impl Fixed {
         // `div_small(2*k+1)` or `div_small((2*k)*(2*k+1))` with
         // k < 400, so the divisor is < ~1.3 million ≪ u64::MAX and
         // this fast path always fires from those sites.
-        if n <= u64::MAX as u128 {
-            let d = n as u64;
-            let dd = n; // already u128, avoids reconvert in the loop
+        if divisor <= u64::MAX as u128 {
+            let divisor_u64 = divisor as u64;
+            let divisor_u128 = divisor; // already u128, avoids reconvert in the loop
             let limbs: [u64; 4] = [
                 self.mag[0] as u64,
                 (self.mag[0] >> 64) as u64,
@@ -631,21 +643,21 @@ impl Fixed {
                 (self.mag[1] >> 64) as u64,
             ];
             let mut out = [0u64; 4];
-            let mut rem: u128 = 0;
+            let mut remainder: u128 = 0;
             // Top-down schoolbook divide in base 2^64. Each step:
             //   (rem << 64 | limb) / d  →  64-bit quotient + 64-bit rem
-            let cur3 = (rem << 64) | u128::from(limbs[3]);
-            out[3] = (cur3 / dd) as u64;
-            rem = cur3 - u128::from(out[3]) * dd;
-            let cur2 = (rem << 64) | u128::from(limbs[2]);
-            out[2] = (cur2 / dd) as u64;
-            rem = cur2 - u128::from(out[2]) * dd;
-            let cur1 = (rem << 64) | u128::from(limbs[1]);
-            out[1] = (cur1 / dd) as u64;
-            rem = cur1 - u128::from(out[1]) * dd;
-            let cur0 = (rem << 64) | u128::from(limbs[0]);
-            out[0] = (cur0 / dd) as u64;
-            let _ = d;
+            let current3 = (remainder << 64) | u128::from(limbs[3]);
+            out[3] = (current3 / divisor_u128) as u64;
+            remainder = current3 - u128::from(out[3]) * divisor_u128;
+            let current2 = (remainder << 64) | u128::from(limbs[2]);
+            out[2] = (current2 / divisor_u128) as u64;
+            remainder = current2 - u128::from(out[2]) * divisor_u128;
+            let current1 = (remainder << 64) | u128::from(limbs[1]);
+            out[1] = (current1 / divisor_u128) as u64;
+            remainder = current1 - u128::from(out[1]) * divisor_u128;
+            let current0 = (remainder << 64) | u128::from(limbs[0]);
+            out[0] = (current0 / divisor_u128) as u64;
+            let _ = divisor_u64;
             let q_lo = u128::from(out[0]) | (u128::from(out[1]) << 64);
             let q_hi = u128::from(out[2]) | (u128::from(out[3]) << 64);
             return Fixed {
@@ -654,7 +666,7 @@ impl Fixed {
             };
         }
         // Fallback: 256-bit / 128-bit long division for divisor > u64::MAX.
-        let mut rem: u128 = 0;
+        let mut remainder: u128 = 0;
         let mut hi = self.mag[1];
         let mut lo = self.mag[0];
         let mut q_hi: u128 = 0;
@@ -665,11 +677,11 @@ impl Fixed {
             let top = (hi >> 127) & 1;
             hi = (hi << 1) | (lo >> 127);
             lo <<= 1;
-            rem = (rem << 1) | top;
+            remainder = (remainder << 1) | top;
             q_hi = (q_hi << 1) | (q_lo >> 127);
             q_lo <<= 1;
-            if rem >= n {
-                rem -= n;
+            if remainder >= divisor {
+                remainder -= divisor;
                 q_lo |= 1;
             }
         }
@@ -686,14 +698,16 @@ impl Fixed {
     /// `√(mag/10^w) · 10^w = √(mag · 10^w)` — the radicand is formed as
     /// a 512-bit value and its integer square root taken exactly. The
     /// caller's working values keep `mag · 10^w < 2^512`.
-    pub(crate) fn sqrt(self, w: u32) -> Fixed {
+    pub(crate) fn sqrt(self, working_scale: u32) -> Fixed {
         // For w <= 38 the multiplier fits a single u128; the
         // collapsed 256x128 multiply skips the two zero sub-products
         // of the general 256x256 schoolbook.
-        let radicand = if w <= 38 {
-            mul_u256_by_u128(self.mag, crate::algos::support::mg_divide::POW10_U128[w as usize])
+        let radicand = if working_scale <= 38 {
+            mul_u256_by_u128(
+                self.mag,
+                crate::algos::support::mg_divide::POW10_U128[working_scale as usize])
         } else {
-            mul_u256(self.mag, Fixed::pow10(w))
+            mul_u256(self.mag, Fixed::pow10(working_scale))
         };
         Fixed {
             negative: false,
@@ -704,20 +718,23 @@ impl Fixed {
     /// Divides by another working-scale value: `(self * 10^w) / rhs`,
     /// truncating toward zero. `rhs` must be non-zero. `self * 10^w`
     /// must fit 512 bits (it always does for the evaluators' inputs).
-    pub(crate) fn div(self, rhs: Fixed, w: u32) -> Fixed {
+    pub(crate) fn div(self, rhs: Fixed, working_scale: u32) -> Fixed {
         // Build the numerator `self.mag * 10^w` as a 512-bit value.
         // The single-u128-limb multiplier specialisation collapses
         // half the sub-products when `w <= 38`; outside that band
         // we go through the general 256x256 schoolbook.
-        let scaled = if w <= 38 {
-            mul_u256_by_u128(self.mag, crate::algos::support::mg_divide::POW10_U128[w as usize])
+        let scaled = if working_scale <= 38 {
+            mul_u256_by_u128(
+                self.mag,
+                crate::algos::support::mg_divide::POW10_U128[working_scale as usize])
         } else {
-            mul_u256(self.mag, Fixed::pow10(w))
+            mul_u256(self.mag, Fixed::pow10(working_scale))
         };
-        let q = div_u512_by_u256(scaled, rhs.mag);
+        let quotient = div_u512_by_u256(scaled, rhs.mag);
         Fixed {
-            negative: (self.negative ^ rhs.negative) && !(q[0] == 0 && q[1] == 0),
-            mag: [q[0], q[1]],
+            negative: (self.negative ^ rhs.negative)
+                && !(quotient[0] == 0 && quotient[1] == 0),
+            mag: [quotient[0], quotient[1]],
         }
     }
 
@@ -739,11 +756,12 @@ impl Fixed {
     #[inline]
     pub(crate) fn round_to_i128_with(
         self,
-        w: u32,
+        working_scale: u32,
         target: u32,
         mode: crate::support::rounding::RoundingMode,
     ) -> Option<i128> {
-        self.round_to_i128_with_exact(w, target, mode).map(|(v, _exact)| v)
+        self.round_to_i128_with_exact(working_scale, target, mode)
+            .map(|(value, _exact)| value)
     }
 
     /// Like [`round_to_i128_with`](Self::round_to_i128_with) but also reports
@@ -756,80 +774,84 @@ impl Fixed {
     #[inline]
     pub(crate) fn round_to_i128_with_exact(
         self,
-        w: u32,
+        working_scale: u32,
         target: u32,
         mode: crate::support::rounding::RoundingMode,
     ) -> Option<(i128, bool)> {
-        let shift = w - target;
+        let shift = working_scale - target;
         if shift == 0 {
             // No rounding; just narrow. An all-zero shift carries no residual,
             // so the value is exactly on grid by construction.
             if self.mag[1] != 0 {
                 return None;
             }
-            let m = self.mag[0];
-            let v = if self.negative {
-                if m > 1u128 << 127 {
+            let magnitude = self.mag[0];
+            let value = if self.negative {
+                if magnitude > 1u128 << 127 {
                     return None;
                 }
-                (m as i128).wrapping_neg()
-            } else if m > i128::MAX as u128 {
+                (magnitude as i128).wrapping_neg()
+            } else if magnitude > i128::MAX as u128 {
                 return None;
             } else {
-                m as i128
+                magnitude as i128
             };
-            return Some((v, true));
+            return Some((value, true));
         }
         let divisor = Fixed::pow10(shift);
-        let (q, r) = divmod_u256_by_pow10(self.mag, divisor, shift);
-        let exact = is_zero_u256(r);
-        self.finish_round_to_i128(q, r, divisor, mode).map(|v| (v, exact))
+        let (quotient, remainder) = divmod_u256_by_pow10(self.mag, divisor, shift);
+        let exact = is_zero_u256(remainder);
+        self.finish_round_to_i128(quotient, remainder, divisor, mode)
+            .map(|value| (value, exact))
     }
 
     /// Shared rounding tail of [`round_to_i128_with_exact`] /
-    /// [`round_to_i128_clear_of_tie`]: folds the split `(q, r)` of the
-    /// magnitude at `divisor = 10^shift` to the signed `i128` storage
-    /// value under `mode`. `None` = does not fit `i128`.
+    /// [`round_to_i128_clear_of_tie`]: folds the split
+    /// `(quotient, remainder)` of the magnitude at `divisor = 10^shift` to
+    /// the signed `i128` storage value under `mode`. `None` = does not fit
+    /// `i128`.
     ///
     /// [`round_to_i128_with_exact`]: Self::round_to_i128_with_exact
     /// [`round_to_i128_clear_of_tie`]: Self::round_to_i128_clear_of_tie
     #[inline]
     fn finish_round_to_i128(
         self,
-        q: U256,
-        r: U256,
+        quotient: U256,
+        remainder: U256,
         divisor: U256,
         mode: crate::support::rounding::RoundingMode,
     ) -> Option<i128> {
-        let rounded = if is_zero_u256(r) {
-            q
+        let rounded = if is_zero_u256(remainder) {
+            quotient
         } else {
-            // |r| is r (already a magnitude); comp = divisor - r.
-            let comp = sub_u256(divisor, r);
-            let cmp_r = cmp_u256(r, comp);
-            let q_is_odd = (q[0] & 1) == 1;
-            let result_positive = !self.negative;
-            if crate::support::rounding::should_bump(mode, cmp_r, q_is_odd, result_positive) {
-                add_u256(q, [1, 0]).0
+            // |r| is r (already a magnitude); complement = divisor - r.
+            let complement = sub_u256(divisor, remainder);
+            let remainder_cmp = cmp_u256(remainder, complement);
+            let quotient_is_odd = (quotient[0] & 1) == 1;
+            let result_is_positive = !self.negative;
+            if crate::support::rounding::should_bump(
+                mode, remainder_cmp, quotient_is_odd, result_is_positive)
+            {
+                add_u256(quotient, [1, 0]).0
             } else {
-                q
+                quotient
             }
         };
         if rounded[1] != 0 {
             return None;
         }
-        let m = rounded[0];
-        let v = if self.negative {
-            if m > 1u128 << 127 {
+        let magnitude = rounded[0];
+        let value = if self.negative {
+            if magnitude > 1u128 << 127 {
                 return None;
             }
-            (m as i128).wrapping_neg()
-        } else if m > i128::MAX as u128 {
+            (magnitude as i128).wrapping_neg()
+        } else if magnitude > i128::MAX as u128 {
             return None;
         } else {
-            m as i128
+            magnitude as i128
         };
-        Some(v)
+        Some(value)
     }
 
     /// Single-shot narrowing with a NEAR-TIE escape hatch — the `Fixed`
@@ -851,36 +873,36 @@ impl Fixed {
     #[inline]
     pub(crate) fn round_to_i128_clear_of_tie(
         self,
-        w: u32,
+        working_scale: u32,
         target: u32,
         mode: crate::support::rounding::RoundingMode,
     ) -> Option<Option<i128>> {
-        let shift = w - target;
+        let shift = working_scale - target;
         if shift < 3 {
             // Degenerate guard: no band to measure — round directly.
-            return Some(self.round_to_i128_with(w, target, mode));
+            return Some(self.round_to_i128_with(working_scale, target, mode));
         }
         let divisor = Fixed::pow10(shift);
-        let (q, r) = divmod_u256_by_pow10(self.mag, divisor, shift);
+        let (quotient, remainder) = divmod_u256_by_pow10(self.mag, divisor, shift);
         let band = Fixed::pow10(shift - 3);
-        let dist = if crate::support::rounding::is_nearest_mode(mode) {
+        let distance = if crate::support::rounding::is_nearest_mode(mode) {
             // Distance to the half-ULP boundary (divisor is even, the
             // halve is exact).
             let half = halve_u256(divisor);
-            if ge_u256(half, r) {
-                sub_u256(half, r)
+            if ge_u256(half, remainder) {
+                sub_u256(half, remainder)
             } else {
-                sub_u256(r, half)
+                sub_u256(remainder, half)
             }
         } else {
             // Distance to the grid line (zero or divisor side).
-            let comp = sub_u256(divisor, r);
-            if ge_u256(comp, r) { r } else { comp }
+            let complement = sub_u256(divisor, remainder);
+            if ge_u256(complement, remainder) { remainder } else { complement }
         };
-        if !matches!(cmp_u256(dist, band), core::cmp::Ordering::Greater) {
+        if !matches!(cmp_u256(distance, band), core::cmp::Ordering::Greater) {
             return None;
         }
-        Some(self.finish_round_to_i128(q, r, divisor, mode))
+        Some(self.finish_round_to_i128(quotient, remainder, divisor, mode))
     }
 }
 
@@ -889,84 +911,85 @@ impl Fixed {
     /// from zero) and returns it as `i128`. Used to find the `k` in the
     /// `exp` range reduction `v = k·ln(2) + s`; `|k|` is small there, so
     /// the result always fits.
-    pub(crate) fn round_to_nearest_int(self, w: u32) -> i128 {
-        let scale = Fixed::pow10(w);
-        let (q, r) = divmod_u256_by_pow10(self.mag, scale, w);
-        let int_mag = if ge_u256(r, halve_u256(scale)) {
-            add_u256(q, [1, 0]).0
+    pub(crate) fn round_to_nearest_int(self, working_scale: u32) -> i128 {
+        let divisor = Fixed::pow10(working_scale);
+        let (quotient, remainder) =
+            divmod_u256_by_pow10(self.mag, divisor, working_scale);
+        let integer_magnitude = if ge_u256(remainder, halve_u256(divisor)) {
+            add_u256(quotient, [1, 0]).0
         } else {
-            q
+            quotient
         };
-        let m = int_mag[0] as i128;
-        if self.negative { -m } else { m }
+        let magnitude = integer_magnitude[0] as i128;
+        if self.negative { -magnitude } else { magnitude }
     }
 }
 
 /// `floor(sqrt(n))` for an unsigned 512-bit value, via Newton's method.
 ///
-/// The result fits `U256`. Callers in this crate keep `n < 2^452`
-/// (a working-scale radicand `mag · 10^w` with `w <= 68`), so the
+/// The result fits `U256`. Callers in this crate keep the radicand below
+/// `2^452` (a working-scale `mag · 10^w` with `w <= 68`), so the
 /// initial overestimate and every iterate stay below `2^256`.
-fn isqrt_u512(n: U512) -> U256 {
-    if n == [0, 0, 0, 0] {
+fn isqrt_u512(radicand: U512) -> U256 {
+    if radicand == [0, 0, 0, 0] {
         return [0, 0];
     }
-    // Bit length of n.
-    let bits = if n[3] != 0 {
-        512 - n[3].leading_zeros()
-    } else if n[2] != 0 {
-        384 - n[2].leading_zeros()
-    } else if n[1] != 0 {
-        256 - n[1].leading_zeros()
+    // Bit length of the radicand.
+    let bits = if radicand[3] != 0 {
+        512 - radicand[3].leading_zeros()
+    } else if radicand[2] != 0 {
+        384 - radicand[2].leading_zeros()
+    } else if radicand[1] != 0 {
+        256 - radicand[1].leading_zeros()
     } else {
-        128 - n[0].leading_zeros()
+        128 - radicand[0].leading_zeros()
     };
     // Initial overestimate y0 = 2^ceil(bits/2) >= sqrt(n); for n < 2^452
     // this is at most 2^226, comfortably inside U256.
     let half_bits = bits.div_ceil(2);
-    let mut y: U256 = if half_bits >= 128 {
+    let mut estimate: U256 = if half_bits >= 128 {
         [0, 1u128 << (half_bits - 128)]
     } else {
         [1u128 << half_bits, 0]
     };
     loop {
-        // nq = n / y (fits U256 because y >= sqrt(n)).
-        let nq = div_u512_by_u256(n, y);
-        let nq = [nq[0], nq[1]];
-        // y_next = (y + nq) / 2.
-        let (sum, _carry) = add_u256(y, nq);
-        let y_next = halve_u256(sum);
-        if ge_u256(y_next, y) {
-            return y;
+        // quotient = radicand / estimate (fits U256 because estimate >= sqrt).
+        let quotient = div_u512_by_u256(radicand, estimate);
+        let quotient = [quotient[0], quotient[1]];
+        // next_estimate = (estimate + quotient) / 2.
+        let (sum, _carry) = add_u256(estimate, quotient);
+        let next_estimate = halve_u256(sum);
+        if ge_u256(next_estimate, estimate) {
+            return estimate;
         }
-        y = y_next;
+        estimate = next_estimate;
     }
 }
 
 /// Bit length of a 256-bit value (`0` for zero, else `floor(log2)+1`).
 #[inline]
-fn bitlen_u256(n: U256) -> u32 {
-    if n[1] != 0 {
-        256 - n[1].leading_zeros()
+fn bitlen_u256(value: U256) -> u32 {
+    if value[1] != 0 {
+        256 - value[1].leading_zeros()
     } else {
-        128 - n[0].leading_zeros()
+        128 - value[0].leading_zeros()
     }
 }
 
-/// `n << shift` for a 256-bit value (`shift < 256`).
+/// `value << shift` for a 256-bit value (`shift < 256`).
 #[inline]
-fn shl_u256(n: U256, shift: u32) -> U256 {
+fn shl_u256(value: U256, shift: u32) -> U256 {
     if shift == 0 {
-        n
+        value
     } else if shift >= 128 {
-        [0, n[0] << (shift - 128)]
+        [0, value[0] << (shift - 128)]
     } else {
-        [n[0] << shift, (n[1] << shift) | (n[0] >> (128 - shift))]
+        [value[0] << shift, (value[1] << shift) | (value[0] >> (128 - shift))]
     }
 }
 
-/// `a / 10^w` and `a % 10^w` for a 256-bit dividend and a working scale
-/// `w in 1..=76`.
+/// `numerator / 10^w` and `numerator % 10^w` for a 256-bit dividend and a
+/// `working_scale` in `1..=76`.
 ///
 /// Uses the Möller-Granlund 2-by-1 magic kernel from
 /// [`crate::algos::support::mg_divide`] when `w <= 38` (the divisor fits a
@@ -976,68 +999,72 @@ fn shl_u256(n: U256, shift: u32) -> U256 {
 /// exceeds u128, outside the MG magic table).
 ///
 /// The fast path matches the divisor `[divisor]` the caller passes
-/// in; `w` and `divisor` must agree (`divisor == Fixed::pow10(w)`).
+/// in; `working_scale` and `divisor` must agree
+/// (`divisor == Fixed::pow10(working_scale)`).
 #[inline]
-fn divmod_u256_by_pow10(a: U256, divisor: U256, w: u32) -> (U256, U256) {
-    if (1..=38).contains(&w) {
-        let exp = crate::algos::support::mg_divide::POW10_U128[w as usize];
+fn divmod_u256_by_pow10(numerator: U256, divisor: U256, working_scale: u32) -> (U256, U256) {
+    if (1..=38).contains(&working_scale) {
+        let pow10_divisor =
+            crate::algos::support::mg_divide::POW10_U128[working_scale as usize];
         // Walk dividend top-down (limb 1, then limb 0).
-        let (q_hi, r1) = crate::algos::support::mg_divide::divmod_pow10_2word(0, a[1], exp, w as usize)
+        let (q_hi, remainder1) = crate::algos::support::mg_divide::divmod_pow10_2word(
+            0, numerator[1], pow10_divisor, working_scale as usize)
             .expect("divmod_u256_by_pow10: invariant violated");
-        let (q_lo, r0) = crate::algos::support::mg_divide::divmod_pow10_2word(r1, a[0], exp, w as usize)
+        let (q_lo, remainder0) = crate::algos::support::mg_divide::divmod_pow10_2word(
+            remainder1, numerator[0], pow10_divisor, working_scale as usize)
             .expect("divmod_u256_by_pow10: invariant violated");
-        // The remainder is `r0` (< exp ≤ u128); the high remainder limb is 0.
-        return ([q_lo, q_hi], [r0, 0]);
+        // The remainder is `remainder0` (< exp ≤ u128); the high limb is 0.
+        return ([q_lo, q_hi], [remainder0, 0]);
     }
-    divmod_u256(a, divisor)
+    divmod_u256(numerator, divisor)
 }
 
-/// `a / b` and `a % b` for 256-bit values.
+/// `numerator / divisor` and `numerator % divisor` for 256-bit values.
 ///
 /// Binary shift-subtract long division, bounded by the dividend's
 /// actual bit length rather than a fixed 256 iterations.
-fn divmod_u256(a: U256, b: U256) -> (U256, U256) {
-    debug_assert!(!is_zero_u256(b), "division by zero");
+fn divmod_u256(numerator: U256, divisor: U256) -> (U256, U256) {
+    debug_assert!(!is_zero_u256(divisor), "division by zero");
     // Fast path: both operands fit in a single 128-bit word.
-    if a[1] == 0 && b[1] == 0 {
-        return ([a[0] / b[0], 0], [a[0] % b[0], 0]);
+    if numerator[1] == 0 && divisor[1] == 0 {
+        return ([numerator[0] / divisor[0], 0], [numerator[0] % divisor[0], 0]);
     }
-    let bits = bitlen_u256(a);
+    let bits = bitlen_u256(numerator);
     if bits == 0 {
         return ([0, 0], [0, 0]);
     }
-    let mut q: U256 = [0, 0];
-    let mut rem: U256 = [0, 0];
-    let mut a = shl_u256(a, 256 - bits);
+    let mut quotient: U256 = [0, 0];
+    let mut remainder: U256 = [0, 0];
+    let mut numerator = shl_u256(numerator, 256 - bits);
     let mut i = bits;
     while i > 0 {
         i -= 1;
-        let bit = (a[1] >> 127) & 1;
-        a[1] = (a[1] << 1) | (a[0] >> 127);
-        a[0] <<= 1;
-        rem[1] = (rem[1] << 1) | (rem[0] >> 127);
-        rem[0] = (rem[0] << 1) | bit;
-        q[1] = (q[1] << 1) | (q[0] >> 127);
-        q[0] <<= 1;
-        if ge_u256(rem, b) {
-            rem = sub_u256(rem, b);
-            q[0] |= 1;
+        let bit = (numerator[1] >> 127) & 1;
+        numerator[1] = (numerator[1] << 1) | (numerator[0] >> 127);
+        numerator[0] <<= 1;
+        remainder[1] = (remainder[1] << 1) | (remainder[0] >> 127);
+        remainder[0] = (remainder[0] << 1) | bit;
+        quotient[1] = (quotient[1] << 1) | (quotient[0] >> 127);
+        quotient[0] <<= 1;
+        if ge_u256(remainder, divisor) {
+            remainder = sub_u256(remainder, divisor);
+            quotient[0] |= 1;
         }
     }
-    (q, rem)
+    (quotient, remainder)
 }
 
-/// `a / 2` for a 256-bit value.
+/// `value / 2` for a 256-bit value.
 #[inline]
-fn halve_u256(a: U256) -> U256 {
-    [(a[0] >> 1) | (a[1] << 127), a[1] >> 1]
+fn halve_u256(value: U256) -> U256 {
+    [(value[0] >> 1) | (value[1] << 127), value[1] >> 1]
 }
 
 /// Three-way comparison of 256-bit values.
 #[inline]
-fn cmp_u256(a: U256, b: U256) -> core::cmp::Ordering {
-    match a[1].cmp(&b[1]) {
-        core::cmp::Ordering::Equal => a[0].cmp(&b[0]),
+fn cmp_u256(lhs: U256, rhs: U256) -> core::cmp::Ordering {
+    match lhs[1].cmp(&rhs[1]) {
+        core::cmp::Ordering::Equal => lhs[0].cmp(&rhs[0]),
         other => other,
     }
 }
@@ -1053,32 +1080,32 @@ mod tests {
         // (2^128) * (2^128) = 2^256.
         assert_eq!(mul_u256([0, 1], [0, 1]), [0, 0, 1, 0]);
         // (2^128 - 1)^2.
-        let m = [u128::MAX, 0];
-        let p = mul_u256(m, m);
+        let max_low_limb = [u128::MAX, 0];
+        let product = mul_u256(max_low_limb, max_low_limb);
         // (2^128-1)^2 = 2^256 - 2^129 + 1.
-        assert_eq!(p, [1, u128::MAX - 1, 0, 0]);
+        assert_eq!(product, [1, u128::MAX - 1, 0, 0]);
     }
 
     #[test]
     fn div_u512_round_trip() {
         // (a * b) / b == a for assorted a, b.
-        for &(a, b) in &[
+        for &(lhs, rhs) in &[
             ([123u128, 0], [456u128, 0]),
             ([u128::MAX, 7], [3, 0]),
             ([0, 1], [0, 1]),
             ([99, 99], [1234567, 0]),
         ] {
-            let prod = mul_u256(a, b);
-            let q = div_u512_by_u256(prod, b);
-            assert_eq!([q[0], q[1]], a, "({a:?} * {b:?}) / {b:?}");
-            assert_eq!(q[2], 0);
-            assert_eq!(q[3], 0);
+            let product = mul_u256(lhs, rhs);
+            let quotient = div_u512_by_u256(product, rhs);
+            assert_eq!([quotient[0], quotient[1]], lhs, "({lhs:?} * {rhs:?}) / {rhs:?}");
+            assert_eq!(quotient[2], 0);
+            assert_eq!(quotient[3], 0);
         }
     }
 
     #[test]
     fn fixed_add_sub_signs() {
-        let w = 6;
+        let working_scale = 6;
         let three = Fixed::from_u128_mag(3_000_000, false); // 3.0
         let two = Fixed::from_u128_mag(2_000_000, false); // 2.0
         assert_eq!(three.add(two), Fixed::from_u128_mag(5_000_000, false));
@@ -1086,57 +1113,57 @@ mod tests {
         assert_eq!(two.sub(three), Fixed::from_u128_mag(1_000_000, true));
         assert_eq!(three.add(two.neg()), Fixed::from_u128_mag(1_000_000, false));
         assert!(three.sub(three).is_zero());
-        let _ = w;
+        let _ = working_scale;
     }
 
     #[test]
     fn fixed_mul_div() {
-        let w = 12;
+        let working_scale = 12;
         let one = Fixed {
             negative: false,
-            mag: Fixed::pow10(w),
+            mag: Fixed::pow10(working_scale),
         };
-        let two = Fixed::from_u128_mag(2 * 10u128.pow(w), false);
-        let three = Fixed::from_u128_mag(3 * 10u128.pow(w), false);
+        let two = Fixed::from_u128_mag(2 * 10u128.pow(working_scale), false);
+        let three = Fixed::from_u128_mag(3 * 10u128.pow(working_scale), false);
         // 2 * 3 == 6
         assert_eq!(
-            two.mul(three, w),
-            Fixed::from_u128_mag(6 * 10u128.pow(w), false)
+            two.mul(three, working_scale),
+            Fixed::from_u128_mag(6 * 10u128.pow(working_scale), false)
         );
         // 6 / 2 == 3
-        let six = Fixed::from_u128_mag(6 * 10u128.pow(w), false);
-        assert_eq!(six.div(two, w), three);
+        let six = Fixed::from_u128_mag(6 * 10u128.pow(working_scale), false);
+        assert_eq!(six.div(two, working_scale), three);
         // x * 1 == x
-        assert_eq!(three.mul(one, w), three);
+        assert_eq!(three.mul(one, working_scale), three);
         // x / 3 (small) — 6 / 3 == 2
         assert_eq!(
             six.div_small(3),
-            Fixed::from_u128_mag(2 * 10u128.pow(w), false)
+            Fixed::from_u128_mag(2 * 10u128.pow(working_scale), false)
         );
         // sign of a negative product
-        assert_eq!(two.neg().mul(three, w).negative, true);
-        assert_eq!(two.neg().mul(three.neg(), w).negative, false);
+        assert_eq!(two.neg().mul(three, working_scale).negative, true);
+        assert_eq!(two.neg().mul(three.neg(), working_scale).negative, false);
     }
 
     #[test]
     fn fixed_sqrt_basic() {
-        let w = 12;
-        let one = 10u128.pow(w);
+        let working_scale = 12;
+        let one = 10u128.pow(working_scale);
         // sqrt(4) == 2
         assert_eq!(
-            Fixed::from_u128_mag(4 * one, false).sqrt(w),
+            Fixed::from_u128_mag(4 * one, false).sqrt(working_scale),
             Fixed::from_u128_mag(2 * one, false)
         );
         // sqrt(2) ≈ 1.414213562373 (truncated at scale 12)
-        let s2 = Fixed::from_u128_mag(2 * one, false).sqrt(w);
-        assert_eq!(s2.mag[0], 1_414_213_562_373);
-        assert_eq!(s2.mag[1], 0);
+        let sqrt_two = Fixed::from_u128_mag(2 * one, false).sqrt(working_scale);
+        assert_eq!(sqrt_two.mag[0], 1_414_213_562_373);
+        assert_eq!(sqrt_two.mag[1], 0);
         // sqrt(1) == 1, sqrt(0) == 0
         assert_eq!(
-            Fixed::from_u128_mag(one, false).sqrt(w),
+            Fixed::from_u128_mag(one, false).sqrt(working_scale),
             Fixed::from_u128_mag(one, false)
         );
-        assert!(Fixed::ZERO.sqrt(w).is_zero());
+        assert!(Fixed::ZERO.sqrt(working_scale).is_zero());
     }
 
     // ── Wide shifts ─────────────────────────────────────────────────
@@ -1152,30 +1179,30 @@ mod tests {
         let shifted = one.shl(130);
         assert_eq!(shifted.mag, [0, 4]);
         // shl(0) is identity.
-        let v = Fixed::from_u128_mag(7, false);
-        assert_eq!(v.shl(0).mag, [7, 0]);
+        let value = Fixed::from_u128_mag(7, false);
+        assert_eq!(value.shl(0).mag, [7, 0]);
     }
 
     #[test]
     fn fixed_shr_crosses_limb_boundary() {
         // A value with bits only in the high limb shifted right by 130
         // ends up in the low limb.
-        let v = Fixed {
+        let value = Fixed {
             negative: false,
             mag: [0, 4],
         };
-        let shifted = v.shr(130);
+        let shifted = value.shr(130);
         assert_eq!(shifted.mag, [1, 0]);
         // Negative magnitude shifted to zero loses its sign.
-        let neg = Fixed {
+        let negative_value = Fixed {
             negative: true,
             mag: [0, 1],
         };
-        let shifted = neg.shr(200);
+        let shifted = negative_value.shr(200);
         assert!(shifted.is_zero());
         // shr(0) is identity.
-        let v = Fixed::from_u128_mag(7, false);
-        assert_eq!(v.shr(0).mag, [7, 0]);
+        let value = Fixed::from_u128_mag(7, false);
+        assert_eq!(value.shr(0).mag, [7, 0]);
     }
 
     // ── Opposite-sign add with both zero ────────────────────────────
@@ -1193,8 +1220,8 @@ mod tests {
             negative: true,
             mag: [0, 0],
         };
-        let r = pos_zero.add(neg_zero);
-        assert!(r.is_zero());
+        let result_value = pos_zero.add(neg_zero);
+        assert!(result_value.is_zero());
     }
 
     // ── div_small exercises the bit-loop body ──────────────────────
@@ -1210,20 +1237,20 @@ mod tests {
             negative: false,
             mag: [0, 4],
         };
-        let r = big.div_small(4);
-        assert_eq!(r.mag, [0, 1]);
+        let result_value = big.div_small(4);
+        assert_eq!(result_value.mag, [0, 1]);
         // (3 · 10^36) / 6 = 5 · 10^35 (fits one limb).
         let three_e36 = Fixed::from_u128_mag(3 * 10u128.pow(36), false);
-        let r = three_e36.div_small(6);
-        assert_eq!(r.mag, [5 * 10u128.pow(35), 0]);
+        let result_value = three_e36.div_small(6);
+        assert_eq!(result_value.mag, [5 * 10u128.pow(35), 0]);
         // Negative magnitude carries sign correctly.
-        let neg = Fixed {
+        let negative_value = Fixed {
             negative: true,
             mag: [0, 4],
         };
-        let r = neg.div_small(4);
-        assert_eq!(r.mag, [0, 1]);
-        assert!(r.negative);
+        let result_value = negative_value.div_small(4);
+        assert_eq!(result_value.mag, [0, 1]);
+        assert!(result_value.negative);
     }
 
     // ── round_to_i128 overflow paths ───────────────────────────────
@@ -1236,29 +1263,29 @@ mod tests {
         use crate::support::rounding::RoundingMode;
         let hte = RoundingMode::HalfToEven;
         // High limb non-zero — instant overflow.
-        let v = Fixed {
+        let value = Fixed {
             negative: false,
             mag: [0, 1],
         };
-        assert_eq!(v.round_to_i128_with(0, 0, hte), None);
+        assert_eq!(value.round_to_i128_with(0, 0, hte), None);
         // Low limb just above i128::MAX (positive).
-        let v = Fixed {
+        let value = Fixed {
             negative: false,
             mag: [(i128::MAX as u128) + 1, 0],
         };
-        assert_eq!(v.round_to_i128_with(0, 0, hte), None);
+        assert_eq!(value.round_to_i128_with(0, 0, hte), None);
         // Negative magnitude just past i128::MIN's absolute value.
-        let v = Fixed {
+        let value = Fixed {
             negative: true,
             mag: [(i128::MAX as u128) + 2, 0],
         };
-        assert_eq!(v.round_to_i128_with(0, 0, hte), None);
+        assert_eq!(value.round_to_i128_with(0, 0, hte), None);
         // i128::MIN itself round-trips exactly.
-        let v = Fixed {
+        let value = Fixed {
             negative: true,
             mag: [1u128 << 127, 0],
         };
-        assert_eq!(v.round_to_i128_with(0, 0, hte), Some(i128::MIN));
+        assert_eq!(value.round_to_i128_with(0, 0, hte), Some(i128::MIN));
     }
 
     #[test]
@@ -1276,16 +1303,16 @@ mod tests {
             negative: false,
             mag: [0, 1],
         };
-        let r = two_to_128.round_to_i128_with(1, 0, hte);
+        let result_value = two_to_128.round_to_i128_with(1, 0, hte);
         // 2^128 / 10 ≈ 3.4e37, still > i128::MAX (1.7e38? No, 1.7e38; 3.4e37 < 1.7e38).
         // So the result actually fits i128. Sanity:
-        assert!(r.is_some(), "2^128 / 10 fits i128");
+        assert!(result_value.is_some(), "2^128 / 10 fits i128");
         // The full-MAX value definitely overflows after rounding.
-        let v = Fixed {
+        let value = Fixed {
             negative: false,
             mag: [u128::MAX, u128::MAX],
         };
-        assert_eq!(v.round_to_i128_with(0, 0, hte), None);
+        assert_eq!(value.round_to_i128_with(0, 0, hte), None);
         // A value just above 10 · i128::MAX at working scale 1 overflows
         // after the /10 round.
         let huge = Fixed {
@@ -1297,28 +1324,28 @@ mod tests {
 
     // ── Large-radicand isqrt ────────────────────────────────────────
     //
-    // The `Fixed::sqrt` path forms `mag · 10^w` as a 512-bit value. With
-    // `mag` near 2^128 and `w` large, the radicand needs the top 512-bit
+    // The `Fixed::sqrt` path forms `mag · 10^working_scale` as a 512-bit value. With
+    // `mag` near 2^128 and `working_scale` large, the radicand needs the top 512-bit
     // limb (`n[3]`) — exercising the high-limb branch of `isqrt_u512`.
 
     #[test]
     fn fixed_sqrt_at_large_working_scale() {
-        // At `w = 30`, the radicand `mag · 10^w` for `mag = 10^30` is
+        // At `working_scale = 30`, the radicand `mag · 10^working_scale` for `mag = 10^30` is
         // `10^60` which lives in the 512-bit value's third limb,
         // exercising the high-limb branch of `isqrt_u512`.
-        let w = 30;
+        let working_scale = 30;
         let one_w = Fixed {
             negative: false,
-            mag: Fixed::pow10(w),
+            mag: Fixed::pow10(working_scale),
         };
-        assert_eq!(one_w.sqrt(w), one_w);
-        // sqrt(4 at w=30) ought to be 2 at w=30.
+        assert_eq!(one_w.sqrt(working_scale), one_w);
+        // sqrt(4 at working_scale=30) ought to be 2 at working_scale=30.
         let four_w = Fixed {
             negative: false,
-            mag: [4 * 10u128.pow(w), 0],
+            mag: [4 * 10u128.pow(working_scale), 0],
         };
-        let r = four_w.sqrt(w);
-        assert_eq!(r.mag, [2 * 10u128.pow(w), 0]);
+        let result_value = four_w.sqrt(working_scale);
+        assert_eq!(result_value.mag, [2 * 10u128.pow(working_scale), 0]);
     }
 
     #[test]
@@ -1327,25 +1354,25 @@ mod tests {
         // Working scale 6, round to scale 0. Pin the mode so this
         // test asserts HalfToEven specifically regardless of the
         // active `rounding-*` feature.
-        let w = 6;
+        let working_scale = 6;
         let hte = RoundingMode::HalfToEven;
         // 2.5 -> 2 (tie to even)
-        let v = Fixed::from_u128_mag(2_500_000, false);
-        assert_eq!(v.round_to_i128_with(w, 0, hte), Some(2));
+        let value = Fixed::from_u128_mag(2_500_000, false);
+        assert_eq!(value.round_to_i128_with(working_scale, 0, hte), Some(2));
         // 3.5 -> 4 (tie to even)
-        let v = Fixed::from_u128_mag(3_500_000, false);
-        assert_eq!(v.round_to_i128_with(w, 0, hte), Some(4));
+        let value = Fixed::from_u128_mag(3_500_000, false);
+        assert_eq!(value.round_to_i128_with(working_scale, 0, hte), Some(4));
         // 2.4 -> 2
-        let v = Fixed::from_u128_mag(2_400_000, false);
-        assert_eq!(v.round_to_i128_with(w, 0, hte), Some(2));
+        let value = Fixed::from_u128_mag(2_400_000, false);
+        assert_eq!(value.round_to_i128_with(working_scale, 0, hte), Some(2));
         // 2.6 -> 3
-        let v = Fixed::from_u128_mag(2_600_000, false);
-        assert_eq!(v.round_to_i128_with(w, 0, hte), Some(3));
+        let value = Fixed::from_u128_mag(2_600_000, false);
+        assert_eq!(value.round_to_i128_with(working_scale, 0, hte), Some(3));
         // negative: -2.5 -> -2
-        let v = Fixed::from_u128_mag(2_500_000, true);
-        assert_eq!(v.round_to_i128_with(w, 0, hte), Some(-2));
+        let value = Fixed::from_u128_mag(2_500_000, true);
+        assert_eq!(value.round_to_i128_with(working_scale, 0, hte), Some(-2));
         // same-scale narrowing (no rounding needed)
-        let v = Fixed::from_u128_mag(123_456, false);
-        assert_eq!(v.round_to_i128_with(w, w, hte), Some(123_456));
+        let value = Fixed::from_u128_mag(123_456, false);
+        assert_eq!(value.round_to_i128_with(working_scale, working_scale, hte), Some(123_456));
     }
 }

--- a/src/algos/support/mg_divide.rs
+++ b/src/algos/support/mg_divide.rs
@@ -8,12 +8,13 @@
 //! This module provides two `pub(crate)` entry points used by the
 //! arithmetic layer:
 //!
-//! - [`mul_div_pow10`] -- computes `(a * b) / 10^SCALE` with a 256-bit
+//! - [`mul_div_pow10`] -- computes `(lhs * rhs) / 10^SCALE` with a 256-bit
 //! intermediate product to avoid silent overflow from the naive
-//! `(a * b) / multiplier()` form.
+//! `(lhs * rhs) / multiplier()` form.
 //!
-//! - [`div_pow10_div`] -- computes `(a * 10^SCALE) / b` with a 256-bit
-//! intermediate numerator, used for the division rescale.
+//! - [`div_pow10_div`] -- computes `(dividend * 10^SCALE) / divisor`
+//! with a 256-bit intermediate numerator, used for the division
+//! rescale.
 //!
 //! Both functions return `None` when the final `i128` quotient would
 //! overflow; the caller maps `None` to a panic (debug) or wrapping
@@ -77,32 +78,33 @@ pub(crate) const POW10_U128: [u128; 39] = {
 ///
 /// For our divisors `d = 10^k` the only proper divisors of `2^256 - 1`
 /// that could perturb the floor are powers of two, which `10^k` is not,
-/// so `floor((2^256 - 1) / d_norm) == floor(2^256 / d_norm)`; the
+/// so `floor((2^256 - 1) / d) == floor(2^256 / d)` at the normalised
+/// divisor; the
 /// implementation divides `2^256` (the cleaner constant) by binary
 /// long division. The 129th bit is asserted to be exactly 1.
-const fn mg_reciprocal(d: u128) -> u128 {
-    let s = d.leading_zeros();
-    let d_norm = d << s;
+const fn mg_reciprocal(divisor: u128) -> u128 {
+    let shift = divisor.leading_zeros();
+    let divisor_normalised = divisor << shift;
 
-    // Binary long division of 2^256 by `d_norm`. The numerator has a
-    // single set bit at position 256; we sweep bit positions 256..=0,
+    // Binary long division of 2^256 by `divisor_normalised`. The numerator
+    // has a single set bit at position 256; we sweep bit positions 256..=0,
     // shifting the running remainder left one place per step and pulling
-    // in the numerator bit. The remainder stays strictly below `d_norm`
-    // (< 2^128), but the pre-comparison value `(rem << 1) | nbit` can
-    // reach the 129th bit, so the carry-out of the shift is tracked
-    // separately in `rem_carry`.
+    // in the numerator bit. The remainder stays strictly below the
+    // normalised divisor (< 2^128), but the pre-comparison value
+    // `(rem << 1) | nbit` can reach the 129th bit, so the carry-out of the
+    // shift is tracked separately in `remainder_carry`.
     let mut quot_lo: u128 = 0; // low 128 bits of the quotient
     let mut quot_hi: u128 = 0; // bits 128.. (must end as exactly 1)
-    let mut rem: u128 = 0;
+    let mut remainder: u128 = 0;
     let mut pos: i32 = 256;
     while pos >= 0 {
-        let rem_carry = rem >> 127;
-        let shifted = (rem << 1) | if pos == 256 { 1 } else { 0 };
+        let remainder_carry = remainder >> 127;
+        let shifted = (remainder << 1) | if pos == 256 { 1 } else { 0 };
         // Quotient bit is set when the 129-bit value
-        // (rem_carry:shifted) is >= d_norm.
-        let fits = rem_carry == 1 || shifted >= d_norm;
-        rem = if fits {
-            shifted.wrapping_sub(d_norm)
+        // (remainder_carry:shifted) is >= divisor_normalised.
+        let fits = remainder_carry == 1 || shifted >= divisor_normalised;
+        remainder = if fits {
+            shifted.wrapping_sub(divisor_normalised)
         } else {
             shifted
         };
@@ -131,8 +133,8 @@ const MG_EXP_MAGICS: [(u128, u32); 39] = {
     let mut table = [(0u128, 0u32); 39];
     let mut i = 1;
     while i < 39 {
-        let d = POW10_U128[i];
-        table[i] = (mg_reciprocal(d), d.leading_zeros());
+        let divisor = POW10_U128[i];
+        table[i] = (mg_reciprocal(divisor), divisor.leading_zeros());
         i += 1;
     }
     table
@@ -140,8 +142,8 @@ const MG_EXP_MAGICS: [(u128, u32); 39] = {
 
 /// Full 256-bit product of two unsigned 128-bit integers.
 ///
-/// Returns `(high, low)` with `high * 2^128 + low == a * b` exactly for
-/// every `a`, `b` in `0..=u128::MAX`. `const fn`, so products of
+/// Returns `(high, low)` with `high * 2^128 + low == lhs * rhs` exactly
+/// for every `lhs`, `rhs` in `0..=u128::MAX`. `const fn`, so products of
 /// constants (e.g. the magic-table reciprocals) fold at compile time.
 ///
 /// # Method
@@ -157,16 +159,16 @@ const MG_EXP_MAGICS: [(u128, u32); 39] = {
 ///
 /// Strict: all arithmetic is integer-only; result is bit-exact.
 #[inline]
-pub(crate) const fn mul_u128_to_u256(a: u128, b: u128) -> (u128, u128) {
+pub(crate) const fn mul_u128_to_u256(lhs: u128, rhs: u128) -> (u128, u128) {
     const LOW64: u128 = u64::MAX as u128;
-    let (a_lo, a_hi) = (a & LOW64, a >> 64);
-    let (b_lo, b_hi) = (b & LOW64, b >> 64);
+    let (lhs_lo, lhs_hi) = (lhs & LOW64, lhs >> 64);
+    let (rhs_lo, rhs_hi) = (rhs & LOW64, rhs >> 64);
 
     // Column 0 (weight 2^0) and the two column-1 (weight 2^64) partials.
-    let p00 = a_lo * b_lo;
-    let p01 = a_lo * b_hi;
-    let p10 = a_hi * b_lo;
-    let p11 = a_hi * b_hi; // column 2 (weight 2^128)
+    let p00 = lhs_lo * rhs_lo;
+    let p01 = lhs_lo * rhs_hi;
+    let p10 = lhs_hi * rhs_lo;
+    let p11 = lhs_hi * rhs_hi; // column 2 (weight 2^128)
 
     // Result low half: column 0 plus the low 64 bits of each column-1
     // partial. Accumulate the column-1 contribution to the low word and
@@ -220,13 +222,13 @@ pub(crate) fn divmod_pow10_2word(
         return None;
     }
 
-    let (recip, s) = MG_EXP_MAGICS[scale_idx];
+    let (recip, shift) = MG_EXP_MAGICS[scale_idx];
 
     // Normalise the dividend by the same shift used to derive `recip`
-    // (the divisor's leading-zero count). `s < 128` for every scale in
-    // range, so `128 - s` is a valid shift width.
-    let top = (n_high << s) | (n_low >> (128 - s));
-    let bottom = n_low << s;
+    // (the divisor's leading-zero count). `shift < 128` for every scale in
+    // range, so `128 - shift` is a valid shift width.
+    let top = (n_high << shift) | (n_low >> (128 - shift));
+    let bottom = n_low << shift;
 
     // Quotient estimate = high 128 bits of `(2^128 + recip) * n_norm`,
     // where `n_norm = top * 2^128 + bottom`. The `2^128` factor
@@ -236,31 +238,32 @@ pub(crate) fn divmod_pow10_2word(
     let (hi_from_top, lo_from_top) = mul_u128_to_u256(recip, top);
     let (carry_from_bottom, _) = mul_u128_to_u256(recip, bottom);
 
-    let (acc_low, c0) = lo_from_top.overflowing_add(carry_from_bottom);
-    let acc_high = hi_from_top + u128::from(c0);
+    let (acc_low, carry0) = lo_from_top.overflowing_add(carry_from_bottom);
+    let acc_high = hi_from_top + u128::from(carry0);
 
     // Folding the normalised low word back in completes the high-word
-    // extraction; `q` is the floor quotient, possibly one too small.
-    let (_, c1) = acc_low.overflowing_add(bottom);
-    let q = acc_high + top + u128::from(c1);
+    // extraction; `quotient` is the floor quotient, possibly one too small.
+    let (_, carry1) = acc_low.overflowing_add(bottom);
+    let quotient = acc_high + top + u128::from(carry1);
 
     // Exact remainder against the un-normalised divisor, then the single
-    // add-back: at most one increment makes `q` exact.
-    let (_, prod_low) = mul_u128_to_u256(q, exp);
-    let (rem, under) = n_low.overflowing_sub(prod_low);
-    debug_assert!(n_high == mul_u128_to_u256(q, exp).0 + u128::from(under));
+    // add-back: at most one increment makes `quotient` exact.
+    let (_, prod_low) = mul_u128_to_u256(quotient, exp);
+    let (remainder, under) = n_low.overflowing_sub(prod_low);
+    debug_assert!(n_high == mul_u128_to_u256(quotient, exp).0 + u128::from(under));
 
-    if rem < exp {
-        Some((q, rem))
+    if remainder < exp {
+        Some((quotient, remainder))
     } else {
-        Some((q + 1, rem - exp))
+        Some((quotient + 1, remainder - exp))
     }
 }
 
 /// Width-agnostic single-chunk MG divide of a u128-limb magnitude slice
 /// by `10^scale` (`1 ≤ scale ≤ 38`), in place, with `mode`-aware
 /// rounding. `mag` is the little-endian unsigned magnitude (zero-padded
-/// to its full length); `neg` is the result sign for rounding tie-breaks.
+/// to its full length); `is_negative` is the result sign for rounding
+/// tie-breaks.
 ///
 /// This is the slice core extracted from [`div_wide_pow10`]: the
 /// `BigInt` packing/unpacking is the only difference between the two, so
@@ -272,12 +275,12 @@ pub(crate) fn divmod_pow10_2word(
 pub(crate) fn div_pow10_mag_u128(
     mag: &mut [u128],
     scale: u32,
-    neg: bool,
+    is_negative: bool,
     mode: crate::support::rounding::RoundingMode,
 ) {
     debug_assert!((1..=38).contains(&scale));
     let scale_idx = scale as usize;
-    let exp = POW10_U128[scale_idx];
+    let divisor = POW10_U128[scale_idx];
 
     // Skip trailing zero limbs (buffers are zero-padded to full width).
     let mut top = mag.len();
@@ -285,29 +288,32 @@ pub(crate) fn div_pow10_mag_u128(
         top -= 1;
     }
 
-    // Base-2^128 long divide of `mag[..top]` by `exp`, top-limb first.
-    let mut rem: u128 = 0;
+    // Base-2^128 long divide of `mag[..top]` by the divisor, top-limb first.
+    let mut remainder: u128 = 0;
     let mut i = top;
     while i > 0 {
         i -= 1;
         let limb = mag[i];
-        let (q_limb, r_limb) = divmod_pow10_2word(rem, limb, exp, scale_idx)
-            .expect("MG: rem < exp invariant violated");
-        mag[i] = q_limb;
-        rem = r_limb;
+        let (quotient_limb, remainder_limb) =
+            divmod_pow10_2word(remainder, limb, divisor, scale_idx)
+                .expect("MG: rem < exp invariant violated");
+        mag[i] = quotient_limb;
+        remainder = remainder_limb;
     }
 
     // Round the magnitude per `mode`.
-    if rem != 0 {
-        let q_is_odd = (mag[0] & 1) != 0;
-        let comp = exp - rem;
-        let cmp_r = rem.cmp(&comp);
-        if crate::support::rounding::should_bump(mode, cmp_r, q_is_odd, !neg) {
+    if remainder != 0 {
+        let quotient_is_odd = (mag[0] & 1) != 0;
+        let complement = divisor - remainder;
+        let remainder_cmp = remainder.cmp(&complement);
+        if crate::support::rounding::should_bump(
+            mode, remainder_cmp, quotient_is_odd, !is_negative)
+        {
             let mut carry: u128 = 1;
             for limb in mag.iter_mut() {
-                let (s, c) = limb.overflowing_add(carry);
-                *limb = s;
-                if !c {
+                let (sum, carried) = limb.overflowing_add(carry);
+                *limb = sum;
+                if !carried {
                     carry = 0;
                     break;
                 }
@@ -337,19 +343,20 @@ pub(crate) fn div_pow10_mag_u128(
 ///
 /// Bit-exact half-to-even (and every other `RoundingMode`) across
 /// `SCALE ∈ 39..=∞`. The chain produces a per-pass remainder sequence
-/// `r_1, …, r_k` (from each `÷10^38`) plus a final `r_last < 10^s`
+/// `r_1, …, r_k` (from each `÷10^38`) plus a final `last_remainder < 10^s`
 /// (`s = SCALE − 38·k`). The combined remainder
-/// `r_total = r_last·10^{38·k} + (lower chunks)` is compared against
-/// `10^SCALE / 2`: this reduces to `r_last` vs `10^s / 2`, with a tie
-/// broken upward iff any lower chunk is non-zero — captured by the
-/// `lower_any_nonzero` flag. (`r_last == 0` ⇒ `r_total < 10^SCALE/2`,
-/// because each lower chunk `< 10^38` and the chunks cannot sum to the
-/// half.) Identical decision to a single exact `r` vs `10^SCALE/2` test.
+/// `r_total = last_remainder·10^{38·k} + (lower chunks)` is compared
+/// against `10^SCALE / 2`: this reduces to `last_remainder` vs `10^s / 2`,
+/// with a tie broken upward iff any lower chunk is non-zero — captured by
+/// the `lower_any_nonzero` flag. (`last_remainder == 0` ⇒
+/// `r_total < 10^SCALE/2`, because each lower chunk `< 10^38` and the
+/// chunks cannot sum to the half.) Identical decision to a single exact
+/// `r` vs `10^SCALE/2` test.
 #[inline]
 pub(crate) fn div_pow10_chain_mag_u128(
     mag: &mut [u128],
     scale: u32,
-    neg: bool,
+    is_negative: bool,
     mode: crate::support::rounding::RoundingMode,
 ) {
     debug_assert!(
@@ -357,7 +364,7 @@ pub(crate) fn div_pow10_chain_mag_u128(
         "chain path is for SCALE > 38; callers handle smaller scales"
     );
 
-    let exp38 = POW10_U128[38];
+    let pow10_38 = POW10_U128[38];
 
     // Live (leading-zero-trimmed) limb cursor; passes shrink it.
     let mut top = mag.len();
@@ -371,16 +378,17 @@ pub(crate) fn div_pow10_chain_mag_u128(
     let mut lower_any_nonzero = false;
     let mut remaining = scale;
     while remaining > 38 {
-        let mut rem: u128 = 0;
+        let mut remainder: u128 = 0;
         let mut i = top;
         while i > 0 {
             i -= 1;
-            let (q, r) = divmod_pow10_2word(rem, mag[i], exp38, 38)
-                .expect("MG chain: rem < exp invariant violated");
-            mag[i] = q;
-            rem = r;
+            let (quotient, chunk_remainder) =
+                divmod_pow10_2word(remainder, mag[i], pow10_38, 38)
+                    .expect("MG chain: rem < exp invariant violated");
+            mag[i] = quotient;
+            remainder = chunk_remainder;
         }
-        if rem != 0 {
+        if remainder != 0 {
             lower_any_nonzero = true;
         }
         remaining -= 38;
@@ -390,39 +398,42 @@ pub(crate) fn div_pow10_chain_mag_u128(
     }
 
     // Final divide by 10^remaining (1..=38); its remainder is the
-    // top-chunk remainder r_last.
+    // top-chunk `last_remainder`.
     let scale_idx = remaining as usize;
-    let exp_last = POW10_U128[scale_idx];
-    let mut r_last: u128 = 0;
+    let pow10_last = POW10_U128[scale_idx];
+    let mut last_remainder: u128 = 0;
     let mut i = top;
     while i > 0 {
         i -= 1;
-        let (q, r) = divmod_pow10_2word(r_last, mag[i], exp_last, scale_idx)
-            .expect("MG chain: rem < exp invariant violated");
-        mag[i] = q;
-        r_last = r;
+        let (quotient, chunk_remainder) =
+            divmod_pow10_2word(last_remainder, mag[i], pow10_last, scale_idx)
+                .expect("MG chain: rem < exp invariant violated");
+        mag[i] = quotient;
+        last_remainder = chunk_remainder;
     }
 
-    // Combined-remainder rounding: cmp_r is r_total vs 10^SCALE / 2.
-    let combined_nonzero = r_last != 0 || lower_any_nonzero;
+    // Combined-remainder rounding: the comparison is r_total vs 10^SCALE / 2.
+    let combined_nonzero = last_remainder != 0 || lower_any_nonzero;
     if combined_nonzero {
-        let half = exp_last / 2; // exact; exp_last = 10^scale_idx is even
-        let cmp_r = if r_last > half {
+        let half = pow10_last / 2; // exact; 10^scale_idx is even
+        let remainder_cmp = if last_remainder > half {
             core::cmp::Ordering::Greater
-        } else if r_last < half {
+        } else if last_remainder < half {
             core::cmp::Ordering::Less
         } else if lower_any_nonzero {
             core::cmp::Ordering::Greater
         } else {
             core::cmp::Ordering::Equal
         };
-        let q_is_odd = (mag[0] & 1) != 0;
-        if crate::support::rounding::should_bump(mode, cmp_r, q_is_odd, !neg) {
+        let quotient_is_odd = (mag[0] & 1) != 0;
+        if crate::support::rounding::should_bump(
+            mode, remainder_cmp, quotient_is_odd, !is_negative)
+        {
             let mut carry: u128 = 1;
             for limb in mag.iter_mut() {
-                let (s, c) = limb.overflowing_add(carry);
-                *limb = s;
-                if !c {
+                let (sum, carried) = limb.overflowing_add(carry);
+                *limb = sum;
+                if !carried {
                     carry = 0;
                     break;
                 }
@@ -445,7 +456,7 @@ pub(crate) fn div_pow10_chain_mag_u128(
 /// [`ComputeLimbs`]: crate::int::types::compute_limbs::ComputeLimbs
 #[inline]
 pub(crate) fn div_wide_pow10<W>(
-    n: W,
+    value: W,
     scale: u32,
     mode: crate::support::rounding::RoundingMode,
 ) -> W
@@ -455,9 +466,9 @@ where
 {
     let mut buf = <W::Scratch as crate::int::types::compute_limbs::ComputeLimbs>::single_u128();
     let mag = &mut buf.as_mut()[..W::U128_LIMBS];
-    let neg = n.mag_into_u128(mag);
-    div_pow10_mag_u128(mag, scale, neg, mode);
-    W::from_mag_sign_u128(mag, neg)
+    let is_negative = value.mag_into_u128(mag);
+    div_pow10_mag_u128(mag, scale, is_negative, mode);
+    W::from_mag_sign_u128(mag, is_negative)
 }
 
 /// Width-generic extension of [`div_wide_pow10`] to scales past `38`,
@@ -479,7 +490,7 @@ where
 /// [`ComputeLimbs`]: crate::int::types::compute_limbs::ComputeLimbs
 #[inline]
 pub(crate) fn div_wide_pow10_chain<W>(
-    n: W,
+    value: W,
     scale: u32,
     mode: crate::support::rounding::RoundingMode,
 ) -> W
@@ -489,13 +500,13 @@ where
 {
     let mut buf = <W::Scratch as crate::int::types::compute_limbs::ComputeLimbs>::single_u128();
     let mag = &mut buf.as_mut()[..W::U128_LIMBS];
-    let neg = n.mag_into_u128(mag);
-    div_pow10_chain_mag_u128(mag, scale, neg, mode);
-    W::from_mag_sign_u128(mag, neg)
+    let is_negative = value.mag_into_u128(mag);
+    div_pow10_chain_mag_u128(mag, scale, is_negative, mode);
+    W::from_mag_sign_u128(mag, is_negative)
 }
 
-/// Mode-aware rounding for an *unsigned* magnitude `q` with remainder
-/// `r` against divisor `m`, given the result sign — returns the
+/// Mode-aware rounding for an *unsigned* `quotient` with `remainder`
+/// against `divisor`, given the result sign — returns the
 /// rounded magnitude. Caller applies the sign afterwards.
 ///
 /// All mode-specific behaviour is delegated to
@@ -503,43 +514,46 @@ where
 /// the inputs from the unsigned-magnitude representation.
 #[inline]
 fn round_mag_with_mode(
-    q: u128,
-    r: u128,
-    m: u128,
+    quotient: u128,
+    remainder: u128,
+    divisor: u128,
     mode: crate::support::rounding::RoundingMode,
-    result_positive: bool,
+    result_is_positive: bool,
 ) -> u128 {
-    if r == 0 {
-        return q;
+    if remainder == 0 {
+        return quotient;
     }
-    let comp = m - r;
-    let cmp_r = r.cmp(&comp);
-    let q_is_odd = (q & 1) != 0;
-    if crate::support::rounding::should_bump(mode, cmp_r, q_is_odd, result_positive) {
-        q + 1
+    let complement = divisor - remainder;
+    let remainder_cmp = remainder.cmp(&complement);
+    let quotient_is_odd = (quotient & 1) != 0;
+    if crate::support::rounding::should_bump(
+        mode, remainder_cmp, quotient_is_odd, result_is_positive)
+    {
+        quotient + 1
     } else {
-        q
+        quotient
     }
 }
 
 // Binary shift-subtract long-divide for the variable-divisor path.
 //
-// Used when dividing a 256-bit numerator by an arbitrary 128-bit `b`
-// (not a power of 10), so no magic table applies. The loop runs exactly
-// 256 iterations -- one per bit of the numerator -- and is competitive
-// in practice because the widening path is taken only for large `a`.
+// Used when dividing a 256-bit numerator by an arbitrary 128-bit
+// `divisor` (not a power of 10), so no magic table applies. The loop
+// runs exactly 256 iterations -- one per bit of the numerator -- and is
+// competitive in practice because the widening path is taken only for
+// large `dividend`.
 
 /// Divide the unsigned 256-bit value `(n_high, n_low)` by the 128-bit
-/// divisor `d` using a binary shift-subtract algorithm. Returns
+/// `divisor` using a binary shift-subtract algorithm. Returns
 /// `Some(quotient)` if the quotient fits in 128 bits, or `None` if
-/// `d == 0` or the quotient would overflow 128 bits.
+/// the divisor is `0` or the quotient would overflow 128 bits.
 ///
 /// # Precision
 ///
 /// Strict: all arithmetic is integer-only; result is bit-exact.
 #[inline]
-fn div_long_256_by_128(n_high: u128, n_low: u128, d: u128) -> Option<u128> {
-    div_long_256_by_128_with_rem(n_high, n_low, d).map(|(q, _)| q)
+fn div_long_256_by_128(n_high: u128, n_low: u128, divisor: u128) -> Option<u128> {
+    div_long_256_by_128_with_rem(n_high, n_low, divisor).map(|(quotient, _)| quotient)
 }
 
 /// Remainder-returning companion of [`div_long_256_by_128`]. Same
@@ -550,17 +564,17 @@ fn div_long_256_by_128(n_high: u128, n_low: u128, d: u128) -> Option<u128> {
 fn div_long_256_by_128_with_rem(
     mut n_high: u128,
     mut n_low: u128,
-    d: u128,
+    divisor: u128,
 ) -> Option<(u128, u128)> {
-    if d == 0 {
+    if divisor == 0 {
         return None;
     }
     // Fast path: dividend already fits 128 bits.
     if n_high == 0 {
-        return Some((n_low / d, n_low % d));
+        return Some((n_low / divisor, n_low % divisor));
     }
-    // Overflow check: quotient must fit in 128 bits, so n_high < d.
-    if n_high >= d {
+    // Overflow check: quotient must fit in 128 bits, so n_high < divisor.
+    if n_high >= divisor {
         return None;
     }
 
@@ -568,25 +582,25 @@ fn div_long_256_by_128_with_rem(
     // schoolbook base-2^64 long division — one hardware divide per
     // 64-bit limb instead of a 256-iteration bit loop. Every
     // `10^scale` for `scale <= 19` lands here.
-    if d <= u128::from(u64::MAX) {
+    if divisor <= u128::from(u64::MAX) {
         let limbs = [
             n_low as u64,
             (n_low >> 64) as u64,
             n_high as u64,
             (n_high >> 64) as u64,
         ];
-        // `n_high < d` guarantees the quotient fits in 128 bits, so the
-        // top two limbs of the result are always zero.
+        // `n_high < divisor` guarantees the quotient fits in 128 bits, so
+        // the top two limbs of the result are always zero.
         let mut out = [0u64; 4];
-        let mut rem: u128 = 0;
+        let mut remainder: u128 = 0;
         let mut i = 4;
         while i > 0 {
             i -= 1;
-            let cur = (rem << 64) | u128::from(limbs[i]);
-            out[i] = (cur / d) as u64;
-            rem = cur % d;
+            let current = (remainder << 64) | u128::from(limbs[i]);
+            out[i] = (current / divisor) as u64;
+            remainder = current % divisor;
         }
-        return Some((u128::from(out[0]) | (u128::from(out[1]) << 64), rem));
+        return Some((u128::from(out[0]) | (u128::from(out[1]) << 64), remainder));
     }
 
     // Shift-subtract over only the significant bits of the dividend.
@@ -603,21 +617,21 @@ fn div_long_256_by_128_with_rem(
         n_high = (n_high << shift) | (n_low >> (128 - shift));
         n_low <<= shift;
     }
-    let mut q: u128 = 0;
-    let mut rem: u128 = 0;
+    let mut quotient: u128 = 0;
+    let mut remainder: u128 = 0;
     let mut i = bits;
     while i > 0 {
         i -= 1;
-        rem = (rem << 1) | (n_high >> 127);
+        remainder = (remainder << 1) | (n_high >> 127);
         n_high = (n_high << 1) | (n_low >> 127);
         n_low <<= 1;
-        q <<= 1;
-        if rem >= d {
-            rem -= d;
-            q |= 1;
+        quotient <<= 1;
+        if remainder >= divisor {
+            remainder -= divisor;
+            quotient |= 1;
         }
     }
-    Some((q, rem))
+    Some((quotient, remainder))
 }
 
 /// `floor(sqrt(N))` for the unsigned 256-bit value `N = hi·2^128 + lo`.
@@ -656,18 +670,19 @@ pub(crate) fn isqrt_256(hi: u128, lo: u128) -> u128 {
     let n_limbs = [lo as u64, (lo >> 64) as u64, hi as u64, (hi >> 64) as u64];
     let mut seed_limbs = [0u64; 4];
     crate::algo_x_support::seed::sqrt_seed(&n_limbs, bits, &mut seed_limbs);
-    let mut q: u128 = (seed_limbs[0] as u128) | ((seed_limbs[1] as u128) << 64);
+    let mut estimate: u128 = (seed_limbs[0] as u128) | ((seed_limbs[1] as u128) << 64);
     loop {
-        // q ≥ sqrt(N) on every iteration, so N / q ≤ sqrt(N) < 2^127
-        // and the divide always succeeds.
-        let nq = div_long_256_by_128(hi, lo, q)
+        // estimate ≥ sqrt(N) on every iteration, so N / estimate ≤ sqrt(N)
+        // < 2^127 and the divide always succeeds.
+        let quotient = div_long_256_by_128(hi, lo, estimate)
             .expect("isqrt_256: q >= sqrt(N), so N/q fits in 128 bits");
-        // q_next = (q + nq) / 2, computed without the q+nq overflow.
-        let q_next = (q >> 1) + (nq >> 1) + (q & nq & 1);
-        if q_next >= q {
-            return q;
+        // next_estimate = (estimate + quotient) / 2, without the overflow.
+        let next_estimate =
+            (estimate >> 1) + (quotient >> 1) + (estimate & quotient & 1);
+        if next_estimate >= estimate {
+            return estimate;
         }
-        q = q_next;
+        estimate = next_estimate;
     }
 }
 
@@ -691,8 +706,8 @@ pub(crate) fn isqrt_256(hi: u128, lo: u128) -> u128 {
 ///
 /// Strict: integer-only; the result is within 0.5 ULP of the exact
 /// square root — it is the exact result correctly rounded.
-pub(crate) fn sqrt_raw_correctly_rounded(r: u128, scale: u32) -> u128 {
-    sqrt_raw_with(r, scale, crate::support::rounding::RoundingMode::HalfToEven)
+pub(crate) fn sqrt_raw_correctly_rounded(raw: u128, scale: u32) -> u128 {
+    sqrt_raw_with(raw, scale, crate::support::rounding::RoundingMode::HalfToEven)
 }
 
 /// Mode-aware variant of [`sqrt_raw_correctly_rounded`].
@@ -710,12 +725,12 @@ pub(crate) fn sqrt_raw_correctly_rounded(r: u128, scale: u32) -> u128 {
 /// - half-modes: bump to `q + 1` iff `N > q² + q` (equivalently
 ///   `diff > q`), the standard round-to-nearest-integer test.
 pub(crate) fn sqrt_raw_with(
-    r: u128,
+    raw: u128,
     scale: u32,
     mode: crate::support::rounding::RoundingMode,
 ) -> u128 {
     use crate::support::rounding::RoundingMode;
-    if r == 0 {
+    if raw == 0 {
         return 0;
     }
 
@@ -733,17 +748,17 @@ pub(crate) fn sqrt_raw_with(
     // and the table lookup `POW10_U128[scale]` const-fold and the
     // branch is statically resolved per-monomorphisation.
     let scale_idx = scale as usize;
-    let pow = POW10_U128[scale_idx];
-    // u128 overflow check: `r ≤ u128::MAX / pow` iff `r * pow ≤ u128::MAX`.
-    if r <= u128::MAX / pow {
-        let n = r * pow;
-        let q = n.isqrt();
+    let pow10_scale = POW10_U128[scale_idx];
+    // u128 overflow check: `raw ≤ u128::MAX / pow` iff `raw * pow ≤ u128::MAX`.
+    if raw <= u128::MAX / pow10_scale {
+        let radicand = raw * pow10_scale;
+        let root = radicand.isqrt();
         // Residual `N − q²` and the round-to-nearest tie test `diff > q`
         // mirror the 256-bit branch exactly: `q² ≤ N` always, so the
         // subtraction never underflows.
-        let diff = n - q * q;
+        let diff = radicand - root * root;
         let diff_nonzero = diff != 0;
-        let halfway_round_up = diff > q;
+        let halfway_round_up = diff > root;
         let bump = match mode {
             RoundingMode::HalfToEven
             | RoundingMode::HalfAwayFromZero
@@ -751,21 +766,21 @@ pub(crate) fn sqrt_raw_with(
             RoundingMode::Trunc | RoundingMode::Floor => false,
             RoundingMode::Ceiling => diff_nonzero,
         };
-        return if bump { q + 1 } else { q };
+        return if bump { root + 1 } else { root };
     }
 
-    // Widening path: `r · 10^SCALE` overflows `u128`, so the full
+    // Widening path: `raw · 10^SCALE` overflows `u128`, so the full
     // 256-bit machinery is required.
-    let (hi, lo) = mul_u128_to_u256(r, pow);
-    let q = isqrt_256(hi, lo);
-    let (q_sq_hi, q_sq_lo) = mul_u128_to_u256(q, q);
-    let (diff_hi, diff_lo) = if lo >= q_sq_lo {
-        (hi - q_sq_hi, lo - q_sq_lo)
+    let (hi, lo) = mul_u128_to_u256(raw, pow10_scale);
+    let root = isqrt_256(hi, lo);
+    let (root_sq_hi, root_sq_lo) = mul_u128_to_u256(root, root);
+    let (diff_hi, diff_lo) = if lo >= root_sq_lo {
+        (hi - root_sq_hi, lo - root_sq_lo)
     } else {
-        (hi - q_sq_hi - 1, lo.wrapping_sub(q_sq_lo))
+        (hi - root_sq_hi - 1, lo.wrapping_sub(root_sq_lo))
     };
     let diff_nonzero = diff_hi != 0 || diff_lo != 0;
-    let halfway_round_up = diff_hi != 0 || diff_lo > q;
+    let halfway_round_up = diff_hi != 0 || diff_lo > root;
     let bump = match mode {
         RoundingMode::HalfToEven
         | RoundingMode::HalfAwayFromZero
@@ -773,7 +788,7 @@ pub(crate) fn sqrt_raw_with(
         RoundingMode::Trunc | RoundingMode::Floor => false,
         RoundingMode::Ceiling => diff_nonzero,
     };
-    if bump { q + 1 } else { q }
+    if bump { root + 1 } else { root }
 }
 
 // ─────────────────────────────────────────────────────────────────────
@@ -799,98 +814,102 @@ fn pow10_256(exp: u32) -> [u128; 2] {
     }
 }
 
-/// `a * m` where `m` is a 256-bit value `[lo, hi]`; result is 384-bit.
-fn mul_u128_by_256(a: u128, m: [u128; 2]) -> [u128; 3] {
-    let (p0_hi, p0_lo) = mul_u128_to_u256(a, m[0]);
-    let (p1_hi, p1_lo) = mul_u128_to_u256(a, m[1]);
+/// `value * wide` where `wide` is a 256-bit value `[lo, hi]`; result is
+/// 384-bit.
+fn mul_u128_by_256(value: u128, wide: [u128; 2]) -> [u128; 3] {
+    let (p0_hi, p0_lo) = mul_u128_to_u256(value, wide[0]);
+    let (p1_hi, p1_lo) = mul_u128_to_u256(value, wide[1]);
     let limb0 = p0_lo;
-    let (limb1, c1) = p0_hi.overflowing_add(p1_lo);
-    let limb2 = p1_hi + u128::from(c1);
+    let (limb1, carry1) = p0_hi.overflowing_add(p1_lo);
+    let limb2 = p1_hi + u128::from(carry1);
     [limb0, limb1, limb2]
 }
 
-/// `s * b` where `s` is a 256-bit value `[lo, hi]`; result is 384-bit.
-fn mul_u256_by_u128(s: [u128; 2], b: u128) -> [u128; 3] {
-    let (p0_hi, p0_lo) = mul_u128_to_u256(s[0], b);
-    let (p1_hi, p1_lo) = mul_u128_to_u256(s[1], b);
+/// `wide * multiplier` where `wide` is a 256-bit value `[lo, hi]`; result
+/// is 384-bit.
+fn mul_u256_by_u128(wide: [u128; 2], multiplier: u128) -> [u128; 3] {
+    let (p0_hi, p0_lo) = mul_u128_to_u256(wide[0], multiplier);
+    let (p1_hi, p1_lo) = mul_u128_to_u256(wide[1], multiplier);
     let limb0 = p0_lo;
-    let (limb1, c1) = p0_hi.overflowing_add(p1_lo);
-    let limb2 = p1_hi + u128::from(c1);
+    let (limb1, carry1) = p0_hi.overflowing_add(p1_lo);
+    let limb2 = p1_hi + u128::from(carry1);
     [limb0, limb1, limb2]
 }
 
 /// Left-shift a 384-bit value by 3 bits. The caller guarantees no
 /// significant bits are lost (used only on `N < 2^380`, so `8N < 2^383`).
-fn shl3_384(n: [u128; 3]) -> [u128; 3] {
+fn shl3_384(value: [u128; 3]) -> [u128; 3] {
     [
-        n[0] << 3,
-        (n[1] << 3) | (n[0] >> 125),
-        (n[2] << 3) | (n[1] >> 125),
+        value[0] << 3,
+        (value[1] << 3) | (value[0] >> 125),
+        (value[2] << 3) | (value[1] >> 125),
     ]
 }
 
-/// `a >= b` for 384-bit values.
-fn ge_384(a: [u128; 3], b: [u128; 3]) -> bool {
-    if a[2] != b[2] {
-        a[2] > b[2]
-    } else if a[1] != b[1] {
-        a[1] > b[1]
+/// `lhs >= rhs` for 384-bit values.
+fn ge_384(lhs: [u128; 3], rhs: [u128; 3]) -> bool {
+    if lhs[2] != rhs[2] {
+        lhs[2] > rhs[2]
+    } else if lhs[1] != rhs[1] {
+        lhs[1] > rhs[1]
     } else {
-        a[0] >= b[0]
+        lhs[0] >= rhs[0]
     }
 }
 
-/// `a >= b` for 256-bit values `[lo, hi]`.
-fn ge_256(a: [u128; 2], b: [u128; 2]) -> bool {
-    a[1] > b[1] || (a[1] == b[1] && a[0] >= b[0])
+/// `lhs >= rhs` for 256-bit values `[lo, hi]`.
+fn ge_256(lhs: [u128; 2], rhs: [u128; 2]) -> bool {
+    lhs[1] > rhs[1] || (lhs[1] == rhs[1] && lhs[0] >= rhs[0])
 }
 
-/// `a - b` for 256-bit values `[lo, hi]`; caller guarantees `a >= b`.
-fn sub_256(a: [u128; 2], b: [u128; 2]) -> [u128; 2] {
-    let (lo, borrow) = a[0].overflowing_sub(b[0]);
-    let hi = a[1] - b[1] - u128::from(borrow);
+/// `lhs - rhs` for 256-bit values `[lo, hi]`; caller guarantees
+/// `lhs >= rhs`.
+fn sub_256(lhs: [u128; 2], rhs: [u128; 2]) -> [u128; 2] {
+    let (lo, borrow) = lhs[0].overflowing_sub(rhs[0]);
+    let hi = lhs[1] - rhs[1] - u128::from(borrow);
     [lo, hi]
 }
 
-/// Divide the 384-bit `num` by the 256-bit `d` via binary
+/// Divide the 384-bit `numerator` by the 256-bit `divisor` via binary
 /// shift-subtract. The caller guarantees the quotient fits in `u128`.
-fn div_384_by_256(mut num: [u128; 3], d: [u128; 2]) -> u128 {
-    let mut rem: [u128; 2] = [0, 0];
-    let mut q: u128 = 0;
+fn div_384_by_256(mut numerator: [u128; 3], divisor: [u128; 2]) -> u128 {
+    let mut remainder: [u128; 2] = [0, 0];
+    let mut quotient: u128 = 0;
     let mut i = 0;
     while i < 384 {
-        // Shift the top bit of `num` into `rem`, both left by 1.
-        let num_top = num[2] >> 127;
-        num[2] = (num[2] << 1) | (num[1] >> 127);
-        num[1] = (num[1] << 1) | (num[0] >> 127);
-        num[0] <<= 1;
-        rem[1] = (rem[1] << 1) | (rem[0] >> 127);
-        rem[0] = (rem[0] << 1) | num_top;
-        q <<= 1;
-        if ge_256(rem, d) {
-            rem = sub_256(rem, d);
-            q |= 1;
+        // Shift the top bit of the numerator into the remainder, both
+        // left by 1.
+        let numerator_top = numerator[2] >> 127;
+        numerator[2] = (numerator[2] << 1) | (numerator[1] >> 127);
+        numerator[1] = (numerator[1] << 1) | (numerator[0] >> 127);
+        numerator[0] <<= 1;
+        remainder[1] = (remainder[1] << 1) | (remainder[0] >> 127);
+        remainder[0] = (remainder[0] << 1) | numerator_top;
+        quotient <<= 1;
+        if ge_256(remainder, divisor) {
+            remainder = sub_256(remainder, divisor);
+            quotient |= 1;
         }
         i += 1;
     }
-    q
+    quotient
 }
 
-/// `floor((carry · 2^128 + val) / 3)` for `carry` in `0..=2`. Used by
+/// `floor((carry · 2^128 + value) / 3)` for `carry` in `0..=2`. Used by
 /// the cube-root Newton step, where `2y + N/y²` can be a 130-bit value.
-fn floor_div3(mut carry: u128, mut val: u128) -> u128 {
+fn floor_div3(mut carry: u128, mut value: u128) -> u128 {
     // 2^128 = 3·K + 1, with K = (2^128 - 1) / 3.
     const K: u128 = u128::MAX / 3;
-    let mut q: u128 = 0;
+    let mut quotient: u128 = 0;
     loop {
         if carry == 0 {
-            return q + val / 3;
+            return quotient + value / 3;
         }
-        // carry·2^128 + val = 3·carry·K + (carry + val).
-        q += carry * K;
-        let (next_val, c) = val.overflowing_add(carry);
-        carry = u128::from(c);
-        val = next_val;
+        // carry·2^128 + value = 3·carry·K + (carry + value).
+        quotient += carry * K;
+        let (next_value, carried) = value.overflowing_add(carry);
+        carry = u128::from(carried);
+        value = next_value;
     }
 }
 
@@ -902,17 +921,17 @@ fn floor_div3(mut carry: u128, mut val: u128) -> u128 {
 /// stays within `u128`). The scaled-fixed-point caller forms
 /// `N = r · 10^(2·SCALE)` with `r < 2^127` and `2·SCALE <= 76`, so
 /// `N < 2^380`.
-fn icbrt_384(n: [u128; 3]) -> u128 {
-    if n == [0, 0, 0] {
+fn icbrt_384(radicand: [u128; 3]) -> u128 {
+    if radicand == [0, 0, 0] {
         return 0;
     }
     // Bit length of N.
-    let bits = if n[2] != 0 {
-        384 - n[2].leading_zeros()
-    } else if n[1] != 0 {
-        256 - n[1].leading_zeros()
+    let bits = if radicand[2] != 0 {
+        384 - radicand[2].leading_zeros()
+    } else if radicand[1] != 0 {
+        256 - radicand[1].leading_zeros()
     } else {
-        128 - n[0].leading_zeros()
+        128 - radicand[0].leading_zeros()
     };
     // Initial over-estimate from the shared seed library: under `std` the
     // hardware `f64::cbrt` of the top 64 bits with the exact `2^(r/3)`
@@ -925,31 +944,31 @@ fn icbrt_384(n: [u128; 3]) -> u128 {
     // packs little-endian into six u64 limbs; the seed `< 2^127`
     // (`N < 2^381`) reads back from the low two.
     let n_limbs = [
-        n[0] as u64,
-        (n[0] >> 64) as u64,
-        n[1] as u64,
-        (n[1] >> 64) as u64,
-        n[2] as u64,
-        (n[2] >> 64) as u64,
+        radicand[0] as u64,
+        (radicand[0] >> 64) as u64,
+        radicand[1] as u64,
+        (radicand[1] >> 64) as u64,
+        radicand[2] as u64,
+        (radicand[2] >> 64) as u64,
     ];
     let mut seed_limbs = [0u64; 6];
     crate::algo_x_support::seed::cbrt_seed(&n_limbs, bits, &mut seed_limbs);
-    let mut y: u128 = (seed_limbs[0] as u128) | ((seed_limbs[1] as u128) << 64);
+    let mut estimate: u128 = (seed_limbs[0] as u128) | ((seed_limbs[1] as u128) << 64);
     loop {
-        // y² as a 256-bit divisor.
-        let (yy_hi, yy_lo) = mul_u128_to_u256(y, y);
-        // nq = N / y²; y >= cbrt(N) keeps this below 2^128.
-        let nq = div_384_by_256(n, [yy_lo, yy_hi]);
-        // y_next = (2y + nq) / 3, computed via a (carry, sum) pair so
-        // the up-to-130-bit intermediate never overflows `u128`.
-        let (two_y, c0) = y.overflowing_add(y);
-        let (sum, c1) = two_y.overflowing_add(nq);
-        let carry = u128::from(c0) + u128::from(c1);
-        let y_next = floor_div3(carry, sum);
-        if y_next >= y {
-            return y;
+        // estimate² as a 256-bit divisor.
+        let (yy_hi, yy_lo) = mul_u128_to_u256(estimate, estimate);
+        // quotient = N / estimate²; estimate >= cbrt(N) keeps this below 2^128.
+        let quotient = div_384_by_256(radicand, [yy_lo, yy_hi]);
+        // next_estimate = (2y + quotient) / 3, computed via a (carry, sum)
+        // pair so the up-to-130-bit intermediate never overflows `u128`.
+        let (two_y, carry0) = estimate.overflowing_add(estimate);
+        let (sum, carry1) = two_y.overflowing_add(quotient);
+        let carry = u128::from(carry0) + u128::from(carry1);
+        let next_estimate = floor_div3(carry, sum);
+        if next_estimate >= estimate {
+            return estimate;
         }
-        y = y_next;
+        estimate = next_estimate;
     }
 }
 
@@ -974,8 +993,8 @@ fn icbrt_384(n: [u128; 3]) -> u128 {
 ///
 /// Strict: integer-only; the result is within 0.5 ULP of the exact
 /// cube root — it is the exact result correctly rounded.
-pub(crate) fn cbrt_raw_correctly_rounded(r: u128, scale: u32) -> u128 {
-    cbrt_raw_with_unsigned_mag(r, scale, crate::support::rounding::RoundingMode::HalfToEven)
+pub(crate) fn cbrt_raw_correctly_rounded(raw: u128, scale: u32) -> u128 {
+    cbrt_raw_with_unsigned_mag(raw, scale, crate::support::rounding::RoundingMode::HalfToEven)
 }
 
 /// Mode-aware variant of [`cbrt_raw_correctly_rounded`] operating on
@@ -1001,29 +1020,29 @@ pub(crate) fn cbrt_raw_correctly_rounded(r: u128, scale: u32) -> u128 {
 /// follows the conservative reading: `>=` triggers a bump for the
 /// `HalfAwayFromZero` and `HalfToEven` modes, `>` for `HalfTowardZero`.
 pub(crate) fn cbrt_raw_with_unsigned_mag(
-    r: u128,
+    raw: u128,
     scale: u32,
     mode: crate::support::rounding::RoundingMode,
 ) -> u128 {
-    cbrt_raw_with_signed(r, scale, false, mode)
+    cbrt_raw_with_signed(raw, scale, false, mode)
 }
 
-/// Sign-aware mode dispatch for the cbrt raw computation. `negative`
+/// Sign-aware mode dispatch for the cbrt raw computation. `is_negative`
 /// is the sign of the source value (cbrt preserves sign).
 pub(crate) fn cbrt_raw_with_signed(
-    r: u128,
+    raw: u128,
     scale: u32,
-    negative: bool,
+    is_negative: bool,
     mode: crate::support::rounding::RoundingMode,
 ) -> u128 {
     use crate::support::rounding::RoundingMode;
-    if r == 0 {
+    if raw == 0 {
         return 0;
     }
-    let n = mul_u128_by_256(r, pow10_256(2 * scale));
-    let q = icbrt_384(n);
-    let eight_n = shl3_384(n);
-    let two_q_plus_1 = 2 * q + 1;
+    let radicand = mul_u128_by_256(raw, pow10_256(2 * scale));
+    let root = icbrt_384(radicand);
+    let eight_n = shl3_384(radicand);
+    let two_q_plus_1 = 2 * root + 1;
     let (sq_hi, sq_lo) = mul_u128_to_u256(two_q_plus_1, two_q_plus_1);
     let cube = mul_u256_by_u128([sq_lo, sq_hi], two_q_plus_1);
     let halfway_geq = ge_384(eight_n, cube);
@@ -1034,9 +1053,9 @@ pub(crate) fn cbrt_raw_with_signed(
     // `n != q · q · q`, but that requires another 384-bit mul. Reuse
     // the eight_n vs (2q)³ comparison: 8N > 8q³ iff N > q³ iff there's
     // a residual.
-    let two_q = q + q;
+    let two_q = root + root;
     let (tq_sq_hi, tq_sq_lo) = mul_u128_to_u256(two_q, two_q);
-    let eight_q_cubed = if q == 0 {
+    let eight_q_cubed = if root == 0 {
         [0u128, 0, 0]
     } else {
         mul_u256_by_u128([tq_sq_lo, tq_sq_hi], two_q)
@@ -1044,31 +1063,31 @@ pub(crate) fn cbrt_raw_with_signed(
     let residual_nonzero = gt_384(eight_n, eight_q_cubed);
     let tie = halfway_geq && !halfway_gt;
     let bump = match mode {
-        RoundingMode::HalfToEven => halfway_gt || (tie && (q & 1 == 1)),
+        RoundingMode::HalfToEven => halfway_gt || (tie && (root & 1 == 1)),
         RoundingMode::HalfAwayFromZero => halfway_geq,
         RoundingMode::HalfTowardZero => halfway_gt,
         RoundingMode::Trunc => false,
-        RoundingMode::Floor => negative && residual_nonzero,
-        RoundingMode::Ceiling => !negative && residual_nonzero,
+        RoundingMode::Floor => is_negative && residual_nonzero,
+        RoundingMode::Ceiling => !is_negative && residual_nonzero,
     };
-    if bump { q + 1 } else { q }
+    if bump { root + 1 } else { root }
 }
 
 /// 384-bit strictly-greater comparison, mirroring [`ge_384`].
-fn gt_384(a: [u128; 3], b: [u128; 3]) -> bool {
-    if a[2] != b[2] {
-        return a[2] > b[2];
+fn gt_384(lhs: [u128; 3], rhs: [u128; 3]) -> bool {
+    if lhs[2] != rhs[2] {
+        return lhs[2] > rhs[2];
     }
-    if a[1] != b[1] {
-        return a[1] > b[1];
+    if lhs[1] != rhs[1] {
+        return lhs[1] > rhs[1];
     }
-    a[0] > b[0]
+    lhs[0] > rhs[0]
 }
 
-/// Compute `(a * b) / 10^SCALE` with truncating division semantics
+/// Compute `(lhs * rhs) / 10^SCALE` with truncating division semantics
 /// matching `i128 /`. Returns `None` if the result overflows `i128`.
 ///
-/// When `a * b` fits in `i128` the multiply is done directly and the
+/// When `lhs * rhs` fits in `i128` the multiply is done directly and the
 /// result is divided by the scale multiplier. When the product would
 /// overflow `i128`, the unsigned absolute values are multiplied to a
 /// full 256-bit result via [`mul_u128_to_u256`], divided by `10^SCALE` using the
@@ -1076,7 +1095,7 @@ fn gt_384(a: [u128; 3], b: [u128; 3]) -> bool {
 /// restored.
 ///
 /// At `SCALE = 0` the multiplier is 1 and the function reduces to
-/// `a.checked_mul(b)`.
+/// `lhs.checked_mul(rhs)`.
 ///
 /// # Precision
 ///
@@ -1095,8 +1114,8 @@ fn gt_384(a: [u128; 3], b: [u128; 3]) -> bool {
 /// assert_eq!(result, Some(1_500_000_000_000_000_000_000_000_000_000_000_i128));
 /// ```
 #[inline]
-pub(crate) fn mul_div_pow10<const SCALE: u32>(a: i128, b: i128) -> Option<i128> {
-    mul_div_pow10_with::<SCALE>(a, b, crate::support::rounding::DEFAULT_ROUNDING_MODE)
+pub(crate) fn mul_div_pow10<const SCALE: u32>(lhs: i128, rhs: i128) -> Option<i128> {
+    mul_div_pow10_with::<SCALE>(lhs, rhs, crate::support::rounding::DEFAULT_ROUNDING_MODE)
 }
 
 /// Mode-aware variant of [`mul_div_pow10`]: rounds the
@@ -1105,27 +1124,27 @@ pub(crate) fn mul_div_pow10<const SCALE: u32>(a: i128, b: i128) -> Option<i128> 
 /// [`crate::support::rounding::DEFAULT_ROUNDING_MODE`].
 #[inline]
 pub(crate) fn mul_div_pow10_with<const SCALE: u32>(
-    a: i128,
-    b: i128,
+    lhs: i128,
+    rhs: i128,
     mode: crate::support::rounding::RoundingMode,
 ) -> Option<i128> {
-    // SCALE = 0: multiplier is 1, result is just a * b. No rounding
+    // SCALE = 0: multiplier is 1, result is just lhs * rhs. No rounding
     // step possible.
     if SCALE == 0 {
-        return a.checked_mul(b);
+        return lhs.checked_mul(rhs);
     }
 
     // Fast path: i128 * i128 didn't overflow. Apply `mode` at the
     // divide-by-10^SCALE step.
-    if let Some(prod) = a.checked_mul(b) {
+    if let Some(product) = lhs.checked_mul(rhs) {
         return Some(crate::support::rounding::apply_rounding(
-            prod,
+            product,
             crate::D::<crate::int::types::Int<2>, SCALE>::multiplier().as_i128(),
             mode,
         ));
     }
 
-    // Widening path: |a*b| > i128::MAX. Compute the unsigned product;
+    // Widening path: |lhs*rhs| > i128::MAX. Compute the unsigned product;
     // when it still fits a single u128 use a hardware u128 divide
     // (one DIV instruction), only falling through to the full 256-bit
     // magic-divide when the unsigned product overflows u128 too. The
@@ -1133,11 +1152,11 @@ pub(crate) fn mul_div_pow10_with<const SCALE: u32>(
     // sqrt(u128::MAX), i.e. ~1.3e19 < |op| < ~1.8e19 — the SCALE 19
     // typical-input window, sparing it the full mul_u128_to_u256 +
     // div_exp_fast_2word machinery.
-    let ua = a.unsigned_abs();
-    let ub = b.unsigned_abs();
-    let exp = crate::D::<crate::int::types::Int<2>, SCALE>::multiplier().as_i128() as u128;
+    let abs_lhs = lhs.unsigned_abs();
+    let abs_rhs = rhs.unsigned_abs();
+    let divisor = crate::D::<crate::int::types::Int<2>, SCALE>::multiplier().as_i128() as u128;
 
-    let (uprod, hi_overflow) = ua.overflowing_mul(ub);
+    let (unsigned_product, hi_overflow) = abs_lhs.overflowing_mul(abs_rhs);
     if !hi_overflow {
         // u128 product fits. For SCALE <= 19 the divisor `exp = 10^SCALE`
         // also fits a single u64, in which case the LLVM `__udivti3`
@@ -1146,83 +1165,86 @@ pub(crate) fn mul_div_pow10_with<const SCALE: u32>(
         // x86_64 instead of the soft routine. The branch is const-folded
         // per-SCALE so the runtime cost is just the branch the compiler
         // proves away.
-        let (q_floor, r) = if SCALE <= 19 {
-            let d = exp as u64;
-            let hi = (uprod >> 64) as u64;
-            let lo = uprod as u64;
+        let (floor_quotient, remainder) = if SCALE <= 19 {
+            let divisor_u64 = divisor as u64;
+            let hi = (unsigned_product >> 64) as u64;
+            let lo = unsigned_product as u64;
             if hi == 0 {
                 // Single-limb dividend: one hardware divide suffices.
-                let q = lo / d;
-                let r = lo % d;
-                (q as u128, r as u128)
+                let quotient = lo / divisor_u64;
+                let remainder = lo % divisor_u64;
+                (quotient as u128, remainder as u128)
             } else {
                 // Two-limb schoolbook divide in base 2^64.
-                let q_hi = hi / d;
-                let r_hi = hi % d;
-                let cur = ((r_hi as u128) << 64) | (lo as u128);
-                let q_lo_u128 = cur / (d as u128);
-                let r = cur - q_lo_u128 * (d as u128);
-                let q = ((q_hi as u128) << 64) | (q_lo_u128 & u128::from(u64::MAX));
-                (q, r)
+                let q_hi = hi / divisor_u64;
+                let r_hi = hi % divisor_u64;
+                let current = ((r_hi as u128) << 64) | (lo as u128);
+                let q_lo_u128 = current / (divisor_u64 as u128);
+                let remainder = current - q_lo_u128 * (divisor_u64 as u128);
+                let quotient = ((q_hi as u128) << 64) | (q_lo_u128 & u128::from(u64::MAX));
+                (quotient, remainder)
             }
         } else {
-            let q = uprod / exp;
-            (q, uprod - q * exp)
+            let quotient = unsigned_product / divisor;
+            (quotient, unsigned_product - quotient * divisor)
         };
-        let neg = (a < 0) ^ (b < 0);
-        let q = round_mag_with_mode(q_floor, r, exp, mode, !neg);
-        return if neg {
-            if q <= i128::MAX as u128 {
-                Some(-(q as i128))
-            } else if q == (i128::MAX as u128) + 1 {
+        let is_negative = (lhs < 0) ^ (rhs < 0);
+        let magnitude =
+            round_mag_with_mode(floor_quotient, remainder, divisor, mode, !is_negative);
+        return if is_negative {
+            if magnitude <= i128::MAX as u128 {
+                Some(-(magnitude as i128))
+            } else if magnitude == (i128::MAX as u128) + 1 {
                 Some(i128::MIN)
             } else {
                 None
             }
-        } else if q <= i128::MAX as u128 {
-            Some(q as i128)
+        } else if magnitude <= i128::MAX as u128 {
+            Some(magnitude as i128)
         } else {
             None
         };
     }
 
     // Truly wide path: unsigned 256-bit product, magic-divide by 10^SCALE.
-    let (mhigh, mlow) = mul_u128_to_u256(ua, ub);
-    let (q_floor, r) = divmod_pow10_2word(mhigh, mlow, exp, SCALE as usize)?;
+    let (mhigh, mlow) = mul_u128_to_u256(abs_lhs, abs_rhs);
+    let (floor_quotient, remainder) =
+        divmod_pow10_2word(mhigh, mlow, divisor, SCALE as usize)?;
     // Sign: result is negative iff exactly one operand is negative.
-    let neg = (a < 0) ^ (b < 0);
-    let q = round_mag_with_mode(q_floor, r, exp, mode, !neg);
-    if neg {
-        // -q must fit in i128. q == 2^127 is fine (that is i128::MIN).
-        if q <= i128::MAX as u128 {
-            Some(-(q as i128))
-        } else if q == (i128::MAX as u128) + 1 {
+    let is_negative = (lhs < 0) ^ (rhs < 0);
+    let magnitude =
+        round_mag_with_mode(floor_quotient, remainder, divisor, mode, !is_negative);
+    if is_negative {
+        // -magnitude must fit i128. 2^127 is fine (that is i128::MIN).
+        if magnitude <= i128::MAX as u128 {
+            Some(-(magnitude as i128))
+        } else if magnitude == (i128::MAX as u128) + 1 {
             Some(i128::MIN)
         } else {
             None
         }
     } else {
-        // Positive: q must be <= i128::MAX.
-        if q <= i128::MAX as u128 {
-            Some(q as i128)
+        // Positive: the magnitude must be <= i128::MAX.
+        if magnitude <= i128::MAX as u128 {
+            Some(magnitude as i128)
         } else {
             None
         }
     }
 }
 
-/// Compute `(a * 10^SCALE) / b` with truncating division semantics
-/// matching `i128 /`. Returns `None` if the result overflows `i128` or
-/// `b == 0`.
+/// Compute `(dividend * 10^SCALE) / divisor` with truncating division
+/// semantics matching `i128 /`. Returns `None` if the result overflows
+/// `i128` or `divisor == 0`.
 ///
-/// When `a * 10^SCALE` fits in `i128` the multiply-then-divide is done
-/// directly. When it would overflow, the unsigned absolute value of `a`
-/// is multiplied by the scale multiplier to a full 256-bit result via
-/// [`mul_u128_to_u256`], divided by `|b|` using the binary long-divide, and the
-/// correct sign is restored.
+/// When `dividend * 10^SCALE` fits in `i128` the multiply-then-divide is
+/// done directly. When it would overflow, the unsigned absolute value of
+/// `dividend` is multiplied by the scale multiplier to a full 256-bit
+/// result via [`mul_u128_to_u256`], divided by `|divisor|` using the
+/// binary long-divide, and the correct sign is restored.
 ///
 /// At `SCALE = 0` the multiplier is 1 and the function reduces to
-/// `a.checked_div(b)`.
+/// `dividend.checked_div(divisor)`.
 ///
 /// # Precision
 ///
@@ -1237,8 +1259,8 @@ pub(crate) fn mul_div_pow10_with<const SCALE: u32>(
 /// assert_eq!(result, Some(5 * 10_i128.pow(33)));
 /// ```
 #[inline]
-pub(crate) fn div_pow10_div<const SCALE: u32>(a: i128, b: i128) -> Option<i128> {
-    div_pow10_div_with::<SCALE>(a, b, crate::support::rounding::DEFAULT_ROUNDING_MODE)
+pub(crate) fn div_pow10_div<const SCALE: u32>(dividend: i128, divisor: i128) -> Option<i128> {
+    div_pow10_div_with::<SCALE>(dividend, divisor, crate::support::rounding::DEFAULT_ROUNDING_MODE)
 }
 
 /// Mode-aware variant of [`div_pow10_div`]: rounds the final divide
@@ -1246,84 +1268,87 @@ pub(crate) fn div_pow10_div<const SCALE: u32>(a: i128, b: i128) -> Option<i128> 
 /// wrapper that passes [`crate::support::rounding::DEFAULT_ROUNDING_MODE`].
 #[inline]
 pub(crate) fn div_pow10_div_with<const SCALE: u32>(
-    a: i128,
-    b: i128,
+    dividend: i128,
+    divisor: i128,
     mode: crate::support::rounding::RoundingMode,
 ) -> Option<i128> {
-    if b == 0 {
+    if divisor == 0 {
         return None;
     }
     // Probe for the `i128::MIN / -1` overflow case so the rounding path
-    // below can rely on `a / b` not panicking.
-    a.checked_div(b)?;
+    // below can rely on the division not panicking.
+    dividend.checked_div(divisor)?;
 
-    // SCALE = 0: scale-narrowing step is `a / b` itself; apply mode.
+    // SCALE = 0: scale-narrowing step is the division itself; apply mode.
     if SCALE == 0 {
-        return Some(crate::support::rounding::apply_rounding(a, b, mode));
+        return Some(crate::support::rounding::apply_rounding(dividend, divisor, mode));
     }
 
-    let mult = crate::D::<crate::int::types::Int<2>, SCALE>::multiplier().as_i128();
+    let multiplier = crate::D::<crate::int::types::Int<2>, SCALE>::multiplier().as_i128();
 
-    // Fast path 1: a * mult fits in i128. At SCALE <= 18, i64::MAX * 10^18
-    // fits with headroom; for larger SCALE the overflow check below
-    // handles the fallthrough.
-    if let Some(num) = a.checked_mul(mult) {
-        return Some(crate::support::rounding::apply_rounding(num, b, mode));
+    // Fast path 1: dividend * multiplier fits in i128. At SCALE <= 18,
+    // i64::MAX * 10^18 fits with headroom; for larger SCALE the overflow
+    // check below handles the fallthrough.
+    if let Some(numerator) = dividend.checked_mul(multiplier) {
+        return Some(crate::support::rounding::apply_rounding(numerator, divisor, mode));
     }
 
-    // Fast path 2: `|a| * mult` overflows `i128` but still fits `u128`
-    // (so the i128-signed `checked_mul` rejected it only because of the
-    // sign bit, OR `|a|` is just past `i128::MAX / mult`). Skip the
-    // 256-bit `mul_u128_to_u256 + div_long_256_by_128` path — a single hardware
-    // `u128 / u128` suffices.
+    // Fast path 2: `|dividend| * mult` overflows `i128` but still fits
+    // `u128` (so the i128-signed `checked_mul` rejected it only because
+    // of the sign bit, OR `|dividend|` is just past `i128::MAX / mult`).
+    // Skip the 256-bit `mul_u128_to_u256 + div_long_256_by_128` path —
+    // a single hardware `u128 / u128` suffices.
     //
-    // Predicate: `|a| ≤ u128::MAX / mult`. Const-folded per SCALE.
-    let ua = a.unsigned_abs();
-    let umult = mult as u128;
-    if ua <= u128::MAX / umult {
-        let num = ua * umult;
-        let ub = b.unsigned_abs();
-        let q_floor = num / ub;
-        let r = num % ub;
-        let neg = (a < 0) ^ (b < 0);
-        let q = round_mag_with_mode(q_floor, r, ub, mode, !neg);
-        return if neg {
-            if q <= i128::MAX as u128 {
-                Some(-(q as i128))
-            } else if q == (i128::MAX as u128) + 1 {
+    // Predicate: `|dividend| ≤ u128::MAX / mult`. Const-folded per SCALE.
+    let abs_dividend = dividend.unsigned_abs();
+    let abs_multiplier = multiplier as u128;
+    if abs_dividend <= u128::MAX / abs_multiplier {
+        let numerator = abs_dividend * abs_multiplier;
+        let abs_divisor = divisor.unsigned_abs();
+        let floor_quotient = numerator / abs_divisor;
+        let remainder = numerator % abs_divisor;
+        let is_negative = (dividend < 0) ^ (divisor < 0);
+        let magnitude =
+            round_mag_with_mode(floor_quotient, remainder, abs_divisor, mode, !is_negative);
+        return if is_negative {
+            if magnitude <= i128::MAX as u128 {
+                Some(-(magnitude as i128))
+            } else if magnitude == (i128::MAX as u128) + 1 {
                 Some(i128::MIN)
             } else {
                 None
             }
-        } else if q <= i128::MAX as u128 {
-            Some(q as i128)
+        } else if magnitude <= i128::MAX as u128 {
+            Some(magnitude as i128)
         } else {
             None
         };
     }
 
-    // Widening path: |a|*mult overflows u128. Compute it as a 256-bit
-    // unsigned, divide by |b| keeping the remainder, round per `mode`,
-    // restore sign.
-    let (mhigh, mlow) = mul_u128_to_u256(ua, umult);
+    // Widening path: |dividend|*mult overflows u128. Compute it as a
+    // 256-bit unsigned, divide by |divisor| keeping the remainder, round
+    // per `mode`, restore sign.
+    let (mhigh, mlow) = mul_u128_to_u256(abs_dividend, abs_multiplier);
 
-    let ub = b.unsigned_abs();
-    let (q_floor, r) = div_long_256_by_128_with_rem(mhigh, mlow, ub)?;
+    let abs_divisor = divisor.unsigned_abs();
+    let (floor_quotient, remainder) =
+        div_long_256_by_128_with_rem(mhigh, mlow, abs_divisor)?;
 
-    // Sign: result is negative iff exactly one of `a` and `b` is
-    // negative. (mult is always positive.)
-    let neg = (a < 0) ^ (b < 0);
-    let q = round_mag_with_mode(q_floor, r, ub, mode, !neg);
-    if neg {
-        if q <= i128::MAX as u128 {
-            Some(-(q as i128))
-        } else if q == (i128::MAX as u128) + 1 {
+    // Sign: result is negative iff exactly one of the operands is
+    // negative. (The multiplier is always positive.)
+    let is_negative = (dividend < 0) ^ (divisor < 0);
+    let magnitude =
+        round_mag_with_mode(floor_quotient, remainder, abs_divisor, mode, !is_negative);
+    if is_negative {
+        if magnitude <= i128::MAX as u128 {
+            Some(-(magnitude as i128))
+        } else if magnitude == (i128::MAX as u128) + 1 {
             Some(i128::MIN)
         } else {
             None
         }
-    } else if q <= i128::MAX as u128 {
-        Some(q as i128)
+    } else if magnitude <= i128::MAX as u128 {
+        Some(magnitude as i128)
     } else {
         None
     }
@@ -1338,10 +1363,10 @@ mod tests {
     #[test]
     fn mul_div_pow10_small_matches_naive() {
         const SCALE: u32 = 12;
-        let a: i128 = 1_500_000_000;
-        let b: i128 = 2_300_000_000;
-        let expected = (a * b) / 1_000_000_000_000_i128;
-        assert_eq!(mul_div_pow10::<SCALE>(a, b), Some(expected));
+        let lhs: i128 = 1_500_000_000;
+        let rhs: i128 = 2_300_000_000;
+        let expected = (lhs * rhs) / 1_000_000_000_000_i128;
+        assert_eq!(mul_div_pow10::<SCALE>(lhs, rhs), Some(expected));
     }
 
     /// Mid-range operands: still fits the i128 fast path with a wider
@@ -1349,10 +1374,10 @@ mod tests {
     #[test]
     fn mul_div_pow10_mid_matches_naive() {
         const SCALE: u32 = 12;
-        let a: i128 = 3_000_000_000_000_000;
-        let b: i128 = 4_700_000_000_000_000;
-        let expected = (a * b) / 1_000_000_000_000_i128;
-        assert_eq!(mul_div_pow10::<SCALE>(a, b), Some(expected));
+        let lhs: i128 = 3_000_000_000_000_000;
+        let rhs: i128 = 4_700_000_000_000_000;
+        let expected = (lhs * rhs) / 1_000_000_000_000_i128;
+        assert_eq!(mul_div_pow10::<SCALE>(lhs, rhs), Some(expected));
     }
 
     /// Operands near the boundary of the i128 fast path; still within
@@ -1361,10 +1386,10 @@ mod tests {
     fn mul_div_pow10_bound_matches_naive() {
         const SCALE: u32 = 12;
         // 7e18 * 4.7e18 = 3.29e37 < i128::MAX (1.7e38)
-        let a: i128 = 7_000_000_000_000_000_000;
-        let b: i128 = 4_700_000_000_000_000_000;
-        let expected = (a * b) / 1_000_000_000_000_i128;
-        assert_eq!(mul_div_pow10::<SCALE>(a, b), Some(expected));
+        let lhs: i128 = 7_000_000_000_000_000_000;
+        let rhs: i128 = 4_700_000_000_000_000_000;
+        let expected = (lhs * rhs) / 1_000_000_000_000_i128;
+        assert_eq!(mul_div_pow10::<SCALE>(lhs, rhs), Some(expected));
     }
 
     /// Wide operands: 5e22 * 3e22 = 1.5e45, past i128::MAX. The widening
@@ -1372,12 +1397,12 @@ mod tests {
     #[test]
     fn mul_div_pow10_wide_correctness() {
         const SCALE: u32 = 12;
-        let a: i128 = 50_000_000_000_000_000_000_000;
-        let b: i128 = 30_000_000_000_000_000_000_000;
-        // a * b == 1.5e45 raw; / 10^12 == 1.5e33 raw.
+        let lhs: i128 = 50_000_000_000_000_000_000_000;
+        let rhs: i128 = 30_000_000_000_000_000_000_000;
+        // lhs * rhs == 1.5e45 raw; / 10^12 == 1.5e33 raw.
         // 1.5e33 < i128::MAX (1.7e38), so the result fits.
         let expected: i128 = 1_500_000_000_000_000_000_000_000_000_000_000_i128;
-        assert_eq!(mul_div_pow10::<SCALE>(a, b), Some(expected));
+        assert_eq!(mul_div_pow10::<SCALE>(lhs, rhs), Some(expected));
     }
 
     /// When the final i128 quotient would overflow, the function returns
@@ -1385,33 +1410,33 @@ mod tests {
     #[test]
     fn mul_div_pow10_overflows_to_none() {
         const SCALE: u32 = 12;
-        // a*b = 10^52; /10^12 = 10^40. i128::MAX < 10^39, so this overflows.
-        let a: i128 = 10_i128.pow(26);
-        let b: i128 = 10_i128.pow(26);
-        assert_eq!(mul_div_pow10::<SCALE>(a, b), None);
+        // lhs*rhs = 10^52; /10^12 = 10^40. i128::MAX < 10^39, so this overflows.
+        let lhs: i128 = 10_i128.pow(26);
+        let rhs: i128 = 10_i128.pow(26);
+        assert_eq!(mul_div_pow10::<SCALE>(lhs, rhs), None);
     }
 
     /// One negative operand produces a negative result.
     #[test]
     fn mul_div_pow10_negative_one_sided() {
         const SCALE: u32 = 12;
-        let a: i128 = -50_000_000_000_000_000_000_000;
-        let b: i128 = 30_000_000_000_000_000_000_000;
+        let lhs: i128 = -50_000_000_000_000_000_000_000;
+        let rhs: i128 = 30_000_000_000_000_000_000_000;
         let expected: i128 = -1_500_000_000_000_000_000_000_000_000_000_000_i128;
-        assert_eq!(mul_div_pow10::<SCALE>(a, b), Some(expected));
+        assert_eq!(mul_div_pow10::<SCALE>(lhs, rhs), Some(expected));
     }
 
     /// Two negative operands produce a positive result.
     #[test]
     fn mul_div_pow10_negative_both() {
         const SCALE: u32 = 12;
-        let a: i128 = -50_000_000_000_000_000_000_000;
-        let b: i128 = -30_000_000_000_000_000_000_000;
+        let lhs: i128 = -50_000_000_000_000_000_000_000;
+        let rhs: i128 = -30_000_000_000_000_000_000_000;
         let expected: i128 = 1_500_000_000_000_000_000_000_000_000_000_000_i128;
-        assert_eq!(mul_div_pow10::<SCALE>(a, b), Some(expected));
+        assert_eq!(mul_div_pow10::<SCALE>(lhs, rhs), Some(expected));
     }
 
-    /// `SCALE = 0`: identity multiplier; result is just `a * b`.
+    /// `SCALE = 0`: identity multiplier; result is just `lhs * rhs`.
     #[test]
     fn mul_div_pow10_scale_zero() {
         const SCALE: u32 = 0;
@@ -1434,9 +1459,9 @@ mod tests {
     fn mul_div_pow10_scale_eighteen() {
         const SCALE: u32 = 18;
         // 10^18 * 10^18 = 10^36; / 10^18 = 10^18.
-        let a: i128 = 10_i128.pow(18);
-        let b: i128 = 10_i128.pow(18);
-        assert_eq!(mul_div_pow10::<SCALE>(a, b), Some(10_i128.pow(18)));
+        let lhs: i128 = 10_i128.pow(18);
+        let rhs: i128 = 10_i128.pow(18);
+        assert_eq!(mul_div_pow10::<SCALE>(lhs, rhs), Some(10_i128.pow(18)));
     }
 
     /// Division: small operands match the naive form.
@@ -1447,12 +1472,12 @@ mod tests {
         }
         // `expected` is the truncating result and matches under
         // HalfToEven only when the remainder is below half — true here
-        // (a*10^12 / 7 leaves a remainder well under 3.5).
+        // (dividend*10^12 / 7 leaves a remainder well under 3.5).
         const SCALE: u32 = 12;
-        let a: i128 = 1_500_000_000;
-        let b: i128 = 7;
-        let expected = (a * 1_000_000_000_000_i128) / b;
-        assert_eq!(div_pow10_div::<SCALE>(a, b), Some(expected));
+        let dividend: i128 = 1_500_000_000;
+        let divisor: i128 = 7;
+        let expected = (dividend * 1_000_000_000_000_i128) / divisor;
+        assert_eq!(div_pow10_div::<SCALE>(dividend, divisor), Some(expected));
     }
 
     /// Division by zero returns `None`.
@@ -1462,8 +1487,8 @@ mod tests {
         assert_eq!(div_pow10_div::<SCALE>(123, 0), None);
     }
 
-    /// `SCALE = 0`: scale-narrowing step is `a / b`, rounded by the
-    /// crate-default rounding mode (HalfToEven by default).
+    /// `SCALE = 0`: scale-narrowing step is `dividend / divisor`, rounded
+    /// by the crate-default rounding mode (HalfToEven by default).
     #[test]
     fn div_pow10_div_scale_zero() {
         if !crate::support::rounding::DEFAULT_IS_HALF_TO_EVEN {
@@ -1505,44 +1530,45 @@ mod tests {
     #[test]
     fn div_pow10_div_wide_correctness() {
         const SCALE: u32 = 12;
-        let a: i128 = 10_i128.pow(22);
-        let b: i128 = 2;
-        // a * 10^12 = 10^34; / 2 = 5e33.
+        let dividend: i128 = 10_i128.pow(22);
+        let divisor: i128 = 2;
+        // dividend * 10^12 = 10^34; / 2 = 5e33.
         let expected: i128 = 5 * 10_i128.pow(33);
-        assert_eq!(div_pow10_div::<SCALE>(a, b), Some(expected));
+        assert_eq!(div_pow10_div::<SCALE>(dividend, divisor), Some(expected));
     }
 
-    /// Round-trip within i128 range: `(a / b) * b` recovers `a`.
+    /// Round-trip within i128 range: `(dividend / divisor) * divisor`
+    /// recovers `dividend`.
     #[test]
     fn div_pow10_div_round_trip_small() {
         const SCALE: u32 = 12;
         // 6.0 / 2.0 == 3.0 (raw: 6e12 / 2e12 -> in scaled space:
         // (6e12 * 1e12) / 2e12 == 3e12)
-        let a: i128 = 6_000_000_000_000;
-        let b: i128 = 2_000_000_000_000;
-        assert_eq!(div_pow10_div::<SCALE>(a, b), Some(3_000_000_000_000));
+        let dividend: i128 = 6_000_000_000_000;
+        let divisor: i128 = 2_000_000_000_000;
+        assert_eq!(div_pow10_div::<SCALE>(dividend, divisor), Some(3_000_000_000_000));
     }
 
     /// Negative dividend with positive divisor produces a negative result.
     #[test]
     fn div_pow10_div_negative_dividend() {
         const SCALE: u32 = 12;
-        let a: i128 = -6_000_000_000_000;
-        let b: i128 = 2_000_000_000_000;
-        assert_eq!(div_pow10_div::<SCALE>(a, b), Some(-3_000_000_000_000));
+        let dividend: i128 = -6_000_000_000_000;
+        let divisor: i128 = 2_000_000_000_000;
+        assert_eq!(div_pow10_div::<SCALE>(dividend, divisor), Some(-3_000_000_000_000));
     }
 
-    /// Round-trip property: `(a * b) / b == a` on the widening path.
+    /// Round-trip property: `(lhs * rhs) / rhs == lhs` on the widening path.
     #[test]
     fn mul_div_round_trip_wide() {
         const SCALE: u32 = 12;
-        let a: i128 = 50_000_000_000_000_000_000_000;
-        let b: i128 = 30_000_000_000_000_000_000_000;
-        // a * b / 10^12 = 1.5e33
-        let prod = mul_div_pow10::<SCALE>(a, b).expect("wide mul");
-        // Dividing back by b should recover a (up to truncation).
-        let recovered = div_pow10_div::<SCALE>(prod, b).expect("wide div");
-        assert_eq!(recovered, a);
+        let lhs: i128 = 50_000_000_000_000_000_000_000;
+        let rhs: i128 = 30_000_000_000_000_000_000_000;
+        // lhs * rhs / 10^12 = 1.5e33
+        let prod = mul_div_pow10::<SCALE>(lhs, rhs).expect("wide mul");
+        // Dividing back by rhs should recover lhs (up to truncation).
+        let recovered = div_pow10_div::<SCALE>(prod, rhs).expect("wide div");
+        assert_eq!(recovered, lhs);
     }
 
     /// `divide_pow_64limb_with` performs the 64-limb magnitude bump
@@ -1558,12 +1584,17 @@ mod tests {
         use crate::support::rounding::RoundingMode;
         // 1 / 3 = 0.333... — non-zero remainder, three modes pick
         // different last digits.
-        let a: i128 = 1_000_000_000_000; // 1.0 at S=12
-        let b: i128 = 3_000_000_000_000;
-        let trunc = div_pow10_div_with::<SCALE>(a, b, RoundingMode::Trunc).unwrap();
-        let ceil = div_pow10_div_with::<SCALE>(a, b, RoundingMode::Ceiling).unwrap();
-        let floor = div_pow10_div_with::<SCALE>(a, b, RoundingMode::Floor).unwrap();
-        let ha = div_pow10_div_with::<SCALE>(a, b, RoundingMode::HalfAwayFromZero).unwrap();
+        let dividend: i128 = 1_000_000_000_000; // 1.0 at S=12
+        let divisor: i128 = 3_000_000_000_000;
+        let trunc =
+            div_pow10_div_with::<SCALE>(dividend, divisor, RoundingMode::Trunc).unwrap();
+        let ceil =
+            div_pow10_div_with::<SCALE>(dividend, divisor, RoundingMode::Ceiling).unwrap();
+        let floor =
+            div_pow10_div_with::<SCALE>(dividend, divisor, RoundingMode::Floor).unwrap();
+        let ha = div_pow10_div_with::<SCALE>(dividend, divisor,
+            RoundingMode::HalfAwayFromZero)
+        .unwrap();
         // All within 1 LSB of each other.
         let bits = [trunc, ceil, floor, ha];
         let min = *bits.iter().min().unwrap();
@@ -1572,8 +1603,10 @@ mod tests {
         // Ceiling should bump positive, Floor truncates positive.
         assert!(ceil >= trunc);
         // Negative side: Floor pushes away from zero, Ceiling truncates.
-        let neg_floor = div_pow10_div_with::<SCALE>(-a, b, RoundingMode::Floor).unwrap();
-        let neg_trunc = div_pow10_div_with::<SCALE>(-a, b, RoundingMode::Trunc).unwrap();
+        let neg_floor =
+            div_pow10_div_with::<SCALE>(-dividend, divisor, RoundingMode::Floor).unwrap();
+        let neg_trunc =
+            div_pow10_div_with::<SCALE>(-dividend, divisor, RoundingMode::Trunc).unwrap();
         assert!(neg_floor <= neg_trunc);
     }
 
@@ -1586,16 +1619,16 @@ mod tests {
     /// `sqrt_raw_correctly_rounded(0, scale) == 0` short-circuit.
     #[test]
     fn sqrt_raw_correctly_rounded_zero_input() {
-        for s in 0..=12 {
-            assert_eq!(sqrt_raw_correctly_rounded(0, s), 0);
+        for scale in 0..=12 {
+            assert_eq!(sqrt_raw_correctly_rounded(0, scale), 0);
         }
     }
 
     /// `cbrt_raw_correctly_rounded(0, scale) == 0` short-circuit.
     #[test]
     fn cbrt_raw_correctly_rounded_zero_input() {
-        for s in 0..=12 {
-            assert_eq!(cbrt_raw_correctly_rounded(0, s), 0);
+        for scale in 0..=12 {
+            assert_eq!(cbrt_raw_correctly_rounded(0, scale), 0);
         }
     }
 
@@ -1608,34 +1641,34 @@ mod tests {
     /// the post-condition holds for every one.
     #[test]
     fn sqrt_raw_correctly_rounded_post_condition_holds() {
-        for r in [
+        for raw in [
             7u128,
             1_500_000_000_000u128,
             10u128.pow(20),
             (i128::MAX as u128) / 7,
         ] {
-            let q = sqrt_raw_correctly_rounded(r, 12);
-            let (n_hi, n_lo) = mul_u128_to_u256(r, POW10_U128[12]);
-            let q_floor = isqrt_256(n_hi, n_lo);
+            let root = sqrt_raw_correctly_rounded(raw, 12);
+            let (n_hi, n_lo) = mul_u128_to_u256(raw, POW10_U128[12]);
+            let root_floor = isqrt_256(n_hi, n_lo);
             // q must be either floor(sqrt(N)) or floor+1.
             assert!(
-                q == q_floor || q == q_floor + 1,
-                "sqrt({r}, 12): q={q}, floor={q_floor}",
+                root == root_floor || root == root_floor + 1,
+                "sqrt({raw}, 12): q={root}, floor={root_floor}",
             );
             // The round-up decision must agree with `N - q² > q`.
-            let (qq_hi, qq_lo) = mul_u128_to_u256(q_floor, q_floor);
+            let (qq_hi, qq_lo) = mul_u128_to_u256(root_floor, root_floor);
             let (diff_hi, diff_lo) = if n_lo >= qq_lo {
                 (n_hi - qq_hi, n_lo - qq_lo)
             } else {
                 (n_hi - qq_hi - 1, n_lo.wrapping_sub(qq_lo))
             };
-            let should_round_up = diff_hi != 0 || diff_lo > q_floor;
+            let should_round_up = diff_hi != 0 || diff_lo > root_floor;
             let expected = if should_round_up {
-                q_floor + 1
+                root_floor + 1
             } else {
-                q_floor
+                root_floor
             };
-            assert_eq!(q, expected, "sqrt({r}, 12): wrong round-up decision");
+            assert_eq!(root, expected, "sqrt({raw}, 12): wrong round-up decision");
         }
     }
 
@@ -1649,30 +1682,30 @@ mod tests {
     /// into the 384-bit mid limb.
     #[test]
     fn cbrt_raw_high_limb_radicand_post_condition_holds() {
-        for r in [
+        for raw in [
             8u128,
             27u128,
             1_000_000u128,
             10u128.pow(20),
             (i128::MAX as u128) / 7,
         ] {
-            let q = cbrt_raw_correctly_rounded(r, 12);
-            let n = mul_u128_by_256(r, pow10_256(24));
-            let q_floor = icbrt_384(n);
+            let root = cbrt_raw_correctly_rounded(raw, 12);
+            let radicand = mul_u128_by_256(raw, pow10_256(24));
+            let root_floor = icbrt_384(radicand);
             assert!(
-                q == q_floor || q == q_floor + 1,
-                "cbrt({r}, 12): q={q}, floor={q_floor}",
+                root == root_floor || root == root_floor + 1,
+                "cbrt({raw}, 12): q={root}, floor={root_floor}",
             );
-            let eight_n = shl3_384(n);
-            let two_q_plus_1 = 2 * q_floor + 1;
+            let eight_n = shl3_384(radicand);
+            let two_q_plus_1 = 2 * root_floor + 1;
             let (sq_hi, sq_lo) = mul_u128_to_u256(two_q_plus_1, two_q_plus_1);
             let cube = mul_u256_by_u128([sq_lo, sq_hi], two_q_plus_1);
             let expected = if ge_384(eight_n, cube) {
-                q_floor + 1
+                root_floor + 1
             } else {
-                q_floor
+                root_floor
             };
-            assert_eq!(q, expected, "cbrt({r}, 12): wrong round-up decision");
+            assert_eq!(root, expected, "cbrt({raw}, 12): wrong round-up decision");
         }
     }
 
@@ -1684,7 +1717,7 @@ mod tests {
     /// half-LSB comparison for the round-up cases.
     #[test]
     fn cbrt_raw_correctly_rounded_post_condition_holds() {
-        for (r, scale) in [
+        for (raw, scale) in [
             (8u128, 0),  // exact cube of 2
             (27u128, 0), // exact cube of 3
             (9u128, 0),  // non-perfect — nearest cube root is 2
@@ -1692,35 +1725,35 @@ mod tests {
             (65u128, 0),
             (10u128.pow(12), 6), // mid-range with scale
         ] {
-            let q = cbrt_raw_correctly_rounded(r, scale);
+            let root = cbrt_raw_correctly_rounded(raw, scale);
             // q³ ≤ N ≤ (q+1)³ OR q is the round-up of floor cbrt.
             // Express via the same integer identity the function uses:
             // round up iff 8·N ≥ (2q+1)³. We re-derive the floor and
             // compare.
             // N as 384-bit:
-            let n = mul_u128_by_256(r, pow10_256(2 * scale));
-            let q_floor = icbrt_384(n);
+            let radicand = mul_u128_by_256(raw, pow10_256(2 * scale));
+            let root_floor = icbrt_384(radicand);
             // Either q == q_floor (no round-up) or q == q_floor + 1
             // (rounded up).
             assert!(
-                q == q_floor || q == q_floor + 1,
-                "cbrt({r}, {scale}): q={q}, floor={q_floor} — expected q ∈ {{floor, floor+1}}",
+                root == root_floor || root == root_floor + 1,
+                "cbrt({raw}, {scale}): q={root}, floor={root_floor} — expected q ∈ {{floor, floor+1}}",
             );
             // And the round-up decision must agree with the
             // `8·N ≥ (2q_floor+1)³` test.
-            let eight_n = shl3_384(n);
-            let two_q_plus_1 = 2 * q_floor + 1;
+            let eight_n = shl3_384(radicand);
+            let two_q_plus_1 = 2 * root_floor + 1;
             let (sq_hi, sq_lo) = mul_u128_to_u256(two_q_plus_1, two_q_plus_1);
             let cube = mul_u256_by_u128([sq_lo, sq_hi], two_q_plus_1);
             let should_round_up = ge_384(eight_n, cube);
             let expected = if should_round_up {
-                q_floor + 1
+                root_floor + 1
             } else {
-                q_floor
+                root_floor
             };
             assert_eq!(
-                q, expected,
-                "cbrt({r}, {scale}): round-up decision mismatched",
+                root, expected,
+                "cbrt({raw}, {scale}): round-up decision mismatched",
             );
         }
     }
@@ -1737,24 +1770,24 @@ mod tests {
     /// Reference sqrt that bypasses the fast path: always uses the
     /// 256-bit `mul_u128_to_u256 + isqrt_256` machinery.
     fn sqrt_raw_reference(
-        r: u128,
+        raw: u128,
         scale: u32,
         mode: crate::support::rounding::RoundingMode,
     ) -> u128 {
         use crate::support::rounding::RoundingMode;
-        if r == 0 {
+        if raw == 0 {
             return 0;
         }
-        let (hi, lo) = mul_u128_to_u256(r, POW10_U128[scale as usize]);
-        let q = isqrt_256(hi, lo);
-        let (q_sq_hi, q_sq_lo) = mul_u128_to_u256(q, q);
-        let (diff_hi, diff_lo) = if lo >= q_sq_lo {
-            (hi - q_sq_hi, lo - q_sq_lo)
+        let (hi, lo) = mul_u128_to_u256(raw, POW10_U128[scale as usize]);
+        let root = isqrt_256(hi, lo);
+        let (root_sq_hi, root_sq_lo) = mul_u128_to_u256(root, root);
+        let (diff_hi, diff_lo) = if lo >= root_sq_lo {
+            (hi - root_sq_hi, lo - root_sq_lo)
         } else {
-            (hi - q_sq_hi - 1, lo.wrapping_sub(q_sq_lo))
+            (hi - root_sq_hi - 1, lo.wrapping_sub(root_sq_lo))
         };
         let diff_nonzero = diff_hi != 0 || diff_lo != 0;
-        let halfway_round_up = diff_hi != 0 || diff_lo > q;
+        let halfway_round_up = diff_hi != 0 || diff_lo > root;
         let bump = match mode {
             RoundingMode::HalfToEven
             | RoundingMode::HalfAwayFromZero
@@ -1762,7 +1795,7 @@ mod tests {
             RoundingMode::Trunc | RoundingMode::Floor => false,
             RoundingMode::Ceiling => diff_nonzero,
         };
-        if bump { q + 1 } else { q }
+        if bump { root + 1 } else { root }
     }
 
     /// SplitMix64 — small deterministic 64-bit PRNG with good
@@ -1833,44 +1866,47 @@ mod tests {
     /// bypassing both the i128 and the u128 fast paths. Used to
     /// cross-check the u128 fast path in `div_pow10_div_with`.
     fn div_pow10_div_reference<const SCALE: u32>(
-        a: i128,
-        b: i128,
+        dividend: i128,
+        divisor: i128,
         mode: crate::support::rounding::RoundingMode,
     ) -> Option<i128> {
-        if b == 0 {
+        if divisor == 0 {
             return None;
         }
-        a.checked_div(b)?;
+        dividend.checked_div(divisor)?;
         if SCALE == 0 {
-            return Some(crate::support::rounding::apply_rounding(a, b, mode));
+            return Some(crate::support::rounding::apply_rounding(dividend, divisor, mode));
         }
-        let mult = crate::D::<crate::int::types::Int<2>, SCALE>::multiplier().as_i128();
-        let ua = a.unsigned_abs();
-        let umult = mult as u128;
-        let (mhigh, mlow) = mul_u128_to_u256(ua, umult);
-        let ub = b.unsigned_abs();
-        let (q_floor, r) = div_long_256_by_128_with_rem(mhigh, mlow, ub)?;
-        let neg = (a < 0) ^ (b < 0);
-        let q = round_mag_with_mode(q_floor, r, ub, mode, !neg);
-        if neg {
-            if q <= i128::MAX as u128 {
-                Some(-(q as i128))
-            } else if q == (i128::MAX as u128) + 1 {
+        let multiplier = crate::D::<crate::int::types::Int<2>, SCALE>::multiplier().as_i128();
+        let abs_dividend = dividend.unsigned_abs();
+        let abs_multiplier = multiplier as u128;
+        let (mhigh, mlow) = mul_u128_to_u256(abs_dividend, abs_multiplier);
+        let abs_divisor = divisor.unsigned_abs();
+        let (floor_quotient, remainder) =
+            div_long_256_by_128_with_rem(mhigh, mlow, abs_divisor)?;
+        let is_negative = (dividend < 0) ^ (divisor < 0);
+        let magnitude =
+            round_mag_with_mode(floor_quotient, remainder, abs_divisor, mode, !is_negative);
+        if is_negative {
+            if magnitude <= i128::MAX as u128 {
+                Some(-(magnitude as i128))
+            } else if magnitude == (i128::MAX as u128) + 1 {
                 Some(i128::MIN)
             } else {
                 None
             }
-        } else if q <= i128::MAX as u128 {
-            Some(q as i128)
+        } else if magnitude <= i128::MAX as u128 {
+            Some(magnitude as i128)
         } else {
             None
         }
     }
 
     /// Targeted sweep for the SCALEs where the u128 fast path can fire
-    /// (SCALE ≤ ~38; the predicate `|a| ≤ u128::MAX / 10^S` is checked
-    /// dynamically). For each scale × mode, draw `a, b` from the full
-    /// `i128` range and assert fast-dispatch matches the reference.
+    /// (SCALE ≤ ~38; the predicate `|dividend| ≤ u128::MAX / 10^S` is
+    /// checked dynamically). For each scale × mode, draw `dividend,
+    /// divisor` from the full `i128` range and assert fast-dispatch
+    /// matches the reference.
     #[test]
     fn div_pow10_div_fast_path_matches_reference() {
         const ITERS: usize = 100_000;
@@ -1881,17 +1917,18 @@ mod tests {
                 for mode in all_modes() {
                     let mut rng = SplitMix64(0xDEADBEEF_u64 + SCALE as u64);
                     for _ in 0..ITERS {
-                        // a: full i128 spread; b: nonzero, also full spread.
-                        let a = rng.next_u128() as i128;
-                        let mut b: i128 = rng.next_u128() as i128;
-                        if b == 0 {
-                            b = 1;
+                        // dividend: full i128 spread; divisor: nonzero, also full spread.
+                        let dividend = rng.next_u128() as i128;
+                        let mut divisor: i128 = rng.next_u128() as i128;
+                        if divisor == 0 {
+                            divisor = 1;
                         }
-                        let got = div_pow10_div_with::<SCALE>(a, b, mode);
-                        let expected = div_pow10_div_reference::<SCALE>(a, b, mode);
+                        let got = div_pow10_div_with::<SCALE>(dividend, divisor, mode);
+                        let expected =
+                            div_pow10_div_reference::<SCALE>(dividend, divisor, mode);
                         assert_eq!(
                             got, expected,
-                            "div mismatch: a={a}, b={b}, scale={SCALE}, mode={mode:?}",
+                            "div mismatch: a={dividend}, b={divisor}, scale={SCALE}, mode={mode:?}",
                         );
                     }
                 }
@@ -1915,31 +1952,32 @@ mod tests {
     /// is the audit gate for routing `round_div` through the MG kernel
     /// whenever the divisor is `10^w` with `w ≤ 38`.
     #[cfg(any(feature = "d76", feature = "wide"))]
-    fn round_div_reference_int256(n: crate::int::types::Int<4>, w: u32) -> crate::int::types::Int<4> {
+    fn round_div_reference_int256(
+        numerator: crate::int::types::Int<4>, scale: u32) -> crate::int::types::Int<4> {
         use crate::int::types::Int;
-        let d_u128 = POW10_U128[w as usize];
-        let d: Int<4> = Int::from_u128(d_u128);
+        let divisor_u128 = POW10_U128[scale as usize];
+        let divisor: Int<4> = Int::from_u128(divisor_u128);
         let zero: Int<4> = Int::from_u128(0u128);
         let one: Int<4> = Int::from_u128(1u128);
-        let (q, r) = n.div_rem(d);
-        if r == zero {
-            return q;
+        let (quotient, remainder) = numerator.div_rem(divisor);
+        if remainder == zero {
+            return quotient;
         }
-        let ar = if r < zero { -r } else { r };
-        let comp = d - ar;
-        let cmp_r = ar.cmp(&comp);
-        let q_is_odd = q.bit(0);
-        let result_positive = n >= zero;
+        let abs_remainder = if remainder < zero { -remainder } else { remainder };
+        let complement = divisor - abs_remainder;
+        let remainder_cmp = abs_remainder.cmp(&complement);
+        let quotient_is_odd = quotient.bit(0);
+        let result_is_positive = numerator >= zero;
         let bump = crate::support::rounding::should_bump(
             crate::support::rounding::RoundingMode::HalfToEven,
-            cmp_r,
-            q_is_odd,
-            result_positive,
+            remainder_cmp,
+            quotient_is_odd,
+            result_is_positive,
         );
         if bump {
-            if result_positive { q + one } else { q - one }
+            if result_is_positive { quotient + one } else { quotient - one }
         } else {
-            q
+            quotient
         }
     }
 
@@ -1959,29 +1997,30 @@ mod tests {
     /// path passes.
     #[cfg(any(feature = "d76", feature = "wide"))]
     fn round_div_reference_int256_with(
-        n: crate::int::types::Int<4>,
-        w: u32,
+        numerator: crate::int::types::Int<4>,
+        scale: u32,
         mode: crate::support::rounding::RoundingMode,
     ) -> crate::int::types::Int<4> {
         use crate::int::types::Int;
-        let d_u128 = POW10_U128[w as usize];
-        let d: Int<4> = Int::from_u128(d_u128);
+        let divisor_u128 = POW10_U128[scale as usize];
+        let divisor: Int<4> = Int::from_u128(divisor_u128);
         let zero: Int<4> = Int::from_u128(0u128);
         let one: Int<4> = Int::from_u128(1u128);
-        let (q, r) = n.div_rem(d);
-        if r == zero {
-            return q;
+        let (quotient, remainder) = numerator.div_rem(divisor);
+        if remainder == zero {
+            return quotient;
         }
-        let ar = if r < zero { -r } else { r };
-        let comp = d - ar;
-        let cmp_r = ar.cmp(&comp);
-        let q_is_odd = q.bit(0);
-        let result_positive = n >= zero;
-        let bump = crate::support::rounding::should_bump(mode, cmp_r, q_is_odd, result_positive);
+        let abs_remainder = if remainder < zero { -remainder } else { remainder };
+        let complement = divisor - abs_remainder;
+        let remainder_cmp = abs_remainder.cmp(&complement);
+        let quotient_is_odd = quotient.bit(0);
+        let result_is_positive = numerator >= zero;
+        let bump = crate::support::rounding::should_bump(
+            mode, remainder_cmp, quotient_is_odd, result_is_positive);
         if bump {
-            if result_positive { q + one } else { q - one }
+            if result_is_positive { quotient + one } else { quotient - one }
         } else {
-            q
+            quotient
         }
     }
 
@@ -1990,8 +2029,8 @@ mod tests {
     fn round_div_audit_mg_matches_div_rem_int256() {
         use crate::int::types::Int;
         const ITERS: usize = 10_000;
-        for w in 1u32..=38 {
-            let mut rng = SplitMix64(0xA17D17_u64.wrapping_add(w as u64));
+        for scale in 1u32..=38 {
+            let mut rng = SplitMix64(0xA17D17_u64.wrapping_add(scale as u64));
             for _ in 0..ITERS {
                 // Build a numerator drawn from a mix of regimes:
                 //   - small (fits one u128 limb)
@@ -2009,12 +2048,12 @@ mod tests {
                     let hi: Int<4> = Int::from_u128(mag_high);
                     (hi << 128_u32) + lo
                 };
-                let n: Int<4> = if regime % 2 == 1 { -pos } else { pos };
+                let numerator: Int<4> = if regime % 2 == 1 { -pos } else { pos };
 
                 let got =
-                    crate::algos::support::mg_divide::div_wide_pow10::<Int<4>>(n, w, crate::support::rounding::RoundingMode::HalfToEven);
-                let expected = round_div_reference_int256(n, w);
-                assert_eq!(got, expected, "round_div MG audit mismatch: w={w}, n={n:?}",);
+                    crate::algos::support::mg_divide::div_wide_pow10::<Int<4>>(numerator, scale, crate::support::rounding::RoundingMode::HalfToEven);
+                let expected = round_div_reference_int256(numerator, scale);
+                assert_eq!(got, expected, "round_div MG audit mismatch: w={scale}, n={numerator:?}",);
             }
         }
     }
@@ -2030,9 +2069,9 @@ mod tests {
         use crate::int::types::Int;
         const ITERS: usize = 2_000;
         let scales: &[u32] = &[1, 5, 10, 19, 28, 38];
-        for &w in scales {
+        for &scale in scales {
             for mode in all_modes() {
-                let mut rng = SplitMix64(0xCAFE_u64.wrapping_add(w as u64 ^ mode as u64));
+                let mut rng = SplitMix64(0xCAFE_u64.wrapping_add(scale as u64 ^ mode as u64));
                 for _ in 0..ITERS {
                     let regime = rng.next() % 4;
                     let mag_high = if regime >= 2 {
@@ -2046,12 +2085,13 @@ mod tests {
                         let hi: Int<4> = Int::from_u128(mag_high);
                         (hi << 128_u32) + lo
                     };
-                    let n: Int<4> = if regime % 2 == 1 { -pos } else { pos };
-                    let got = crate::algos::support::mg_divide::div_wide_pow10::<Int<4>>(n, w, mode);
-                    let expected = round_div_reference_int256_with(n, w, mode);
+                    let numerator: Int<4> = if regime % 2 == 1 { -pos } else { pos };
+                    let got = crate::algos::support::mg_divide::div_wide_pow10::<Int<4>>(
+                        numerator, scale, mode);
+                    let expected = round_div_reference_int256_with(numerator, scale, mode);
                     assert_eq!(
                         got, expected,
-                        "round_div MG all-modes mismatch: w={w}, mode={mode:?}",
+                        "round_div MG all-modes mismatch: w={scale}, mode={mode:?}",
                     );
                 }
             }
@@ -2069,47 +2109,48 @@ mod tests {
         let zero: Int<16> = Int::from_u128(0u128);
         let one: Int<16> = Int::from_u128(1u128);
         const ITERS: usize = 5_000;
-        for w in 1u32..=38 {
-            let mut rng = SplitMix64(0xB02ED2_u64.wrapping_add(w as u64));
-            let d: Int<16> = Int::from_u128(POW10_U128[w as usize]);
+        for scale in 1u32..=38 {
+            let mut rng = SplitMix64(0xB02ED2_u64.wrapping_add(scale as u64));
+            let divisor: Int<16> = Int::from_u128(POW10_U128[scale as usize]);
             for _ in 0..ITERS {
                 // Fill up to 6 u128 limbs (768 bits) of magnitude — well
                 // past one MG kernel pass.
                 let limbs = (rng.next() % 7) as usize;
-                let mut n: Int<16> = zero;
+                let mut numerator: Int<16> = zero;
                 for k in 0..limbs {
                     let chunk: Int<16> = Int::from_u128(rng.next_u128());
-                    n = n + (chunk << ((k * 128) as u32));
+                    numerator = numerator + (chunk << ((k * 128) as u32));
                 }
                 if rng.next() & 1 == 1 {
-                    n = -n;
+                    numerator = -numerator;
                 }
 
                 let got =
-                    crate::algos::support::mg_divide::div_wide_pow10::<Int<16>>(n, w, crate::support::rounding::RoundingMode::HalfToEven);
+                    crate::algos::support::mg_divide::div_wide_pow10::<Int<16>>(numerator, scale, crate::support::rounding::RoundingMode::HalfToEven);
                 // Reference half-to-even via div_rem.
-                let (q, r) = n.div_rem(d);
-                let expected = if r == zero {
-                    q
+                let (quotient, remainder) = numerator.div_rem(divisor);
+                let expected = if remainder == zero {
+                    quotient
                 } else {
-                    let ar = if r < zero { -r } else { r };
-                    let comp = d - ar;
-                    let cmp_r = ar.cmp(&comp);
-                    let q_is_odd = q.bit(0);
-                    let result_positive = n >= zero;
+                    let abs_remainder =
+                        if remainder < zero { -remainder } else { remainder };
+                    let complement = divisor - abs_remainder;
+                    let remainder_cmp = abs_remainder.cmp(&complement);
+                    let quotient_is_odd = quotient.bit(0);
+                    let result_is_positive = numerator >= zero;
                     let bump = crate::support::rounding::should_bump(
                         crate::support::rounding::RoundingMode::HalfToEven,
-                        cmp_r,
-                        q_is_odd,
-                        result_positive,
+                        remainder_cmp,
+                        quotient_is_odd,
+                        result_is_positive,
                     );
                     if bump {
-                        if result_positive { q + one } else { q - one }
+                        if result_is_positive { quotient + one } else { quotient - one }
                     } else {
-                        q
+                        quotient
                     }
                 };
-                assert_eq!(got, expected, "round_div MG audit (Int<16>) mismatch: w={w}",);
+                assert_eq!(got, expected, "round_div MG audit (Int<16>) mismatch: w={scale}",);
             }
         }
     }
@@ -2135,32 +2176,32 @@ mod tests {
 
     /// Build `10^w` in the target wide integer width.
     #[cfg(any(feature = "d76", feature = "wide"))]
-    fn pow10_int256(w: u32) -> crate::int::types::Int<4> {
+    fn pow10_int256(scale: u32) -> crate::int::types::Int<4> {
         use crate::int::types::Int;
-        let mut d: Int<4> = Int::from_u128(1u128);
+        let mut power: Int<4> = Int::from_u128(1u128);
         // 10^38 fits in u128, so we can build with chunks of up to 38.
-        let mut remaining = w;
+        let mut remaining = scale;
         while remaining > 0 {
             let chunk = remaining.min(38);
             let factor: Int<4> = Int::from_u128(POW10_U128[chunk as usize]);
-            d = d * factor;
+            power = power * factor;
             remaining -= chunk;
         }
-        d
+        power
     }
 
     #[cfg(any(feature = "d307", feature = "wide"))]
-    fn pow10_int1024(w: u32) -> crate::int::types::Int<16> {
+    fn pow10_int1024(scale: u32) -> crate::int::types::Int<16> {
         use crate::int::types::Int;
-        let mut d: Int<16> = Int::from_u128(1u128);
-        let mut remaining = w;
+        let mut power: Int<16> = Int::from_u128(1u128);
+        let mut remaining = scale;
         while remaining > 0 {
             let chunk = remaining.min(38);
             let factor: Int<16> = Int::from_u128(POW10_U128[chunk as usize]);
-            d = d * factor;
+            power = power * factor;
             remaining -= chunk;
         }
-        d
+        power
     }
 
     /// Int<4> reference quotient via div_rem + should_bump for any
@@ -2169,55 +2210,57 @@ mod tests {
     /// single u128 limb (so w can exceed 38).
     #[cfg(any(feature = "d76", feature = "wide"))]
     fn round_div_chain_reference_int256(
-        n: crate::int::types::Int<4>,
-        w: u32,
+        numerator: crate::int::types::Int<4>,
+        scale: u32,
         mode: crate::support::rounding::RoundingMode,
     ) -> crate::int::types::Int<4> {
         use crate::int::types::Int;
-        let d = pow10_int256(w);
+        let divisor = pow10_int256(scale);
         let zero: Int<4> = Int::from_u128(0u128);
         let one: Int<4> = Int::from_u128(1u128);
-        let (q, r) = n.div_rem(d);
-        if r == zero {
-            return q;
+        let (quotient, remainder) = numerator.div_rem(divisor);
+        if remainder == zero {
+            return quotient;
         }
-        let ar = if r < zero { -r } else { r };
-        let comp = d - ar;
-        let cmp_r = ar.cmp(&comp);
-        let q_is_odd = q.bit(0);
-        let result_positive = n >= zero;
-        let bump = crate::support::rounding::should_bump(mode, cmp_r, q_is_odd, result_positive);
+        let abs_remainder = if remainder < zero { -remainder } else { remainder };
+        let complement = divisor - abs_remainder;
+        let remainder_cmp = abs_remainder.cmp(&complement);
+        let quotient_is_odd = quotient.bit(0);
+        let result_is_positive = numerator >= zero;
+        let bump = crate::support::rounding::should_bump(
+            mode, remainder_cmp, quotient_is_odd, result_is_positive);
         if bump {
-            if result_positive { q + one } else { q - one }
+            if result_is_positive { quotient + one } else { quotient - one }
         } else {
-            q
+            quotient
         }
     }
 
     #[cfg(any(feature = "d307", feature = "wide"))]
     fn round_div_chain_reference_int1024(
-        n: crate::int::types::Int<16>,
-        w: u32,
+        numerator: crate::int::types::Int<16>,
+        scale: u32,
         mode: crate::support::rounding::RoundingMode,
     ) -> crate::int::types::Int<16> {
         use crate::int::types::Int;
-        let d = pow10_int1024(w);
+        let divisor = pow10_int1024(scale);
         let zero: Int<16> = Int::from_u128(0u128);
         let one: Int<16> = Int::from_u128(1u128);
-        let (q, r) = n.div_rem(d);
-        if r == zero {
-            return q;
+        let (quotient, remainder) = numerator.div_rem(divisor);
+        if remainder == zero {
+            return quotient;
         }
-        let ar = if r < zero { -r } else { r };
-        let comp = d - ar;
-        let cmp_r = ar.cmp(&comp);
-        let q_is_odd = q.bit(0);
-        let result_positive = n >= zero;
-        let bump = crate::support::rounding::should_bump(mode, cmp_r, q_is_odd, result_positive);
+        let abs_remainder = if remainder < zero { -remainder } else { remainder };
+        let complement = divisor - abs_remainder;
+        let remainder_cmp = abs_remainder.cmp(&complement);
+        let quotient_is_odd = quotient.bit(0);
+        let result_is_positive = numerator >= zero;
+        let bump = crate::support::rounding::should_bump(
+            mode, remainder_cmp, quotient_is_odd, result_is_positive);
         if bump {
-            if result_positive { q + one } else { q - one }
+            if result_is_positive { quotient + one } else { quotient - one }
         } else {
-            q
+            quotient
         }
     }
 
@@ -2231,14 +2274,15 @@ mod tests {
         use crate::int::types::Int;
         const ITERS_HTE: usize = 5_000;
         const ITERS_OTHER: usize = 1_000;
-        for w in 39u32..=76 {
+        for scale in 39u32..=76 {
             for mode in all_modes() {
                 let iters = if matches!(mode, crate::support::rounding::RoundingMode::HalfToEven) {
                     ITERS_HTE
                 } else {
                     ITERS_OTHER
                 };
-                let mut rng = SplitMix64(0xC4A1_u64.wrapping_add((w as u64) << 8 ^ (mode as u64)));
+                let mut rng =
+                    SplitMix64(0xC4A1_u64.wrapping_add((scale as u64) << 8 ^ (mode as u64)));
                 for _ in 0..iters {
                     let regime = rng.next() % 4;
                     let mag_high = if regime >= 2 {
@@ -2252,13 +2296,14 @@ mod tests {
                         let hi: Int<4> = Int::from_u128(mag_high);
                         (hi << 128_u32) + lo
                     };
-                    let n: Int<4> = if regime % 2 == 1 { -pos } else { pos };
+                    let numerator: Int<4> = if regime % 2 == 1 { -pos } else { pos };
 
-                    let got = crate::algos::support::mg_divide::div_wide_pow10_chain::<Int<4>>(n, w, mode);
-                    let expected = round_div_chain_reference_int256(n, w, mode);
+                    let got = crate::algos::support::mg_divide::div_wide_pow10_chain::<Int<4>>(
+                        numerator, scale, mode);
+                    let expected = round_div_chain_reference_int256(numerator, scale, mode);
                     assert_eq!(
                         got, expected,
-                        "chain MG audit (Int<4>) mismatch: w={w}, mode={mode:?}, n={n:?}",
+                        "chain MG audit (Int<4>) mismatch: w={scale}, mode={mode:?}, n={numerator:?}",
                     );
                 }
             }
@@ -2275,27 +2320,27 @@ mod tests {
         use crate::int::types::Int;
         let zero: Int<16> = Int::from_u128(0u128);
         const ITERS_HTE: usize = 3_000;
-        for w in 39u32..=100 {
-            let mut rng = SplitMix64(0x5C5C_u64.wrapping_add(w as u64));
+        for scale in 39u32..=100 {
+            let mut rng = SplitMix64(0x5C5C_u64.wrapping_add(scale as u64));
             for _ in 0..ITERS_HTE {
                 let limbs = (rng.next() % 7) as usize;
-                let mut n: Int<16> = zero;
+                let mut numerator: Int<16> = zero;
                 for k in 0..limbs {
                     let chunk: Int<16> = Int::from_u128(rng.next_u128());
-                    n = n + (chunk << ((k * 128) as u32));
+                    numerator = numerator + (chunk << ((k * 128) as u32));
                 }
                 if rng.next() & 1 == 1 {
-                    n = -n;
+                    numerator = -numerator;
                 }
 
                 let got =
-                    crate::algos::support::mg_divide::div_wide_pow10_chain::<Int<16>>(n, w, crate::support::rounding::RoundingMode::HalfToEven);
+                    crate::algos::support::mg_divide::div_wide_pow10_chain::<Int<16>>(numerator, scale, crate::support::rounding::RoundingMode::HalfToEven);
                 let expected = round_div_chain_reference_int1024(
-                    n,
-                    w,
+                    numerator,
+                    scale,
                     crate::support::rounding::RoundingMode::HalfToEven,
                 );
-                assert_eq!(got, expected, "chain MG audit (Int<16> HTE) mismatch: w={w}",);
+                assert_eq!(got, expected, "chain MG audit (Int<16> HTE) mismatch: w={scale}",);
             }
         }
     }
@@ -2312,24 +2357,26 @@ mod tests {
         let zero: Int<16> = Int::from_u128(0u128);
         const ITERS: usize = 1_000;
         let ws: &[u32] = &[39, 50, 57, 76, 77, 88, 100];
-        for &w in ws {
+        for &scale in ws {
             for mode in all_modes() {
-                let mut rng = SplitMix64(0x9E15_u64.wrapping_add((w as u64) << 4 ^ mode as u64));
+                let mut rng =
+                    SplitMix64(0x9E15_u64.wrapping_add((scale as u64) << 4 ^ mode as u64));
                 for _ in 0..ITERS {
                     let limbs = (rng.next() % 7) as usize;
-                    let mut n: Int<16> = zero;
+                    let mut numerator: Int<16> = zero;
                     for k in 0..limbs {
                         let chunk: Int<16> = Int::from_u128(rng.next_u128());
-                        n = n + (chunk << ((k * 128) as u32));
+                        numerator = numerator + (chunk << ((k * 128) as u32));
                     }
                     if rng.next() & 1 == 1 {
-                        n = -n;
+                        numerator = -numerator;
                     }
-                    let got = crate::algos::support::mg_divide::div_wide_pow10_chain::<Int<16>>(n, w, mode);
-                    let expected = round_div_chain_reference_int1024(n, w, mode);
+                    let got = crate::algos::support::mg_divide::div_wide_pow10_chain::<Int<16>>(
+                        numerator, scale, mode);
+                    let expected = round_div_chain_reference_int1024(numerator, scale, mode);
                     assert_eq!(
                         got, expected,
-                        "chain MG audit (Int<16> all modes) mismatch: w={w}, mode={mode:?}",
+                        "chain MG audit (Int<16> all modes) mismatch: w={scale}, mode={mode:?}",
                     );
                 }
             }
@@ -2348,8 +2395,8 @@ mod tests {
         use crate::int::types::Int;
         let two: Int<16> = Int::from_u128(2u128);
         let ws: &[u32] = &[39, 50, 57, 76, 77, 100];
-        for &w in ws {
-            let pow_w = pow10_int1024(w);
+        for &scale in ws {
+            let pow_w = pow10_int1024(scale);
             let half = pow_w / two;
             // Three q values: 0, 1, large.
             let qs: [Int<16>; 3] = [
@@ -2362,17 +2409,18 @@ mod tests {
                 -Int::<16>::from_u128(1u128),
                 Int::<16>::from_u128(1u128),
             ];
-            for q in qs {
+            for quotient in qs {
                 for delta in deltas {
                     for &sign_neg in &[false, true] {
-                        let pos_n = q * pow_w + half + delta;
-                        let n = if sign_neg { -pos_n } else { pos_n };
+                        let pos_n = quotient * pow_w + half + delta;
+                        let numerator = if sign_neg { -pos_n } else { pos_n };
                         for mode in all_modes() {
-                            let got = crate::algos::support::mg_divide::div_wide_pow10_chain::<Int<16>>(n, w, mode);
-                            let expected = round_div_chain_reference_int1024(n, w, mode);
+                            let got = crate::algos::support::mg_divide::div_wide_pow10_chain::<Int<16>>(numerator, scale, mode);
+                            let expected =
+                                round_div_chain_reference_int1024(numerator, scale, mode);
                             assert_eq!(
                                 got, expected,
-                                "chain MG half-tie mismatch: w={w}, mode={mode:?}, n={n:?}",
+                                "chain MG half-tie mismatch: w={scale}, mode={mode:?}, n={numerator:?}",
                             );
                         }
                     }
@@ -2384,17 +2432,17 @@ mod tests {
     /// Builds `10^w` as an `Int<256>` via chunked multiply (analogue of
     /// [`pow10_int1024`] at the widest work-integer width).
     #[cfg(any(feature = "d1232", feature = "xx-wide"))]
-    fn pow10_int16384(w: u32) -> crate::int::types::Int<256> {
+    fn pow10_int16384(scale: u32) -> crate::int::types::Int<256> {
         use crate::int::types::Int;
-        let mut d: Int<256> = Int::from_u128(1u128);
-        let mut remaining = w;
+        let mut power: Int<256> = Int::from_u128(1u128);
+        let mut remaining = scale;
         while remaining > 0 {
             let chunk = remaining.min(38);
             let factor: Int<256> = Int::from_u128(POW10_U128[chunk as usize]);
-            d = d * factor;
+            power = power * factor;
             remaining -= chunk;
         }
-        d
+        power
     }
 
     /// Regression for the original `div_wide_pow10_chain` buffer
@@ -2426,45 +2474,47 @@ mod tests {
 
         for &bit in high_bit_positions {
             // n = (1 << bit) | low-entropy limbs.
-            let mut n: Int<256> = one << bit;
-            n = n
+            let mut base_numerator: Int<256> = one << bit;
+            base_numerator = base_numerator
                 + (Int::<256>::from_u128(0xdead_beef_cafe_f00d_u128)
                     << 64_u32);
-            n = n + Int::<256>::from_u128(0x1234_5678_9abc_def0_u128);
+            base_numerator =
+                base_numerator + Int::<256>::from_u128(0x1234_5678_9abc_def0_u128);
 
-            for &w in scales {
+            for &scale in scales {
                 for &sign_neg in &[false, true] {
-                    let nn = if sign_neg { -n } else { n };
+                    let numerator = if sign_neg { -base_numerator } else { base_numerator };
                     for mode in all_modes() {
-                        let got = crate::algos::support::mg_divide::div_wide_pow10_chain::<Int<256>>(nn, w, mode);
+                        let got = crate::algos::support::mg_divide::div_wide_pow10_chain::<Int<256>>(numerator, scale, mode);
 
                         // Schoolbook reference on the untruncated value.
-                        let d = pow10_int16384(w);
-                        let (q, r) = nn.div_rem(d);
-                        let expected = if r == zero {
-                            q
+                        let divisor = pow10_int16384(scale);
+                        let (quotient, remainder) = numerator.div_rem(divisor);
+                        let expected = if remainder == zero {
+                            quotient
                         } else {
-                            let ar = if r < zero { -r } else { r };
-                            let comp = d - ar;
-                            let cmp_r = ar.cmp(&comp);
-                            let q_is_odd = q.bit(0);
-                            let result_positive = nn >= zero;
+                            let abs_remainder =
+                                if remainder < zero { -remainder } else { remainder };
+                            let complement = divisor - abs_remainder;
+                            let remainder_cmp = abs_remainder.cmp(&complement);
+                            let quotient_is_odd = quotient.bit(0);
+                            let result_is_positive = numerator >= zero;
                             if crate::support::rounding::should_bump(
                                 mode,
-                                cmp_r,
-                                q_is_odd,
-                                result_positive,
+                                remainder_cmp,
+                                quotient_is_odd,
+                                result_is_positive,
                             ) {
-                                if result_positive { q + one } else { q - one }
+                                if result_is_positive { quotient + one } else { quotient - one }
                             } else {
-                                q
+                                quotient
                             }
                         };
 
                         assert_eq!(
                             got, expected,
                             "Int<256> chain divide truncated above 8192 bits: \
-                             bit={bit}, w={w}, mode={mode:?}, neg={sign_neg}",
+                             bit={bit}, w={scale}, mode={mode:?}, neg={sign_neg}",
                         );
                     }
                 }
@@ -2481,42 +2531,51 @@ mod tests {
     /// the divide kernel needs.
     #[test]
     fn mg_magics_match_paper_formula() {
-        for k in 1..=38usize {
-            let d = POW10_U128[k];
-            let (recip, s) = MG_EXP_MAGICS[k];
-            assert_eq!(s, d.leading_zeros(), "shift for 10^{k}");
+        for scale_idx in 1..=38usize {
+            let divisor = POW10_U128[scale_idx];
+            let (recip, shift) = MG_EXP_MAGICS[scale_idx];
+            assert_eq!(shift, divisor.leading_zeros(), "shift for 10^{scale_idx}");
 
-            let d_norm = d << s;
+            let divisor_normalised = divisor << shift;
             // floor(2^256 / d_norm) recomputed independently here as
             // 2^128 + floor((2^256 - d_norm*2^128) / d_norm) using the
             // identity 2^256 = (2^128) * 2^128. We verify via the
             // defining product instead: (2^128 + recip) * d_norm must be
             // the largest multiple of d_norm at or below 2^256.
-            let (q_hi, q_lo) = mul_u128_to_u256(recip, d_norm);
+            let (q_hi, q_lo) = mul_u128_to_u256(recip, divisor_normalised);
             // (2^128 + recip) * d_norm = recip*d_norm + d_norm*2^128.
             // Its high 128 bits: q_hi + d_norm; low: q_lo.
-            let prod_hi = q_hi + d_norm;
+            let prod_hi = q_hi + divisor_normalised;
             // Largest multiple of d_norm <= 2^256 means prod_hi <= 2^128
             // (i.e. high word of 2^256 is 1 at bit 128) and one more
             // d_norm would cross 2^256.
             // prod_hi as a 129-bit count: it must not exceed 2^128, and
             // adding d_norm must overflow past 2^256.
             assert!(
-                prod_hi <= 1u128 << 127 || q_hi <= d_norm,
-                "reciprocal lower bound 10^{k}"
+                prod_hi <= 1u128 << 127 || q_hi <= divisor_normalised,
+                "reciprocal lower bound 10^{scale_idx}"
             );
             // Exactness check through the kernel: dividing the boundary
             // value 2^128*10^k - 1 (the largest n with quotient < 10^k
             // would overflow) is awkward; instead spot-check the kernel
             // against hardware u128 division across a few dividends.
-            let exp = d;
-            for &n_low in &[0u128, 1, exp - 1, exp, exp + 7, u128::MAX] {
+            let pow10_divisor = divisor;
+            for &n_low in &[0u128, 1, pow10_divisor - 1, pow10_divisor,
+                            pow10_divisor + 7, u128::MAX] {
                 // n_high = 0 keeps the true quotient within u128 and lets
                 // us compare against the native u128 divide.
-                let (q, r) =
-                    divmod_pow10_2word(0, n_low, exp, k).expect("quotient fits when n_high == 0");
-                assert_eq!(q, n_low / exp, "kernel quotient 10^{k}, n_low={n_low}");
-                assert_eq!(r, n_low % exp, "kernel remainder 10^{k}, n_low={n_low}");
+                let (quotient, remainder) = divmod_pow10_2word(0, n_low, pow10_divisor, scale_idx)
+                    .expect("quotient fits when n_high == 0");
+                assert_eq!(
+                    quotient,
+                    n_low / pow10_divisor,
+                    "kernel quotient 10^{scale_idx}, n_low={n_low}"
+                );
+                assert_eq!(
+                    remainder,
+                    n_low % pow10_divisor,
+                    "kernel remainder 10^{scale_idx}, n_low={n_low}"
+                );
             }
         }
     }

--- a/src/algos/support/narrow_ziv.rs
+++ b/src/algos/support/narrow_ziv.rs
@@ -42,49 +42,49 @@ use crate::support::rounding::RoundingMode;
 /// (`exp_series_2limb::WNarrow`) already runs in on every build.
 pub(crate) type WZiv = Int<24>;
 
-/// Lifts a raw `i128` storage value to the working scale: `raw · 10^guard`
-/// as a signed [`WZiv`]. Total for every `i128` (the magnitude goes
-/// through `from_u128`, so `i128::MIN` does not wrap).
+/// Lifts a raw `i128` storage value to the working scale:
+/// `raw · 10^guard_digits` as a signed [`WZiv`]. Total for every `i128`
+/// (the magnitude goes through `from_u128`, so `i128::MIN` does not wrap).
 #[inline]
-pub(crate) fn lift(raw: i128, guard: u32) -> WZiv {
-    let mag = WZiv::from_u128(raw.unsigned_abs())
-        * crate::consts::pow10::dispatch::<WZiv>(guard);
-    if raw < 0 { -mag } else { mag }
+pub(crate) fn lift(raw: i128, guard_digits: u32) -> WZiv {
+    let magnitude = WZiv::from_u128(raw.unsigned_abs())
+        * crate::consts::pow10::dispatch::<WZiv>(guard_digits);
+    if raw < 0 { -magnitude } else { magnitude }
 }
 
 /// `π · 10^w`, correctly rounded, at a runtime working scale.
 #[inline]
-pub(crate) fn pi_w(w: u32) -> WZiv {
-    crate::consts::pi_by_working_scale::<WZiv>(w, RoundingMode::HalfToEven)
+pub(crate) fn pi_w(working_scale: u32) -> WZiv {
+    crate::consts::pi_by_working_scale::<WZiv>(working_scale, RoundingMode::HalfToEven)
 }
 
 /// `ln 2 · 10^w`, correctly rounded, at a runtime working scale.
 #[inline]
-pub(crate) fn ln2_w(w: u32) -> WZiv {
-    crate::consts::ln2_by_working_scale::<WZiv>(w, RoundingMode::HalfToEven)
+pub(crate) fn ln2_w(working_scale: u32) -> WZiv {
+    crate::consts::ln2_by_working_scale::<WZiv>(working_scale, RoundingMode::HalfToEven)
 }
 
 /// `ln 10 · 10^w`, correctly rounded, at a runtime working scale.
 #[inline]
-pub(crate) fn ln10_w(w: u32) -> WZiv {
-    crate::consts::ln10_by_working_scale::<WZiv>(w, RoundingMode::HalfToEven)
+pub(crate) fn ln10_w(working_scale: u32) -> WZiv {
+    crate::consts::ln10_by_working_scale::<WZiv>(working_scale, RoundingMode::HalfToEven)
 }
 
 /// The plain directed/nearest Ziv walker at the narrow storage —
-/// `recompute(guard)` returns the kernel value at working scale
-/// `scale + guard` in [`WZiv`]. Result-sign-agnostic at the cap (no
+/// `recompute(guard_digits)` returns the kernel value at working scale
+/// `scale + guard_digits` in [`WZiv`]. Result-sign-agnostic at the cap (no
 /// never-exact tail assumption): the unresolved endgame snaps to the
 /// clean base narrowing, which is the correct answer for an EXACTLY
 /// boundary-valued input (`powf(4, 0.5)`, `log_4(8)`).
 #[inline]
 pub(crate) fn walk(
-    base_guard: u32,
+    base_guard_digits: u32,
     scale: u32,
     mode: RoundingMode,
     recompute: impl FnMut(u32) -> WZiv,
 ) -> i128 {
     wtc::round_to_storage_directed_g::<Int<2>, WZiv>(
-        base_guard,
+        base_guard_digits,
         scale,
         mode,
         Int::<2>::MAX,
@@ -100,13 +100,13 @@ pub(crate) fn walk(
 /// sub-resolution tail. Mirrors the wide `exp`/`cosh` shape.
 #[inline]
 pub(crate) fn walk_never_exact(
-    base_guard: u32,
+    base_guard_digits: u32,
     scale: u32,
     mode: RoundingMode,
     recompute: impl FnMut(u32) -> WZiv,
 ) -> i128 {
     wtc::round_to_storage_directed_never_exact_g::<Int<2>, WZiv>(
-        base_guard,
+        base_guard_digits,
         scale,
         mode,
         Int::<2>::MAX,
@@ -119,39 +119,39 @@ pub(crate) fn walk_never_exact(
 /// Option-contract wrapper over [`walk`] for the kernels whose overflow
 /// contract is a returned `None` (`ln`/`log`/`powf`/`exp`): the walker's
 /// range check PANICS past storage, so a near-tie AT the storage extreme
-/// (where the walker's ±1 could leave range) keeps the single-shot
-/// verdict `base` instead — `base` is the plain rounding of the same
+/// (where the walker's ±1 could leave range) keeps the `single_shot`
+/// verdict instead — `single_shot` is the plain rounding of the same
 /// working value, and a tie that deep at the extreme is the
-/// Table-Maker's-Dilemma residue either way. `base == None` (out of
+/// Table-Maker's-Dilemma residue either way. `single_shot == None` (out of
 /// range) propagates.
 #[inline]
 pub(crate) fn walk_checked(
-    base: Option<i128>,
-    base_guard: u32,
+    single_shot: Option<i128>,
+    base_guard_digits: u32,
     scale: u32,
     mode: RoundingMode,
     recompute: impl FnMut(u32) -> WZiv,
 ) -> Option<i128> {
-    match base {
+    match single_shot {
         None => None,
-        Some(b) if b.unsigned_abs() >= (i128::MAX as u128) - 1 => Some(b),
-        Some(_) => Some(walk(base_guard, scale, mode, recompute)),
+        Some(value) if value.unsigned_abs() >= (i128::MAX as u128) - 1 => Some(value),
+        Some(_) => Some(walk(base_guard_digits, scale, mode, recompute)),
     }
 }
 
 /// [`walk_checked`] with the `never_exact` polarity (`exp` / `exp2`).
 #[inline]
 pub(crate) fn walk_checked_never_exact(
-    base: Option<i128>,
-    base_guard: u32,
+    single_shot: Option<i128>,
+    base_guard_digits: u32,
     scale: u32,
     mode: RoundingMode,
     recompute: impl FnMut(u32) -> WZiv,
 ) -> Option<i128> {
-    match base {
+    match single_shot {
         None => None,
-        Some(b) if b.unsigned_abs() >= (i128::MAX as u128) - 1 => Some(b),
-        Some(_) => Some(walk_never_exact(base_guard, scale, mode, recompute)),
+        Some(value) if value.unsigned_abs() >= (i128::MAX as u128) - 1 => Some(value),
+        Some(_) => Some(walk_never_exact(base_guard_digits, scale, mode, recompute)),
     }
 }
 
@@ -160,13 +160,13 @@ pub(crate) fn walk_checked_never_exact(
 /// wide `acosh`/`atanh` shape.
 #[inline]
 pub(crate) fn walk_near_special(
-    base_guard: u32,
+    base_guard_digits: u32,
     scale: u32,
     mode: RoundingMode,
     recompute: impl FnMut(u32) -> WZiv,
 ) -> i128 {
     wtc::round_to_storage_directed_near_special_g::<Int<2>, WZiv>(
-        base_guard,
+        base_guard_digits,
         scale,
         mode,
         Int::<2>::MAX,

--- a/src/algos/support/newton_reciprocal.rs
+++ b/src/algos/support/newton_reciprocal.rs
@@ -250,9 +250,9 @@ impl NewtonReciprocal {
             r[..k_u64 + 1].copy_from_slice(baked);
         } else {
             // numerator = 2^(64 * k_u64) — a single 1 in limb position k_u64.
-            let mut num = [0u64; MAX_R_U64];
-            num[k_u64] = 1u64;
-            let mut rem = [0u64; MAX_POW_U64];
+            let mut numerator = [0u64; MAX_R_U64];
+            numerator[k_u64] = 1u64;
+            let mut remainder = [0u64; MAX_POW_U64];
             // EXACT module-sized Knuth scratch — never the build-max slice
             // blanket. The dividend spans `k_u64 + 1 ≤ MAX_R_U64` limbs
             // (asserted above), which exceeds the blanket divide's
@@ -268,14 +268,14 @@ impl NewtonReciprocal {
             // `exp_generic::div_rem_exact` precedent; the u128-limb
             // refinement falls to the value-identical base-2⁶⁴ Knuth).
             use crate::int::policy::div_rem::{select_for_limbs, Algorithm};
-            match select_for_limbs(&num[..k_u64 + 1], &pow_scale[..pow_len]) {
+            match select_for_limbs(&numerator[..k_u64 + 1], &pow_scale[..pow_len]) {
                 // Single-limb divisor: hardware remainder, no normalisation
                 // scratch involved.
                 Algorithm::Rem => crate::int::algos::div::div_rem::div_rem(
-                    &num[..k_u64 + 1],
+                    &numerator[..k_u64 + 1],
                     &pow_scale[..pow_len],
                     &mut r[..k_u64 + 1],
-                    &mut rem[..pow_len],
+                    &mut remainder[..pow_len],
                 ),
                 _ => {
                     // Verdict collapse: any non-Rem algorithm (including the
@@ -285,15 +285,15 @@ impl NewtonReciprocal {
                     // but MUST be re-verified whenever an Algorithm arm joins
                     // `int::policy::div_rem`; a new engine winning for these
                     // shapes would need an explicit arm, not a silent Knuth fall.
-                    let mut u = [0u64; MAX_R_U64 + 2];
-                    let mut v = [0u64; MAX_POW_U64];
+                    let mut dividend_scratch = [0u64; MAX_R_U64 + 2];
+                    let mut divisor_scratch = [0u64; MAX_POW_U64];
                     crate::int::algos::div::div_knuth::div_knuth_into(
-                        &num[..k_u64 + 1],
+                        &numerator[..k_u64 + 1],
                         &pow_scale[..pow_len],
                         &mut r[..k_u64 + 1],
-                        &mut rem[..pow_len],
-                        &mut u,
-                        &mut v,
+                        &mut remainder[..pow_len],
+                        &mut dividend_scratch,
+                        &mut divisor_scratch,
                     );
                 }
             }
@@ -344,10 +344,10 @@ impl NewtonReciprocal {
 
 /// Per-call Newton-reciprocal divide.
 ///
-/// `n` is the unsigned numerator magnitude in little-endian u64 limbs.
-/// The quotient `floor(n / 10^scale)` is written into `quot` (caller-
-/// sized to the target width); the remainder is written into `rem_out`
-/// and its live limb count returned, for rounding-aware callers.
+/// `numerator` is the unsigned numerator magnitude in little-endian u64
+/// limbs. The quotient `floor(n / 10^scale)` is written into `quot`
+/// (caller-sized to the target width); the remainder is written into
+/// `rem_out` and its live limb count returned, for rounding-aware callers.
 ///
 /// # Precision
 ///
@@ -355,19 +355,19 @@ impl NewtonReciprocal {
 /// add-back step ensures correctness for the at-most-1 over/under
 /// estimate the truncated reciprocal produces.
 fn div_newton(
-    n: &[u64],
+    numerator: &[u64],
     table: &NewtonReciprocal,
     quot: &mut [u64],
     rem_out: &mut [u64],
 ) -> usize {
-    let r = &table.r[..table.r_len];
+    let reciprocal = &table.r[..table.r_len];
     let pow_scale = &table.pow_scale[..table.pow_len];
 
-    // product = n * r
-    let prod_len = n.len() + r.len();
+    // product = numerator * reciprocal
+    let prod_len = numerator.len() + reciprocal.len();
     debug_assert!(prod_len <= MAX_PROD_U64, "product buffer too small");
     let mut prod = [0u64; MAX_PROD_U64];
-    mul_slice(n, r, &mut prod[..prod_len]);
+    mul_slice(numerator, reciprocal, &mut prod[..prod_len]);
 
     // q_approx = prod >> (64 * k_u64)
     let lo = table.k_u64.min(prod_len);
@@ -379,16 +379,16 @@ fn div_newton(
         *dst = 0;
     }
 
-    // r_approx = n - q_approx * pow_scale  (mod 2^width)
+    // r_approx = numerator - q_approx * pow_scale  (mod 2^width)
     let prod2_len = quot.len() + pow_scale.len();
     debug_assert!(prod2_len <= MAX_PROD_U64, "product buffer too small");
     let mut prod2 = [0u64; MAX_PROD_U64];
     mul_slice(quot, pow_scale, &mut prod2[..prod2_len]);
 
-    // rem = n - prod2 (mod 2^width), held in n.len()+1 limbs.
-    let rem_len = n.len() + 1;
+    // rem = numerator - prod2 (mod 2^width), in numerator.len()+1 limbs.
+    let rem_len = numerator.len() + 1;
     debug_assert!(rem_len <= MAX_MAG_U64 + 1, "rem buffer too small");
-    for (dst, src) in rem_out.iter_mut().take(rem_len).zip(n.iter()) {
+    for (dst, src) in rem_out.iter_mut().take(rem_len).zip(numerator.iter()) {
         *dst = *src;
     }
     rem_out[rem_len - 1] = 0;
@@ -402,8 +402,8 @@ fn div_newton(
         if cmp(&rem_out[..rem_len], pow_scale) < 0 {
             break;
         }
-        let s = rem_len.min(pow_scale.len());
-        let _ = sub_assign(&mut rem_out[..s], &pow_scale[..s]);
+        let common_len = rem_len.min(pow_scale.len());
+        let _ = sub_assign(&mut rem_out[..common_len], &pow_scale[..common_len]);
         // quot += 1
         let mut carry: u64 = 1;
         for limb in quot.iter_mut() {
@@ -430,48 +430,48 @@ fn div_newton(
 // paying the pack cost ONCE in the amortised `precompute`.
 
 #[inline]
-const fn cmp_u128(a: &[u128], b: &[u128]) -> i32 {
-    let mut alen = a.len();
-    while alen > 0 && a[alen - 1] == 0 { alen -= 1; }
-    let mut blen = b.len();
-    while blen > 0 && b[blen - 1] == 0 { blen -= 1; }
-    if alen != blen { return if alen > blen { 1 } else { -1 }; }
-    let mut i = alen;
+const fn cmp_u128(lhs: &[u128], rhs: &[u128]) -> i32 {
+    let mut lhs_len = lhs.len();
+    while lhs_len > 0 && lhs[lhs_len - 1] == 0 { lhs_len -= 1; }
+    let mut rhs_len = rhs.len();
+    while rhs_len > 0 && rhs[rhs_len - 1] == 0 { rhs_len -= 1; }
+    if lhs_len != rhs_len { return if lhs_len > rhs_len { 1 } else { -1 }; }
+    let mut i = lhs_len;
     while i > 0 {
         i -= 1;
-        if a[i] != b[i] { return if a[i] > b[i] { 1 } else { -1 }; }
+        if lhs[i] != rhs[i] { return if lhs[i] > rhs[i] { 1 } else { -1 }; }
     }
     0
 }
 
 #[inline]
-const fn sub_assign_u128(a: &mut [u128], b: &[u128]) -> bool {
+const fn sub_assign_u128(lhs: &mut [u128], rhs: &[u128]) -> bool {
     let mut borrow: u128 = 0;
     let mut i = 0;
-    while i < a.len() {
-        let bi = if i < b.len() { b[i] } else { 0 };
-        let (s1, c1) = a[i].overflowing_sub(bi);
+    while i < lhs.len() {
+        let rhs_limb = if i < rhs.len() { rhs[i] } else { 0 };
+        let (s1, c1) = lhs[i].overflowing_sub(rhs_limb);
         let (s2, c2) = s1.overflowing_sub(borrow);
-        a[i] = s2;
+        lhs[i] = s2;
         borrow = (c1 as u128) | (c2 as u128);
         i += 1;
     }
     borrow != 0
 }
 
-/// `out = a * b` schoolbook on u128 limb slices. Inner step uses the
+/// `out = lhs * rhs` schoolbook on u128 limb slices. Inner step uses the
 /// 4xu64*u64->u128 partials decomposition (`<u128 as Limb>::widening_mul`).
 #[inline]
-fn mul_schoolbook_u128(a: &[u128], b: &[u128], out: &mut [u128]) {
+fn mul_schoolbook_u128(lhs: &[u128], rhs: &[u128], out: &mut [u128]) {
     use crate::int::types::compute_limbs::Limb;
     let mut i = 0;
-    while i < a.len() {
-        if a[i] != 0 {
+    while i < lhs.len() {
+        if lhs[i] != 0 {
             let mut carry: u128 = 0;
             let mut j = 0;
-            while j < b.len() {
-                if b[j] != 0 || carry != 0 {
-                    let (prod_lo, prod_hi) = <u128 as Limb>::widening_mul(a[i], b[j]);
+            while j < rhs.len() {
+                if rhs[j] != 0 || carry != 0 {
+                    let (prod_lo, prod_hi) = <u128 as Limb>::widening_mul(lhs[i], rhs[j]);
                     let idx = i + j;
                     let (s1, c1) = out[idx].overflowing_add(prod_lo);
                     let (s2, c2) = s1.overflowing_add(carry);
@@ -480,7 +480,7 @@ fn mul_schoolbook_u128(a: &[u128], b: &[u128], out: &mut [u128]) {
                 }
                 j += 1;
             }
-            let mut idx = i + b.len();
+            let mut idx = i + rhs.len();
             while carry != 0 && idx < out.len() {
                 let (s, c) = out[idx].overflowing_add(carry);
                 out[idx] = s;
@@ -492,29 +492,31 @@ fn mul_schoolbook_u128(a: &[u128], b: &[u128], out: &mut [u128]) {
     }
 }
 
-/// HIGH product: `out[i] = limb (base + i)` of `a * b` (the full product has
-/// `a.len()+b.len()` limbs), forming only the partials with `i + j >= base`.
+/// HIGH product: `out[i] = limb (base + i)` of `lhs * rhs` (the full product
+/// has `lhs.len()+rhs.len()` limbs), forming only the partials with
+/// `i + j >= base`.
 /// The dropped low partials (`i + j < base`) are NOT included, so their carry
 /// into limb `base` is missing — making the high limbs too-LOW by a bounded
 /// amount. The Newton quotient `q = (a·b) >> k` reads this with a small guard
 /// (`base = k - GUARD`), bounding the deficit to `< 1` ULP at the `k`-cut; the
 /// Newton correction LOOP (`while rem >= D { q += 1 }`) adds back any residual,
 /// so the result is EXACT regardless of guard — the guard only bounds the loop
-/// count (perf). `out` pre-zeroed; `out.len() >= a.len()+b.len() - base`. This
-/// halves the `mag·r` work vs the full product (only the high half is kept).
+/// count (perf). `out` pre-zeroed;
+/// `out.len() >= lhs.len()+rhs.len() - base`. This halves the `mag·r` work
+/// vs the full product (only the high half is kept).
 #[inline]
-fn mul_high_schoolbook_u128(a: &[u128], b: &[u128], out: &mut [u128], base: usize) {
+fn mul_high_schoolbook_u128(lhs: &[u128], rhs: &[u128], out: &mut [u128], base: usize) {
     use crate::int::types::compute_limbs::Limb;
     let out_len = out.len();
     let mut i = 0;
-    while i < a.len() {
-        if a[i] != 0 {
+    while i < lhs.len() {
+        if lhs[i] != 0 {
             // Smallest j with i + j >= base; skip the dropped-low partials.
             let j0 = base.saturating_sub(i);
             let mut carry: u128 = 0;
             let mut j = j0;
-            while j < b.len() {
-                let (lo, hi) = <u128 as Limb>::widening_mul(a[i], b[j]);
+            while j < rhs.len() {
+                let (lo, hi) = <u128 as Limb>::widening_mul(lhs[i], rhs[j]);
                 let idx = i + j - base; // i + j >= base for j >= j0
                 let (s1, c1) = out[idx].overflowing_add(lo);
                 let (s2, c2) = s1.overflowing_add(carry);
@@ -522,7 +524,7 @@ fn mul_high_schoolbook_u128(a: &[u128], b: &[u128], out: &mut [u128], base: usiz
                 carry = hi.wrapping_add(c1 as u128).wrapping_add(c2 as u128);
                 j += 1;
             }
-            let mut idx = i + b.len() - base;
+            let mut idx = i + rhs.len() - base;
             while carry != 0 && idx < out_len {
                 let (s, c) = out[idx].overflowing_add(carry);
                 out[idx] = s;
@@ -538,15 +540,15 @@ fn mul_high_schoolbook_u128(a: &[u128], b: &[u128], out: &mut [u128], base: usiz
 /// All multiplies run on the precomputed u128-packed `r` and `pow_scale` (NO
 /// per-call pack); operand/output stay in u128 throughout.
 fn div_newton_u128(
-    n: &[u128],
+    numerator: &[u128],
     table: &NewtonReciprocal,
     quot: &mut [u128],
     rem_out: &mut [u128],
 ) -> usize {
-    let r = &table.r_u128[..table.r_u128_len];
+    let reciprocal = &table.r_u128[..table.r_u128_len];
     let pow_scale = &table.pow_u128[..table.pow_u128_len];
 
-    let prod_len = n.len() + r.len();
+    let prod_len = numerator.len() + reciprocal.len();
     let lo = table.k_u128.min(prod_len);
     // q = (n·r) >> (128·k_u128) reads only the HIGH limbs [lo..]. Form just
     // those (plus GUARD guard limbs) with the high-product — dropping the low
@@ -557,7 +559,7 @@ fn div_newton_u128(
     let high_len = prod_len - base;
     debug_assert!(high_len <= MAX_PROD_U128, "u128 high-product buffer too small");
     let mut prod = [0u128; MAX_PROD_U128];
-    mul_high_schoolbook_u128(n, r, &mut prod[..high_len], base);
+    mul_high_schoolbook_u128(numerator, reciprocal, &mut prod[..high_len], base);
 
     // q = limbs [lo..prod_len] of n·r = prod[lo - base .. high_len].
     let q_slice = &prod[lo - base..high_len];
@@ -569,17 +571,17 @@ fn div_newton_u128(
     let mut prod2 = [0u128; MAX_PROD_U128];
     mul_schoolbook_u128(quot, pow_scale, &mut prod2[..prod2_len]);
 
-    let rem_len = n.len() + 1;
+    let rem_len = numerator.len() + 1;
     debug_assert!(rem_len <= MAX_MAG_U128 + 1, "u128 rem buffer too small");
-    for (dst, src_) in rem_out.iter_mut().take(rem_len).zip(n.iter()) { *dst = *src_; }
+    for (dst, src_) in rem_out.iter_mut().take(rem_len).zip(numerator.iter()) { *dst = *src_; }
     rem_out[rem_len - 1] = 0;
     let sub_len = prod2_len.min(rem_len);
     let _ = sub_assign_u128(&mut rem_out[..sub_len], &prod2[..sub_len]);
 
     loop {
         if cmp_u128(&rem_out[..rem_len], pow_scale) < 0 { break; }
-        let s = rem_len.min(pow_scale.len());
-        let _ = sub_assign_u128(&mut rem_out[..s], &pow_scale[..s]);
+        let common_len = rem_len.min(pow_scale.len());
+        let _ = sub_assign_u128(&mut rem_out[..common_len], &pow_scale[..common_len]);
         let mut carry: u128 = 1;
         for limb in quot.iter_mut() {
             let (s, c) = limb.overflowing_add(carry);
@@ -598,7 +600,7 @@ fn div_newton_u128(
 /// path `newton_pow10_mag_u128`.
 pub(crate) fn newton_pow10_mag_u128_packed(
     mag_u128: &mut [u128],
-    neg: bool,
+    is_negative: bool,
     mode: crate::support::rounding::RoundingMode,
     table: &NewtonReciprocal,
 ) {
@@ -627,13 +629,13 @@ pub(crate) fn newton_pow10_mag_u128_packed(
             carry_in = next_carry;
         }
 
-        let cmp_r = match cmp_u128(&rem[..rem_len], &half[..pow_len]) {
-            n if n < 0 => core::cmp::Ordering::Less,
+        let remainder_cmp = match cmp_u128(&rem[..rem_len], &half[..pow_len]) {
+            ordering if ordering < 0 => core::cmp::Ordering::Less,
             0 => core::cmp::Ordering::Equal,
             _ => core::cmp::Ordering::Greater,
         };
-        let q_is_odd = (quot[0] & 1) != 0;
-        if rounding::should_bump(mode, cmp_r, q_is_odd, !neg) {
+        let quotient_is_odd = (quot[0] & 1) != 0;
+        if rounding::should_bump(mode, remainder_cmp, quotient_is_odd, !is_negative) {
             let mut carry: u128 = 1;
             for limb in quot[..mag_len].iter_mut() {
                 let (s, c) = limb.overflowing_add(carry);
@@ -680,7 +682,7 @@ const fn newton_u128_wins(width_bits: u32) -> bool {
 /// Direct analogue of [`crate::algos::support::mg_divide::div_wide_pow10_chain`]
 /// — same signature, same semantics, different inner algorithm.
 pub(crate) fn div_wide_pow10_newton_with<W: crate::int::types::traits::BigInt>(
-    n: W,
+    value: W,
     scale: u32,
     mode: crate::support::rounding::RoundingMode,
     table: &NewtonReciprocal,
@@ -701,9 +703,9 @@ pub(crate) fn div_wide_pow10_newton_with<W: crate::int::types::traits::BigInt>(
     let mut mag_u128 = crate::int::types::compute_limbs::max_u128_limb();
     let limbs = <W as crate::int::types::traits::BigInt>::U128_LIMBS;
     let mag = &mut mag_u128[..limbs];
-    let neg = n.mag_into_u128(mag);
-    newton_pow10_mag_u128(mag, neg, mode, table);
-    W::from_mag_sign_u128(mag, neg)
+    let is_negative = value.mag_into_u128(mag);
+    newton_pow10_mag_u128(mag, is_negative, mode, table);
+    W::from_mag_sign_u128(mag, is_negative)
 }
 
 /// Width-agnostic Newton-reciprocal divide of a u128-limb magnitude slice
@@ -717,7 +719,7 @@ pub(crate) fn div_wide_pow10_newton_with<W: crate::int::types::traits::BigInt>(
 /// the quotient back into `mag` in place.
 pub(crate) fn newton_pow10_mag_u128(
     mag_u128: &mut [u128],
-    neg: bool,
+    is_negative: bool,
     mode: crate::support::rounding::RoundingMode,
     table: &NewtonReciprocal,
 ) {
@@ -725,9 +727,9 @@ pub(crate) fn newton_pow10_mag_u128(
 
     // Transcode the u128 magnitude to the u64 limbs the kernel runs in.
     let mut mag = [0u64; MAX_MAG_U64];
-    for (i, &v) in mag_u128.iter().enumerate() {
-        mag[2 * i] = v as u64;
-        mag[2 * i + 1] = (v >> 64) as u64;
+    for (i, &limb) in mag_u128.iter().enumerate() {
+        mag[2 * i] = limb as u64;
+        mag[2 * i + 1] = (limb >> 64) as u64;
     }
     let mag_len = mag_u128.len() * 2;
 
@@ -758,13 +760,13 @@ pub(crate) fn newton_pow10_mag_u128(
             carry_in = next_carry;
         }
 
-        let cmp_r = match cmp(&rem[..rem_len], &half[..pow_len]) {
-            n if n < 0 => core::cmp::Ordering::Less,
+        let remainder_cmp = match cmp(&rem[..rem_len], &half[..pow_len]) {
+            ordering if ordering < 0 => core::cmp::Ordering::Less,
             0 => core::cmp::Ordering::Equal,
             _ => core::cmp::Ordering::Greater,
         };
-        let q_is_odd = (quot[0] & 1) != 0;
-        if rounding::should_bump(mode, cmp_r, q_is_odd, !neg) {
+        let quotient_is_odd = (quot[0] & 1) != 0;
+        if rounding::should_bump(mode, remainder_cmp, quotient_is_odd, !is_negative) {
             let mut carry: u64 = 1;
             for limb in quot[..mag_len].iter_mut() {
                 let (s, c) = limb.overflowing_add(carry);
@@ -794,8 +796,8 @@ pub(crate) fn newton_pow10_mag_u128(
 /// is the magnitude width in bits — the typed door
 /// ([`crate::algos::support::rescale::dispatch_wide_pow10`]) passes the
 /// SIGNIFICANT length here (task 9.24), so `precompute` sizes the reciprocal +
-/// quotient to the real magnitude, not the full work buffer; `neg` is the
-/// result sign for the rounding tie-break.
+/// quotient to the real magnitude, not the full work buffer; `is_negative`
+/// is the result sign for the rounding tie-break.
 ///
 /// This is the `Newton` arm of the rescale matcher
 /// ([`crate::algos::support::rescale`]) — **SELECTED** for the wide /
@@ -809,7 +811,7 @@ pub(crate) fn newton_pow10_mag_u128(
 pub(crate) fn newton_rescale_arm(
     mag: &mut [u128],
     scale: u32,
-    neg: bool,
+    is_negative: bool,
     mode: crate::support::rounding::RoundingMode,
     width_bits: u32,
 ) {
@@ -822,9 +824,9 @@ pub(crate) fn newton_rescale_arm(
         let width_limbs = (width_bits as usize) / 64;
         let table = NewtonReciprocal::precompute(scale, width_limbs);
         if newton_u128_wins(width_bits) {
-            newton_pow10_mag_u128_packed(mag, neg, mode, &table);
+            newton_pow10_mag_u128_packed(mag, is_negative, mode, &table);
         } else {
-            newton_pow10_mag_u128(mag, neg, mode, &table);
+            newton_pow10_mag_u128(mag, is_negative, mode, &table);
         }
     }
 
@@ -833,7 +835,8 @@ pub(crate) fn newton_rescale_arm(
         // no_std has no Newton path (the per-call Knuth precompute is too
         // costly); forward to the MG chain — the kernel the matcher selects.
         let _ = width_bits;
-        crate::algos::support::mg_divide::div_pow10_chain_mag_u128(mag, scale, neg, mode);
+        crate::algos::support::mg_divide::div_pow10_chain_mag_u128(
+            mag, scale, is_negative, mode);
     }
 }
 
@@ -898,18 +901,20 @@ mod tests {
                     }
                     assert_eq!(carry, 0, "10^{scale} overflowed pow_len");
                 }
-                let k_raw = width_limbs + pow_len;
-                let k = if k_raw % 2 == 0 { k_raw } else { k_raw + 1 };
+                let top_limb_raw = width_limbs + pow_len;
+                let top_limb =
+                    if top_limb_raw % 2 == 0 { top_limb_raw } else { top_limb_raw + 1 };
                 let mut num = [0u64; MAX_R_U64];
-                num[k] = 1;
-                let mut r = [0u64; MAX_R_U64];
+                num[top_limb] = 1;
+                let mut recip = [0u64; MAX_R_U64];
                 let mut rem = [0u64; MAX_POW_U64];
-                div_rem_mag_slice(&num[..k + 1], &pow[..pow_len], &mut r[..k + 1], &mut rem[..pow_len]);
+                div_rem_mag_slice(&num[..top_limb + 1], &pow[..pow_len],
+                    &mut recip[..top_limb + 1], &mut rem[..pow_len]);
                 let baked = crate::consts::newton_recip_le(scale, width_limbs)
                     .expect("baked reciprocal in range");
                 assert_eq!(
                     baked,
-                    &r[..k + 1],
+                    &recip[..top_limb + 1],
                     "baked != runtime divide: width_limbs={width_limbs} scale={scale}"
                 );
             }
@@ -928,10 +933,12 @@ mod tests {
         let mut limbs = [0u128; 64];
         limbs[6] = 1u128 << 32;
         limbs[0] = 42;
-        let n = <Int<16> as crate::int::types::traits::BigInt>::from_mag_sign_u128(&limbs, false);
+        let numerator = <Int<16> as crate::int::types::traits::BigInt>::from_mag_sign_u128(
+            &limbs, false);
 
-        let got = div_wide_pow10_newton_with(n, scale, RoundingMode::HalfToEven, &table);
-        let want = div_wide_pow10_chain::<Int<16>>(n, scale, RoundingMode::HalfToEven);
+        let got =
+            div_wide_pow10_newton_with(numerator, scale, RoundingMode::HalfToEven, &table);
+        let want = div_wide_pow10_chain::<Int<16>>(numerator, scale, RoundingMode::HalfToEven);
         assert_eq!(got, want, "Newton differs from MG chain at D307 s=150");
     }
 
@@ -948,10 +955,12 @@ mod tests {
         let mut limbs = [0u128; 64];
         limbs[10] = 1u128 << 24;
         limbs[2] = 0xfeedfacecafef00d_u128;
-        let n = <Int<24> as crate::int::types::traits::BigInt>::from_mag_sign_u128(&limbs, false);
+        let numerator = <Int<24> as crate::int::types::traits::BigInt>::from_mag_sign_u128(
+            &limbs, false);
 
-        let got = div_wide_pow10_newton_with(n, scale, RoundingMode::HalfToEven, &table);
-        let want = div_wide_pow10_chain::<Int<24>>(n, scale, RoundingMode::HalfToEven);
+        let got =
+            div_wide_pow10_newton_with(numerator, scale, RoundingMode::HalfToEven, &table);
+        let want = div_wide_pow10_chain::<Int<24>>(numerator, scale, RoundingMode::HalfToEven);
         assert_eq!(got, want, "Newton differs from MG chain at Int<24> s=202");
     }
 
@@ -965,10 +974,12 @@ mod tests {
         let mut limbs = [0u128; 64];
         limbs[10] = 1u128 << 8;
         limbs[1] = 0xdeadbeef_cafef00d_u128;
-        let n = <Int<24> as crate::int::types::traits::BigInt>::from_mag_sign_u128(&limbs, false);
+        let numerator = <Int<24> as crate::int::types::traits::BigInt>::from_mag_sign_u128(
+            &limbs, false);
 
-        let got = div_wide_pow10_newton_with(n, scale, RoundingMode::HalfToEven, &table);
-        let want = div_wide_pow10_chain::<Int<24>>(n, scale, RoundingMode::HalfToEven);
+        let got =
+            div_wide_pow10_newton_with(numerator, scale, RoundingMode::HalfToEven, &table);
+        let want = div_wide_pow10_chain::<Int<24>>(numerator, scale, RoundingMode::HalfToEven);
         assert_eq!(got, want, "Newton differs from MG chain at Int<24> s=259");
     }
 
@@ -983,10 +994,12 @@ mod tests {
         let mut limbs = [0u128; 64];
         limbs[14] = 1u128 << 16;
         limbs[3] = 0xdeadbeef;
-        let n = <Int<32> as crate::int::types::traits::BigInt>::from_mag_sign_u128(&limbs, false);
+        let numerator = <Int<32> as crate::int::types::traits::BigInt>::from_mag_sign_u128(
+            &limbs, false);
 
-        let got = div_wide_pow10_newton_with(n, scale, RoundingMode::HalfToEven, &table);
-        let want = div_wide_pow10_chain::<Int<32>>(n, scale, RoundingMode::HalfToEven);
+        let got =
+            div_wide_pow10_newton_with(numerator, scale, RoundingMode::HalfToEven, &table);
+        let want = div_wide_pow10_chain::<Int<32>>(numerator, scale, RoundingMode::HalfToEven);
         assert_eq!(got, want, "Newton differs from MG chain at D616 s=308");
     }
 
@@ -1001,10 +1014,12 @@ mod tests {
         let mut limbs = [0u128; 64];
         limbs[30] = 1u128 << 8;
         limbs[5] = 0xcafef00d;
-        let n = <Int<64> as crate::int::types::traits::BigInt>::from_mag_sign_u128(&limbs, false);
+        let numerator = <Int<64> as crate::int::types::traits::BigInt>::from_mag_sign_u128(
+            &limbs, false);
 
-        let got = div_wide_pow10_newton_with(n, scale, RoundingMode::HalfToEven, &table);
-        let want = div_wide_pow10_chain::<Int<64>>(n, scale, RoundingMode::HalfToEven);
+        let got =
+            div_wide_pow10_newton_with(numerator, scale, RoundingMode::HalfToEven, &table);
+        let want = div_wide_pow10_chain::<Int<64>>(numerator, scale, RoundingMode::HalfToEven);
         assert_eq!(got, want, "Newton differs from MG chain at D1232 s=615");
     }
 
@@ -1150,9 +1165,11 @@ mod tests {
         let mut limbs = [0u128; 64];
         limbs[40] = 1u128 << 24;
         limbs[3] = 0xfeedfacecafef00d_u128;
-        let n = <Int<96> as crate::int::types::traits::BigInt>::from_mag_sign_u128(&limbs, false);
-        let got = div_wide_pow10_newton_with(n, scale, RoundingMode::HalfToEven, &table);
-        let want = div_wide_pow10_chain::<Int<96>>(n, scale, RoundingMode::HalfToEven);
+        let numerator = <Int<96> as crate::int::types::traits::BigInt>::from_mag_sign_u128(
+            &limbs, false);
+        let got =
+            div_wide_pow10_newton_with(numerator, scale, RoundingMode::HalfToEven, &table);
+        let want = div_wide_pow10_chain::<Int<96>>(numerator, scale, RoundingMode::HalfToEven);
         assert_eq!(got, want, "Newton differs from MG chain at Int<96> s=200");
     }
 
@@ -1165,9 +1182,11 @@ mod tests {
         let mut limbs = [0u128; 64];
         limbs[46] = 1u128 << 8;
         limbs[1] = 0xdeadbeef_cafef00d_u128;
-        let n = <Int<96> as crate::int::types::traits::BigInt>::from_mag_sign_u128(&limbs, false);
-        let got = div_wide_pow10_newton_with(n, scale, RoundingMode::HalfToEven, &table);
-        let want = div_wide_pow10_chain::<Int<96>>(n, scale, RoundingMode::HalfToEven);
+        let numerator = <Int<96> as crate::int::types::traits::BigInt>::from_mag_sign_u128(
+            &limbs, false);
+        let got =
+            div_wide_pow10_newton_with(numerator, scale, RoundingMode::HalfToEven, &table);
+        let want = div_wide_pow10_chain::<Int<96>>(numerator, scale, RoundingMode::HalfToEven);
         assert_eq!(got, want, "Newton differs from MG chain at Int<96> s=953");
     }
 

--- a/src/algos/support/rescale.rs
+++ b/src/algos/support/rescale.rs
@@ -111,13 +111,13 @@ const fn select(scale: u32, width_bits: u32) -> Algorithm {
 }
 
 /// `mag /= 10^scale` in place, rounded under `mode` — the **slice door**.
-/// `neg` is the result sign (rounding tie-break); `width_bits` is the work
-/// width in bits (the Newton key). `scale == 0` is a no-op.
+/// `is_negative` is the result sign (rounding tie-break); `width_bits` is the
+/// work width in bits (the Newton key). `scale == 0` is a no-op.
 #[inline]
 pub(crate) fn dispatch_mag(
     mag: &mut [u128],
     scale: u32,
-    neg: bool,
+    is_negative: bool,
     mode: RoundingMode,
     width_bits: u32,
 ) {
@@ -126,13 +126,14 @@ pub(crate) fn dispatch_mag(
     }
     match select(scale, width_bits) {
         Algorithm::MgSingle => {
-            crate::algos::support::mg_divide::div_pow10_mag_u128(mag, scale, neg, mode)
+            crate::algos::support::mg_divide::div_pow10_mag_u128(mag, scale, is_negative, mode)
         }
         Algorithm::MgChain => {
-            crate::algos::support::mg_divide::div_pow10_chain_mag_u128(mag, scale, neg, mode)
+            crate::algos::support::mg_divide::div_pow10_chain_mag_u128(
+                mag, scale, is_negative, mode)
         }
         Algorithm::Newton => crate::algos::support::newton_reciprocal::newton_rescale_arm(
-            mag, scale, neg, mode, width_bits,
+            mag, scale, is_negative, mode, width_bits,
         ),
     }
 }
@@ -163,29 +164,31 @@ pub(crate) fn dispatch_mag(
 /// typed door narrows. Bit-identical: every kernel computes the exact
 /// correctly-rounded floor division regardless of the routed width.
 #[inline]
-pub(crate) fn dispatch_wide_pow10<W>(n: W, scale: u32, mode: RoundingMode) -> W
+pub(crate) fn dispatch_wide_pow10<W>(value: W, scale: u32, mode: RoundingMode) -> W
 where
     W: BigInt,
     W::Scratch: ComputeLimbs,
 {
     let mut buf = <W::Scratch as ComputeLimbs>::single_u128();
     let mag = &mut buf.as_mut()[..W::U128_LIMBS];
-    let neg = n.mag_into_u128(mag);
+    let is_negative = value.mag_into_u128(mag);
 
     // Significant u128-limb length (strip the leading-zero high limbs). The
     // numerator's high limbs above the value are zero (`mag_into_u128` wrote the
     // full magnitude), and the quotient `floor(mag / 10^scale) ≤ mag` so its
-    // significant length never exceeds `sig` — the high limbs stay zero and are
-    // read back unchanged by `from_mag_sign_u128`.
-    let mut sig = mag.len();
-    while sig > 1 && mag[sig - 1] == 0 {
-        sig -= 1;
+    // significant length never exceeds `significant_limbs` — the high limbs stay
+    // zero and are read back unchanged by `from_mag_sign_u128`.
+    let mut significant_limbs = mag.len();
+    while significant_limbs > 1 && mag[significant_limbs - 1] == 0 {
+        significant_limbs -= 1;
     }
     // u128 limbs → bits (128 b/limb), capped at the work width so we never claim
     // more than the buffer's real bit width (odd-`N` storage rounds `U128_LIMBS`
     // up, leaving the top u128 limb only half-populated).
-    let sig_bits = (sig as u32).saturating_mul(128).min(<W as BigInt>::BITS);
+    let significant_bits =
+        (significant_limbs as u32).saturating_mul(128).min(<W as BigInt>::BITS);
 
-    dispatch_mag(&mut mag[..sig], scale, neg, mode, sig_bits);
-    W::from_mag_sign_u128(mag, neg)
+    dispatch_mag(
+        &mut mag[..significant_limbs], scale, is_negative, mode, significant_bits);
+    W::from_mag_sign_u128(mag, is_negative)
 }

--- a/src/algos/support/seed_bridge.rs
+++ b/src/algos/support/seed_bridge.rs
@@ -34,13 +34,13 @@ use crate::algo_x_support::seed::sqrt_seed;
 use crate::int::types::compute_limbs::ComputeLimbs;
 use crate::int::types::traits::BigInt;
 
-/// Unpacks the magnitude of `n` into the `u64` work slice `out_u64`
+/// Unpacks the magnitude of `value` into the `u64` work slice `out_u64`
 /// (little-endian), returning the populated length. Bridges the kept
 /// u128 magnitude surface ([`BigInt::mag_into_u128`]) to the seed leaf's
 /// `&[u64]` interface — pure primitive limb splitting, no `BigInt`
 /// method beyond the existing magnitude bridge.
 #[inline]
-fn mag_to_u64<W: BigInt>(n: W, out_u64: &mut [u64]) -> usize
+fn mag_to_u64<W: BigInt>(value: W, out_u64: &mut [u64]) -> usize
 where
     W::Scratch: ComputeLimbs,
 {
@@ -49,12 +49,12 @@ where
     // sourced from `W`'s scratch carrier (`W::Scratch = Limbs<W::LIMBS>`).
     let mut mag_buf = W::Scratch::single_u128();
     let mag = mag_buf.as_mut();
-    n.mag_into_u128(&mut mag[..u128_len]);
+    value.mag_into_u128(&mut mag[..u128_len]);
     let mut i = 0;
     while i < u128_len {
-        let v = mag[i];
-        out_u64[2 * i] = v as u64;
-        out_u64[2 * i + 1] = (v >> 64) as u64;
+        let limb = mag[i];
+        out_u64[2 * i] = limb as u64;
+        out_u64[2 * i + 1] = (limb >> 64) as u64;
         i += 1;
     }
     2 * u128_len
@@ -91,17 +91,17 @@ where
 /// cross-algorithm seed leaf ([`crate::algo_x_support::seed::sqrt_seed`]).
 ///
 /// Bridges the leaf's `&[u64]` interface to generic `W` (see the module
-/// docs): unpacks `n`'s magnitude to a `u64` work slice, calls the leaf,
-/// repacks the `u64` seed limbs into `W`. The leaf chooses the `std` f64
-/// bootstrap or the `no_std` 1-bit fallback internally; both are safe
-/// over-estimates. Always returns `≥ W::ONE`.
+/// docs): unpacks the `radicand`'s magnitude to a `u64` work slice, calls
+/// the leaf, repacks the `u64` seed limbs into `W`. The leaf chooses the
+/// `std` f64 bootstrap or the `no_std` 1-bit fallback internally; both are
+/// safe over-estimates. Always returns `≥ W::ONE`.
 #[inline]
 #[must_use]
-pub(crate) fn sqrt_seed_w<W: BigInt>(n: W) -> W
+pub(crate) fn sqrt_seed_w<W: BigInt>(radicand: W) -> W
 where
     W::Scratch: ComputeLimbs,
 {
-    let bits = n.bit_length();
+    let bits = radicand.bit_length();
     if bits <= 1 {
         // n == 1 → ⌊√1⌋ = 1; the leaf's preconditions assume bits ≥ 2.
         return W::ONE;
@@ -109,11 +109,11 @@ where
     // Exact per-`W` u64 work slices (`single_buffered_u64` = `W::LIMBS + 2`, covering
     // the magnitude's `≤ W::LIMBS + 1` live limbs), no build-max blanket. Sourced
     // from `W`'s scratch carrier (`W::Scratch = Limbs<W::LIMBS>`).
-    let mut n_u64_buf = W::Scratch::single_buffered_u64();
-    let n_u64 = n_u64_buf.as_mut();
-    let n_len = mag_to_u64(n, n_u64);
+    let mut radicand_u64_buf = W::Scratch::single_buffered_u64();
+    let radicand_u64 = radicand_u64_buf.as_mut();
+    let radicand_len = mag_to_u64(radicand, radicand_u64);
     let mut seed_u64_buf = W::Scratch::single_buffered_u64();
     let seed_u64 = seed_u64_buf.as_mut();
-    sqrt_seed(&n_u64[..n_len], bits, &mut seed_u64[..n_len]);
-    u64_to_w::<W>(&seed_u64[..n_len])
+    sqrt_seed(&radicand_u64[..radicand_len], bits, &mut seed_u64[..radicand_len]);
+    u64_to_w::<W>(&seed_u64[..radicand_len])
 }

--- a/src/algos/support/wide_trig_core.rs
+++ b/src/algos/support/wide_trig_core.rs
@@ -100,8 +100,8 @@ pub(crate) trait WideTrigCore {
     /// Rounds a working-scale `W` value at scale `w` to scale `target`
     /// under `mode` and narrows to storage.
     fn round_to_storage_with(
-        v: Self::W,
-        w: u32,
+        working_value: Self::W,
+        working_scale: u32,
         target: u32,
         mode: RoundingMode,
     ) -> Self::Storage;
@@ -112,15 +112,16 @@ pub(crate) trait WideTrigCore {
     /// to scale `target` under `mode` (the `Wagm` sibling of
     /// [`Self::round_to_storage_with`]).
     fn round_to_storage_with_agm(
-        v: Self::Wagm,
-        w: u32,
+        working_value: Self::Wagm,
+        working_scale: u32,
         target: u32,
         mode: RoundingMode,
     ) -> Self::Storage;
-    /// Directed-rounding narrowing with Ziv escalation. `recompute(g)`
-    /// returns the kernel value computed with `g` guard digits.
+    /// Directed-rounding narrowing with Ziv escalation.
+    /// `recompute(guard_digits)` returns the kernel value computed with
+    /// that many guard digits.
     fn round_to_storage_directed(
-        base_guard: u32,
+        base_guard_digits: u32,
         target: u32,
         mode: RoundingMode,
         recompute: &mut dyn FnMut(u32) -> Self::W,
@@ -136,7 +137,7 @@ pub(crate) trait WideTrigCore {
     /// work integer's resolution (e.g. `exp(-10^-S)` just under `1.0`). The
     /// caller MUST pin its algebraic-exact inputs (`exp 0`) before this.
     fn round_to_storage_directed_never_exact(
-        base_guard: u32,
+        base_guard_digits: u32,
         target: u32,
         mode: RoundingMode,
         recompute: &mut dyn FnMut(u32) -> Self::W,
@@ -144,9 +145,9 @@ pub(crate) trait WideTrigCore {
 
     // ── the per-tier guard-digit kernels ──────────────────────────────
 
-    /// `e^v` for a working-scale value `v` at scale `w`. `SCALE`
+    /// `e^v` for a `working_value` at `working_scale`. `SCALE`
     /// const-folds the internal `ln 2` — see [`Self::ln_fixed`].
-    fn exp_fixed<const SCALE: u32>(v_w: Self::W, w: u32) -> Self::W;
+    fn exp_fixed<const SCALE: u32>(working_value: Self::W, working_scale: u32) -> Self::W;
     /// Natural log of a positive working-scale value at scale `w`.
     ///
     /// `SCALE` is the decimal layer's own storage scale: on the common
@@ -154,39 +155,40 @@ pub(crate) trait WideTrigCore {
     /// constant from the compile-time baked `WideConst<SCALE>` rather
     /// than re-deriving it at runtime; any other `w` (Ziv escalation)
     /// falls to the runtime const. Bit-identical either way.
-    fn ln_fixed<const SCALE: u32>(v_w: Self::W, w: u32) -> Self::W;
-    /// Sine of a working-scale value at scale `w`. `SCALE` const-folds
+    fn ln_fixed<const SCALE: u32>(working_value: Self::W, working_scale: u32) -> Self::W;
+    /// Sine of a working-scale value at `working_scale`. `SCALE` const-folds
     /// the internal `π` — see [`Self::ln_fixed`].
-    fn sin_fixed<const SCALE: u32>(v_w: Self::W, w: u32) -> Self::W;
-    /// Cosine of a working-scale value at scale `w`. `SCALE` const-folds
+    fn sin_fixed<const SCALE: u32>(working_value: Self::W, working_scale: u32) -> Self::W;
+    /// Cosine of a working-scale value at `working_scale`. `SCALE` const-folds
     /// the internal `π` — see [`Self::ln_fixed`].
-    fn cos_fixed<const SCALE: u32>(v_w: Self::W, w: u32) -> Self::W;
-    /// Joint sine + cosine of a working-scale value at scale `w`. `SCALE`
+    fn cos_fixed<const SCALE: u32>(working_value: Self::W, working_scale: u32) -> Self::W;
+    /// Joint sine + cosine of a working-scale value at `working_scale`. `SCALE`
     /// const-folds the internal `π` — see [`Self::ln_fixed`].
-    fn sin_cos_fixed<const SCALE: u32>(v_w: Self::W, w: u32) -> (Self::W, Self::W);
-    /// Arctangent of a working-scale value at scale `w`. `SCALE`
+    fn sin_cos_fixed<const SCALE: u32>(
+        working_value: Self::W, working_scale: u32) -> (Self::W, Self::W);
+    /// Arctangent of a working-scale value at `working_scale`. `SCALE`
     /// const-folds the internal `π/2` — see [`Self::ln_fixed`].
-    fn atan_fixed<const SCALE: u32>(v_w: Self::W, w: u32) -> Self::W;
+    fn atan_fixed<const SCALE: u32>(working_value: Self::W, working_scale: u32) -> Self::W;
 
     // ── working-scale helpers the tan kernel needs ────────────────────
 
-    /// `(a · 10^w) / b`, rounded half-to-even.
-    fn div(a: Self::W, b: Self::W, w: u32) -> Self::W;
-    /// `(a · b) / 10^w`, rounded half-to-even — the plain work-int
+    /// `(numerator · 10^w) / divisor`, rounded half-to-even.
+    fn div(numerator: Self::W, divisor: Self::W, working_scale: u32) -> Self::W;
+    /// `(lhs · rhs) / 10^w`, rounded half-to-even — the plain work-int
     /// multiply. Needed by the inverse / inverse-hyperbolic schoolbooks
     /// (`x^2`, `inv^2`, `t*(t+2)`).
-    fn mul(a: Self::W, b: Self::W, w: u32) -> Self::W;
+    fn mul(lhs: Self::W, rhs: Self::W, working_scale: u32) -> Self::W;
     /// Integer square root of a non-negative working-scale value at
     /// scale `w` (`sqrt(v / 10^w) * 10^w`). The leaf asin/acos/asinh/
     /// acosh schoolbooks need it (`asin = atan(x / sqrt(1 - x^2))`).
     /// Dispatches down to the work-int root.
-    fn sqrt_fixed(v: Self::W, w: u32) -> Self::W;
-    /// `ln(1 + t)` at working scale `w`, accurate for small `t` — the
+    fn sqrt_fixed(value: Self::W, working_scale: u32) -> Self::W;
+    /// `ln(1 + t)` at `working_scale`, accurate for small `t` — the
     /// near-1 branch of the acosh schoolbook (avoids the `v^2 - 1`
     /// cancellation as `v -> 1`).
-    fn log1p_fixed(t: Self::W, w: u32) -> Self::W;
+    fn log1p_fixed(argument: Self::W, working_scale: u32) -> Self::W;
     /// Bit length of `|v|` (0 for zero).
-    fn bit_length(v: Self::W) -> u32;
+    fn bit_length(value: Self::W) -> u32;
 
     // hyperbolic exp-identity kernels (sinh/cosh/tanh schoolbooks)
 
@@ -198,16 +200,19 @@ pub(crate) trait WideTrigCore {
     /// identity (composed in the wider [`Self::Wexp`]); caller reapplies
     /// the sign. `SCALE` const-folds the internal `ln 2` (via
     /// `exp_fixed`) — see [`Self::ln_fixed`].
-    fn sinh_pos_wide<const SCALE: u32>(av_w: Self::W, w: u32) -> Self::W;
-    /// `cosh(|x|)` at working scale `w` via the `(e^x + e^-x)/2`
+    fn sinh_pos_wide<const SCALE: u32>(
+        abs_working_value: Self::W, working_scale: u32) -> Self::W;
+    /// `cosh(|x|)` at `working_scale` via the `(e^x + e^-x)/2`
     /// identity. `SCALE` const-folds the internal `ln 2` — see
     /// [`Self::sinh_pos_wide`].
-    fn cosh_pos_wide<const SCALE: u32>(av_w: Self::W, w: u32) -> Self::W;
-    /// `tanh(|x|)` at working scale `w` via the
+    fn cosh_pos_wide<const SCALE: u32>(
+        abs_working_value: Self::W, working_scale: u32) -> Self::W;
+    /// `tanh(|x|)` at `working_scale` via the
     /// `(e^x - e^-x)/(e^x + e^-x)` identity; caller reapplies the sign.
     /// `SCALE` const-folds the internal `ln 2` — see
     /// [`Self::sinh_pos_wide`].
-    fn tanh_pos_wide<const SCALE: u32>(av_w: Self::W, w: u32) -> Self::W;
+    fn tanh_pos_wide<const SCALE: u32>(
+        abs_working_value: Self::W, working_scale: u32) -> Self::W;
 
     /// Tang/Series-ROUTED working-scale natural log on the wide
     /// composition integer [`Self::Wagm`] — the per-tier
@@ -215,13 +220,14 @@ pub(crate) trait WideTrigCore {
     /// it, Series otherwise; the per-tier Tang CAP is a macro literal,
     /// which is why this is a trait binding rather than a free generic).
     /// Consumed by the acosh / atanh canonical kernels.
-    fn ln_fixed_routed_agm<const SCALE: u32>(v_w: Self::Wagm, w: u32) -> Self::Wagm;
+    fn ln_fixed_routed_agm<const SCALE: u32>(
+        working_value: Self::Wagm, working_scale: u32) -> Self::Wagm;
 
     /// Directed-rounding narrowing with Ziv escalation, forcing a
     /// confirm recompute even in nearest modes — the acosh / atanh
     /// near-special path (the residual can sit on a rounding boundary).
     fn round_to_storage_directed_near_special(
-        base_guard: u32,
+        base_guard_digits: u32,
         target: u32,
         mode: RoundingMode,
         recompute: &mut dyn FnMut(u32) -> Self::W,
@@ -229,23 +235,23 @@ pub(crate) trait WideTrigCore {
 
     // ── working-scale helpers the Tang lookup kernels need ─────────────
 
-    /// The work-integer `1` at working scale `w` (`10^w`), cached.
-    fn one(w: u32) -> Self::W;
-    /// The work-integer literal `n` (small unsigned).
-    fn lit(n: u128) -> Self::W;
-    /// `ln 2` at working scale `w`, const-folded at the layer's own
+    /// The work-integer `1` at `working_scale` (`10^w`), cached.
+    fn one(working_scale: u32) -> Self::W;
+    /// The work-integer literal `value` (small unsigned).
+    fn lit(value: u128) -> Self::W;
+    /// `ln 2` at `working_scale`, const-folded at the layer's own
     /// `SCALE` (the baked `WideConst<SCALE>` on the common
     /// `w == SCALE + GUARD` path) — see [`Self::ln_fixed`].
-    fn ln2<const SCALE: u32>(w: u32) -> Self::W;
-    /// `(a · 10^w) / b`, rounded half-to-even, with a precomputed
-    /// `10^w` numerator factor (loop-friendly).
-    fn div_cached(a: Self::W, b: Self::W, pow10_w: Self::W) -> Self::W;
+    fn ln2<const SCALE: u32>(working_scale: u32) -> Self::W;
+    /// `(numerator · 10^w) / divisor`, rounded half-to-even, with a
+    /// precomputed `10^w` numerator factor (loop-friendly).
+    fn div_cached(numerator: Self::W, divisor: Self::W, cached_pow10: Self::W) -> Self::W;
     /// Rounds a working-scale value to the nearest integer (ties away
     /// from zero); the range-reduction quotient for the Tang exp kernel.
-    fn round_to_nearest_int(v: Self::W, w: u32) -> i128;
-    /// `10^n` in the work integer (the un-cached power; used to widen by
-    /// `extra` digits in the Tang exp reassembly).
-    fn pow10(n: u32) -> Self::W;
+    fn round_to_nearest_int(working_value: Self::W, working_scale: u32) -> i128;
+    /// `10^exponent` in the work integer (the un-cached power; used to widen
+    /// by `extra_digits` in the Tang exp reassembly).
+    fn pow10(exponent: u32) -> Self::W;
     /// `Self::W::BITS` — the work integer's bit width.
     fn w_bits() -> u32;
 
@@ -253,41 +259,43 @@ pub(crate) trait WideTrigCore {
     /// size `M = 128`; the `i = 0` slot is `0`, the `i = M` slot is
     /// `ln 2`). Recomputed on the stack per call; `SCALE` const-folds
     /// the internal `ln 2` — see [`Self::ln_fixed`].
-    fn ln_table_entry<const SCALE: u32>(w: u32, idx: usize) -> Self::W;
+    fn ln_table_entry<const SCALE: u32>(working_scale: u32, idx: usize) -> Self::W;
 
-    /// The Tang exp table slot `exp(j · ln2 / M)` at working scale `w`
-    /// for table size `M`. Recomputed on the stack per call; `SCALE`
+    /// The Tang exp table slot `exp(j · ln2 / M)` at `working_scale`
+    /// for `table_size`. Recomputed on the stack per call; `SCALE`
     /// const-folds the internal `ln 2` — see [`Self::ln_fixed`].
-    fn exp_table_entry<const SCALE: u32>(w: u32, idx: usize, m: u32) -> Self::W;
+    fn exp_table_entry<const SCALE: u32>(
+        working_scale: u32, idx: usize, table_size: u32) -> Self::W;
 
     // ── π constants + the sincos Tang table (the sincos Tang kernel) ───
 
     /// `π` at working scale `w`, const-folded at the layer's own `SCALE`
     /// (the baked `WideConst<SCALE>` on the common `w == SCALE + GUARD`
     /// path) — see [`Self::ln_fixed`].
-    fn pi<const SCALE: u32>(w: u32) -> Self::W;
-    /// `π/2` at working scale `w`, const-folded at the layer's own
+    fn pi<const SCALE: u32>(working_scale: u32) -> Self::W;
+    /// `π/2` at `working_scale`, const-folded at the layer's own
     /// `SCALE` — see [`Self::pi`].
-    fn half_pi<const SCALE: u32>(w: u32) -> Self::W;
+    fn half_pi<const SCALE: u32>(working_scale: u32) -> Self::W;
 
     /// `180/π` (degrees per radian) at working scale `w`, const-folded at
     /// the layer's own `SCALE` — see [`Self::pi`]. The exact angle-scale
     /// factor the `to_degrees` `MulPiRatio` kernel multiplies by (`x *
     /// 180/π`), replacing the runtime divide-by-`π`.
-    fn deg_per_rad<const SCALE: u32>(w: u32) -> Self::W;
+    fn deg_per_rad<const SCALE: u32>(working_scale: u32) -> Self::W;
     /// `π/180` (radians per degree) at working scale `w`, const-folded at
     /// the layer's own `SCALE` — see [`Self::pi`]. The exact angle-scale
     /// factor the `to_radians` `MulPiRatio` kernel multiplies by (`x *
     /// π/180`).
-    fn rad_per_deg<const SCALE: u32>(w: u32) -> Self::W;
+    fn rad_per_deg<const SCALE: u32>(working_scale: u32) -> Self::W;
 
-    /// The sincos Tang table slot `(sin(c_j), cos(c_j))` at working
-    /// scale `w` for table size `m`, where `c_j = j · π / (4·m)` and
+    /// The sincos Tang table slot `(sin(c_j), cos(c_j))` at
+    /// `working_scale` for `table_size`, where `c_j = j · π / (4·m)` and
     /// `j ∈ [0, m]` (the `j = m` slot is `(sin π/4, cos π/4)`, needed
     /// because rounding can lift a residual to the table boundary).
     /// Recomputed on the stack per call; `SCALE` const-folds the
     /// internal `π` — see [`Self::ln_fixed`].
-    fn sincos_table_entry<const SCALE: u32>(w: u32, idx: usize, m: u32) -> (Self::W, Self::W);
+    fn sincos_table_entry<const SCALE: u32>(
+        working_scale: u32, idx: usize, table_size: u32) -> (Self::W, Self::W);
 }
 
 /// Near-min analytic pin for `exp`. When `|v| < 10^(-SCALE/2)` the deviation
@@ -312,24 +320,25 @@ fn exp_near_min_pin<C: WideTrigCore, const SCALE: u32>(
     if half == 0 || raw == zero {
         return None;
     }
-    let absr = if raw < zero { zero - raw } else { raw };
+    let abs_raw = if raw < zero { zero - raw } else { raw };
     // `10^half` has ≈ half·log2(10) bits; skip the pow10 unless |raw| is plausibly
     // below it (true only for genuinely tiny inputs — every normal call exits here).
-    // A value of bit-length `bl` is at least `2^(bl−1)`, so the exit is certain
-    // only once `2^(bl−1) >= 10^half` ⟺ `(bl−1)·log10(2) >= half` — comparing
-    // `bl` itself (not `bl−1`) silently dropped the top quarter of the band.
-    let bl = <C::Storage as BigInt>::BITS - absr.leading_zeros();
-    if ((bl - 1) as u64) * 100_000 >= (half as u64) * 332_193 {
+    // A value of bit-length `bit_len` is at least `2^(bit_len−1)`, so the exit is
+    // certain only once `2^(bit_len−1) >= 10^half` ⟺ `(bit_len−1)·log10(2) >= half`
+    // — comparing `bit_len` itself (not `bit_len−1`) silently dropped the top
+    // quarter of the band.
+    let bit_len = <C::Storage as BigInt>::BITS - abs_raw.leading_zeros();
+    if ((bit_len - 1) as u64) * 100_000 >= (half as u64) * 332_193 {
         return None;
     }
     // Exact: |raw| < 10^half ⟺ v²/2 < ½ ULP and the deviation sits past the scale.
-    if absr >= crate::consts::pow10::dispatch::<C::Storage>(half) {
+    if abs_raw >= crate::consts::pow10::dispatch::<C::Storage>(half) {
         return None;
     }
-    let g = C::storage_one(SCALE) + raw; // (1 + v), exact since |v| < 1
+    let linear_value = C::storage_one(SCALE) + raw; // (1 + v), exact since |v| < 1
     Some(match mode {
-        RoundingMode::Ceiling => g + <C::Storage as BigInt>::from_i128(1),
-        _ => g,
+        RoundingMode::Ceiling => linear_value + <C::Storage as BigInt>::from_i128(1),
+        _ => linear_value,
     })
 }
 
@@ -351,8 +360,8 @@ where
     if raw == C::storage_zero() {
         return C::storage_one(SCALE);
     }
-    if let Some(r) = exp_near_min_pin::<C, SCALE>(raw, mode) {
-        return r;
+    if let Some(pinned) = exp_near_min_pin::<C, SCALE>(raw, mode) {
+        return pinned;
     }
     // `exp(x)` for `x != 0` is transcendental (Lindemann–Weierstrass), so its
     // true value is never exactly on a storage grid line — a zero working
@@ -375,18 +384,18 @@ where
         true,
         C::storage_max(),
         C::storage_min(),
-        |guard| {
-            let v = C::to_work_scaled(raw, guard);
+        |guard_digits| {
+            let working_value = C::to_work_scaled(raw, guard_digits);
             crate::algos::exp::exp_generic::exp_fixed_tagged_with::<C::W>(
-                v,
-                SCALE + guard,
-                || C::exp_fixed::<SCALE>(v, SCALE + guard),
+                working_value,
+                SCALE + guard_digits,
+                || C::exp_fixed::<SCALE>(working_value, SCALE + guard_digits),
             )
         },
-        |guard| {
+        |guard_digits| {
             crate::algos::exp::exp_generic::exp_fixed_tagged::<C::Wexp>(
-                to_work_scaled_g::<C::Storage, C::Wexp>(raw, guard),
-                SCALE + guard,
+                to_work_scaled_g::<C::Storage, C::Wexp>(raw, guard_digits),
+                SCALE + guard_digits,
             )
         },
     )
@@ -423,8 +432,8 @@ where
     if raw == C::storage_zero() {
         return C::storage_one(SCALE);
     }
-    if let Some(r) = exp_near_min_pin::<C, SCALE>(raw, mode) {
-        return r;
+    if let Some(pinned) = exp_near_min_pin::<C, SCALE>(raw, mode) {
+        return pinned;
     }
     round_to_storage_widening_tail_signed_g::<C::Storage, Wk, C::Wexp>(
         C::GUARD,
@@ -433,24 +442,24 @@ where
         true,
         C::storage_max(),
         C::storage_min(),
-        |guard| {
-            let w = SCALE + guard;
-            let v = to_work_scaled_g::<C::Storage, Wk>(raw, guard);
-            eg::exp_fixed_tagged_with::<Wk>(v, w, || {
-                if eg::exp_peak_fits::<Wk>(v, w) {
-                    eg::exp_fixed::<Wk>(v, w)
+        |guard_digits| {
+            let working_scale = SCALE + guard_digits;
+            let working_value = to_work_scaled_g::<C::Storage, Wk>(raw, guard_digits);
+            eg::exp_fixed_tagged_with::<Wk>(working_value, working_scale, || {
+                if eg::exp_peak_fits::<Wk>(working_value, working_scale) {
+                    eg::exp_fixed::<Wk>(working_value, working_scale)
                 } else {
                     eg::resize_or_panic::<C::Wexp, Wk>(eg::exp_fixed::<C::Wexp>(
-                        to_work_scaled_g::<C::Storage, C::Wexp>(raw, guard),
-                        w,
+                        to_work_scaled_g::<C::Storage, C::Wexp>(raw, guard_digits),
+                        working_scale,
                     ))
                 }
             })
         },
-        |guard| {
+        |guard_digits| {
             eg::exp_fixed_tagged::<C::Wexp>(
-                to_work_scaled_g::<C::Storage, C::Wexp>(raw, guard),
-                SCALE + guard,
+                to_work_scaled_g::<C::Storage, C::Wexp>(raw, guard_digits),
+                SCALE + guard_digits,
             )
         },
     )
@@ -496,19 +505,20 @@ where
         mode,
         C::storage_max(),
         C::storage_min(),
-        |guard| {
-            let w = SCALE + guard;
-            let ln2 = if w == SCALE + C::GUARD {
-                crate::consts::ln2_by_scale::<Wk>(w, crate::support::rounding::DEFAULT_ROUNDING_MODE)
+        |guard_digits| {
+            let working_scale = SCALE + guard_digits;
+            let ln2 = if working_scale == SCALE + C::GUARD {
+                crate::consts::ln2_by_scale::<Wk>(
+                    working_scale, crate::support::rounding::DEFAULT_ROUNDING_MODE)
             } else {
                 crate::consts::ln2_by_working_scale::<Wk>(
-                    w,
+                    working_scale,
                     crate::support::rounding::DEFAULT_ROUNDING_MODE,
                 )
             };
             crate::algos::exp::exp_generic::ln_fixed::<Wk>(
-                to_work_scaled_g::<C::Storage, Wk>(raw, guard),
-                w,
+                to_work_scaled_g::<C::Storage, Wk>(raw, guard_digits),
+                working_scale,
                 ln2,
             )
         },
@@ -530,29 +540,32 @@ where
     // layer so the bare tier kernel and the rung-dispatched path agree): the
     // cubic deciding digit sits below the work integer's Ziv reach AND the
     // const-table provisioning, so only the analytic sign resolves it.
-    if let Some(v) = tiny_x_linear_directed::<C::Storage, SCALE>(raw, mode, false) {
-        return v;
+    if let Some(pinned) = tiny_x_linear_directed::<C::Storage, SCALE>(raw, mode, false) {
+        return pinned;
     }
-    let (r, decided) = round_to_storage_directed_decided_g::<C::Storage, C::W>(
+    let (rounded, decided) = round_to_storage_directed_decided_g::<C::Storage, C::W>(
         C::GUARD,
         SCALE,
         mode,
         C::storage_max(),
         C::storage_min(),
-        |guard| C::sin_fixed::<SCALE>(C::to_work_scaled(raw, guard), SCALE + guard),
+        |guard_digits| C::sin_fixed::<SCALE>(
+            C::to_work_scaled(raw, guard_digits), SCALE + guard_digits),
     );
     // Deep sub-resolution band (deciding `x^{j*}`, `j* ≥ 5`): the walker is
     // mode-blind (`decided == false`); the sign is analytic (`sin` alternates).
     // The exact alternating-series bracket first: where it closes it PROVES
-    // which side of `r` the true value lies on, superseding the `j*`-parity
-    // rule whose exactness premise fails for a multi-digit significand.
-    if let Some(v) =
-        adjust_alternating_bracket::<C::Storage, C::W, SCALE>(r, raw, mode, AlternatingSeries::Sin)
+    // which side of `rounded` the true value lies on, superseding the
+    // `j*`-parity rule whose exactness premise fails for a multi-digit
+    // significand.
+    if let Some(bracketed) = adjust_alternating_bracket::<C::Storage, C::W, SCALE>(
+        rounded, raw, mode, AlternatingSeries::Sin)
     {
-        return v;
+        return bracketed;
     }
-    let r = tiny_x_deep_directed_adjust::<C::Storage, SCALE>(r, decided, raw, mode, true, <C::W as BigInt>::BITS);
-    adjust_bounded_extremum::<C, SCALE>(r, raw, mode)
+    let rounded = tiny_x_deep_directed_adjust::<C::Storage, SCALE>(
+        rounded, decided, raw, mode, true, <C::W as BigInt>::BITS);
+    adjust_bounded_extremum::<C, SCALE>(rounded, raw, mode)
 }
 
 /// `cos_strict` for a wide tier — generic over the tier `C`. Standalone
@@ -567,20 +580,20 @@ pub(crate) fn cos_series<C: WideTrigCore, const SCALE: u32>(
 where
     <C::W as BigInt>::Scratch: crate::int::types::compute_limbs::ComputeLimbs,
 {
-    let r = C::round_to_storage_directed(C::GUARD, SCALE, mode, &mut |guard| {
-        C::cos_fixed::<SCALE>(C::to_work_scaled(raw, guard), SCALE + guard)
+    let rounded = C::round_to_storage_directed(C::GUARD, SCALE, mode, &mut |guard_digits| {
+        C::cos_fixed::<SCALE>(C::to_work_scaled(raw, guard_digits), SCALE + guard_digits)
     });
     // [`adjust_bounded_extremum`] covers only a landing exactly ON `±10^SCALE`.
     // A landing on a DIFFERENT grid point near the extremum needs the bracket
     // to place it — the `cos(3·10⁻⁶⁴)` family, whose leading terms are exact
     // ULP multiples and whose first non-terminating term is `x⁸/8!` (the
     // factor `7` in `8!`) sitting below the walker's reach.
-    if let Some(v) =
-        adjust_alternating_bracket::<C::Storage, C::W, SCALE>(r, raw, mode, AlternatingSeries::Cos)
+    if let Some(bracketed) = adjust_alternating_bracket::<C::Storage, C::W, SCALE>(
+        rounded, raw, mode, AlternatingSeries::Cos)
     {
-        return v;
+        return bracketed;
     }
-    adjust_bounded_extremum::<C, SCALE>(r, raw, mode)
+    adjust_bounded_extremum::<C, SCALE>(rounded, raw, mode)
 }
 
 /// Directed-rounding post-adjust for `sin`/`cos` near an extremum the
@@ -598,9 +611,9 @@ where
 ///
 /// Because the true value is strictly interior, the directed side is known a
 /// priori with no extra precision:
-/// - just below `+1` (`result == +one`): Floor / Trunc step down one LSB to
+/// - just below `+1` (`rounded == +one`): Floor / Trunc step down one LSB to
 ///   `one − 1`; Ceiling keeps `one`.
-/// - just above `−1` (`result == −one`): Ceiling / Trunc step toward zero to
+/// - just above `−1` (`rounded == −one`): Ceiling / Trunc step toward zero to
 ///   `−one + 1`; Floor keeps `−one`.
 ///
 /// Nearest modes are unaffected (rounding to `±1` IS correct to nearest there).
@@ -610,27 +623,27 @@ where
 /// whole near-extremum region, not fitted to one benched cell.
 #[inline]
 pub(crate) fn adjust_bounded_extremum<C: WideTrigCore, const SCALE: u32>(
-    result: C::Storage,
+    rounded: C::Storage,
     raw: C::Storage,
     mode: RoundingMode,
 ) -> C::Storage {
     if crate::support::rounding::is_nearest_mode(mode) || raw == C::storage_zero() {
-        return result;
+        return rounded;
     }
     let one = C::storage_one(SCALE);
     let neg_one = C::storage_zero() - one;
-    if result == one {
+    if rounded == one {
         match mode {
             RoundingMode::Floor | RoundingMode::Trunc => one - <C::Storage as BigInt>::ONE,
-            _ => result,
+            _ => rounded,
         }
-    } else if result == neg_one {
+    } else if rounded == neg_one {
         match mode {
             RoundingMode::Ceiling | RoundingMode::Trunc => neg_one + <C::Storage as BigInt>::ONE,
-            _ => result,
+            _ => rounded,
         }
     } else {
-        result
+        rounded
     }
 }
 
@@ -674,12 +687,12 @@ pub(crate) fn tiny_x_linear_directed<St: BigInt, const SCALE: u32>(
     if raw == zero {
         return None; // f(0) is the kernel's exact-zero pin
     }
-    let absr = if raw < zero { zero - raw } else { raw };
+    let abs_raw = if raw < zero { zero - raw } else { raw };
     // The small-x linear band exponent, conservative by one digit (matches the
     // narrow `small_x_linear_threshold`): `|raw| ≤ 10^(SCALE − ⌈SCALE/3⌉)`.
-    let thresh_exp = SCALE - SCALE.div_ceil(3);
+    let threshold_exponent = SCALE - SCALE.div_ceil(3);
     // One table-read + one compare exits for every normal-magnitude argument.
-    if absr > crate::consts::pow10::dispatch::<St>(thresh_exp) {
+    if abs_raw > crate::consts::pow10::dispatch::<St>(threshold_exponent) {
         return None;
     }
     // `one` is ONE STORAGE ULP (the integer `1`), the step the directed
@@ -792,9 +805,9 @@ const TINY_X_DEEP_JMAX: u32 = 41;
 ///    `decided == false` ALONE is not "mode-blind" — the walker can RESOLVE
 ///    the deciding term correctly yet still report `decided == false` when its
 ///    CONFIRM probe lands on the cap-clamped (`tainted`) rung. Only when the
-///    term is genuinely past `reach` is `r` the mode-blind grid value `G`.
+///    term is genuinely past `reach` is `rounded` the mode-blind grid value `G`.
 ///
-/// When both hold the value is on the grid (`r == G`, every above-scale term
+/// When both hold the value is on the grid (`rounded == G`, every above-scale term
 /// terminated — an off-grid value's non-terminating tail is at depth `~SCALE`,
 /// well WITHIN `reach`, so the walker resolves it and `j*·k ≤ reach` keeps this
 /// off). The result is `G ± 1 ULP` per the deciding sign via the same
@@ -806,7 +819,7 @@ const TINY_X_DEEP_JMAX: u32 = 41;
 /// `[5, JMAX]`, or `j*·k ≤ reach`.
 #[inline]
 pub(crate) fn tiny_x_deep_directed_adjust<St: BigInt, const SCALE: u32>(
-    r: St,
+    rounded: St,
     decided: bool,
     raw: St,
     mode: RoundingMode,
@@ -814,22 +827,22 @@ pub(crate) fn tiny_x_deep_directed_adjust<St: BigInt, const SCALE: u32>(
     work_bits: u32,
 ) -> St {
     if decided || crate::support::rounding::is_nearest_mode(mode) || SCALE == 0 {
-        return r;
+        return rounded;
     }
     let zero = <St as BigInt>::ZERO;
     if raw == zero {
-        return r;
+        return rounded;
     }
-    let absr = if raw < zero { zero - raw } else { raw };
+    let abs_raw = if raw < zero { zero - raw } else { raw };
     // Leading-digit position `k`: `|x| = |raw|·10^(−SCALE)` and `|x| ≈ 10^(−k)`,
     // so `k = SCALE − digits(|raw|) + 1`. `|x| ≥ 1` (digits > SCALE) is not tiny.
-    let digits = dec_digits_g::<St>(absr);
+    let digits = dec_digits_g::<St>(abs_raw);
     if digits == 0 || digits > SCALE {
-        return r;
+        return rounded;
     }
     let k = SCALE - digits + 1;
     if k == 0 {
-        return r;
+        return rounded;
     }
     // `j*` = smallest ODD `j` with `j·k > SCALE`. `floor(SCALE/k)+1` is the
     // smallest integer with the property (`(⌊SCALE/k⌋+1)·k = ⌊SCALE/k⌋·k + k >
@@ -839,37 +852,38 @@ pub(crate) fn tiny_x_deep_directed_adjust<St: BigInt, const SCALE: u32>(
     // `j* = 3` is the linear band's [`tiny_x_linear_directed`] pre-empt; only the
     // deeper terms reach here. The upper bound excludes the non-tiny corner.
     if !(5..=TINY_X_DEEP_JMAX).contains(&j_star) {
-        return r;
+        return rounded;
     }
-    // The deciding term must be BEYOND the walker's reach (else it RESOLVED `r`
-    // correctly — see the doc). `j*·k` is its fractional depth.
+    // The deciding term must be BEYOND the walker's reach (else it RESOLVED
+    // `rounded` correctly — see the doc). `j*·k` is its fractional depth.
     let reach = (work_bits / 8).saturating_sub(8);
     if j_star.saturating_mul(k) <= reach {
-        return r;
+        return rounded;
     }
     let expanding = if alternating { j_star % 4 == 1 } else { true };
     let one = <St as BigInt>::ONE;
     if expanding {
-        crate::support::rounding::tiny_odd_expanding_directed(r, zero, one, mode)
+        crate::support::rounding::tiny_odd_expanding_directed(rounded, zero, one, mode)
     } else {
-        crate::support::rounding::tiny_odd_compressing_directed(r, zero, one, mode)
+        crate::support::rounding::tiny_odd_compressing_directed(rounded, zero, one, mode)
     }
 }
 
-/// Significant limb length of `a` (index of the highest non-zero limb plus
+/// Significant limb length of `limbs` (index of the highest non-zero limb plus
 /// one), clamped to at least 1 so a zero magnitude has length 1.
 #[inline]
-fn sig_len(a: &[u64]) -> usize {
-    let mut l = a.len();
-    while l > 1 && a[l - 1] == 0 {
-        l -= 1;
+fn sig_len(limbs: &[u64]) -> usize {
+    let mut len = limbs.len();
+    while len > 1 && limbs[len - 1] == 0 {
+        len -= 1;
     }
-    l
+    len
 }
 
-/// Exact three-way comparison of `a²` against `b · c` for three NON-NEGATIVE
-/// values, evaluated at DOUBLE `Wk` width. `None` means "not decidable in the
-/// available scratch" — see the fail-closed note below.
+/// Exact three-way comparison of `squared_operand²` against
+/// `product_lhs · product_rhs` for three NON-NEGATIVE values, evaluated at
+/// DOUBLE `Wk` width. `None` means "not decidable in the available
+/// scratch" — see the fail-closed note below.
 ///
 /// The parabola test in [`adjust_log_near_zero`] compares `δ²` against
 /// `2·D·10^SCALE`, and `δ²` legitimately overflows every SINGLE width in play:
@@ -894,7 +908,8 @@ fn sig_len(a: &[u64]) -> usize {
 ///
 /// [`ComputeLimbs`]: crate::int::types::compute_limbs::ComputeLimbs
 #[inline]
-fn cmp_sq_vs_prod<Wk: BigInt>(a: Wk, b: Wk, c: Wk) -> Option<core::cmp::Ordering>
+fn cmp_sq_vs_prod<Wk: BigInt>(
+    squared_operand: Wk, product_lhs: Wk, product_rhs: Wk) -> Option<core::cmp::Ordering>
 where
     <Wk as BigInt>::Scratch: crate::int::types::compute_limbs::ComputeLimbs,
 {
@@ -902,37 +917,37 @@ where
     use crate::int::policy::mul::dispatch_slice as mul_slice;
     use crate::int::types::compute_limbs::ComputeLimbs;
 
-    let mut abuf = <<Wk as BigInt>::Scratch as ComputeLimbs>::single_u64();
-    let mut bbuf = <<Wk as BigInt>::Scratch as ComputeLimbs>::single_u64();
-    let mut cbuf = <<Wk as BigInt>::Scratch as ComputeLimbs>::single_u64();
-    eg::unpack_mag::<Wk>(a, abuf.as_mut());
-    eg::unpack_mag::<Wk>(b, bbuf.as_mut());
-    eg::unpack_mag::<Wk>(c, cbuf.as_mut());
-    let al = sig_len(abuf.as_ref());
-    let bl = sig_len(bbuf.as_ref());
-    let cl = sig_len(cbuf.as_ref());
+    let mut squared_limbs = <<Wk as BigInt>::Scratch as ComputeLimbs>::single_u64();
+    let mut lhs_limbs = <<Wk as BigInt>::Scratch as ComputeLimbs>::single_u64();
+    let mut rhs_limbs = <<Wk as BigInt>::Scratch as ComputeLimbs>::single_u64();
+    eg::unpack_mag::<Wk>(squared_operand, squared_limbs.as_mut());
+    eg::unpack_mag::<Wk>(product_lhs, lhs_limbs.as_mut());
+    eg::unpack_mag::<Wk>(product_rhs, rhs_limbs.as_mut());
+    let squared_len = sig_len(squared_limbs.as_ref());
+    let lhs_len = sig_len(lhs_limbs.as_ref());
+    let rhs_len = sig_len(rhs_limbs.as_ref());
 
     let mut lhs = <<Wk as BigInt>::Scratch as ComputeLimbs>::double_buffered_u64();
     let mut rhs = <<Wk as BigInt>::Scratch as ComputeLimbs>::double_buffered_u64();
     let cap = lhs.as_ref().len();
-    if 2 * al > cap || bl + cl > cap {
+    if 2 * squared_len > cap || lhs_len + rhs_len > cap {
         return None; // fail closed — the caller makes no adjustment
     }
     mul_slice(
-        &abuf.as_ref()[..al],
-        &abuf.as_ref()[..al],
-        &mut lhs.as_mut()[..2 * al],
+        &squared_limbs.as_ref()[..squared_len],
+        &squared_limbs.as_ref()[..squared_len],
+        &mut lhs.as_mut()[..2 * squared_len],
     );
     mul_slice(
-        &bbuf.as_ref()[..bl],
-        &cbuf.as_ref()[..cl],
-        &mut rhs.as_mut()[..bl + cl],
+        &lhs_limbs.as_ref()[..lhs_len],
+        &rhs_limbs.as_ref()[..rhs_len],
+        &mut rhs.as_mut()[..lhs_len + rhs_len],
     );
     // Both buffers are the same length and zero above their product, so the
     // full-slice compare is the product compare.
     Some(
         match crate::int::algos::support::limbs::cmp(lhs.as_ref(), rhs.as_ref()) {
-            d if d < 0 => core::cmp::Ordering::Less,
+            ordering if ordering < 0 => core::cmp::Ordering::Less,
             0 => core::cmp::Ordering::Equal,
             _ => core::cmp::Ordering::Greater,
         },
@@ -981,24 +996,24 @@ where
 ///
 /// # The two grid points, and why the second needs the parabola
 ///
-/// * **On the tangent** (`result == δ`) — the quadratic `Q` itself fell below
+/// * **On the tangent** (`rounded == δ`) — the quadratic `Q` itself fell below
 ///   the reachable working scale. `V < δ` settles it, so a downward-directed
 ///   result steps down one ULP: `Floor` for both signs, `Trunc` only for
 ///   `δ > 0` (for `δ < 0` truncation moves UP and `δ` is already correct).
-/// * **On the parabola** (`result == δ − Q`, `Q` an exact whole number of
+/// * **On the parabola** (`rounded == δ − Q`, `Q` an exact whole number of
 ///   ULPs) — the `δ² ≡ 0 (mod 2·10^SCALE)` family. Its quadratic term is an
 ///   exact ULP multiple, so the value steps to a DIFFERENT grid point and the
 ///   tangent test above no-ops; the CUBIC then decides, at fractional depth
 ///   `≈ 3·SCALE/2`, far past the walker's reach.
 ///
-/// The parabola test is `result ≤ δ − Q  ⟺  Q ≤ D  ⟺  δ² ≤ 2·D·one`, where
-/// `D = δ − result` — an exact integer comparison ([`cmp_sq_vs_prod`]), never
+/// The parabola test is `rounded ≤ δ − Q  ⟺  Q ≤ D  ⟺  δ² ≤ 2·D·one`, where
+/// `D = δ − rounded` — an exact integer comparison ([`cmp_sq_vs_prod`]), never
 /// a tolerance.
 ///
 /// # It cannot fire on a correct result
 ///
-/// A correct `Ceiling` has `result = ⌈V⌉ ≥ V`, whereas `Q ≤ D` rearranges to
-/// `result ≤ δ − Q < V` — a contradiction. So the test is FALSE for every
+/// A correct `Ceiling` has `rounded = ⌈V⌉ ≥ V`, whereas `Q ≤ D` rearranges to
+/// `rounded ≤ δ − Q < V` — a contradiction. So the test is FALSE for every
 /// correctly-rounded `Ceiling`, at every input, and the mirror argument holds
 /// for `Floor` at `δ < 0`. The step is therefore reachable only from a
 /// genuinely wrong result, which is what lets it be applied without any
@@ -1009,7 +1024,7 @@ where
 /// [`adjust_bounded_extremum`] / [`adjust_cosh_near_min`].
 #[inline]
 pub(crate) fn adjust_log_near_zero<St: BigInt + Copy, Wk: BigInt>(
-    result: St,
+    rounded: St,
     delta: St,
     one: St,
     mode: RoundingMode,
@@ -1020,55 +1035,59 @@ where
     use core::cmp::Ordering;
 
     if crate::support::rounding::is_nearest_mode(mode) {
-        return result;
+        return rounded;
     }
     let zero = <St as BigInt>::ZERO;
     if delta == zero {
-        return result; // ln(1) = 0 / log1p(0) = 0 — the one exact point
+        return rounded; // ln(1) = 0 / log1p(0) = 0 — the one exact point
     }
     let unit = <St as BigInt>::ONE;
-    let up = delta > zero;
+    let is_up = delta > zero;
 
     // ── the TANGENT bracket: `V < δ` for every `δ ≠ 0` ─────────────────
-    if result == delta {
+    if rounded == delta {
         return match mode {
-            RoundingMode::Floor => result - unit,
-            RoundingMode::Trunc if up => result - unit,
-            _ => result,
+            RoundingMode::Floor => rounded - unit,
+            RoundingMode::Trunc if is_up => rounded - unit,
+            _ => rounded,
         };
     }
 
     // ── the PARABOLA bracket ───────────────────────────────────────────
-    // `D = δ − result`: the gap from the linear term to the grid point the
+    // `D = δ − rounded`: the gap from the linear term to the grid point the
     // walker returned, in storage ULPs.
-    let d = delta - result;
-    let mag = if up { delta } else { -delta };
+    let gap = delta - rounded;
+    let abs_delta = if is_up { delta } else { -delta };
     match mode {
         // `V > δ − Q`: a Ceiling sitting AT or BELOW the parabola is strictly
         // below the true value, so it must step up.
-        RoundingMode::Ceiling if up => {
-            if d <= zero {
-                return result; // `Q > 0`, so `Q ≤ D` cannot hold
+        RoundingMode::Ceiling if is_up => {
+            if gap <= zero {
+                return rounded; // `Q > 0`, so `Q ≤ D` cannot hold
             }
-            let dw = d.resize_to::<Wk>();
-            match cmp_sq_vs_prod::<Wk>(mag.resize_to::<Wk>(), dw + dw, one.resize_to::<Wk>()) {
-                Some(Ordering::Less | Ordering::Equal) => result + unit,
-                _ => result,
+            let gap_wide = gap.resize_to::<Wk>();
+            match cmp_sq_vs_prod::<Wk>(
+                abs_delta.resize_to::<Wk>(), gap_wide + gap_wide, one.resize_to::<Wk>())
+            {
+                Some(Ordering::Less | Ordering::Equal) => rounded + unit,
+                _ => rounded,
             }
         }
         // `V < δ − Q`: a Floor sitting AT or ABOVE the parabola is strictly
         // above the true value, so it must step down.
-        RoundingMode::Floor if !up => {
-            if d <= zero {
-                return result - unit; // `Q > 0 ≥ D`, so `Q ≥ D` holds
+        RoundingMode::Floor if !is_up => {
+            if gap <= zero {
+                return rounded - unit; // `Q > 0 ≥ D`, so `Q ≥ D` holds
             }
-            let dw = d.resize_to::<Wk>();
-            match cmp_sq_vs_prod::<Wk>(mag.resize_to::<Wk>(), dw + dw, one.resize_to::<Wk>()) {
-                Some(Ordering::Greater | Ordering::Equal) => result - unit,
-                _ => result,
+            let gap_wide = gap.resize_to::<Wk>();
+            match cmp_sq_vs_prod::<Wk>(
+                abs_delta.resize_to::<Wk>(), gap_wide + gap_wide, one.resize_to::<Wk>())
+            {
+                Some(Ordering::Greater | Ordering::Equal) => rounded - unit,
+                _ => rounded,
             }
         }
-        _ => result,
+        _ => rounded,
     }
 }
 
@@ -1361,7 +1380,7 @@ where
 ///
 /// [`ComputeLimbs`]: crate::int::types::compute_limbs::ComputeLimbs
 pub(crate) fn adjust_alternating_bracket<St: BigInt, Wk: BigInt, const SCALE: u32>(
-    result: St,
+    rounded: St,
     raw: St,
     mode: RoundingMode,
     series: AlternatingSeries,
@@ -1380,12 +1399,12 @@ where
     if raw == zero {
         return None;
     }
-    let n = if raw < zero { zero - raw } else { raw };
+    let abs_raw = if raw < zero { zero - raw } else { raw };
     // The tiny-argument band — the SAME continuous band
     // [`tiny_x_deep_directed_adjust`] uses, read from the same constant so the
     // family keeps one band definition. `digits > SCALE` is `|x| ≥ 1`, where
     // the strictly-decreasing-terms precondition fails.
-    let digits = dec_digits_g::<St>(n);
+    let digits = dec_digits_g::<St>(abs_raw);
     if digits == 0 || digits > SCALE {
         return None;
     }
@@ -1396,13 +1415,13 @@ where
     if SCALE / k + 1 > TINY_X_DEEP_JMAX {
         return None;
     }
-    let rho = if result < zero { zero - result } else { result };
+    let rho = if rounded < zero { zero - rounded } else { rounded };
 
     // The work integer `Wk` carries the scratch (its `ComputeLimbs` bound is
     // the one already in scope at every caller), so the fixed point is `2^F`
     // with `F = Wk::BITS` — wider than the storage width, never narrower.
-    let nl = <Wk as BigInt>::LIMBS;
-    let w = 2 * nl;
+    let limb_count = <Wk as BigInt>::LIMBS;
+    let double_limbs = 2 * limb_count;
     let f_bits = <Wk as BigInt>::BITS;
 
     let mut nb_b = <<Wk as BigInt>::Scratch as ComputeLimbs>::single_u64();
@@ -1418,35 +1437,37 @@ where
     let pr = pr_b.as_mut();
     let qt = qt_b.as_mut();
     // Capacity is CHECKED, never assumed.
-    if nb.len() < nl
-        || y.len() < nl
-        || t.len() < w
-        || bd.len() < w
-        || pr.len() < 4 * nl
-        || qt.len() < 4 * nl
+    if nb.len() < limb_count
+        || y.len() < limb_count
+        || t.len() < double_limbs
+        || bd.len() < double_limbs
+        || pr.len() < 4 * limb_count
+        || qt.len() < 4 * limb_count
     {
         return None;
     }
 
     // ── setup: `y = ⌊x²·2^F⌋`, the term-ratio multiplier ──────────────────
-    eg::unpack_mag::<Wk>(n.resize_to::<Wk>(), nb);
-    let ln = sig_len(&nb[..nl]);
+    eg::unpack_mag::<Wk>(abs_raw.resize_to::<Wk>(), nb);
+    let abs_raw_len = sig_len(&nb[..limb_count]);
     for p in pr.iter_mut() {
         *p = 0;
     }
-    if nl + 2 * ln > pr.len() {
+    if limb_count + 2 * abs_raw_len > pr.len() {
         return None;
     }
     // `n²·2^F`: the shift is a whole number of limbs (`F = 64·N`), so the
     // product is written straight into the offset window — no shift needed.
-    crate::int::policy::mul::dispatch_slice(&nb[..ln], &nb[..ln], &mut pr[nl..nl + 2 * ln]);
-    let lp = pow10_into(2 * SCALE, bd, qt)?;
-    let dl = sig_len(&pr[..nl + 2 * ln]);
-    // `dl < lp` would be a divide with a longer divisor than dividend — it
-    // cannot arise for a band argument (`|x| ≥ 10^−SCALE` gives
-    // `x²·2^F ≥ 1`), but the shape is checked rather than assumed.
-    // `t` is still unused here, so it serves as the remainder buffer.
-    if qt.len() < dl || t.len() < lp || dl < lp {
+    crate::int::policy::mul::dispatch_slice(&nb[..abs_raw_len], &nb[..abs_raw_len],
+        &mut pr[limb_count..limb_count + 2 * abs_raw_len]);
+    let pow_len = pow10_into(2 * SCALE, bd, qt)?;
+    let dividend_len = sig_len(&pr[..limb_count + 2 * abs_raw_len]);
+    // A dividend shorter than the divisor would be a divide with a longer
+    // divisor than dividend — it cannot arise for a band argument
+    // (`|x| ≥ 10^−SCALE` gives `x²·2^F ≥ 1`), but the shape is checked rather
+    // than assumed. `t` is still unused here, so it serves as the remainder
+    // buffer.
+    if qt.len() < dividend_len || t.len() < pow_len || dividend_len < pow_len {
         return None;
     }
     for q in qt.iter_mut() {
@@ -1455,16 +1476,18 @@ where
     for e in t.iter_mut() {
         *e = 0;
     }
-    if !bracket_div::<Wk>(&pr[..dl], &bd[..lp], &mut qt[..dl], &mut t[..lp]) {
+    if !bracket_div::<Wk>(
+        &pr[..dividend_len], &bd[..pow_len], &mut qt[..dividend_len], &mut t[..pow_len])
+    {
         return None;
     }
     // `|x| < 1` so `y < 2^F`, i.e. at most `N` limbs. A wider quotient would
     // mean a non-tiny argument slipped the band gate — fail closed rather
     // than silently truncate.
-    if sig_len(&qt[..dl]) > nl {
+    if sig_len(&qt[..dividend_len]) > limb_count {
         return None;
     }
-    y[..nl].copy_from_slice(&qt[..nl]);
+    y[..limb_count].copy_from_slice(&qt[..limb_count]);
 
     // ── the leading term, scaled by `2^F` ─────────────────────────────────
     for e in t.iter_mut() {
@@ -1472,14 +1495,14 @@ where
     }
     if series == AlternatingSeries::Cos {
         // The even face's leading term is the constant `1` = `10^SCALE` ULPs.
-        // `n` is no longer needed, so its buffer carries the constant.
+        // `abs_raw` is no longer needed, so its buffer carries the constant.
         let unit = crate::consts::pow10::dispatch::<Wk>(SCALE);
         eg::unpack_mag::<Wk>(unit, nb);
-        lb::shl(&nb[..nl], f_bits, &mut t[..w]);
+        lb::shl(&nb[..limb_count], f_bits, &mut t[..double_limbs]);
     } else {
-        lb::shl(&nb[..ln], f_bits, &mut t[..w]);
+        lb::shl(&nb[..abs_raw_len], f_bits, &mut t[..double_limbs]);
     }
-    alternating_bracket_core::<St, Wk>(result, rho, mode, series, t, y, nb, bd, pr)
+    alternating_bracket_core::<St, Wk>(rounded, rho, mode, series, t, y, nb, bd, pr)
 }
 
 /// The RATIO face of [`adjust_alternating_bracket`] — `atan2`.
@@ -1509,7 +1532,7 @@ where
 /// gating on it is conservative — it can only decline to attempt the proof,
 /// never admit an argument outside the band.
 pub(crate) fn adjust_alternating_bracket_ratio<St: BigInt, Wk: BigInt, const SCALE: u32>(
-    result: St,
+    rounded: St,
     y_raw: St,
     x_raw: St,
     mode: RoundingMode,
@@ -1527,11 +1550,11 @@ where
     if y_raw == zero || x_raw <= zero {
         return None;
     }
-    let ny = if y_raw < zero { zero - y_raw } else { y_raw };
-    if ny >= x_raw {
+    let abs_y = if y_raw < zero { zero - y_raw } else { y_raw };
+    if abs_y >= x_raw {
         return None; // |z| ≥ 1 — outside the reduced branch and the band
     }
-    let dy = dec_digits_g::<St>(ny);
+    let dy = dec_digits_g::<St>(abs_y);
     let dx = dec_digits_g::<St>(x_raw);
     if dy == 0 || dx <= dy {
         return None;
@@ -1540,12 +1563,12 @@ where
     if k == 0 || SCALE / k + 1 > TINY_X_DEEP_JMAX {
         return None;
     }
-    let rho = if result < zero { zero - result } else { result };
+    let rho = if rounded < zero { zero - rounded } else { rounded };
 
     // `·2^F` is applied throughout as a whole-limb offset (`F = Wk::BITS`), so
     // no bit shift is needed here — the products are written into the window.
-    let nl = <Wk as BigInt>::LIMBS;
-    let w = 2 * nl;
+    let limb_count = <Wk as BigInt>::LIMBS;
+    let double_limbs = 2 * limb_count;
 
     let mut nb_b = <<Wk as BigInt>::Scratch as ComputeLimbs>::single_u64();
     let mut xb_b = <<Wk as BigInt>::Scratch as ComputeLimbs>::single_u64();
@@ -1561,38 +1584,40 @@ where
     let bd = bd_b.as_mut();
     let pr = pr_b.as_mut();
     let qt = qt_b.as_mut();
-    if nb.len() < nl
-        || xb.len() < nl
-        || y.len() < nl
-        || t.len() < w
-        || bd.len() < w
-        || pr.len() < 4 * nl
-        || qt.len() < 4 * nl
+    if nb.len() < limb_count
+        || xb.len() < limb_count
+        || y.len() < limb_count
+        || t.len() < double_limbs
+        || bd.len() < double_limbs
+        || pr.len() < 4 * limb_count
+        || qt.len() < 4 * limb_count
     {
         return None;
     }
 
-    eg::unpack_mag::<Wk>(ny.resize_to::<Wk>(), nb);
+    eg::unpack_mag::<Wk>(abs_y.resize_to::<Wk>(), nb);
     eg::unpack_mag::<Wk>(x_raw.resize_to::<Wk>(), xb);
-    let ln = sig_len(&nb[..nl]);
-    let lx = sig_len(&xb[..nl]);
+    let abs_y_len = sig_len(&nb[..limb_count]);
+    let x_len = sig_len(&xb[..limb_count]);
 
     // ── the term ratio: `y_fp = ⌊|y|²·2^F / x²⌋` ──────────────────────────
     for p in pr.iter_mut() {
         *p = 0;
     }
-    if nl + 2 * ln > pr.len() || 2 * lx > bd.len() {
+    if limb_count + 2 * abs_y_len > pr.len() || 2 * x_len > bd.len() {
         return None;
     }
     // `·2^F` is a whole-limb offset, so the square is written straight into it.
-    crate::int::policy::mul::dispatch_slice(&nb[..ln], &nb[..ln], &mut pr[nl..nl + 2 * ln]);
-    for e in bd[..2 * lx].iter_mut() {
+    crate::int::policy::mul::dispatch_slice(&nb[..abs_y_len], &nb[..abs_y_len],
+        &mut pr[limb_count..limb_count + 2 * abs_y_len]);
+    for e in bd[..2 * x_len].iter_mut() {
         *e = 0;
     }
-    crate::int::policy::mul::dispatch_slice(&xb[..lx], &xb[..lx], &mut bd[..2 * lx]);
-    let dl = sig_len(&pr[..nl + 2 * ln]);
-    let lp = sig_len(&bd[..2 * lx]);
-    if qt.len() < dl || t.len() < lp || dl < lp {
+    crate::int::policy::mul::dispatch_slice(
+        &xb[..x_len], &xb[..x_len], &mut bd[..2 * x_len]);
+    let dividend_len = sig_len(&pr[..limb_count + 2 * abs_y_len]);
+    let divisor_len = sig_len(&bd[..2 * x_len]);
+    if qt.len() < dividend_len || t.len() < divisor_len || dividend_len < divisor_len {
         return None;
     }
     for q in qt.iter_mut() {
@@ -1601,29 +1626,33 @@ where
     for e in t.iter_mut() {
         *e = 0;
     }
-    if !bracket_div::<Wk>(&pr[..dl], &bd[..lp], &mut qt[..dl], &mut t[..lp]) {
+    if !bracket_div::<Wk>(&pr[..dividend_len], &bd[..divisor_len],
+        &mut qt[..dividend_len], &mut t[..divisor_len])
+    {
         return None;
     }
-    // `|z| < 1` so `y_fp < 2^F` — at most `nl` limbs. Anything wider means the
-    // band gate admitted a non-tiny ratio; fail closed rather than truncate.
-    if sig_len(&qt[..dl]) > nl {
+    // `|z| < 1` so `y_fp < 2^F` — at most `limb_count` limbs. Anything wider
+    // means the band gate admitted a non-tiny ratio; fail closed rather than
+    // truncate.
+    if sig_len(&qt[..dividend_len]) > limb_count {
         return None;
     }
-    y[..nl].copy_from_slice(&qt[..nl]);
+    y[..limb_count].copy_from_slice(&qt[..limb_count]);
 
     // ── the leading term: `t = ⌊10^SCALE·|y|·2^F / x⌋` ────────────────────
     let unit = crate::consts::pow10::dispatch::<Wk>(SCALE);
     eg::unpack_mag::<Wk>(unit, bd);
-    let lu = sig_len(&bd[..nl]);
+    let unit_len = sig_len(&bd[..limb_count]);
     for p in pr.iter_mut() {
         *p = 0;
     }
-    if nl + lu + ln > pr.len() {
+    if limb_count + unit_len + abs_y_len > pr.len() {
         return None;
     }
-    crate::int::policy::mul::dispatch_slice(&bd[..lu], &nb[..ln], &mut pr[nl..nl + lu + ln]);
-    let dl2 = sig_len(&pr[..nl + lu + ln]);
-    if qt.len() < dl2 || bd.len() < lx || dl2 < lx {
+    crate::int::policy::mul::dispatch_slice(&bd[..unit_len], &nb[..abs_y_len],
+        &mut pr[limb_count..limb_count + unit_len + abs_y_len]);
+    let term_dividend_len = sig_len(&pr[..limb_count + unit_len + abs_y_len]);
+    if qt.len() < term_dividend_len || bd.len() < x_len || term_dividend_len < x_len {
         return None;
     }
     for q in qt.iter_mut() {
@@ -1632,17 +1661,19 @@ where
     for e in bd.iter_mut() {
         *e = 0;
     }
-    if !bracket_div::<Wk>(&pr[..dl2], &xb[..lx], &mut qt[..dl2], &mut bd[..lx]) {
+    if !bracket_div::<Wk>(&pr[..term_dividend_len], &xb[..x_len],
+        &mut qt[..term_dividend_len], &mut bd[..x_len])
+    {
         return None;
     }
     // `T_1 = 10^SCALE·|z| < 10^SCALE`, so the scaled leading term fits `2N`.
-    if sig_len(&qt[..dl2]) > w {
+    if sig_len(&qt[..term_dividend_len]) > double_limbs {
         return None;
     }
-    t[..w].copy_from_slice(&qt[..w]);
+    t[..double_limbs].copy_from_slice(&qt[..double_limbs]);
 
     alternating_bracket_core::<St, Wk>(
-        result,
+        rounded,
         rho,
         mode,
         AlternatingSeries::Atan,
@@ -1668,7 +1699,7 @@ where
 /// has produced `term` and `sq_ratio`, and are reused here rather than re-allocated.
 #[allow(clippy::too_many_arguments)]
 fn alternating_bracket_core<St: BigInt, Wk: BigInt>(
-    result: St,
+    rounded: St,
     grid_magnitude: St,
     mode: RoundingMode,
     series: AlternatingSeries,
@@ -1754,7 +1785,7 @@ where
 
     for _ in 0..max_steps {
         // ── next term: `term ← ⌊⌊term·sq_ratio / 2^F⌋ · a_j / b_j⌋` ──────
-        let (a, b) = series.ratio(j);
+        let (ratio_num, ratio_den) = series.ratio(j);
         for p in product.iter_mut() {
             *p = 0;
         }
@@ -1768,21 +1799,23 @@ where
         );
         lb::shr(&product[..3 * work_limbs], f_bits, &mut term[..acc_limbs]);
         let mut term_len = sig_len(&term[..acc_limbs]);
-        if a != 1 {
+        if ratio_num != 1 {
             if term_len + 1 > acc_limbs {
                 return None;
             }
-            term_len = mul_small(term, term_len, a, product);
+            term_len = mul_small(term, term_len, ratio_num, product);
         }
-        if b != 1 {
+        if ratio_den != 1 {
             for p in product[..term_len].iter_mut() {
                 *p = 0;
             }
-            let mut r1 = [0u64; 1];
+            let mut remainder = [0u64; 1];
             // A single-limb divisor, so this takes the scratch-free `Rem` arm;
             // routed through the same helper so no divide in this kernel can
             // reach a build-max engine.
-            if !bracket_div::<Wk>(&term[..term_len], &[b], &mut product[..term_len], &mut r1) {
+            if !bracket_div::<Wk>(
+                &term[..term_len], &[ratio_den], &mut product[..term_len], &mut remainder)
+            {
                 return None;
             }
             term[..term_len].copy_from_slice(&product[..term_len]);
@@ -1835,12 +1868,12 @@ where
                 }
             }
         }
-        if let Some(up) = expanding {
+        if let Some(is_expanding) = expanding {
             let one = <St as BigInt>::ONE;
-            return Some(if up {
-                crate::support::rounding::tiny_odd_expanding_directed(result, zero, one, mode)
+            return Some(if is_expanding {
+                crate::support::rounding::tiny_odd_expanding_directed(rounded, zero, one, mode)
             } else {
-                crate::support::rounding::tiny_odd_compressing_directed(result, zero, one, mode)
+                crate::support::rounding::tiny_odd_compressing_directed(rounded, zero, one, mode)
             });
         }
 
@@ -1857,7 +1890,7 @@ where
 /// term is `δ = raw − 10^SCALE`, so the adjust reads the gap against `one`.
 #[inline]
 pub(crate) fn adjust_ln_near_one<C: WideTrigCore, const SCALE: u32>(
-    result: C::Storage,
+    rounded: C::Storage,
     raw: C::Storage,
     mode: RoundingMode,
 ) -> C::Storage
@@ -1865,10 +1898,10 @@ where
     <C::W as BigInt>::Scratch: crate::int::types::compute_limbs::ComputeLimbs,
 {
     if crate::support::rounding::is_nearest_mode(mode) {
-        return result;
+        return rounded;
     }
     let one = C::storage_one(SCALE);
-    adjust_log_near_zero::<C::Storage, C::W>(result, raw - one, one, mode)
+    adjust_log_near_zero::<C::Storage, C::W>(rounded, raw - one, one, mode)
 }
 
 /// `tan_strict` for a wide tier — generic over the tier `C`. Panics at
@@ -1889,72 +1922,77 @@ where
     }
     // Analytic tiny-`x` directed decision (relocated from the policy layer) —
     // `tan(x) = x + x³/3 + …` EXPANDS (every Taylor coefficient is positive).
-    if let Some(v) = tiny_x_linear_directed::<C::Storage, SCALE>(raw, mode, true) {
-        return v;
+    if let Some(pinned) = tiny_x_linear_directed::<C::Storage, SCALE>(raw, mode, true) {
+        return pinned;
     }
-    let w0 = SCALE + C::GUARD;
-    let (sin0, cos0) = C::sin_cos_fixed::<SCALE>(C::to_work(raw), w0);
-    if cos0 == C::zero() {
+    let base_working_scale = SCALE + C::GUARD;
+    let (sin_base, cos_base) =
+        C::sin_cos_fixed::<SCALE>(C::to_work(raw), base_working_scale);
+    if cos_base == C::zero() {
         panic!("wide-tier tan: cosine is zero (argument is an odd multiple of pi/2)");
     }
-    let probe = C::div(sin0, cos0, w0);
-    let extra = crate::algos::trig::near_pole_tan::tan_extra_digits(C::bit_length(probe), w0)
+    let probe = C::div(sin_base, cos_base, base_working_scale);
+    let extra_digits = crate::algos::trig::near_pole_tan::tan_extra_digits(
+        C::bit_length(probe), base_working_scale)
         .saturating_sub(C::GUARD);
-    if extra == 0 {
+    if extra_digits == 0 {
         // Near-tie escape: a fixed-w single shot cannot see a deciding
         // digit below w (`tan(x) = x + x^3/3 + ...` lands an exact
         // rational partial on a boundary with the deciding tail deeper -
         // the asin(3e-60) family). Clear-of-band residuals keep the
         // single-shot cost; the band escalates through the walker.
-        if let Some(st) = round_to_storage_clear_of_tie_g::<C::Storage, C::W>(
-            probe, w0, SCALE, mode, C::storage_max(), C::storage_min(),
+        if let Some(narrowed) = round_to_storage_clear_of_tie_g::<C::Storage, C::W>(
+            probe, base_working_scale, SCALE, mode, C::storage_max(), C::storage_min(),
         ) {
-            return st;
+            return narrowed;
         }
         return tan_walker::<C, SCALE>(raw, C::GUARD, mode);
     }
-    let w = w0 + extra;
-    let (sin_w, cos_w) = C::sin_cos_fixed::<SCALE>(C::to_work_scaled(raw, C::GUARD + extra), w);
-    let r = C::div(sin_w, cos_w, w);
-    if let Some(st) = round_to_storage_clear_of_tie_g::<C::Storage, C::W>(
-        r, w, SCALE, mode, C::storage_max(), C::storage_min(),
+    let working_scale = base_working_scale + extra_digits;
+    let (sin_w, cos_w) = C::sin_cos_fixed::<SCALE>(
+        C::to_work_scaled(raw, C::GUARD + extra_digits), working_scale);
+    let ratio = C::div(sin_w, cos_w, working_scale);
+    if let Some(narrowed) = round_to_storage_clear_of_tie_g::<C::Storage, C::W>(
+        ratio, working_scale, SCALE, mode, C::storage_max(), C::storage_min(),
     ) {
-        return st;
+        return narrowed;
     }
-    tan_walker::<C, SCALE>(raw, C::GUARD + extra, mode)
+    tan_walker::<C, SCALE>(raw, C::GUARD + extra_digits, mode)
 }
 
 /// The tier-width Ziv walker for `tan` near a rounding boundary: the
 /// ratio recomputed per probe at `w = SCALE + guard`, escalating from
-/// the (near-pole-lifted) `base_guard`. Reached only from the near-tie
+/// the (near-pole-lifted) `base_guard_digits`. Reached only from the near-tie
 /// band of the single-shot terminals above / in the rung kernel.
 fn tan_walker<C: WideTrigCore, const SCALE: u32>(
     raw: C::Storage,
-    base_guard: u32,
+    base_guard_digits: u32,
     mode: RoundingMode,
 ) -> C::Storage
 where
     <C::W as BigInt>::Scratch: crate::int::types::compute_limbs::ComputeLimbs,
 {
-    let (r, decided) = round_to_storage_directed_decided_g::<C::Storage, C::W>(
-        base_guard,
+    let (rounded, decided) = round_to_storage_directed_decided_g::<C::Storage, C::W>(
+        base_guard_digits,
         SCALE,
         mode,
         C::storage_max(),
         C::storage_min(),
-        |guard| {
-            let w = SCALE + guard;
-            let (s, c) = C::sin_cos_fixed::<SCALE>(C::to_work_scaled(raw, guard), w);
-            if c == C::zero() {
+        |guard_digits| {
+            let working_scale = SCALE + guard_digits;
+            let (sin_value, cos_value) =
+                C::sin_cos_fixed::<SCALE>(C::to_work_scaled(raw, guard_digits), working_scale);
+            if cos_value == C::zero() {
                 panic!("wide-tier tan: cosine is zero (argument is an odd multiple of pi/2)");
             }
-            C::div(s, c, w)
+            C::div(sin_value, cos_value, working_scale)
         },
     );
     // Deep sub-resolution tiny-`x` band (`j* ≥ 5`): `tan` always EXPANDS.
     // A near-pole tie (`|x| ≈ π/2`, not tiny) has `j*` far above `JMAX`, so
     // the adjust is a no-op there.
-    tiny_x_deep_directed_adjust::<C::Storage, SCALE>(r, decided, raw, mode, false, <C::W as BigInt>::BITS)
+    tiny_x_deep_directed_adjust::<C::Storage, SCALE>(
+        rounded, decided, raw, mode, false, <C::W as BigInt>::BITS)
 }
 
 /// `atan_strict` for a wide tier — generic over the tier `C`. Result in
@@ -1970,24 +2008,26 @@ where
 {
     // Analytic tiny-`x` directed decision (relocated from the policy layer) —
     // `atan` alternates like `sin` (`atan(x) = x − x³/3 + x⁵/5 − …`).
-    if let Some(v) = tiny_x_linear_directed::<C::Storage, SCALE>(raw, mode, false) {
-        return v;
+    if let Some(pinned) = tiny_x_linear_directed::<C::Storage, SCALE>(raw, mode, false) {
+        return pinned;
     }
-    let (r, decided) = round_to_storage_directed_decided_g::<C::Storage, C::W>(
+    let (rounded, decided) = round_to_storage_directed_decided_g::<C::Storage, C::W>(
         C::GUARD,
         SCALE,
         mode,
         C::storage_max(),
         C::storage_min(),
-        |guard| C::atan_fixed::<SCALE>(C::to_work_scaled(raw, guard), SCALE + guard),
+        |guard_digits| C::atan_fixed::<SCALE>(
+            C::to_work_scaled(raw, guard_digits), SCALE + guard_digits),
     );
     // Exact bracket first — see [`sin_series`]; `atan` alternates identically.
-    if let Some(v) =
-        adjust_alternating_bracket::<C::Storage, C::W, SCALE>(r, raw, mode, AlternatingSeries::Atan)
+    if let Some(bracketed) = adjust_alternating_bracket::<C::Storage, C::W, SCALE>(
+        rounded, raw, mode, AlternatingSeries::Atan)
     {
-        return v;
+        return bracketed;
     }
-    tiny_x_deep_directed_adjust::<C::Storage, SCALE>(r, decided, raw, mode, true, <C::W as BigInt>::BITS)
+    tiny_x_deep_directed_adjust::<C::Storage, SCALE>(
+        rounded, decided, raw, mode, true, <C::W as BigInt>::BITS)
 }
 
 /// Narrow-`GUARD` single-shot `atan_strict` for a wide tier — generic
@@ -2008,8 +2048,8 @@ pub(crate) fn atan_narrow<C: WideTrigCore, const SCALE: u32, const GUARD: u32>(
     // rounding boundary with the deciding tail below the band's fixed
     // working scale (the asin(3e-60) family). The walker's base probe is
     // the same single evaluation; clear-of-band inputs exit there.
-    C::round_to_storage_directed(GUARD, SCALE, mode, &mut |guard| {
-        C::atan_fixed::<SCALE>(C::to_work_scaled(raw, guard), SCALE + guard)
+    C::round_to_storage_directed(GUARD, SCALE, mode, &mut |guard_digits| {
+        C::atan_fixed::<SCALE>(C::to_work_scaled(raw, guard_digits), SCALE + guard_digits)
     })
 }
 
@@ -2046,39 +2086,42 @@ where
     // Analytic tiny-`x` directed decision — the SAME pre-empt the tier
     // [`sin_series`] carries (relocated from the policy layer), so this
     // rung-dispatched path and the bare tier kernel agree.
-    if let Some(v) = tiny_x_linear_directed::<C::Storage, SCALE>(raw, mode, false) {
-        return v;
+    if let Some(pinned) = tiny_x_linear_directed::<C::Storage, SCALE>(raw, mode, false) {
+        return pinned;
     }
     // Two-width fall-up: an unresolved-at-rung-cap near-tie reruns the
     // walker at the tier work width `C::W` (the recompute closure is the
     // tier kernel's, verbatim), so the conclusion is never weaker than
     // the tier path's — see `round_to_storage_directed_widening_g`.
-    let (r, decided) = round_to_storage_directed_widening_decided_g::<C::Storage, Wk, C::W>(
+    let (rounded, decided) = round_to_storage_directed_widening_decided_g::<C::Storage, Wk, C::W>(
         GUARD,
         SCALE,
         mode,
         C::storage_max(),
         C::storage_min(),
-        |guard| {
-            let w = SCALE + guard;
+        |guard_digits| {
+            let working_scale = SCALE + guard_digits;
             crate::algos::trig::trig_generic::sin_fixed::<Wk>(
-                to_work_scaled_g::<C::Storage, Wk>(raw, guard),
-                w,
-                pi_at_rung::<Wk>(w, SCALE + GUARD),
+                to_work_scaled_g::<C::Storage, Wk>(raw, guard_digits),
+                working_scale,
+                pi_at_rung::<Wk>(working_scale, SCALE + GUARD),
             )
         },
-        |guard| C::sin_fixed::<SCALE>(C::to_work_scaled(raw, guard), SCALE + guard),
+        |guard_digits| C::sin_fixed::<SCALE>(
+            C::to_work_scaled(raw, guard_digits), SCALE + guard_digits),
     );
     // The exact alternating-series bracket first: where it closes it PROVES
-    // which side of `r` the true value lies on, superseding the `j*`-parity
-    // rule whose exactness premise fails for a multi-digit significand.
-    if let Some(v) =
-        adjust_alternating_bracket::<C::Storage, C::W, SCALE>(r, raw, mode, AlternatingSeries::Sin)
+    // which side of `rounded` the true value lies on, superseding the
+    // `j*`-parity rule whose exactness premise fails for a multi-digit
+    // significand.
+    if let Some(bracketed) = adjust_alternating_bracket::<C::Storage, C::W, SCALE>(
+        rounded, raw, mode, AlternatingSeries::Sin)
     {
-        return v;
+        return bracketed;
     }
-    let r = tiny_x_deep_directed_adjust::<C::Storage, SCALE>(r, decided, raw, mode, true, <C::W as BigInt>::BITS);
-    adjust_bounded_extremum::<C, SCALE>(r, raw, mode)
+    let rounded = tiny_x_deep_directed_adjust::<C::Storage, SCALE>(
+        rounded, decided, raw, mode, true, <C::W as BigInt>::BITS);
+    adjust_bounded_extremum::<C, SCALE>(rounded, raw, mode)
 }
 
 /// Rung-generic `cos_strict` — see [`sin_series_g`]. Standalone
@@ -2098,30 +2141,31 @@ where
         return C::storage_one(SCALE);
     }
     // Two-width fall-up — see [`sin_series_g`].
-    let r = round_to_storage_directed_widening_g::<C::Storage, Wk, C::W>(
+    let rounded = round_to_storage_directed_widening_g::<C::Storage, Wk, C::W>(
         GUARD,
         SCALE,
         mode,
         C::storage_max(),
         C::storage_min(),
-        |guard| {
-            let w = SCALE + guard;
+        |guard_digits| {
+            let working_scale = SCALE + guard_digits;
             crate::algos::trig::trig_generic::cos_fixed::<Wk>(
-                to_work_scaled_g::<C::Storage, Wk>(raw, guard),
-                w,
-                pi_at_rung::<Wk>(w, SCALE + GUARD),
+                to_work_scaled_g::<C::Storage, Wk>(raw, guard_digits),
+                working_scale,
+                pi_at_rung::<Wk>(working_scale, SCALE + GUARD),
             )
         },
-        |guard| C::cos_fixed::<SCALE>(C::to_work_scaled(raw, guard), SCALE + guard),
+        |guard_digits| C::cos_fixed::<SCALE>(
+            C::to_work_scaled(raw, guard_digits), SCALE + guard_digits),
     );
     // See [`cos_series`] — the near-extremum grid point the bounded-extremum
     // guard cannot reach.
-    if let Some(v) =
-        adjust_alternating_bracket::<C::Storage, C::W, SCALE>(r, raw, mode, AlternatingSeries::Cos)
+    if let Some(bracketed) = adjust_alternating_bracket::<C::Storage, C::W, SCALE>(
+        rounded, raw, mode, AlternatingSeries::Cos)
     {
-        return v;
+        return bracketed;
     }
-    adjust_bounded_extremum::<C, SCALE>(r, raw, mode)
+    adjust_bounded_extremum::<C, SCALE>(rounded, raw, mode)
 }
 
 /// Rung-generic `tan_strict` — see [`sin_series_g`]. One kernel covers
@@ -2166,60 +2210,60 @@ where
     }
     // Analytic tiny-`x` directed decision — the SAME pre-empt the tier
     // [`tan_series`] carries (relocated from the policy layer).
-    if let Some(v) = tiny_x_linear_directed::<C::Storage, SCALE>(raw, mode, true) {
-        return v;
+    if let Some(pinned) = tiny_x_linear_directed::<C::Storage, SCALE>(raw, mode, true) {
+        return pinned;
     }
-    let w0 = SCALE + GUARD;
-    let (sin0, cos0) = crate::algos::trig::trig_generic::sin_cos_fixed::<Wk>(
+    let base_working_scale = SCALE + GUARD;
+    let (sin_base, cos_base) = crate::algos::trig::trig_generic::sin_cos_fixed::<Wk>(
         to_work_scaled_g::<C::Storage, Wk>(raw, GUARD),
-        w0,
-        pi_at_rung::<Wk>(w0, w0),
+        base_working_scale,
+        pi_at_rung::<Wk>(base_working_scale, base_working_scale),
     );
-    if cos0 == eg::zero::<Wk>() {
+    if cos_base == eg::zero::<Wk>() {
         panic!("wide-tier tan: cosine is zero (argument is an odd multiple of pi/2)");
     }
-    let probe = eg::div::<Wk>(sin0, cos0, w0);
+    let probe = eg::div::<Wk>(sin_base, cos_base, base_working_scale);
     if !NEAR_POLE {
         // Near-tie escape — see [`tan_series`]: clear-of-band residuals
         // keep the single-shot cost; the band escalates (rung first,
         // tier fall-up).
-        if let Some(st) = round_to_storage_clear_of_tie_g::<C::Storage, Wk>(
-            probe, w0, SCALE, mode, C::storage_max(), C::storage_min(),
+        if let Some(narrowed) = round_to_storage_clear_of_tie_g::<C::Storage, Wk>(
+            probe, base_working_scale, SCALE, mode, C::storage_max(), C::storage_min(),
         ) {
-            return st;
+            return narrowed;
         }
         return tan_walker_rung_g::<C, Wk, SCALE>(raw, GUARD, mode);
     }
-    let extra_raw =
-        crate::algos::trig::near_pole_tan::tan_extra_digits(eg::bit_length::<Wk>(probe), w0);
-    let extra = if SUB_GUARD { extra_raw.saturating_sub(GUARD) } else { extra_raw };
-    if extra == 0 {
-        if let Some(st) = round_to_storage_clear_of_tie_g::<C::Storage, Wk>(
-            probe, w0, SCALE, mode, C::storage_max(), C::storage_min(),
+    let extra_raw = crate::algos::trig::near_pole_tan::tan_extra_digits(
+        eg::bit_length::<Wk>(probe), base_working_scale);
+    let extra_digits = if SUB_GUARD { extra_raw.saturating_sub(GUARD) } else { extra_raw };
+    if extra_digits == 0 {
+        if let Some(narrowed) = round_to_storage_clear_of_tie_g::<C::Storage, Wk>(
+            probe, base_working_scale, SCALE, mode, C::storage_max(), C::storage_min(),
         ) {
-            return st;
+            return narrowed;
         }
         return tan_walker_rung_g::<C, Wk, SCALE>(raw, GUARD, mode);
     }
     // Near-pole recompute at the tier work width (the `w` here is off the
     // hot `SCALE + GUARD` path, so π comes from the runtime-keyed table —
     // exactly the per-tier `pi_cf` fallback the tier path takes).
-    let w = w0 + extra;
+    let working_scale = base_working_scale + extra_digits;
     let (sin_w, cos_w) = crate::algos::trig::trig_generic::sin_cos_fixed::<C::W>(
-        to_work_scaled_g::<C::Storage, C::W>(raw, GUARD + extra),
-        w,
+        to_work_scaled_g::<C::Storage, C::W>(raw, GUARD + extra_digits),
+        working_scale,
         crate::consts::pi_by_working_scale::<C::W>(
-            w,
+            working_scale,
             crate::support::rounding::DEFAULT_ROUNDING_MODE,
         ),
     );
-    let r = eg::div::<C::W>(sin_w, cos_w, w);
-    if let Some(st) = round_to_storage_clear_of_tie_g::<C::Storage, C::W>(
-        r, w, SCALE, mode, C::storage_max(), C::storage_min(),
+    let ratio = eg::div::<C::W>(sin_w, cos_w, working_scale);
+    if let Some(narrowed) = round_to_storage_clear_of_tie_g::<C::Storage, C::W>(
+        ratio, working_scale, SCALE, mode, C::storage_max(), C::storage_min(),
     ) {
-        return st;
+        return narrowed;
     }
-    tan_walker::<C, SCALE>(raw, GUARD + extra, mode)
+    tan_walker::<C, SCALE>(raw, GUARD + extra_digits, mode)
 }
 
 /// Two-width near-tie walker for the rung `tan` shapes: the ratio
@@ -2229,7 +2273,7 @@ where
 #[cfg(feature = "_wide-support")]
 fn tan_walker_rung_g<C: WideTrigCore, Wk: BigInt, const SCALE: u32>(
     raw: C::Storage,
-    base_guard: u32,
+    base_guard_digits: u32,
     mode: RoundingMode,
 ) -> C::Storage
 where
@@ -2237,36 +2281,38 @@ where
     <C::W as BigInt>::Scratch: crate::int::types::compute_limbs::ComputeLimbs,
 {
     use crate::algos::exp::exp_generic as eg;
-    let base_w = SCALE + base_guard;
-    let (r, decided) = round_to_storage_directed_widening_decided_g::<C::Storage, Wk, C::W>(
-        base_guard,
+    let base_working_scale = SCALE + base_guard_digits;
+    let (rounded, decided) = round_to_storage_directed_widening_decided_g::<C::Storage, Wk, C::W>(
+        base_guard_digits,
         SCALE,
         mode,
         C::storage_max(),
         C::storage_min(),
-        |guard| {
-            let w = SCALE + guard;
-            let (s, c) = crate::algos::trig::trig_generic::sin_cos_fixed::<Wk>(
-                to_work_scaled_g::<C::Storage, Wk>(raw, guard),
-                w,
-                pi_at_rung::<Wk>(w, base_w),
+        |guard_digits| {
+            let working_scale = SCALE + guard_digits;
+            let (sin_value, cos_value) = crate::algos::trig::trig_generic::sin_cos_fixed::<Wk>(
+                to_work_scaled_g::<C::Storage, Wk>(raw, guard_digits),
+                working_scale,
+                pi_at_rung::<Wk>(working_scale, base_working_scale),
             );
-            if c == eg::zero::<Wk>() {
+            if cos_value == eg::zero::<Wk>() {
                 panic!("wide-tier tan: cosine is zero (argument is an odd multiple of pi/2)");
             }
-            eg::div::<Wk>(s, c, w)
+            eg::div::<Wk>(sin_value, cos_value, working_scale)
         },
-        |guard| {
-            let w = SCALE + guard;
-            let (s, c) = C::sin_cos_fixed::<SCALE>(C::to_work_scaled(raw, guard), w);
-            if c == C::zero() {
+        |guard_digits| {
+            let working_scale = SCALE + guard_digits;
+            let (sin_value, cos_value) =
+                C::sin_cos_fixed::<SCALE>(C::to_work_scaled(raw, guard_digits), working_scale);
+            if cos_value == C::zero() {
                 panic!("wide-tier tan: cosine is zero (argument is an odd multiple of pi/2)");
             }
-            C::div(s, c, w)
+            C::div(sin_value, cos_value, working_scale)
         },
     );
     // Deep sub-resolution tiny-`x` band (`j* ≥ 5`): `tan` always EXPANDS.
-    tiny_x_deep_directed_adjust::<C::Storage, SCALE>(r, decided, raw, mode, false, <C::W as BigInt>::BITS)
+    tiny_x_deep_directed_adjust::<C::Storage, SCALE>(
+        rounded, decided, raw, mode, false, <C::W as BigInt>::BITS)
 }
 
 /// Rung-generic `atan_strict` — the inverse-tangent kernel run at an
@@ -2307,10 +2353,10 @@ where
 {
     // Analytic tiny-`x` directed decision — the SAME pre-empt the tier
     // [`atan_series`] carries (relocated from the policy layer).
-    if let Some(v) = tiny_x_linear_directed::<C::Storage, SCALE>(raw, mode, false) {
-        return v;
+    if let Some(pinned) = tiny_x_linear_directed::<C::Storage, SCALE>(raw, mode, false) {
+        return pinned;
     }
-    let (r, decided) = if DIRECTED {
+    let (rounded, decided) = if DIRECTED {
         // Two-width fall-up — see [`sin_series_g`].
         round_to_storage_directed_widening_decided_g::<C::Storage, Wk, C::W>(
             GUARD,
@@ -2318,15 +2364,16 @@ where
             mode,
             C::storage_max(),
             C::storage_min(),
-            |guard| {
-                let w = SCALE + guard;
+            |guard_digits| {
+                let working_scale = SCALE + guard_digits;
                 crate::algos::trig::trig_generic::atan_fixed::<Wk>(
-                    to_work_scaled_g::<C::Storage, Wk>(raw, guard),
-                    w,
-                    pi_at_rung::<Wk>(w, SCALE + GUARD),
+                    to_work_scaled_g::<C::Storage, Wk>(raw, guard_digits),
+                    working_scale,
+                    pi_at_rung::<Wk>(working_scale, SCALE + GUARD),
                 )
             },
-            |guard| C::atan_fixed::<SCALE>(C::to_work_scaled(raw, guard), SCALE + guard),
+            |guard_digits| C::atan_fixed::<SCALE>(
+                C::to_work_scaled(raw, guard_digits), SCALE + guard_digits),
         )
     } else {
         // Band shape: same Ziv-escalated two-width walker, from the band
@@ -2334,32 +2381,34 @@ where
         // digit below the band's fixed working scale — see
         // [`atan_narrow`]). `DIRECTED` still selects the policy-side
         // out-of-budget fallback kernel; the narrowing machinery is one.
-        let base_w = SCALE + GUARD;
+        let base_working_scale = SCALE + GUARD;
         round_to_storage_directed_widening_decided_g::<C::Storage, Wk, C::W>(
             GUARD,
             SCALE,
             mode,
             C::storage_max(),
             C::storage_min(),
-            |guard| {
-                let w = SCALE + guard;
+            |guard_digits| {
+                let working_scale = SCALE + guard_digits;
                 crate::algos::trig::trig_generic::atan_fixed::<Wk>(
-                    to_work_scaled_g::<C::Storage, Wk>(raw, guard),
-                    w,
-                    pi_at_rung::<Wk>(w, base_w),
+                    to_work_scaled_g::<C::Storage, Wk>(raw, guard_digits),
+                    working_scale,
+                    pi_at_rung::<Wk>(working_scale, base_working_scale),
                 )
             },
-            |guard| C::atan_fixed::<SCALE>(C::to_work_scaled(raw, guard), SCALE + guard),
+            |guard_digits| C::atan_fixed::<SCALE>(
+                C::to_work_scaled(raw, guard_digits), SCALE + guard_digits),
         )
     };
     // Deep sub-resolution band (`j* ≥ 5`): `atan` alternates like `sin`.
     // Exact bracket first — see [`sin_series`].
-    if let Some(v) =
-        adjust_alternating_bracket::<C::Storage, C::W, SCALE>(r, raw, mode, AlternatingSeries::Atan)
+    if let Some(bracketed) = adjust_alternating_bracket::<C::Storage, C::W, SCALE>(
+        rounded, raw, mode, AlternatingSeries::Atan)
     {
-        return v;
+        return bracketed;
     }
-    tiny_x_deep_directed_adjust::<C::Storage, SCALE>(r, decided, raw, mode, true, <C::W as BigInt>::BITS)
+    tiny_x_deep_directed_adjust::<C::Storage, SCALE>(
+        rounded, decided, raw, mode, true, <C::W as BigInt>::BITS)
 }
 
 /// `π` at working scale `w` in the rung integer `Wk`: the per-scale
@@ -2369,12 +2418,13 @@ where
 /// escalation path. Value-identical either way (same table entry).
 #[cfg(feature = "_wide-support")]
 #[inline]
-pub(crate) fn pi_at_rung<Wk: BigInt>(w: u32, base_w: u32) -> Wk {
-    if w == base_w {
-        crate::consts::pi_by_scale::<Wk>(base_w, crate::support::rounding::DEFAULT_ROUNDING_MODE)
+pub(crate) fn pi_at_rung<Wk: BigInt>(working_scale: u32, base_working_scale: u32) -> Wk {
+    if working_scale == base_working_scale {
+        crate::consts::pi_by_scale::<Wk>(
+            base_working_scale, crate::support::rounding::DEFAULT_ROUNDING_MODE)
     } else {
         crate::consts::pi_by_working_scale::<Wk>(
-            w,
+            working_scale,
             crate::support::rounding::DEFAULT_ROUNDING_MODE,
         )
     }
@@ -2389,7 +2439,7 @@ pub(crate) fn pi_at_rung<Wk: BigInt>(w: u32, base_w: u32) -> Wk {
 // trait method (free-fn hoist, no trait-surface growth).
 // `St` (storage) appears only as the input/output type + the range-check
 // bounds; `St` has no trait-level `MAX`/`MIN`, so the caller supplies them
-// (`st_max`/`st_min`). The per-tier macro forwards pass `<$Storage>::MAX/MIN`
+// (`storage_max`/`storage_min`). The per-tier macro forwards pass `<$Storage>::MAX/MIN`
 // (bit-identical to the prior inline bodies); a tier-generic caller passes
 // `C::storage_max()/storage_min()`. The `÷10^shift` divides are already
 // width-generic (`div_wide_pow10::<S>` / `dispatch_wide_pow10::<S>`).
@@ -2415,18 +2465,19 @@ where
 /// `St`, panicking when it exceeds the storage range. When `S` is NARROWER
 /// than `St` (the work-rung case — a rung below the storage width admitted
 /// by the trig magnitude gate) every `S`-representable value fits the wider
-/// storage, so the bounds check is vacuously true and skipped — `st_max` /
-/// `st_min` cannot even be represented in `S` (a down-resize would truncate
+/// storage, so the bounds check is vacuously true and skipped — `storage_max` /
+/// `storage_min` cannot even be represented in `S` (a down-resize would truncate
 /// their magnitude into garbage bounds). The `LIMBS` compare const-folds per
 /// monomorphisation.
 #[inline]
-fn narrow_range_checked_g<St: BigInt + Copy, S: BigInt>(signed: S, st_max: St, st_min: St) -> St
+fn narrow_range_checked_g<St: BigInt + Copy, S: BigInt>(
+    signed: S, storage_max: St, storage_min: St) -> St
 where
     S::Scratch: crate::int::types::compute_limbs::ComputeLimbs,
 {
     if <S as BigInt>::LIMBS >= <St as BigInt>::LIMBS {
-        let max_w = BigInt::resize_to::<S>(st_max);
-        let min_w = BigInt::resize_to::<S>(st_min);
+        let max_w = BigInt::resize_to::<S>(storage_max);
+        let min_w = BigInt::resize_to::<S>(storage_min);
         if signed > max_w || signed < min_w {
             panic!("wide-tier strict transcendental: result out of range");
         }
@@ -2437,38 +2488,38 @@ where
     // its 2-limb storage, below the `Int<24>` work integer the narrow
     // near-tie walkers run in. The up-resizes above are from the SMALLER
     // `St` (its own width bounds the blanket buffer), so they stay.
-    let neg = signed < <S as BigInt>::ZERO;
-    let mag = if neg { -signed } else { signed };
+    let is_negative = signed < <S as BigInt>::ZERO;
+    let mag = if is_negative { -signed } else { signed };
     let mut buf =
         <S::Scratch as crate::int::types::compute_limbs::ComputeLimbs>::single_u64();
     crate::algos::exp::exp_generic::unpack_mag(mag, buf.as_mut());
-    St::from_mag_sign_u64(buf.as_ref(), neg)
+    St::from_mag_sign_u64(buf.as_ref(), is_negative)
 }
 
-/// Work-int-generic narrowing of a working-scale value `v` (at scale `w`) down
+/// Work-int-generic narrowing of a `working_value` (at `working_scale`) down
 /// to storage scale `target`, rounded under `mode`, into storage `St`.
-/// `st_max`/`st_min` are `St::MAX`/`MIN`, caller-supplied.
+/// `storage_max`/`storage_min` are `St::MAX`/`MIN`, caller-supplied.
 #[inline]
 pub(crate) fn round_to_storage_with_g<St: BigInt + Copy, S: BigInt>(
-    v: S,
-    w: u32,
+    working_value: S,
+    working_scale: u32,
     target: u32,
     mode: RoundingMode,
-    st_max: St,
-    st_min: St,
+    storage_max: St,
+    storage_min: St,
 ) -> St
 where
     S::Scratch: crate::int::types::compute_limbs::ComputeLimbs,
 {
-    let shift = w - target;
+    let shift = working_scale - target;
     let rounded = if shift == 0 {
-        v
+        working_value
     } else if shift <= 38 {
-        crate::algos::support::mg_divide::div_wide_pow10::<S>(v, shift, mode)
+        crate::algos::support::mg_divide::div_wide_pow10::<S>(working_value, shift, mode)
     } else {
-        crate::algos::support::rescale::dispatch_wide_pow10::<S>(v, shift, mode)
+        crate::algos::support::rescale::dispatch_wide_pow10::<S>(working_value, shift, mode)
     };
-    narrow_range_checked_g::<St, S>(rounded, st_max, st_min)
+    narrow_range_checked_g::<St, S>(rounded, storage_max, storage_min)
 }
 
 /// Absolute floor (`10^4` work-integer units) separating a genuine deciding-
@@ -2496,13 +2547,13 @@ const ZIV_PRECISION_HORIZON: u32 = 1264;
 /// Bit-length estimate (`digits <= floor(bl·log10 2) + 1`, at most one high),
 /// refined by a single `pow10` compare. Cold-path helper for the positional
 /// cross-depth confirmation below.
-fn dec_digits_g<S: BigInt>(v: S) -> u32 {
-    let bl = <S as BigInt>::BITS - v.leading_zeros();
-    let mut d = ((bl as u64 * 30_103) / 100_000) as u32 + 1;
-    if d > 1 && v < crate::consts::pow10::dispatch::<S>(d - 1) {
-        d -= 1;
+fn dec_digits_g<S: BigInt>(value: S) -> u32 {
+    let bit_len = <S as BigInt>::BITS - value.leading_zeros();
+    let mut digits = ((bit_len as u64 * 30_103) / 100_000) as u32 + 1;
+    if digits > 1 && value < crate::consts::pow10::dispatch::<S>(digits - 1) {
+        digits -= 1;
     }
-    d
+    digits
 }
 
 /// Single-width near-min escalation for `cosh` / `exp`, returning
@@ -2541,12 +2592,12 @@ fn dec_digits_g<S: BigInt>(v: S) -> u32 {
 /// `WideTrigCore` trait surface, which already passes `&mut dyn FnMut`.
 #[allow(clippy::too_many_arguments)]
 fn near_min_resolve_g<St: BigInt + Copy, S: BigInt>(
-    base_guard: u32,
+    base_guard_digits: u32,
     target: u32,
     mode: RoundingMode,
     never_exact: bool,
-    st_max: St,
-    st_min: St,
+    storage_max: St,
+    storage_min: St,
     recompute: &mut dyn FnMut(u32) -> (S, Option<TailSign>),
 ) -> (St, bool)
 where
@@ -2555,9 +2606,9 @@ where
     use crate::support::rounding::{is_nearest_mode, should_bump, RoundingMode};
     let lit = |n: i128| <S as BigInt>::from_i128(n);
     let pow10 = |n: u32| crate::consts::pow10::dispatch::<S>(n);
-    let bit_length = |v: S| -> u32 {
-        let m = if v < <S as BigInt>::ZERO { -v } else { v };
-        <S as BigInt>::BITS - m.leading_zeros()
+    let bit_length = |value: S| -> u32 {
+        let magnitude = if value < <S as BigInt>::ZERO { -value } else { value };
+        <S as BigInt>::BITS - magnitude.leading_zeros()
     };
     let floor = pow10(ZIV_RESOLVE_FLOOR_POW10);
     // The kernels' error is value-RELATIVE (~an ULP of the value at the
@@ -2567,18 +2618,18 @@ where
     // `w > p + int_digits`. The probe horizon therefore extends by
     // `int_digits` (the width cap already subtracts them, protecting the
     // kernel's internal headroom).
-    let max_guard_for = |int_digits: u32| -> u32 {
+    let max_guard_digits_for = |int_digits: u32| -> u32 {
         let cap = (<S>::BITS / 8).saturating_sub(int_digits + 8);
         cap.saturating_sub(target)
             .min((ZIV_PRECISION_HORIZON + int_digits).saturating_sub(target))
-            .max(base_guard)
+            .max(base_guard_digits)
     };
-    let int_digits_of = |v: St| -> u32 {
-        let n = BigInt::resize_to::<S>(v);
-        let m = if n < lit(0) { -n } else { n };
-        ((bit_length(m) as u64 * 30103 / 100_000) as u32 + 1).saturating_sub(target)
+    let int_digits_of = |value: St| -> u32 {
+        let widened = BigInt::resize_to::<S>(value);
+        let magnitude = if widened < lit(0) { -widened } else { widened };
+        ((bit_length(magnitude) as u64 * 30103 / 100_000) as u32 + 1).saturating_sub(target)
     };
-    let range_check = |signed: S| -> St { narrow_range_checked_g::<St, S>(signed, st_max, st_min) };
+    let range_check = |signed: S| -> St { narrow_range_checked_g::<St, S>(signed, storage_max, storage_min) };
     let finish = |neg: bool, q: S, bump: bool| -> St {
         let q_mag = if bump { q + lit(1) } else { q };
         range_check(if neg { -q_mag } else { q_mag })
@@ -2586,14 +2637,16 @@ where
     // Leading fractional-digit position of the deciding residual `dist`
     // (working units at scale `target + g`) — the cross-depth confirmation
     // key: a genuine deciding term keeps this position across depths.
-    let pos_of = |dist: S, g: u32| -> u32 { target + g - dec_digits_g::<S>(dist) + 1 };
+    let pos_of = |dist: S, guard_digits: u32| -> u32 {
+        target + guard_digits - dec_digits_g::<S>(dist) + 1
+    };
     // One working-scale probe: `(neg, q, rem, divisor)` of the recomputed
-    // value at guard `g`, magnitude split at the storage grid.
-    let mut probe = |g: u32| -> (bool, S, S, S, Option<TailSign>) {
-        let (v, tail) = recompute(g);
-        let neg = v < lit(0);
-        let mag = if neg { -v } else { v };
-        let divisor = pow10(g);
+    // value at `guard_digits`, magnitude split at the storage grid.
+    let mut probe = |guard_digits: u32| -> (bool, S, S, S, Option<TailSign>) {
+        let (working_value, tail) = recompute(guard_digits);
+        let neg = working_value < lit(0);
+        let mag = if neg { -working_value } else { working_value };
+        let divisor = pow10(guard_digits);
         // Exact per-width Knuth scratch (the narrow build's blanket is sized
         // to its 2-limb storage; the walkers probe in `Int<24>`).
         let (q, rem) = crate::algos::exp::exp_generic::div_rem_exact(mag, divisor);
@@ -2647,17 +2700,17 @@ where
                 _ => None,
             }
         };
-        let (neg0, q0, rem0, div0, tail0) = probe(base_guard);
-        if let Some(r) = tag_decides(neg0, q0, rem0, div0, tail0) {
-            return (r, true);
+        let (neg0, q0, rem0, div0, tail0) = probe(base_guard_digits);
+        if let Some(tagged) = tag_decides(neg0, q0, rem0, div0, tail0) {
+            return (tagged, true);
         }
         let half0 = div0 / lit(2);
         let dist0 = if rem0 < half0 { half0 - rem0 } else { rem0 - half0 };
-        if dist0 > pow10(base_guard) / lit(1000) {
+        if dist0 > pow10(base_guard_digits) / lit(1000) {
             return (round_half(neg0, q0, rem0, div0), true); // not near a half-ULP tie
         }
         let lo = round_half(neg0, q0, rem0, div0);
-        let max_guard = max_guard_for(int_digits_of(lo));
+        let max_guard_digits = max_guard_digits_for(int_digits_of(lo));
         // Cross-depth confirmation: the kernels' working-scale error can reach
         // well past the absolute noise floor (measured ~10^12 units at some
         // depths), but noise always sits in the BOTTOM digits of whatever `w`
@@ -2665,29 +2718,31 @@ where
         // fractional position. A probe's signal `(position, side)` is therefore
         // trusted only once a probe at a DIFFERENT depth reproduces it.
         let mut pending: Option<(u32, bool)> = if dist0 > floor {
-            Some((pos_of(dist0, base_guard), rem0 > half0))
+            Some((pos_of(dist0, base_guard_digits), rem0 > half0))
         } else {
             None
         };
-        let mut guard = base_guard;
+        let mut guard_digits = base_guard_digits;
         loop {
-            if guard >= max_guard {
+            if guard_digits >= max_guard_digits {
                 // Cap reached without a confirmed deciding term. An unconfirmed
                 // signal from the deepest probe gets ONE shifted confirm probe
                 // (real positions reproduce; noise tracks the bottom of `w`).
-                if let Some((pp, ps)) = pending {
+                if let Some((pending_position, pending_side)) = pending {
                     let back = ZIV_RESOLVE_FLOOR_POW10 + 3;
-                    if max_guard > base_guard + back {
-                        let g_c = max_guard - back;
-                        let (neg, q, rem, div, tail) = probe(g_c);
-                        if let Some(r) = tag_decides(neg, q, rem, div, tail) {
-                            return (r, true);
+                    if max_guard_digits > base_guard_digits + back {
+                        let confirm_guard_digits = max_guard_digits - back;
+                        let (neg, q, rem, div, tail) = probe(confirm_guard_digits);
+                        if let Some(tagged) = tag_decides(neg, q, rem, div, tail) {
+                            return (tagged, true);
                         }
                         let half = div / lit(2);
                         let dist = if rem < half { half - rem } else { rem - half };
                         if dist > floor {
-                            let p = pos_of(dist, g_c);
-                            if (rem > half) == ps && p.abs_diff(pp) <= 1 {
+                            let position = pos_of(dist, confirm_guard_digits);
+                            if (rem > half) == pending_side
+                                && position.abs_diff(pending_position) <= 1
+                            {
                                 return (round_half(neg, q, rem, div), true);
                             }
                         }
@@ -2704,26 +2759,28 @@ where
                 }
                 return (lo, false);
             }
-            let step = (target + base_guard).max(base_guard);
-            let next_guard = guard.saturating_add(step).min(max_guard);
-            let (neg, q, rem, div, tail) = probe(next_guard);
-            if let Some(r) = tag_decides(neg, q, rem, div, tail) {
-                return (r, true);
+            let step = (target + base_guard_digits).max(base_guard_digits);
+            let next_guard_digits = guard_digits.saturating_add(step).min(max_guard_digits);
+            let (neg, q, rem, div, tail) = probe(next_guard_digits);
+            if let Some(tagged) = tag_decides(neg, q, rem, div, tail) {
+                return (tagged, true);
             }
             let half = div / lit(2);
             let hi_dist = if rem < half { half - rem } else { rem - half };
             if hi_dist > floor {
-                let p = pos_of(hi_dist, next_guard);
+                let position = pos_of(hi_dist, next_guard_digits);
                 let above = rem > half;
-                if let Some((pp, ps)) = pending {
-                    if above == ps && p.abs_diff(pp) <= 1 {
+                if let Some((pending_position, pending_side)) = pending {
+                    if above == pending_side
+                        && position.abs_diff(pending_position) <= 1
+                    {
                         // Confirmed deciding digit — trustworthy.
                         return (round_half(neg, q, rem, div), true);
                     }
                 }
-                pending = Some((p, above));
+                pending = Some((position, above));
             }
-            guard = next_guard;
+            guard_digits = next_guard_digits;
         }
     }
 
@@ -2742,35 +2799,37 @@ where
             };
         finish(neg, q, bump)
     };
-    let (neg0, q0, rem0, div0, tail0) = probe(base_guard);
+    let (neg0, q0, rem0, div0, tail0) = probe(base_guard_digits);
     let dist0 = if rem0 < div0 - rem0 { rem0 } else { div0 - rem0 };
-    if dist0 > pow10(base_guard) / lit(1000) {
+    if dist0 > pow10(base_guard_digits) / lit(1000) {
         return (dir_round(neg0, q0, rem0), true); // clear of a grid line
     }
     let base = dir_round(neg0, q0, rem0);
-    let max_guard = max_guard_for(int_digits_of(base));
+    let max_guard_digits = max_guard_digits_for(int_digits_of(base));
     // Cross-depth confirmation — see the nearest branch: a probe's signal
     // `(position, side)` is trusted only once a probe at a different depth
     // reproduces it (noise tracks the bottom of `w`; real digits do not move).
     let mut pending: Option<(u32, bool)> = if dist0 > floor {
-        Some((pos_of(dist0, base_guard), rem0 < div0 - rem0))
+        Some((pos_of(dist0, base_guard_digits), rem0 < div0 - rem0))
     } else {
         None
     };
-    let mut guard = base_guard;
+    let mut guard_digits = base_guard_digits;
     loop {
-        if guard >= max_guard {
+        if guard_digits >= max_guard_digits {
             // Cap reached without a confirmed deciding term. An unconfirmed
             // signal from the deepest probe gets ONE shifted confirm probe.
-            if let Some((pp, ps)) = pending {
+            if let Some((pending_position, pending_side)) = pending {
                 let back = ZIV_RESOLVE_FLOOR_POW10 + 3;
-                if max_guard > base_guard + back {
-                    let g_c = max_guard - back;
-                    let (neg, q, rem, div, _) = probe(g_c);
+                if max_guard_digits > base_guard_digits + back {
+                    let confirm_guard_digits = max_guard_digits - back;
+                    let (neg, q, rem, div, _) = probe(confirm_guard_digits);
                     let dist = if rem < div - rem { rem } else { div - rem };
                     if dist > floor {
-                        let p = pos_of(dist, g_c);
-                        if (rem < div - rem) == ps && p.abs_diff(pp) <= 1 {
+                        let position = pos_of(dist, confirm_guard_digits);
+                        if (rem < div - rem) == pending_side
+                            && position.abs_diff(pending_position) <= 1
+                        {
                             return (dir_round(neg, q, rem), true);
                         }
                     }
@@ -2851,22 +2910,24 @@ where
                 };
             return (finish(neg0, q_base, tail_bump), proven);
         }
-        let step = (target + base_guard).max(base_guard);
-        let next_guard = guard.saturating_add(step).min(max_guard);
-        let (neg, q, rem, div, _) = probe(next_guard);
+        let step = (target + base_guard_digits).max(base_guard_digits);
+        let next_guard_digits = guard_digits.saturating_add(step).min(max_guard_digits);
+        let (neg, q, rem, div, _) = probe(next_guard_digits);
         let hi_dist = if rem < div - rem { rem } else { div - rem };
         if hi_dist > floor {
-            let p = pos_of(hi_dist, next_guard);
+            let position = pos_of(hi_dist, next_guard_digits);
             let above = rem < div - rem;
-            if let Some((pp, ps)) = pending {
-                if above == ps && p.abs_diff(pp) <= 1 {
+            if let Some((pending_position, pending_side)) = pending {
+                if above == pending_side
+                    && position.abs_diff(pending_position) <= 1
+                {
                     // Confirmed deciding digit — trustworthy.
                     return (dir_round(neg, q, rem), true);
                 }
             }
-            pending = Some((p, above));
+            pending = Some((position, above));
         }
-        guard = next_guard;
+        guard_digits = next_guard_digits;
     }
 }
 
@@ -2879,12 +2940,12 @@ where
 #[inline]
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn round_to_storage_widening_g<St: BigInt + Copy, S1: BigInt, S2: BigInt>(
-    base_guard: u32,
+    base_guard_digits: u32,
     target: u32,
     mode: RoundingMode,
     never_exact: bool,
-    st_max: St,
-    st_min: St,
+    storage_max: St,
+    storage_min: St,
     mut recompute1: impl FnMut(u32) -> S1,
     mut recompute2: impl FnMut(u32) -> S2,
 ) -> St
@@ -2893,14 +2954,14 @@ where
     S2::Scratch: crate::int::types::compute_limbs::ComputeLimbs,
 {
     round_to_storage_widening_tail_signed_g::<St, S1, S2>(
-        base_guard,
+        base_guard_digits,
         target,
         mode,
         never_exact,
-        st_max,
-        st_min,
-        |g| (recompute1(g), None),
-        |g| (recompute2(g), None),
+        storage_max,
+        storage_min,
+        |guard_digits| (recompute1(guard_digits), None),
+        |guard_digits| (recompute2(guard_digits), None),
     )
 }
 
@@ -2918,12 +2979,12 @@ where
 #[inline]
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn round_to_storage_widening_tail_signed_g<St: BigInt + Copy, S1: BigInt, S2: BigInt>(
-    base_guard: u32,
+    base_guard_digits: u32,
     target: u32,
     mode: RoundingMode,
     never_exact: bool,
-    st_max: St,
-    st_min: St,
+    storage_max: St,
+    storage_min: St,
     mut recompute1: impl FnMut(u32) -> (S1, Option<TailSign>),
     mut recompute2: impl FnMut(u32) -> (S2, Option<TailSign>),
 ) -> St
@@ -2932,22 +2993,22 @@ where
     S2::Scratch: crate::int::types::compute_limbs::ComputeLimbs,
 {
     let (v1, resolved1) = near_min_resolve_g::<St, S1>(
-        base_guard, target, mode, never_exact, st_max, st_min, &mut recompute1,
+        base_guard_digits, target, mode, never_exact, storage_max, storage_min, &mut recompute1,
     );
     // `S1` only proves a residual is past the probe horizon when its width
     // actually reaches it — and a result carrying integer digits raises both
     // the horizon AND the noise floor by that count (see the resolver), so
     // the reach test must include them.
     let int_digits = {
-        let m = if v1 < <St as BigInt>::ZERO { -v1 } else { v1 };
-        let bl = <St as BigInt>::BITS - m.leading_zeros();
-        ((bl as u64 * 30103 / 100_000) as u32 + 1).saturating_sub(target)
+        let magnitude = if v1 < <St as BigInt>::ZERO { -v1 } else { v1 };
+        let magnitude_bits = <St as BigInt>::BITS - magnitude.leading_zeros();
+        ((magnitude_bits as u64 * 30103 / 100_000) as u32 + 1).saturating_sub(target)
     };
     if resolved1 || (<S1>::BITS / 8) >= ZIV_PRECISION_HORIZON + int_digits {
         return v1;
     }
     near_min_resolve_g::<St, S2>(
-        base_guard, target, mode, never_exact, st_max, st_min, &mut recompute2,
+        base_guard_digits, target, mode, never_exact, storage_max, storage_min, &mut recompute2,
     )
     .0
 }
@@ -2967,25 +3028,26 @@ where
 /// the clear path costs what the plain narrowing cost.
 #[inline]
 pub(crate) fn round_to_storage_clear_of_tie_g<St: BigInt + Copy, S: BigInt>(
-    v: S,
-    w: u32,
+    working_value: S,
+    working_scale: u32,
     target: u32,
     mode: RoundingMode,
-    st_max: St,
-    st_min: St,
+    storage_max: St,
+    storage_min: St,
 ) -> Option<St>
 where
     S::Scratch: crate::int::types::compute_limbs::ComputeLimbs,
 {
     use crate::support::rounding::{is_nearest_mode, should_bump};
     let lit = |n: i128| <S as BigInt>::from_i128(n);
-    let shift = w - target;
+    let shift = working_scale - target;
     if shift == 0 {
         // Already at storage scale: the value IS the answer (no residual).
-        return Some(narrow_range_checked_g::<St, S>(v, st_max, st_min));
+        return Some(narrow_range_checked_g::<St, S>(
+            working_value, storage_max, storage_min));
     }
-    let neg = v < lit(0);
-    let mag = if neg { -v } else { v };
+    let neg = working_value < lit(0);
+    let mag = if neg { -working_value } else { working_value };
     let divisor = crate::consts::pow10::dispatch::<S>(shift);
     let (q, rem) = mag.div_rem(divisor);
     let band = if shift >= 3 {
@@ -3018,25 +3080,25 @@ where
     };
     let q_mag = if bump { q + lit(1) } else { q };
     let signed = if neg { -q_mag } else { q_mag };
-    Some(narrow_range_checked_g::<St, S>(signed, st_max, st_min))
+    Some(narrow_range_checked_g::<St, S>(signed, storage_max, storage_min))
 }
 
 /// Work-int-generic directed-rounding narrowing with Ziv escalation. `St` =
 /// storage output, `S` = work integer (a rung `Wk` or the tier `W`).
 #[inline]
 pub(crate) fn round_to_storage_directed_g<St: BigInt + Copy, S: BigInt>(
-    base_guard: u32,
+    base_guard_digits: u32,
     target: u32,
     mode: RoundingMode,
-    st_max: St,
-    st_min: St,
+    storage_max: St,
+    storage_min: St,
     mut recompute: impl FnMut(u32) -> S,
 ) -> St
 where
     S::Scratch: crate::int::types::compute_limbs::ComputeLimbs,
 {
     round_to_storage_directed_impl_g::<St, S>(
-        base_guard, target, mode, false, false, st_max, st_min, &mut recompute,
+        base_guard_digits, target, mode, false, false, storage_max, storage_min, &mut recompute,
     )
     .0
 }
@@ -3057,18 +3119,18 @@ where
 /// there. One mechanism serves all six.
 #[inline]
 pub(crate) fn round_to_storage_tail_signed_g<St: BigInt + Copy, S: BigInt>(
-    base_guard: u32,
+    base_guard_digits: u32,
     target: u32,
     mode: RoundingMode,
-    st_max: St,
-    st_min: St,
+    storage_max: St,
+    storage_min: St,
     mut recompute: impl FnMut(u32) -> (S, Option<TailSign>),
 ) -> St
 where
     S::Scratch: crate::int::types::compute_limbs::ComputeLimbs,
 {
     round_to_storage_directed_tagged_impl_g::<St, S>(
-        base_guard, target, mode, false, false, st_max, st_min, &mut recompute,
+        base_guard_digits, target, mode, false, false, storage_max, storage_min, &mut recompute,
     )
     .0
 }
@@ -3080,18 +3142,18 @@ where
 /// wrapper. Bit-identical narrowing — only the discarded boolean differs.
 #[inline]
 pub(crate) fn round_to_storage_directed_decided_g<St: BigInt + Copy, S: BigInt>(
-    base_guard: u32,
+    base_guard_digits: u32,
     target: u32,
     mode: RoundingMode,
-    st_max: St,
-    st_min: St,
+    storage_max: St,
+    storage_min: St,
     mut recompute: impl FnMut(u32) -> S,
 ) -> (St, bool)
 where
     S::Scratch: crate::int::types::compute_limbs::ComputeLimbs,
 {
     round_to_storage_directed_impl_g::<St, S>(
-        base_guard, target, mode, false, false, st_max, st_min, &mut recompute,
+        base_guard_digits, target, mode, false, false, storage_max, storage_min, &mut recompute,
     )
 }
 
@@ -3099,18 +3161,18 @@ where
 /// a zero working residual is a sub-resolution positive residual.
 #[inline]
 pub(crate) fn round_to_storage_directed_never_exact_g<St: BigInt + Copy, S: BigInt>(
-    base_guard: u32,
+    base_guard_digits: u32,
     target: u32,
     mode: RoundingMode,
-    st_max: St,
-    st_min: St,
+    storage_max: St,
+    storage_min: St,
     mut recompute: impl FnMut(u32) -> S,
 ) -> St
 where
     S::Scratch: crate::int::types::compute_limbs::ComputeLimbs,
 {
     round_to_storage_directed_impl_g::<St, S>(
-        base_guard, target, mode, false, true, st_max, st_min, &mut recompute,
+        base_guard_digits, target, mode, false, true, storage_max, storage_min, &mut recompute,
     )
     .0
 }
@@ -3119,18 +3181,18 @@ where
 /// force a confirm recompute even in nearest modes.
 #[inline]
 pub(crate) fn round_to_storage_directed_near_special_g<St: BigInt + Copy, S: BigInt>(
-    base_guard: u32,
+    base_guard_digits: u32,
     target: u32,
     mode: RoundingMode,
-    st_max: St,
-    st_min: St,
+    storage_max: St,
+    storage_min: St,
     mut recompute: impl FnMut(u32) -> S,
 ) -> St
 where
     S::Scratch: crate::int::types::compute_limbs::ComputeLimbs,
 {
     round_to_storage_directed_impl_g::<St, S>(
-        base_guard, target, mode, true, false, st_max, st_min, &mut recompute,
+        base_guard_digits, target, mode, true, false, storage_max, storage_min, &mut recompute,
     )
     .0
 }
@@ -3155,11 +3217,11 @@ where
 #[inline]
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn round_to_storage_directed_widening_g<St: BigInt + Copy, S1: BigInt, S2: BigInt>(
-    base_guard: u32,
+    base_guard_digits: u32,
     target: u32,
     mode: RoundingMode,
-    st_max: St,
-    st_min: St,
+    storage_max: St,
+    storage_min: St,
     mut recompute1: impl FnMut(u32) -> S1,
     mut recompute2: impl FnMut(u32) -> S2,
 ) -> St
@@ -3167,14 +3229,14 @@ where
     S1::Scratch: crate::int::types::compute_limbs::ComputeLimbs,
     S2::Scratch: crate::int::types::compute_limbs::ComputeLimbs,
 {
-    let (v, resolved) = round_to_storage_directed_impl_g::<St, S1>(
-        base_guard, target, mode, false, false, st_max, st_min, &mut recompute1,
+    let (narrowed, resolved) = round_to_storage_directed_impl_g::<St, S1>(
+        base_guard_digits, target, mode, false, false, storage_max, storage_min, &mut recompute1,
     );
     if resolved || <S1 as BigInt>::BITS >= <S2 as BigInt>::BITS {
-        return v;
+        return narrowed;
     }
     round_to_storage_directed_impl_g::<St, S2>(
-        base_guard, target, mode, false, false, st_max, st_min, &mut recompute2,
+        base_guard_digits, target, mode, false, false, storage_max, storage_min, &mut recompute2,
     )
     .0
 }
@@ -3186,11 +3248,11 @@ where
 #[inline]
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn round_to_storage_directed_widening_decided_g<St: BigInt + Copy, S1: BigInt, S2: BigInt>(
-    base_guard: u32,
+    base_guard_digits: u32,
     target: u32,
     mode: RoundingMode,
-    st_max: St,
-    st_min: St,
+    storage_max: St,
+    storage_min: St,
     mut recompute1: impl FnMut(u32) -> S1,
     mut recompute2: impl FnMut(u32) -> S2,
 ) -> (St, bool)
@@ -3198,14 +3260,14 @@ where
     S1::Scratch: crate::int::types::compute_limbs::ComputeLimbs,
     S2::Scratch: crate::int::types::compute_limbs::ComputeLimbs,
 {
-    let (v, resolved) = round_to_storage_directed_impl_g::<St, S1>(
-        base_guard, target, mode, false, false, st_max, st_min, &mut recompute1,
+    let (narrowed, resolved) = round_to_storage_directed_impl_g::<St, S1>(
+        base_guard_digits, target, mode, false, false, storage_max, storage_min, &mut recompute1,
     );
     if resolved || <S1 as BigInt>::BITS >= <S2 as BigInt>::BITS {
-        return (v, resolved);
+        return (narrowed, resolved);
     }
     round_to_storage_directed_impl_g::<St, S2>(
-        base_guard, target, mode, false, false, st_max, st_min, &mut recompute2,
+        base_guard_digits, target, mode, false, false, storage_max, storage_min, &mut recompute2,
     )
 }
 
@@ -3220,11 +3282,11 @@ pub(crate) fn round_to_storage_directed_near_special_widening_g<
     S1: BigInt,
     S2: BigInt,
 >(
-    base_guard: u32,
+    base_guard_digits: u32,
     target: u32,
     mode: RoundingMode,
-    st_max: St,
-    st_min: St,
+    storage_max: St,
+    storage_min: St,
     mut recompute1: impl FnMut(u32) -> S1,
     mut recompute2: impl FnMut(u32) -> S2,
 ) -> St
@@ -3232,14 +3294,14 @@ where
     S1::Scratch: crate::int::types::compute_limbs::ComputeLimbs,
     S2::Scratch: crate::int::types::compute_limbs::ComputeLimbs,
 {
-    let (v, resolved) = round_to_storage_directed_impl_g::<St, S1>(
-        base_guard, target, mode, true, false, st_max, st_min, &mut recompute1,
+    let (narrowed, resolved) = round_to_storage_directed_impl_g::<St, S1>(
+        base_guard_digits, target, mode, true, false, storage_max, storage_min, &mut recompute1,
     );
     if resolved || <S1 as BigInt>::BITS >= <S2 as BigInt>::BITS {
-        return v;
+        return narrowed;
     }
     round_to_storage_directed_impl_g::<St, S2>(
-        base_guard, target, mode, true, false, st_max, st_min, &mut recompute2,
+        base_guard_digits, target, mode, true, false, storage_max, storage_min, &mut recompute2,
     )
     .0
 }
@@ -3253,13 +3315,13 @@ where
 /// `WideTrigCore` trait surface, which already passes `&mut dyn FnMut`.
 #[allow(clippy::too_many_arguments)]
 fn round_to_storage_directed_impl_g<St: BigInt + Copy, S: BigInt>(
-    base_guard: u32,
+    base_guard_digits: u32,
     target: u32,
     mode: RoundingMode,
     force_confirm: bool,
     never_exact: bool,
-    st_max: St,
-    st_min: St,
+    storage_max: St,
+    storage_min: St,
     recompute: &mut dyn FnMut(u32) -> S,
 ) -> (St, bool)
 where
@@ -3268,14 +3330,14 @@ where
     // A kernel that cannot say which side its neglected tail falls on gets
     // `None` at every probe, which is the untagged behaviour exactly.
     round_to_storage_directed_tagged_impl_g::<St, S>(
-        base_guard,
+        base_guard_digits,
         target,
         mode,
         force_confirm,
         never_exact,
-        st_max,
-        st_min,
-        &mut |guard| (recompute(guard), None),
+        storage_max,
+        storage_min,
+        &mut |guard_digits| (recompute(guard_digits), None),
     )
 }
 
@@ -3308,13 +3370,13 @@ where
 /// bit-identical to [`round_to_storage_directed_impl_g`] at every argument.
 #[allow(clippy::too_many_arguments)]
 fn round_to_storage_directed_tagged_impl_g<St: BigInt + Copy, S: BigInt>(
-    base_guard: u32,
+    base_guard_digits: u32,
     target: u32,
     mode: RoundingMode,
     force_confirm: bool,
     never_exact: bool,
-    st_max: St,
-    st_min: St,
+    storage_max: St,
+    storage_min: St,
     recompute: &mut dyn FnMut(u32) -> (S, Option<TailSign>),
 ) -> (St, bool)
 where
@@ -3324,9 +3386,9 @@ where
 
     let lit = |n: i128| <S as BigInt>::from_i128(n);
     let pow10 = |n: u32| crate::consts::pow10::dispatch::<S>(n);
-    let bit_length = |v: S| -> u32 {
-        let m = if v < <S as BigInt>::ZERO { -v } else { v };
-        <S as BigInt>::BITS - m.leading_zeros()
+    let bit_length = |value: S| -> u32 {
+        let magnitude = if value < <S as BigInt>::ZERO { -value } else { value };
+        <S as BigInt>::BITS - magnitude.leading_zeros()
     };
     let floor = pow10(ZIV_RESOLVE_FLOOR_POW10);
     // The near-tie band at guard `g` is `divisor/1000 = 10^(g-3)` — a table
@@ -3360,11 +3422,11 @@ where
         // the deep-tie families the deciding term outruns every reachable
         // depth anyway, so the ladder previously ran to its cap only to hand
         // back this same tag-decided base narrowing.
-        let mut nearest_narrow = |guard: u32| -> (St, S, bool) {
-            let (v, tail) = recompute(guard);
-            let neg = v < lit(0);
-            let mag = if neg { -v } else { v };
-            let divisor = pow10(guard);
+        let mut nearest_narrow = |guard_digits: u32| -> (St, S, bool) {
+            let (working_value, tail) = recompute(guard_digits);
+            let neg = working_value < lit(0);
+            let mag = if neg { -working_value } else { working_value };
+            let divisor = pow10(guard_digits);
             // Exact per-width Knuth scratch (the narrow build's blanket is sized
             // to its 2-limb storage; the walkers probe in `Int<24>`).
             let (q, rem) = crate::algos::exp::exp_generic::div_rem_exact(mag, divisor);
@@ -3401,7 +3463,7 @@ where
                 q
             };
             let signed = if neg { -q_mag } else { q_mag };
-            let narrowed = narrow_range_checked_g::<St, S>(signed, st_max, st_min);
+            let narrowed = narrow_range_checked_g::<St, S>(signed, storage_max, storage_min);
             // `divisor = 10^guard` is even for every guard >= 1 (and the
             // guard-0 degenerate `1/2 == 1 >> 1 == 0`), so the half-ULP
             // boundary is an exact one-bit shift — not a divide.
@@ -3409,7 +3471,7 @@ where
             let dist_half = if rem < half { half - rem } else { rem - half };
             (narrowed, dist_half, tag_decided)
         };
-        let (lo, dist0, decided0) = nearest_narrow(base_guard);
+        let (lo, dist0, decided0) = nearest_narrow(base_guard_digits);
         if decided0 {
             return (lo, true);
         }
@@ -3418,25 +3480,25 @@ where
         // narrowing (bit-identical to the prior single-shot path). The escalate
         // trigger stays the wide band; the absolute `floor` below is only the
         // STOP test (signal vs noise), not the escalate trigger.
-        if !force_confirm && dist0 > band_of(base_guard) {
+        if !force_confirm && dist0 > band_of(base_guard_digits) {
             return (lo, true);
         }
         let int_digits = {
-            let n = BigInt::resize_to::<S>(lo);
-            let m = if n < lit(0) { -n } else { n };
-            let bl = bit_length(m);
-            let storage_digits = (bl as u64 * 30103 / 100_000) as u32 + 1;
+            let narrowed = BigInt::resize_to::<S>(lo);
+            let magnitude = if narrowed < lit(0) { -narrowed } else { narrowed };
+            let magnitude_bits = bit_length(magnitude);
+            let storage_digits = (magnitude_bits as u64 * 30103 / 100_000) as u32 + 1;
             storage_digits.saturating_sub(target)
         };
         let cap_digits = (<S>::BITS / 8).saturating_sub(int_digits + 8);
-        let max_guard = cap_digits
+        let max_guard_digits = cap_digits
             .saturating_sub(target)
             .min(ZIV_PRECISION_HORIZON.saturating_sub(target))
-            .max(base_guard);
-        let mut guard = base_guard;
+            .max(base_guard_digits);
+        let mut guard_digits = base_guard_digits;
         let mut best = lo;
         loop {
-            if guard >= max_guard {
+            if guard_digits >= max_guard_digits {
                 // Cap reached without clearing the noise floor. `force_confirm`
                 // (acosh/atanh) trusts its last stable narrowing; otherwise the
                 // deciding digit is below the work integer's / the crate's reach
@@ -3445,17 +3507,17 @@ where
                 // narrowing (which is dominated by kernel noise at this depth).
                 return (if force_confirm { best } else { lo }, false);
             }
-            let step = (target + base_guard).max(base_guard);
-            let unclamped = guard.saturating_add(step);
-            let next_guard = unclamped.min(max_guard);
+            let step = (target + base_guard_digits).max(base_guard_digits);
+            let unclamped = guard_digits.saturating_add(step);
+            let next_guard_digits = unclamped.min(max_guard_digits);
             // A probe whose depth was CLAMPED by this width's escalation cap
             // diverges from the canonical (tier-width) probe sequence — any
             // conclusion drawn from it is reported UNRESOLVED so a two-width
             // caller falls up to the tier walker instead of trusting a
             // cap-limited reading (e.g. a zero remainder that is only the
             // deciding term underflowing at the clamped working scale).
-            let tainted = unclamped > max_guard;
-            let (hi, hi_dist, hi_decided) = nearest_narrow(next_guard);
+            let tainted = unclamped > max_guard_digits;
+            let (hi, hi_dist, hi_decided) = nearest_narrow(next_guard_digits);
             // A tag-decided probe is a proof at WHATEVER depth it fired —
             // clamping cannot taint it (the tag belongs to the probe that
             // produced it, not to the canonical probe sequence), and no
@@ -3475,17 +3537,17 @@ where
                 // probe depth).
                 return (hi, !tainted);
             }
-            guard = next_guard;
+            guard_digits = next_guard_digits;
             best = hi;
         }
     }
 
-    let mut directed_narrow = |guard: u32| -> (S, S) {
-        let w = target + guard;
-        let (v, tail) = recompute(guard);
-        let shift = w - target;
-        let neg = v < lit(0);
-        let mag = if neg { -v } else { v };
+    let mut directed_narrow = |guard_digits: u32| -> (S, S) {
+        let working_scale = target + guard_digits;
+        let (working_value, tail) = recompute(guard_digits);
+        let shift = working_scale - target;
+        let neg = working_value < lit(0);
+        let mag = if neg { -working_value } else { working_value };
         let divisor = pow10(shift);
         // Exact per-width Knuth scratch (the narrow build's blanket is sized
         // to its 2-limb storage; the walkers probe in `Int<24>`).
@@ -3534,9 +3596,9 @@ where
         (signed, dist)
     };
 
-    let (mut lo, dist0) = directed_narrow(base_guard);
+    let (mut lo, dist0) = directed_narrow(base_guard_digits);
 
-    let band0 = band_of(base_guard);
+    let band0 = band_of(base_guard_digits);
     let near_grid = force_confirm || dist0 <= band0;
 
     let (signed, decided) = if !near_grid {
@@ -3547,9 +3609,9 @@ where
         // `lo` through the deeper probes.
         let base = lo;
         let int_digits = {
-            let m = if lo < lit(0) { -lo } else { lo };
-            let bl = bit_length(m);
-            let storage_digits = (bl as u64 * 30103 / 100_000) as u32 + 1;
+            let magnitude = if lo < lit(0) { -lo } else { lo };
+            let magnitude_bits = bit_length(magnitude);
+            let storage_digits = (magnitude_bits as u64 * 30103 / 100_000) as u32 + 1;
             storage_digits.saturating_sub(target)
         };
         // DELIBERATELY the bare `BITS/8` work-integer cap — NOT `.min(
@@ -3572,9 +3634,9 @@ where
         // per width to ≈`BITS/8`), so probing to it never requests a const
         // past the generated table.
         let cap_digits = (<S>::BITS / 8).saturating_sub(int_digits + 8);
-        let max_guard = cap_digits.saturating_sub(target).max(base_guard);
+        let max_guard_digits = cap_digits.saturating_sub(target).max(base_guard_digits);
 
-        let mut guard = base_guard;
+        let mut guard_digits = base_guard_digits;
         // Whether the LAST probe's grid-line distance cleared the absolute
         // noise floor — a genuine, representable deciding digit (a real
         // residual only GROWS with depth, so a final floor-clearing probe is
@@ -3583,7 +3645,7 @@ where
         // visible exactly at the rung's cap-clamped probe).
         let mut last_resolved = false;
         loop {
-            if guard >= max_guard {
+            if guard_digits >= max_guard_digits {
                 // Cap reached. `force_confirm` (acosh/atanh) trusts its
                 // last stable narrowing. A walk whose FINAL probe resolved
                 // (cleared the noise floor) but had no deeper probe left to
@@ -3601,14 +3663,14 @@ where
                 // exp(-62.175…) D38 s17–19 Ceiling/Floor inversion).
                 break (if force_confirm || last_resolved { lo } else { base }, false);
             }
-            let step = (target + base_guard).max(base_guard);
-            let unclamped = guard.saturating_add(step);
-            let next_guard = unclamped.min(max_guard);
+            let step = (target + base_guard_digits).max(base_guard_digits);
+            let unclamped = guard_digits.saturating_add(step);
+            let next_guard_digits = unclamped.min(max_guard_digits);
             // See the nearest branch: a cap-clamped probe departs from the
             // canonical probe sequence, so its conclusion is reported
             // UNRESOLVED for the two-width fall-up.
-            let tainted = unclamped > max_guard;
-            let (hi, hi_dist) = directed_narrow(next_guard);
+            let tainted = unclamped > max_guard_digits;
+            let (hi, hi_dist) = directed_narrow(next_guard_digits);
             // A deciding digit is a genuine SIGNAL once its distance to the
             // grid line clears the ABSOLUTE kernel-noise floor — the same
             // rule the nearest branch applies to its half-boundary
@@ -3630,7 +3692,7 @@ where
             // the right directed answer; `hi == lo` confirms a second,
             // independent depth reached the same conclusion. This is sound
             // for every CURRENT ladder: the step formula (`target +
-            // base_guard`, ≥68 digits in the wide tiers) spans a 10^68×
+            // base_guard_digits`, ≥68 digits in the wide tiers) spans a 10^68×
             // depth gap, making coincidental paired exact-zero remainders
             // impossible unless the residual is genuinely sub-resolution to
             // the ZIV_PRECISION_HORIZON. A future ladder with a stride SHORT
@@ -3644,13 +3706,13 @@ where
             if hi == lo && resolved {
                 break (hi, !tainted);
             }
-            guard = next_guard;
+            guard_digits = next_guard_digits;
             lo = hi;
             last_resolved = resolved;
         }
     };
 
-    (narrow_range_checked_g::<St, S>(signed, st_max, st_min), decided)
+    (narrow_range_checked_g::<St, S>(signed, storage_max, storage_min), decided)
 }
 
 // Directed-walker contract tests: a strictly positive SUB-RESOLUTION
@@ -3710,10 +3772,10 @@ mod directed_walker_contract {
     #[test]
     fn sub_resolution_positive_resolves_correctly_despite_poisoned_tail() {
         for mode in ALL_MODES {
-            let got = run(mode, |g| {
-                let v = <S as BigInt>::from_i128(995)
-                    * crate::consts::pow10::dispatch::<S>(g - BASE_GUARD);
-                if g >= POISON_FROM { -v } else { v }
+            let got = run(mode, |guard_digits| {
+                let probe_value = <S as BigInt>::from_i128(995)
+                    * crate::consts::pow10::dispatch::<S>(guard_digits - BASE_GUARD);
+                if guard_digits >= POISON_FROM { -probe_value } else { probe_value }
             });
             let want = if mode == RoundingMode::Ceiling { 1 } else { 0 };
             assert_eq!(got, want, "sub-resolution positive, mode={mode:?}");
@@ -3729,9 +3791,9 @@ mod directed_walker_contract {
     #[test]
     fn unresolved_cap_returns_clean_base_not_deepest_probe() {
         for mode in ALL_MODES {
-            let got = run(mode, |g| {
-                let v = <S as BigInt>::from_i128(5);
-                if g >= POISON_FROM { -v } else { v }
+            let got = run(mode, |guard_digits| {
+                let probe_value = <S as BigInt>::from_i128(5);
+                if guard_digits >= POISON_FROM { -probe_value } else { probe_value }
             });
             let want = if mode == RoundingMode::Ceiling { 1 } else { 0 };
             assert_eq!(got, want, "noise-scale residual at cap, mode={mode:?}");
@@ -3741,7 +3803,7 @@ mod directed_walker_contract {
     // A deciding digit first visible ONLY at the cap-clamped final probe —
     // the asin(1e-38) D38<38> shape (CI fallout of the cap-endgame fix):
     // value = 1 ULP + 1.667e-77 ULPs, walked at the D57 borrow path's
-    // Int<16> rung (max_guard = 128 − 8 − 38 = 82, first probe 30+68 = 98
+    // Int<16> rung (max_guard_digits = 128 − 8 − 38 = 82, first probe 30+68 = 98
     // clamped to 82). The base probe lands EXACTLY on grid (the deviation
     // is below w = 68's resolution); the single cap-clamped probe shows the
     // genuine residual (1.667e5 work units, above the noise floor) — the
@@ -3762,13 +3824,13 @@ mod directed_walker_contract {
                 mode,
                 St::MAX,
                 St::MIN,
-                |g| {
+                |guard_digits| {
                     // 10^g + ⌊1.667·10^(g−77)⌋ — the deviation appears at
                     // ULP-depth 77 (asin's x³/6 for x = 1e-38).
-                    let one = crate::consts::pow10::dispatch::<Rung>(g);
-                    if g >= 80 {
+                    let one = crate::consts::pow10::dispatch::<Rung>(guard_digits);
+                    if guard_digits >= 80 {
                         one + <Rung as BigInt>::from_i128(1667)
-                            * crate::consts::pow10::dispatch::<Rung>(g - 80)
+                            * crate::consts::pow10::dispatch::<Rung>(guard_digits - 80)
                     } else {
                         one
                     }
@@ -3812,29 +3874,29 @@ mod tiny_x_directed_pins {
     /// the toward-zero directed modes. The three nearest modes round to `x`.
     macro_rules! pin {
         ($scale:literal, $kneg:literal, $f:ident, $expanding:expr, $label:literal) => {{
-            let r = Int::<8>::from_i128(3)
+            let x_raw = Int::<8>::from_i128(3)
                 * crate::consts::pow10::dispatch::<Int<8>>($scale - $kneg);
-            let x = crate::D::<Int<8>, $scale>(r);
-            let nr = -r;
-            let nx = crate::D::<Int<8>, $scale>(nr);
-            for m in [HalfToEven, HalfAwayFromZero, HalfTowardZero] {
-                assert_eq!(x.$f(m).0, r, "{} (+x) {:?}", $label, m);
-                assert_eq!(nx.$f(m).0, nr, "{} (−x) {:?}", $label, m);
+            let x = crate::D::<Int<8>, $scale>(x_raw);
+            let neg_x_raw = -x_raw;
+            let neg_x = crate::D::<Int<8>, $scale>(neg_x_raw);
+            for mode in [HalfToEven, HalfAwayFromZero, HalfTowardZero] {
+                assert_eq!(x.$f(mode).0, x_raw, "{} (+x) {:?}", $label, mode);
+                assert_eq!(neg_x.$f(mode).0, neg_x_raw, "{} (−x) {:?}", $label, mode);
             }
             if $expanding {
-                assert_eq!(x.$f(Ceiling).0, r + ULP, "{} (+x) Ceiling", $label);
-                assert_eq!(x.$f(Floor).0, r, "{} (+x) Floor", $label);
-                assert_eq!(x.$f(Trunc).0, r, "{} (+x) Trunc", $label);
-                assert_eq!(nx.$f(Floor).0, nr - ULP, "{} (−x) Floor", $label);
-                assert_eq!(nx.$f(Ceiling).0, nr, "{} (−x) Ceiling", $label);
-                assert_eq!(nx.$f(Trunc).0, nr, "{} (−x) Trunc", $label);
+                assert_eq!(x.$f(Ceiling).0, x_raw + ULP, "{} (+x) Ceiling", $label);
+                assert_eq!(x.$f(Floor).0, x_raw, "{} (+x) Floor", $label);
+                assert_eq!(x.$f(Trunc).0, x_raw, "{} (+x) Trunc", $label);
+                assert_eq!(neg_x.$f(Floor).0, neg_x_raw - ULP, "{} (−x) Floor", $label);
+                assert_eq!(neg_x.$f(Ceiling).0, neg_x_raw, "{} (−x) Ceiling", $label);
+                assert_eq!(neg_x.$f(Trunc).0, neg_x_raw, "{} (−x) Trunc", $label);
             } else {
-                assert_eq!(x.$f(Floor).0, r - ULP, "{} (+x) Floor", $label);
-                assert_eq!(x.$f(Trunc).0, r - ULP, "{} (+x) Trunc", $label);
-                assert_eq!(x.$f(Ceiling).0, r, "{} (+x) Ceiling", $label);
-                assert_eq!(nx.$f(Ceiling).0, nr + ULP, "{} (−x) Ceiling", $label);
-                assert_eq!(nx.$f(Trunc).0, nr + ULP, "{} (−x) Trunc", $label);
-                assert_eq!(nx.$f(Floor).0, nr, "{} (−x) Floor", $label);
+                assert_eq!(x.$f(Floor).0, x_raw - ULP, "{} (+x) Floor", $label);
+                assert_eq!(x.$f(Trunc).0, x_raw - ULP, "{} (+x) Trunc", $label);
+                assert_eq!(x.$f(Ceiling).0, x_raw, "{} (+x) Ceiling", $label);
+                assert_eq!(neg_x.$f(Ceiling).0, neg_x_raw + ULP, "{} (−x) Ceiling", $label);
+                assert_eq!(neg_x.$f(Trunc).0, neg_x_raw + ULP, "{} (−x) Trunc", $label);
+                assert_eq!(neg_x.$f(Floor).0, neg_x_raw, "{} (−x) Floor", $label);
             }
         }};
     }
@@ -3890,33 +3952,33 @@ mod tiny_x_deep_directed_pins {
     /// per the deciding term's sign.
     macro_rules! pin_deep {
         ($scale:literal, $kneg:literal, $f:ident, $expanding:expr, $label:literal) => {{
-            let r = Int::<32>::from_i128(3)
+            let x_raw = Int::<32>::from_i128(3)
                 * crate::consts::pow10::dispatch::<Int<32>>($scale - $kneg);
-            let x = crate::D::<Int<32>, $scale>(r);
-            let nx = crate::D::<Int<32>, $scale>(-r);
+            let x = crate::D::<Int<32>, $scale>(x_raw);
+            let neg_x = crate::D::<Int<32>, $scale>(-x_raw);
             let g = x.$f(HalfToEven).0; // the on-grid nearest value
-            let ng = nx.$f(HalfToEven).0;
+            let ng = neg_x.$f(HalfToEven).0;
             // Deep-band signature: the nearest value is the terminating partial
             // sum, strictly off the raw linear term `x`.
-            assert_ne!(g, r, "{}: expected the DEEP band (G != x)", $label);
-            for m in [HalfToEven, HalfAwayFromZero, HalfTowardZero] {
-                assert_eq!(x.$f(m).0, g, "{} (+x) {:?}", $label, m);
-                assert_eq!(nx.$f(m).0, ng, "{} (−x) {:?}", $label, m);
+            assert_ne!(g, x_raw, "{}: expected the DEEP band (G != x)", $label);
+            for mode in [HalfToEven, HalfAwayFromZero, HalfTowardZero] {
+                assert_eq!(x.$f(mode).0, g, "{} (+x) {:?}", $label, mode);
+                assert_eq!(neg_x.$f(mode).0, ng, "{} (−x) {:?}", $label, mode);
             }
             if $expanding {
                 assert_eq!(x.$f(Ceiling).0, g + ULP, "{} (+x) Ceiling", $label);
                 assert_eq!(x.$f(Floor).0, g, "{} (+x) Floor", $label);
                 assert_eq!(x.$f(Trunc).0, g, "{} (+x) Trunc", $label);
-                assert_eq!(nx.$f(Floor).0, ng - ULP, "{} (−x) Floor", $label);
-                assert_eq!(nx.$f(Ceiling).0, ng, "{} (−x) Ceiling", $label);
-                assert_eq!(nx.$f(Trunc).0, ng, "{} (−x) Trunc", $label);
+                assert_eq!(neg_x.$f(Floor).0, ng - ULP, "{} (−x) Floor", $label);
+                assert_eq!(neg_x.$f(Ceiling).0, ng, "{} (−x) Ceiling", $label);
+                assert_eq!(neg_x.$f(Trunc).0, ng, "{} (−x) Trunc", $label);
             } else {
                 assert_eq!(x.$f(Floor).0, g - ULP, "{} (+x) Floor", $label);
                 assert_eq!(x.$f(Trunc).0, g - ULP, "{} (+x) Trunc", $label);
                 assert_eq!(x.$f(Ceiling).0, g, "{} (+x) Ceiling", $label);
-                assert_eq!(nx.$f(Ceiling).0, ng + ULP, "{} (−x) Ceiling", $label);
-                assert_eq!(nx.$f(Trunc).0, ng + ULP, "{} (−x) Trunc", $label);
-                assert_eq!(nx.$f(Floor).0, ng, "{} (−x) Floor", $label);
+                assert_eq!(neg_x.$f(Ceiling).0, ng + ULP, "{} (−x) Ceiling", $label);
+                assert_eq!(neg_x.$f(Trunc).0, ng + ULP, "{} (−x) Trunc", $label);
+                assert_eq!(neg_x.$f(Floor).0, ng, "{} (−x) Floor", $label);
             }
         }};
     }

--- a/src/algos/trig/angle_mul_pi_ratio.rs
+++ b/src/algos/trig/angle_mul_pi_ratio.rs
@@ -28,12 +28,12 @@ pub(crate) fn to_degrees_mul_pi_ratio<C: WideTrigCore, const SCALE: u32>(
     raw: C::Storage,
     mode: RoundingMode,
 ) -> C::Storage {
-    let w = SCALE + C::GUARD;
-    let v = C::to_work(raw);
+    let working_scale = SCALE + C::GUARD;
+    let working_value = C::to_work(raw);
     // `x * 180/π`: multiply by the exact oracle `deg_per_rad` factor
     // instead of dividing by `π` (the divide was the main cost).
-    let r = C::mul(v, C::deg_per_rad::<SCALE>(w), w);
-    C::round_to_storage_with(r, w, SCALE, mode)
+    let degrees = C::mul(working_value, C::deg_per_rad::<SCALE>(working_scale), working_scale);
+    C::round_to_storage_with(degrees, working_scale, SCALE, mode)
 }
 
 /// `MulPiRatio` to_radians for a wide tier -- `x * pi / 180` in the
@@ -44,11 +44,11 @@ pub(crate) fn to_radians_mul_pi_ratio<C: WideTrigCore, const SCALE: u32>(
     raw: C::Storage,
     mode: RoundingMode,
 ) -> C::Storage {
-    let w = SCALE + C::GUARD;
-    let v = C::to_work(raw);
+    let working_scale = SCALE + C::GUARD;
+    let working_value = C::to_work(raw);
     // `x * π/180`: multiply by the exact oracle `rad_per_deg` factor.
-    let r = C::mul(v, C::rad_per_deg::<SCALE>(w), w);
-    C::round_to_storage_with(r, w, SCALE, mode)
+    let radians = C::mul(working_value, C::rad_per_deg::<SCALE>(working_scale), working_scale);
+    C::round_to_storage_with(radians, working_scale, SCALE, mode)
 }
 
 // ── Unit tests: the MulPiRatio kernel is bit-exact against the routed
@@ -87,18 +87,18 @@ mod tests {
 
         #[test]
         fn to_degrees_to_radians_mul_pi_ratio_match_routed() {
-            for &u in &INPUTS9 {
-                let r = raw9(u);
+            for &units in &INPUTS9 {
+                let raw = raw9(units);
                 for &mode in &MODES {
                     assert_eq!(
-                        to_degrees_mul_pi_ratio::<Core, S>(r, mode),
-                        D::<Int<3>, S>(r).to_degrees_strict_with(mode).0,
-                        "D57 to_degrees MulPiRatio != routed at units={u} mode={mode:?}"
+                        to_degrees_mul_pi_ratio::<Core, S>(raw, mode),
+                        D::<Int<3>, S>(raw).to_degrees_strict_with(mode).0,
+                        "D57 to_degrees MulPiRatio != routed at units={units} mode={mode:?}"
                     );
                     assert_eq!(
-                        to_radians_mul_pi_ratio::<Core, S>(r, mode),
-                        D::<Int<3>, S>(r).to_radians_strict_with(mode).0,
-                        "D57 to_radians MulPiRatio != routed at units={u} mode={mode:?}"
+                        to_radians_mul_pi_ratio::<Core, S>(raw, mode),
+                        D::<Int<3>, S>(raw).to_radians_strict_with(mode).0,
+                        "D57 to_radians MulPiRatio != routed at units={units} mode={mode:?}"
                     );
                 }
             }

--- a/src/algos/trig/angle_schoolbook.rs
+++ b/src/algos/trig/angle_schoolbook.rs
@@ -33,10 +33,14 @@ pub(crate) fn to_degrees_schoolbook<C: WideTrigCore, const SCALE: u32>(
     raw: C::Storage,
     mode: RoundingMode,
 ) -> C::Storage {
-    let w = SCALE + C::GUARD;
-    let v = C::to_work(raw);
-    let r = C::div(v * C::lit(180), C::pi::<SCALE>(w), w);
-    C::round_to_storage_with(r, w, SCALE, mode)
+    let working_scale = SCALE + C::GUARD;
+    let working_value = C::to_work(raw);
+    let degrees = C::div(
+        working_value * C::lit(180),
+        C::pi::<SCALE>(working_scale),
+        working_scale,
+    );
+    C::round_to_storage_with(degrees, working_scale, SCALE, mode)
 }
 
 /// Schoolbook to_radians for a wide tier -- x * pi / 180.
@@ -46,10 +50,11 @@ pub(crate) fn to_radians_schoolbook<C: WideTrigCore, const SCALE: u32>(
     raw: C::Storage,
     mode: RoundingMode,
 ) -> C::Storage {
-    let w = SCALE + C::GUARD;
-    let v = C::to_work(raw);
-    let r = C::mul(v, C::pi::<SCALE>(w), w) / C::lit(180);
-    C::round_to_storage_with(r, w, SCALE, mode)
+    let working_scale = SCALE + C::GUARD;
+    let working_value = C::to_work(raw);
+    let radians =
+        C::mul(working_value, C::pi::<SCALE>(working_scale), working_scale) / C::lit(180);
+    C::round_to_storage_with(radians, working_scale, SCALE, mode)
 }
 
 // -- Narrow tier -- Int<2> storage, math in the 256-bit Fixed ---------
@@ -60,11 +65,11 @@ fn to_degrees_schoolbook_raw<const SCALE: u32>(raw: i128, mode: RoundingMode) ->
     if raw == 0 {
         return 0;
     }
-    let w = SCALE + STRICT_GUARD;
+    let working_scale = SCALE + STRICT_GUARD;
     to_fixed(raw)
         .mul_u128(180)
-        .div(wide_pi(w), w)
-        .round_to_i128_with(w, SCALE, mode)
+        .div(wide_pi(working_scale), working_scale)
+        .round_to_i128_with(working_scale, SCALE, mode)
         .unwrap_or_else(|| {
             crate::support::diagnostics::overflow_panic_with_scale("to_degrees", SCALE)
         })
@@ -76,11 +81,11 @@ fn to_radians_schoolbook_raw<const SCALE: u32>(raw: i128, mode: RoundingMode) ->
     if raw == 0 {
         return 0;
     }
-    let w = SCALE + STRICT_GUARD;
+    let working_scale = SCALE + STRICT_GUARD;
     to_fixed(raw)
-        .mul(wide_pi(w), w)
+        .mul(wide_pi(working_scale), working_scale)
         .div_small(180)
-        .round_to_i128_with(w, SCALE, mode)
+        .round_to_i128_with(working_scale, SCALE, mode)
         .unwrap_or_else(|| {
             crate::support::diagnostics::overflow_panic_with_scale("to_radians", SCALE)
         })
@@ -183,18 +188,18 @@ mod tests {
 
         #[test]
         fn to_degrees_to_radians_schoolbook_match_routed() {
-            for &u in &INPUTS9 {
-                let r = raw9(u);
+            for &units in &INPUTS9 {
+                let raw = raw9(units);
                 for &mode in &MODES {
                     assert_eq!(
-                        to_degrees_schoolbook::<Core, S>(r, mode),
-                        D::<Int<3>, S>(r).to_degrees_strict_with(mode).0,
-                        "D57 to_degrees schoolbook != routed at units={u} mode={mode:?}"
+                        to_degrees_schoolbook::<Core, S>(raw, mode),
+                        D::<Int<3>, S>(raw).to_degrees_strict_with(mode).0,
+                        "D57 to_degrees schoolbook != routed at units={units} mode={mode:?}"
                     );
                     assert_eq!(
-                        to_radians_schoolbook::<Core, S>(r, mode),
-                        D::<Int<3>, S>(r).to_radians_strict_with(mode).0,
-                        "D57 to_radians schoolbook != routed at units={u} mode={mode:?}"
+                        to_radians_schoolbook::<Core, S>(raw, mode),
+                        D::<Int<3>, S>(raw).to_radians_strict_with(mode).0,
+                        "D57 to_radians schoolbook != routed at units={units} mode={mode:?}"
                     );
                 }
             }

--- a/src/algos/trig/atan_tang_3limb_s44_56.rs
+++ b/src/algos/trig/atan_tang_3limb_s44_56.rs
@@ -5,10 +5,10 @@
 //! `SCALE ∈ 44..=56`.
 //!
 //! At deep storage scales the wide-tier `atan_fixed` runs an
-//! `O(log w)` halving chain (each `atan(x) = 2·atan(x/(1+√(1+x²)))`
+//! `O(log working_scale)` halving chain (each `atan(x) = 2·atan(x/(1+√(1+x²)))`
 //! costs one wide sqrt + one wide div + one wide mul) followed by a
-//! Taylor evaluation on the post-halving residual. With `w = SCALE +
-//! GUARD = 74..=87` and the per-tier halving cap at 7, the halving
+//! Taylor evaluation on the post-halving residual. With `working_scale =
+//! SCALE + GUARD = 74..=87` and the per-tier halving cap at 7, the halving
 //! chain itself burns ~7 wide sqrts (each ~1.2 µs at D57<57>) before
 //! the Taylor loop runs ~30 terms — and every iteration of every
 //! kernel goes through the same `Int<16> / Int<16>` Knuth divide that
@@ -24,7 +24,7 @@
 //! With `M = 512` and `x ∈ [0, 1]` (the existing reciprocal-fold for
 //! `|x| > 1` is preserved), choosing `j = round(x · M)` gives
 //! `|y| ≤ 1/(2M) = 1/1024 ≈ 9.8·10⁻⁴`. The Taylor remainder then
-//! converges in ~15 terms at `w ≤ 87`, vs the 7 halvings + ~30 terms
+//! converges in ~15 terms at `working_scale ≤ 87`, vs the 7 halvings + ~30 terms
 //! the generic path runs.
 //!
 //! The slot is exposed through `crate::policy::trig`
@@ -34,19 +34,19 @@
 //!
 //! ## Correctness
 //!
-//! Error budget at working scale `w` (in LSB-of-`w`):
+//! Error budget at `working_scale` (in LSB-of-`working_scale`):
 //!
 //! - Reciprocal-fold `1/x` (when `|x| > 1`): ≤ 0.5 LSB.
 //! - Table index quantisation `c_j = j/M`: exact (integer division
-//!   of `one(w)` by small `M`, ≤ 0.5 LSB).
+//!   of `one(working_scale)` by small `M`, ≤ 0.5 LSB).
 //! - `y = (x − c_j) / (1 + c_j · x)`: 1 mul + 1 div + 2 add/sub
 //!   → ≤ 1.5 LSB.
 //! - Taylor on `|y| ≤ 1/(2M) ≈ 10⁻³`: ~15 rounded muls → ≤ 7.5 LSB.
 //! - Table lookup `atan(c_j)`: precomputed by the generic
-//!   `atan_fixed` at the same `w`, ≤ 1 LSB after rounding.
+//!   `atan_fixed` at the same `working_scale`, ≤ 1 LSB after rounding.
 //! - One outer add (`atan(c_j) + atan(y)`): ≤ 0.5 LSB.
 //!
-//! Total ≤ ~11 LSB-of-`w` = ~11·10⁻³⁰ at storage scale. The strict
+//! Total ≤ ~11 LSB-of-`working_scale` = ~11·10⁻³⁰ at storage scale. The strict
 //! contract requires ≤ 0.5 LSB-of-storage = 0.5·10⁻ᴿᴱ — a margin of
 //! 28+ orders of magnitude even at `SCALE = 57`.
 
@@ -71,22 +71,23 @@ use crate::int::types::Int;
 ///
 const M: u32 = atan_tang_table::ATAN_TANG_M;
 
-/// `atan(idx / M)` at working scale `w` — the single table slot the
+/// `atan(idx / M)` at `working_scale` — the single table slot the
 /// kernel needs (`idx ∈ [0, M]`). idx = 0 → atan(0) = 0.
 ///
 /// Reads the value from the BAKED binary Tang table
 /// [`atan_tang_table::atan_table_entry_baked`]: the `M + 1` values
 /// `atan(j/M)` are precomputed ONCE by an mpmath oracle as binary
 /// fixed-point `round(atan(j/M) · 2^B)` (committed rodata), then SLICED
-/// to the tier's needed precision and reconstructed to working scale `w`
+/// to the tier's needed precision and reconstructed to `working_scale`
 /// per call — one multiply + one shift. This replaces the previous
 /// per-call `core::atan_fixed` halving-chain Series recompute, which the
 /// samply probe showed dominated the kernel (~74% of total time at
-/// D57<56>). `pow10_w` is `10^w` in the work integer, supplied by the
-/// caller from the kernel's baked `core::one(w)` table lookup.
+/// D57<56>). `pow10_w` is `10^working_scale` in the work integer, supplied
+/// by the caller from the kernel's baked `core::one(working_scale)` table
+/// lookup.
 #[inline]
-fn table_entry(w: u32, idx: usize, pow10_w: core::W) -> core::W {
-    atan_tang_table::atan_table_entry_baked::<core::W>(w, idx, M, pow10_w)
+fn table_entry(working_scale: u32, idx: usize, pow10_w: core::W) -> core::W {
+    atan_tang_table::atan_table_entry_baked::<core::W>(working_scale, idx, M, pow10_w)
 }
 
 /// `atan(x)` strict kernel for `D57<SCALE>` with `SCALE ∈ 44..=56`.
@@ -109,15 +110,15 @@ pub(crate) fn atan_strict<const SCALE: u32>(raw: Int<3>, mode: RoundingMode) -> 
         return Int::<3>::ZERO;
     }
 
-    let w = SCALE + core::GUARD;
-    let v_w = core::to_work(raw);
-    let one_w = core::one(w);
+    let working_scale = SCALE + core::GUARD;
+    let working_value = core::to_work(raw);
+    let one_w = core::one(working_scale);
     let pow10_w = one_w;
 
     // Stage 1: sign + reciprocal fold so the table-reduced argument
     // sits in [0, 1].
-    let sign_neg = v_w < core::zero();
-    let mut x = if sign_neg { -v_w } else { v_w };
+    let sign_neg = working_value < core::zero();
+    let mut x = if sign_neg { -working_value } else { working_value };
     let add_half_pi = x > one_w;
     if add_half_pi {
         x = core::div_cached(one_w, x, pow10_w);
@@ -125,10 +126,10 @@ pub(crate) fn atan_strict<const SCALE: u32>(raw: Int<3>, mode: RoundingMode) -> 
 
     // Stage 2: pick the nearest table entry. `j` is in [0, M].
     // x · M / one_w → integer in [0, M]. We compute it via
-    // `round_to_nearest_int(x · M, w)` so the rounding is half-away
+    // `round_to_nearest_int(x · M, working_scale)` so the rounding is half-away
     // from zero (matching the existing core helper).
     let x_times_m = x * core::lit(M as u128);
-    let j_signed = core::round_to_nearest_int(x_times_m, w);
+    let j_signed = core::round_to_nearest_int(x_times_m, working_scale);
     // Clamp j to [0, M-1] — at x = 1.0 exactly the round would
     // produce M, which is out of the table's range. Folding j = M
     // into j = M - 1 keeps |y| ≤ 1/M ≈ 2·10⁻³, still well below the
@@ -142,7 +143,7 @@ pub(crate) fn atan_strict<const SCALE: u32>(raw: Int<3>, mode: RoundingMode) -> 
         j_signed as u32
     };
 
-    // c_j at working scale.
+    // c_j at the working scale.
     let cj_w = if j_idx == 0 {
         core::zero()
     } else {
@@ -154,7 +155,7 @@ pub(crate) fn atan_strict<const SCALE: u32>(raw: Int<3>, mode: RoundingMode) -> 
         x
     } else {
         let numer = x - cj_w;
-        let denom = one_w + core::mul(cj_w, x, w);
+        let denom = one_w + core::mul(cj_w, x, working_scale);
         core::div_cached(numer, denom, pow10_w)
     };
 
@@ -162,28 +163,28 @@ pub(crate) fn atan_strict<const SCALE: u32>(raw: Int<3>, mode: RoundingMode) -> 
     //   y − y³/3 + y⁵/5 − …
     //
     // For M = 512, |y| ≤ 1/(2M) ≈ 9.8·10⁻⁴, so |y²| ≤ ~10⁻⁶. Each
-    // pair of terms shrinks by |y|² / (2k+1), so the loop exits on a
-    // zero term in ~15 iterations at w ≤ 87. Mirrors
-    // [`core::atan_taylor`]; the `÷10^w` reduce goes through the fast
-    // MG `core::mul` (`round_div_pow10`).
+    // pair of terms shrinks by |y|² / (2·term_index+1), so the loop exits
+    // on a zero term in ~15 iterations at `working_scale ≤ 87`. Mirrors
+    // [`core::atan_taylor`]; the `÷10^working_scale` reduce goes through
+    // the fast MG `core::mul` (`round_div_pow10`).
     let atan_y = {
-        let y2 = core::mul(y, y, w);
+        let y_squared = core::mul(y, y, working_scale);
         let mut sum = y;
         let mut term = y;
-        let mut k: u128 = 1;
+        let mut term_index: u128 = 1;
         loop {
-            term = core::mul(term, y2, w);
-            let contrib = term / core::lit(2 * k + 1);
+            term = core::mul(term, y_squared, working_scale);
+            let contrib = term / core::lit(2 * term_index + 1);
             if contrib == core::zero() {
                 break;
             }
-            if k % 2 == 1 {
+            if term_index % 2 == 1 {
                 sum = sum - contrib;
             } else {
                 sum = sum + contrib;
             }
-            k += 1;
-            if k > 200 {
+            term_index += 1;
+            if term_index > 200 {
                 break;
             }
         }
@@ -191,11 +192,11 @@ pub(crate) fn atan_strict<const SCALE: u32>(raw: Int<3>, mode: RoundingMode) -> 
     };
 
     // atan(|x|) = table[j_idx] + atan(y).
-    let atan_abs_x = table_entry(w, j_idx as usize, pow10_w) + atan_y;
+    let atan_abs_x = table_entry(working_scale, j_idx as usize, pow10_w) + atan_y;
 
     // Stage 4: undo the reciprocal fold then the sign.
     let mut result = if add_half_pi {
-        core::half_pi::<SCALE>(w) - atan_abs_x
+        core::half_pi::<SCALE>(working_scale) - atan_abs_x
     } else {
         atan_abs_x
     };
@@ -204,13 +205,13 @@ pub(crate) fn atan_strict<const SCALE: u32>(raw: Int<3>, mode: RoundingMode) -> 
     }
 
     // Near-tie escape — see `wide_trig_core::tan_series` / the asin(3e-60)
-    // family: a fixed-w single shot cannot see a deciding digit below w.
-    // Clear-of-band residuals keep the single-shot cost; the band falls to
-    // the Ziv-escalating generic kernel (rare).
+    // family: a fixed-working-scale single shot cannot see a deciding digit
+    // below the working scale. Clear-of-band residuals keep the single-shot
+    // cost; the band falls to the Ziv-escalating generic kernel (rare).
     match crate::algos::support::wide_trig_core::round_to_storage_clear_of_tie_g::<Int<3>, _>(
-        result, w, SCALE, mode, Int::<3>::MAX, Int::<3>::MIN,
+        result, working_scale, SCALE, mode, Int::<3>::MAX, Int::<3>::MIN,
     ) {
-        Some(st) => st,
+        Some(rounded) => rounded,
         None => crate::algos::support::wide_trig_core::atan_series::<
             crate::types::widths::wide_trig_d57::Core,
             SCALE,

--- a/src/algos/trig/hyper_exp_identity.rs
+++ b/src/algos/trig/hyper_exp_identity.rs
@@ -10,11 +10,11 @@
 //! magnitude more:
 //!
 //! ```text
-//! ex  = exp(v)
-//! enx = 1 / ex              (exp(-v) identity)
-//! sinh = (ex - enx) / 2
-//! cosh = (ex + enx) / 2
-//! tanh = (ex - enx) / (ex + enx)
+//! exp_x     = exp(working_value)
+//! exp_neg_x = 1 / exp_x                     (the exp(-x) identity)
+//! sinh = (exp_x - exp_neg_x) / 2
+//! cosh = (exp_x + exp_neg_x) / 2
+//! tanh = (exp_x - exp_neg_x) / (exp_x + exp_neg_x)
 //! ```
 //!
 //! ## Layering
@@ -44,20 +44,20 @@ use crate::support::rounding::RoundingMode;
 /// is the tier's Tang table size, `IE` its `INTERNAL_EXTRA` flag.
 #[inline]
 fn ex_enx_agm<C: WideTrigCore, const M: u32, const IE: bool>(
-    v: C::Wagm,
-    w: u32,
+    working_value: C::Wagm,
+    working_scale: u32,
 ) -> (C::Wagm, C::Wagm)
 where
     <C::Wagm as BigInt>::Scratch: ComputeLimbs,
 {
-    let ex = tang_exp_fixed_g::<C::Wagm, M, IE>(v, w, |ww| {
+    let exp_x = tang_exp_fixed_g::<C::Wagm, M, IE>(working_value, working_scale, |ln2_scale| {
         crate::consts::ln2_by_working_scale::<C::Wagm>(
-            ww,
+            ln2_scale,
             crate::support::rounding::DEFAULT_ROUNDING_MODE,
         )
     });
-    let enx = eg::div::<C::Wagm>(eg::one::<C::Wagm>(w), ex, w);
-    (ex, enx)
+    let exp_neg_x = eg::div::<C::Wagm>(eg::one::<C::Wagm>(working_scale), exp_x, working_scale);
+    (exp_x, exp_neg_x)
 }
 
 /// `sinh_strict` for a wide tier — generic over the tier `C`, the band's
@@ -79,20 +79,20 @@ where
     <C::Wagm as BigInt>::Scratch: ComputeLimbs,
     <C::Wexp as BigInt>::Scratch: ComputeLimbs,
 {
-    let w = SCALE + GUARD;
-    let v = C::to_work_scaled_agm(raw, GUARD);
-    let (ex, enx) = ex_enx_agm::<C, M, IE>(v, w);
-    let r = (ex - enx) / eg::lit::<C::Wagm>(2);
+    let working_scale = SCALE + GUARD;
+    let working_value = C::to_work_scaled_agm(raw, GUARD);
+    let (exp_x, exp_neg_x) = ex_enx_agm::<C, M, IE>(working_value, working_scale);
+    let sinh_value = (exp_x - exp_neg_x) / eg::lit::<C::Wagm>(2);
     // Near-tie escape — see `wide_trig_core::tan_series` / the asin(3e-60)
-    // family: a fixed-w single shot cannot see a deciding digit below w.
-    // Clear-of-band residuals keep the single-shot cost; the band falls to
-    // the Ziv-escalating generic kernel (rare).
+    // family: a fixed-working-scale single shot cannot see a deciding digit
+    // below the working scale. Clear-of-band residuals keep the single-shot
+    // cost; the band falls to the Ziv-escalating generic kernel (rare).
     match crate::algos::support::wide_trig_core::round_to_storage_clear_of_tie_g::<
         C::Storage,
         C::Wagm,
-    >(r, w, SCALE, mode, C::storage_max(), C::storage_min())
+    >(sinh_value, working_scale, SCALE, mode, C::storage_max(), C::storage_min())
     {
-        Some(st) => st,
+        Some(rounded) => rounded,
         None => crate::algos::trig::hyper_schoolbook::sinh_schoolbook::<C, SCALE>(raw, mode),
     }
 }
@@ -130,11 +130,11 @@ where
         mode,
         C::storage_max(),
         C::storage_min(),
-        |guard| {
-            let w = SCALE + guard;
-            let v = C::to_work_scaled_agm(raw, guard);
-            let (ex, enx) = ex_enx_agm::<C, M, IE>(v, w);
-            (ex + enx) / eg::lit::<C::Wagm>(2)
+        |guard_digits| {
+            let working_scale = SCALE + guard_digits;
+            let working_value = C::to_work_scaled_agm(raw, guard_digits);
+            let (exp_x, exp_neg_x) = ex_enx_agm::<C, M, IE>(working_value, working_scale);
+            (exp_x + exp_neg_x) / eg::lit::<C::Wagm>(2)
         },
     )
 }
@@ -166,10 +166,10 @@ where
 {
     let zero = C::storage_zero();
     if raw != zero {
-        let thresh_exp = SCALE - SCALE.div_ceil(3);
-        let thresh = <C::Storage as BigInt>::TEN.pow(thresh_exp);
+        let threshold_exponent = SCALE - SCALE.div_ceil(3);
+        let threshold = <C::Storage as BigInt>::TEN.pow(threshold_exponent);
         let abs_raw = if raw < zero { -raw } else { raw };
-        if abs_raw <= thresh {
+        if abs_raw <= threshold {
             return crate::support::rounding::tiny_odd_compressing_directed(
                 raw,
                 zero,
@@ -181,20 +181,20 @@ where
     // General path: outside the tiny band the kernel error is far below
     // half a storage ULP, so a single narrowing is correctly rounded for
     // every mode.
-    let w = SCALE + GUARD;
-    let v = C::to_work_scaled_agm(raw, GUARD);
-    let (ex, enx) = ex_enx_agm::<C, M, IE>(v, w);
-    let r = eg::div::<C::Wagm>(ex - enx, ex + enx, w);
+    let working_scale = SCALE + GUARD;
+    let working_value = C::to_work_scaled_agm(raw, GUARD);
+    let (exp_x, exp_neg_x) = ex_enx_agm::<C, M, IE>(working_value, working_scale);
+    let tanh_value = eg::div::<C::Wagm>(exp_x - exp_neg_x, exp_x + exp_neg_x, working_scale);
     // Near-tie escape — see `wide_trig_core::tan_series` / the asin(3e-60)
-    // family: a fixed-w single shot cannot see a deciding digit below w.
-    // Clear-of-band residuals keep the single-shot cost; the band falls to
-    // the Ziv-escalating generic kernel (rare).
+    // family: a fixed-working-scale single shot cannot see a deciding digit
+    // below the working scale. Clear-of-band residuals keep the single-shot
+    // cost; the band falls to the Ziv-escalating generic kernel (rare).
     match crate::algos::support::wide_trig_core::round_to_storage_clear_of_tie_g::<
         C::Storage,
         C::Wagm,
-    >(r, w, SCALE, mode, C::storage_max(), C::storage_min())
+    >(tanh_value, working_scale, SCALE, mode, C::storage_max(), C::storage_min())
     {
-        Some(st) => st,
+        Some(rounded) => rounded,
         None => crate::algos::trig::hyper_schoolbook::tanh_schoolbook::<C, SCALE>(raw, mode),
     }
 }

--- a/src/algos/trig/hyper_schoolbook.rs
+++ b/src/algos/trig/hyper_schoolbook.rs
@@ -59,10 +59,10 @@ fn hyper_tiny_pin<C: WideTrigCore, const SCALE: u32, const EXPANDING: bool>(
     if raw == zero {
         return None;
     }
-    let thresh_exp = SCALE - SCALE.div_ceil(3);
-    let thresh = crate::consts::pow10::dispatch::<C::Storage>(thresh_exp);
-    let a = if raw < zero { zero - raw } else { raw };
-    if a > thresh {
+    let threshold_exponent = SCALE - SCALE.div_ceil(3);
+    let threshold = crate::consts::pow10::dispatch::<C::Storage>(threshold_exponent);
+    let abs_raw = if raw < zero { zero - raw } else { raw };
+    if abs_raw > threshold {
         return None;
     }
     let one = <C::Storage as crate::int::types::traits::BigInt>::from_i128(1);
@@ -103,11 +103,11 @@ where
 {
     use crate::algos::exp::exp_generic as eg;
     let zero = C::storage_zero();
-    let neg = raw < zero;
-    let a = if neg { zero - raw } else { raw };
-    let sat_x = ((SCALE as u128 + C::GUARD as u128 + 2) * 100_000 / 86_859) as i128;
-    let over = a / crate::consts::pow10::dispatch::<C::Storage>(SCALE)
-        > <C::Storage as crate::int::types::traits::BigInt>::from_i128(sat_x);
+    let is_negative = raw < zero;
+    let abs_raw = if is_negative { zero - raw } else { raw };
+    let saturation_bound = ((SCALE as u128 + C::GUARD as u128 + 2) * 100_000 / 86_859) as i128;
+    let over = abs_raw / crate::consts::pow10::dispatch::<C::Storage>(SCALE)
+        > <C::Storage as crate::int::types::traits::BigInt>::from_i128(saturation_bound);
     if !over {
         return None;
     }
@@ -118,11 +118,15 @@ where
             mode,
             C::storage_max(),
             C::storage_min(),
-            |guard| {
-                let w = SCALE + guard;
-                let sat = eg::one::<C::Wagm>(w)
+            |guard_digits| {
+                let working_scale = SCALE + guard_digits;
+                let all_nines = eg::one::<C::Wagm>(working_scale)
                     - <C::Wagm as crate::int::types::traits::BigInt>::ONE;
-                if neg { eg::zero::<C::Wagm>() - sat } else { sat }
+                if is_negative {
+                    eg::zero::<C::Wagm>() - all_nines
+                } else {
+                    all_nines
+                }
             },
         ),
     )
@@ -153,10 +157,10 @@ where
     if raw == C::storage_zero() {
         return C::storage_zero();
     }
-    if let Some(p) = hyper_tiny_pin::<C, SCALE, true>(raw, mode) {
-        return p;
+    if let Some(pinned) = hyper_tiny_pin::<C, SCALE, true>(raw, mode) {
+        return pinned;
     }
-    let neg = raw < C::storage_zero();
+    let is_negative = raw < C::storage_zero();
     let k_lift = C::exp_result_int_digits(C::to_work_scaled(raw, 0), SCALE);
     let base_guard = C::GUARD + k_lift;
     // sinh(x) is irrational for rational x != 0 (never on a grid line):
@@ -169,23 +173,35 @@ where
         true,
         C::storage_max(),
         C::storage_min(),
-        |guard| {
-            let w = SCALE + guard;
-            let sh = hyper_probe_g::<C, C::Wagm>(
+        |guard_digits| {
+            let working_scale = SCALE + guard_digits;
+            let sinh_value = hyper_probe_g::<C, C::Wagm>(
                 raw,
-                guard,
-                w,
+                guard_digits,
+                working_scale,
                 eg::sinh_pos::<C::Wagm>,
                 eg::sinh_pos::<C::Wexp>,
             );
-            if neg { eg::zero::<C::Wagm>() - sh } else { sh }
+            if is_negative {
+                eg::zero::<C::Wagm>() - sinh_value
+            } else {
+                sinh_value
+            }
         },
-        |guard| {
-            let w = SCALE + guard;
-            let v = to_work_scaled_g::<C::Storage, C::Wexp>(raw, guard);
-            let av = if v < eg::zero::<C::Wexp>() { eg::zero::<C::Wexp>() - v } else { v };
-            let sh = eg::sinh_pos::<C::Wexp>(av, w);
-            if neg { eg::zero::<C::Wexp>() - sh } else { sh }
+        |guard_digits| {
+            let working_scale = SCALE + guard_digits;
+            let working_value = to_work_scaled_g::<C::Storage, C::Wexp>(raw, guard_digits);
+            let abs_working_value = if working_value < eg::zero::<C::Wexp>() {
+                eg::zero::<C::Wexp>() - working_value
+            } else {
+                working_value
+            };
+            let sinh_value = eg::sinh_pos::<C::Wexp>(abs_working_value, working_scale);
+            if is_negative {
+                eg::zero::<C::Wexp>() - sinh_value
+            } else {
+                sinh_value
+            }
         },
     )
 }
@@ -222,21 +238,25 @@ where
         true,
         C::storage_max(),
         C::storage_min(),
-        |guard| {
-            let w = SCALE + guard;
+        |guard_digits| {
+            let working_scale = SCALE + guard_digits;
             hyper_probe_g::<C, C::Wagm>(
                 raw,
-                guard,
-                w,
+                guard_digits,
+                working_scale,
                 eg::cosh_pos::<C::Wagm>,
                 eg::cosh_pos::<C::Wexp>,
             )
         },
-        |guard| {
-            let w = SCALE + guard;
-            let v = to_work_scaled_g::<C::Storage, C::Wexp>(raw, guard);
-            let av = if v < eg::zero::<C::Wexp>() { eg::zero::<C::Wexp>() - v } else { v };
-            eg::cosh_pos::<C::Wexp>(av, w)
+        |guard_digits| {
+            let working_scale = SCALE + guard_digits;
+            let working_value = to_work_scaled_g::<C::Storage, C::Wexp>(raw, guard_digits);
+            let abs_working_value = if working_value < eg::zero::<C::Wexp>() {
+                eg::zero::<C::Wexp>() - working_value
+            } else {
+                working_value
+            };
+            eg::cosh_pos::<C::Wexp>(abs_working_value, working_scale)
         },
     )
 }
@@ -259,13 +279,13 @@ where
 {
     use crate::algos::exp::exp_generic as eg;
     use crate::algos::support::wide_trig_core::round_to_storage_directed_g;
-    if let Some(p) = hyper_tiny_pin::<C, SCALE, false>(raw, mode) {
-        return p;
+    if let Some(pinned) = hyper_tiny_pin::<C, SCALE, false>(raw, mode) {
+        return pinned;
     }
-    if let Some(p) = tanh_saturated::<C, SCALE>(raw, mode) {
-        return p;
+    if let Some(pinned) = tanh_saturated::<C, SCALE>(raw, mode) {
+        return pinned;
     }
-    let neg = raw < C::storage_zero();
+    let is_negative = raw < C::storage_zero();
     let base_guard = C::GUARD + tanh_k_lift::<C, SCALE>(raw);
     // No deep-band analytic adjust: unlike asinh's ln composition (whose
     // partial lands exactly on the storage grid, so the walker is uniformly
@@ -279,24 +299,29 @@ where
         mode,
         C::storage_max(),
         C::storage_min(),
-        |guard| {
-            let w = SCALE + guard;
-            let th = hyper_probe_g::<C, C::Wagm>(
+        |guard_digits| {
+            let working_scale = SCALE + guard_digits;
+            let tanh_value = hyper_probe_g::<C, C::Wagm>(
                 raw,
-                guard,
-                w,
+                guard_digits,
+                working_scale,
                 // The shell's fits-branch form, exactly: the DIRECT ratio
                 // (the k-lifted base guard covers the e^|x| amplification;
                 // the m = e^(-2|x|) identity loses the deficit's deciding
                 // digits in this regime).
-                |av, w| {
-                    let ex = eg::exp_fixed::<C::Wagm>(av, w);
-                    let enx = eg::div::<C::Wagm>(eg::one::<C::Wagm>(w), ex, w);
-                    eg::div::<C::Wagm>(ex - enx, ex + enx, w)
+                |abs_working_value, probe_scale| {
+                    let exp_x = eg::exp_fixed::<C::Wagm>(abs_working_value, probe_scale);
+                    let exp_neg_x =
+                        eg::div::<C::Wagm>(eg::one::<C::Wagm>(probe_scale), exp_x, probe_scale);
+                    eg::div::<C::Wagm>(exp_x - exp_neg_x, exp_x + exp_neg_x, probe_scale)
                 },
                 eg::tanh_pos::<C::Wexp>,
             );
-            if neg { eg::zero::<C::Wagm>() - th } else { th }
+            if is_negative {
+                eg::zero::<C::Wagm>() - tanh_value
+            } else {
+                tanh_value
+            }
         },
     )
 }
@@ -325,31 +350,46 @@ where
         return C::storage_zero();
     }
     // asinh(x) = x − x³/6 + … : compressing (the j* = 3 linear band).
-    if let Some(p) = hyper_tiny_pin::<C, SCALE, false>(raw, mode) {
-        return p;
+    if let Some(pinned) = hyper_tiny_pin::<C, SCALE, false>(raw, mode) {
+        return pinned;
     }
-    let neg = raw < C::storage_zero();
-    let (r, decided) = round_to_storage_directed_decided_g::<C::Storage, C::Wagm>(
+    let is_negative = raw < C::storage_zero();
+    let (rounded, decided) = round_to_storage_directed_decided_g::<C::Storage, C::Wagm>(
         C::GUARD,
         SCALE,
         mode,
         C::storage_max(),
         C::storage_min(),
-        |guard| {
-            let w = SCALE + guard;
-            let ln2_w = ln2_at_rung::<C::Wagm>(w, SCALE + C::GUARD);
-            let one_w = eg::one::<C::Wagm>(w);
-            let v = to_work_scaled_g::<C::Storage, C::Wagm>(raw, guard);
-            let ax = if v < eg::zero::<C::Wagm>() { eg::zero::<C::Wagm>() - v } else { v };
-            let inner = if ax >= one_w {
-                let inv = eg::div::<C::Wagm>(one_w, ax, w);
-                let root = eg::sqrt_fixed::<C::Wagm>(one_w + eg::mul::<C::Wagm>(inv, inv, w), w);
-                eg::ln_fixed::<C::Wagm>(ax, w, ln2_w) + eg::ln_fixed::<C::Wagm>(one_w + root, w, ln2_w)
+        |guard_digits| {
+            let working_scale = SCALE + guard_digits;
+            let ln2_w = ln2_at_rung::<C::Wagm>(working_scale, SCALE + C::GUARD);
+            let one_w = eg::one::<C::Wagm>(working_scale);
+            let working_value = to_work_scaled_g::<C::Storage, C::Wagm>(raw, guard_digits);
+            let abs_working_value = if working_value < eg::zero::<C::Wagm>() {
+                eg::zero::<C::Wagm>() - working_value
             } else {
-                let root = eg::sqrt_fixed::<C::Wagm>(eg::mul::<C::Wagm>(ax, ax, w) + one_w, w);
-                eg::ln_fixed::<C::Wagm>(ax + root, w, ln2_w)
+                working_value
             };
-            if neg { eg::zero::<C::Wagm>() - inner } else { inner }
+            let inner = if abs_working_value >= one_w {
+                let reciprocal = eg::div::<C::Wagm>(one_w, abs_working_value, working_scale);
+                let root = eg::sqrt_fixed::<C::Wagm>(
+                    one_w + eg::mul::<C::Wagm>(reciprocal, reciprocal, working_scale),
+                    working_scale,
+                );
+                eg::ln_fixed::<C::Wagm>(abs_working_value, working_scale, ln2_w)
+                    + eg::ln_fixed::<C::Wagm>(one_w + root, working_scale, ln2_w)
+            } else {
+                let root = eg::sqrt_fixed::<C::Wagm>(
+                    eg::mul::<C::Wagm>(abs_working_value, abs_working_value, working_scale) + one_w,
+                    working_scale,
+                );
+                eg::ln_fixed::<C::Wagm>(abs_working_value + root, working_scale, ln2_w)
+            };
+            if is_negative {
+                eg::zero::<C::Wagm>() - inner
+            } else {
+                inner
+            }
         },
     );
     // Deep sub-resolution band (j* ≥ 5, below the linear pin's reach): asinh's
@@ -362,20 +402,20 @@ where
     // The exact alternating-series bracket first: where it closes it PROVES
     // which side of `r` the true value lies on, superseding the `j*`-parity
     // rule whose exactness premise fails for a multi-digit significand.
-    if let Some(v) = crate::algos::support::wide_trig_core::adjust_alternating_bracket::<
+    if let Some(bracketed) = crate::algos::support::wide_trig_core::adjust_alternating_bracket::<
         C::Storage,
         C::Wagm,
         SCALE,
     >(
-        r,
+        rounded,
         raw,
         mode,
         crate::algos::support::wide_trig_core::AlternatingSeries::Asinh,
     ) {
-        return v;
+        return bracketed;
     }
     tiny_x_deep_directed_adjust::<C::Storage, SCALE>(
-        r,
+        rounded,
         decided,
         raw,
         mode,
@@ -404,8 +444,10 @@ where
         round_to_storage_directed_near_special_g, to_work_scaled_g,
     };
     {
-        let w0 = SCALE + C::GUARD;
-        if to_work_scaled_g::<C::Storage, C::Wagm>(raw, C::GUARD) < eg::one::<C::Wagm>(w0) {
+        let base_working_scale = SCALE + C::GUARD;
+        if to_work_scaled_g::<C::Storage, C::Wagm>(raw, C::GUARD)
+            < eg::one::<C::Wagm>(base_working_scale)
+        {
             panic!("schoolbook acosh: argument must be >= 1");
         }
     }
@@ -415,19 +457,26 @@ where
         mode,
         C::storage_max(),
         C::storage_min(),
-        |guard| {
-            let w = SCALE + guard;
-            let one_w = eg::one::<C::Wagm>(w);
-            let v = to_work_scaled_g::<C::Storage, C::Wagm>(raw, guard);
+        |guard_digits| {
+            let working_scale = SCALE + guard_digits;
+            let one_w = eg::one::<C::Wagm>(working_scale);
+            let working_value = to_work_scaled_g::<C::Storage, C::Wagm>(raw, guard_digits);
             let two_w = one_w + one_w;
-            if v >= two_w {
-                let inv = eg::div::<C::Wagm>(one_w, v, w);
-                let root = eg::sqrt_fixed::<C::Wagm>(one_w - eg::mul::<C::Wagm>(inv, inv, w), w);
-                C::ln_fixed_routed_agm::<SCALE>(v, w) + C::ln_fixed_routed_agm::<SCALE>(one_w + root, w)
+            if working_value >= two_w {
+                let reciprocal = eg::div::<C::Wagm>(one_w, working_value, working_scale);
+                let root = eg::sqrt_fixed::<C::Wagm>(
+                    one_w - eg::mul::<C::Wagm>(reciprocal, reciprocal, working_scale),
+                    working_scale,
+                );
+                C::ln_fixed_routed_agm::<SCALE>(working_value, working_scale)
+                    + C::ln_fixed_routed_agm::<SCALE>(one_w + root, working_scale)
             } else {
-                let t = v - one_w;
-                let root = eg::sqrt_fixed::<C::Wagm>(eg::mul::<C::Wagm>(t, t + two_w, w), w);
-                eg::log1p_fixed::<C::Wagm>(t + root, w)
+                let x_minus_one = working_value - one_w;
+                let root = eg::sqrt_fixed::<C::Wagm>(
+                    eg::mul::<C::Wagm>(x_minus_one, x_minus_one + two_w, working_scale),
+                    working_scale,
+                );
+                eg::log1p_fixed::<C::Wagm>(x_minus_one + root, working_scale)
             }
         },
     )
@@ -452,16 +501,20 @@ where
         round_to_storage_directed_near_special_g, to_work_scaled_g,
     };
     {
-        let w0 = SCALE + C::GUARD;
-        let v0 = to_work_scaled_g::<C::Storage, C::Wagm>(raw, C::GUARD);
-        let ax0 = if v0 < eg::zero::<C::Wagm>() { eg::zero::<C::Wagm>() - v0 } else { v0 };
-        if ax0 >= eg::one::<C::Wagm>(w0) {
+        let base_working_scale = SCALE + C::GUARD;
+        let base_working_value = to_work_scaled_g::<C::Storage, C::Wagm>(raw, C::GUARD);
+        let abs_base_working_value = if base_working_value < eg::zero::<C::Wagm>() {
+            eg::zero::<C::Wagm>() - base_working_value
+        } else {
+            base_working_value
+        };
+        if abs_base_working_value >= eg::one::<C::Wagm>(base_working_scale) {
             panic!("schoolbook atanh: argument out of domain (-1, 1)");
         }
     }
     // atanh(x) = x + x³/3 + … : expanding.
-    if let Some(p) = hyper_tiny_pin::<C, SCALE, true>(raw, mode) {
-        return p;
+    if let Some(pinned) = hyper_tiny_pin::<C, SCALE, true>(raw, mode) {
+        return pinned;
     }
     round_to_storage_directed_near_special_g::<C::Storage, C::Wagm>(
         C::GUARD,
@@ -469,12 +522,12 @@ where
         mode,
         C::storage_max(),
         C::storage_min(),
-        |guard| {
-            let w = SCALE + guard;
-            let one_w = eg::one::<C::Wagm>(w);
-            let v = to_work_scaled_g::<C::Storage, C::Wagm>(raw, guard);
-            (C::ln_fixed_routed_agm::<SCALE>(one_w + v, w)
-                - C::ln_fixed_routed_agm::<SCALE>(one_w - v, w))
+        |guard_digits| {
+            let working_scale = SCALE + guard_digits;
+            let one_w = eg::one::<C::Wagm>(working_scale);
+            let working_value = to_work_scaled_g::<C::Storage, C::Wagm>(raw, guard_digits);
+            (C::ln_fixed_routed_agm::<SCALE>(one_w + working_value, working_scale)
+                - C::ln_fixed_routed_agm::<SCALE>(one_w - working_value, working_scale))
                 >> 1
         },
     )
@@ -502,8 +555,8 @@ where
 #[inline]
 fn hyper_probe_g<C: WideTrigCore, Wk: crate::int::types::traits::BigInt>(
     raw: C::Storage,
-    guard: u32,
-    w: u32,
+    guard_digits: u32,
+    working_scale: u32,
     f_rung: impl Fn(Wk, u32) -> Wk,
     f_wide: impl Fn(C::Wexp, u32) -> C::Wexp,
 ) -> Wk
@@ -514,18 +567,22 @@ where
 {
     use crate::algos::exp::exp_generic as eg;
     use crate::algos::support::wide_trig_core::to_work_scaled_g;
-    let v = to_work_scaled_g::<C::Storage, Wk>(raw, guard);
-    let av = if v < eg::zero::<Wk>() { eg::zero::<Wk>() - v } else { v };
-    if eg::exp_peak_fits::<Wk>(av, w) {
-        f_rung(av, w)
+    let working_value = to_work_scaled_g::<C::Storage, Wk>(raw, guard_digits);
+    let abs_working_value = if working_value < eg::zero::<Wk>() {
+        eg::zero::<Wk>() - working_value
     } else {
-        let v_e = to_work_scaled_g::<C::Storage, C::Wexp>(raw, guard);
-        let av_e = if v_e < eg::zero::<C::Wexp>() {
-            eg::zero::<C::Wexp>() - v_e
+        working_value
+    };
+    if eg::exp_peak_fits::<Wk>(abs_working_value, working_scale) {
+        f_rung(abs_working_value, working_scale)
+    } else {
+        let exp_working_value = to_work_scaled_g::<C::Storage, C::Wexp>(raw, guard_digits);
+        let abs_exp_working_value = if exp_working_value < eg::zero::<C::Wexp>() {
+            eg::zero::<C::Wexp>() - exp_working_value
         } else {
-            v_e
+            exp_working_value
         };
-        eg::resize_or_panic::<C::Wexp, Wk>(f_wide(av_e, w))
+        eg::resize_or_panic::<C::Wexp, Wk>(f_wide(abs_exp_working_value, working_scale))
     }
 }
 
@@ -551,10 +608,10 @@ where
     if raw == C::storage_zero() {
         return C::storage_zero();
     }
-    if let Some(p) = hyper_tiny_pin::<C, SCALE, true>(raw, mode) {
-        return p;
+    if let Some(pinned) = hyper_tiny_pin::<C, SCALE, true>(raw, mode) {
+        return pinned;
     }
-    let neg = raw < C::storage_zero();
+    let is_negative = raw < C::storage_zero();
     let k_lift = C::exp_result_int_digits(C::to_work_scaled(raw, 0), SCALE);
     let base_guard = C::GUARD + k_lift;
     // never_exact two-width widening, rung-first: a near-tie unresolved
@@ -567,23 +624,37 @@ where
         true,
         C::storage_max(),
         C::storage_min(),
-        |guard| {
-            let w = SCALE + guard;
-            let sh = hyper_probe_g::<C, Wk>(
+        |guard_digits| {
+            let working_scale = SCALE + guard_digits;
+            let sinh_value = hyper_probe_g::<C, Wk>(
                 raw,
-                guard,
-                w,
-                |av, w| eg::sinh_pos::<Wk>(av, w),
+                guard_digits,
+                working_scale,
+                |abs_working_value, probe_scale| {
+                    eg::sinh_pos::<Wk>(abs_working_value, probe_scale)
+                },
                 eg::sinh_pos::<C::Wexp>,
             );
-            if neg { eg::zero::<Wk>() - sh } else { sh }
+            if is_negative {
+                eg::zero::<Wk>() - sinh_value
+            } else {
+                sinh_value
+            }
         },
-        |guard| {
-            let w = SCALE + guard;
-            let v = to_work_scaled_g::<C::Storage, C::Wexp>(raw, guard);
-            let av = if v < eg::zero::<C::Wexp>() { eg::zero::<C::Wexp>() - v } else { v };
-            let sh = eg::sinh_pos::<C::Wexp>(av, w);
-            if neg { eg::zero::<C::Wexp>() - sh } else { sh }
+        |guard_digits| {
+            let working_scale = SCALE + guard_digits;
+            let working_value = to_work_scaled_g::<C::Storage, C::Wexp>(raw, guard_digits);
+            let abs_working_value = if working_value < eg::zero::<C::Wexp>() {
+                eg::zero::<C::Wexp>() - working_value
+            } else {
+                working_value
+            };
+            let sinh_value = eg::sinh_pos::<C::Wexp>(abs_working_value, working_scale);
+            if is_negative {
+                eg::zero::<C::Wexp>() - sinh_value
+            } else {
+                sinh_value
+            }
         },
     )
 }
@@ -618,21 +689,27 @@ where
         true,
         C::storage_max(),
         C::storage_min(),
-        |guard| {
-            let w = SCALE + guard;
+        |guard_digits| {
+            let working_scale = SCALE + guard_digits;
             hyper_probe_g::<C, Wk>(
                 raw,
-                guard,
-                w,
-                |av, w| eg::cosh_pos::<Wk>(av, w),
+                guard_digits,
+                working_scale,
+                |abs_working_value, probe_scale| {
+                    eg::cosh_pos::<Wk>(abs_working_value, probe_scale)
+                },
                 eg::cosh_pos::<C::Wexp>,
             )
         },
-        |guard| {
-            let w = SCALE + guard;
-            let v = to_work_scaled_g::<C::Storage, C::Wexp>(raw, guard);
-            let av = if v < eg::zero::<C::Wexp>() { eg::zero::<C::Wexp>() - v } else { v };
-            eg::cosh_pos::<C::Wexp>(av, w)
+        |guard_digits| {
+            let working_scale = SCALE + guard_digits;
+            let working_value = to_work_scaled_g::<C::Storage, C::Wexp>(raw, guard_digits);
+            let abs_working_value = if working_value < eg::zero::<C::Wexp>() {
+                eg::zero::<C::Wexp>() - working_value
+            } else {
+                working_value
+            };
+            eg::cosh_pos::<C::Wexp>(abs_working_value, working_scale)
         },
     )
 }
@@ -657,13 +734,13 @@ where
     // The canonical pins — identical to the tier kernel. The saturation
     // fast path is unreachable at the rung (the policy gate admits
     // |x| < 10, far below the onset) but kept for kernel-level callers.
-    if let Some(p) = hyper_tiny_pin::<C, SCALE, false>(raw, mode) {
-        return p;
+    if let Some(pinned) = hyper_tiny_pin::<C, SCALE, false>(raw, mode) {
+        return pinned;
     }
-    if let Some(p) = tanh_saturated::<C, SCALE>(raw, mode) {
-        return p;
+    if let Some(pinned) = tanh_saturated::<C, SCALE>(raw, mode) {
+        return pinned;
     }
-    let neg = raw < C::storage_zero();
+    let is_negative = raw < C::storage_zero();
     let base_guard = C::GUARD + tanh_k_lift::<C, SCALE>(raw);
     // Two-width fall-up to the tier walker width `Wagm`. No deep-band analytic
     // adjust — see the tier [`tanh_schoolbook`] (the exp-ratio composition
@@ -674,58 +751,75 @@ where
         mode,
         C::storage_max(),
         C::storage_min(),
-        |guard| {
-            let w = SCALE + guard;
-            let th = hyper_probe_g::<C, Wk>(
+        |guard_digits| {
+            let working_scale = SCALE + guard_digits;
+            let tanh_value = hyper_probe_g::<C, Wk>(
                 raw,
-                guard,
-                w,
+                guard_digits,
+                working_scale,
                 // Direct ratio — see the tier kernel.
-                |av, w| {
-                    let ex = eg::exp_fixed::<Wk>(av, w);
-                    let enx = eg::div::<Wk>(eg::one::<Wk>(w), ex, w);
-                    eg::div::<Wk>(ex - enx, ex + enx, w)
+                |abs_working_value, probe_scale| {
+                    let exp_x = eg::exp_fixed::<Wk>(abs_working_value, probe_scale);
+                    let exp_neg_x =
+                        eg::div::<Wk>(eg::one::<Wk>(probe_scale), exp_x, probe_scale);
+                    eg::div::<Wk>(exp_x - exp_neg_x, exp_x + exp_neg_x, probe_scale)
                 },
                 eg::tanh_pos::<C::Wexp>,
             );
-            if neg { eg::zero::<Wk>() - th } else { th }
+            if is_negative {
+                eg::zero::<Wk>() - tanh_value
+            } else {
+                tanh_value
+            }
         },
-        |guard| {
-            let w = SCALE + guard;
-            let th = hyper_probe_g::<C, C::Wagm>(
+        |guard_digits| {
+            let working_scale = SCALE + guard_digits;
+            let tanh_value = hyper_probe_g::<C, C::Wagm>(
                 raw,
-                guard,
-                w,
+                guard_digits,
+                working_scale,
                 // The shell's fits-branch form, exactly: the DIRECT ratio
                 // (the k-lifted base guard covers the e^|x| amplification;
                 // the m = e^(-2|x|) identity loses the deficit's deciding
                 // digits in this regime).
-                |av, w| {
-                    let ex = eg::exp_fixed::<C::Wagm>(av, w);
-                    let enx = eg::div::<C::Wagm>(eg::one::<C::Wagm>(w), ex, w);
-                    eg::div::<C::Wagm>(ex - enx, ex + enx, w)
+                |abs_working_value, probe_scale| {
+                    let exp_x = eg::exp_fixed::<C::Wagm>(abs_working_value, probe_scale);
+                    let exp_neg_x =
+                        eg::div::<C::Wagm>(eg::one::<C::Wagm>(probe_scale), exp_x, probe_scale);
+                    eg::div::<C::Wagm>(exp_x - exp_neg_x, exp_x + exp_neg_x, probe_scale)
                 },
                 eg::tanh_pos::<C::Wexp>,
             );
-            if neg { eg::zero::<C::Wagm>() - th } else { th }
+            if is_negative {
+                eg::zero::<C::Wagm>() - tanh_value
+            } else {
+                tanh_value
+            }
         },
     )
 }
 
-/// `ln 2` at working scale `w` in the rung integer `Wk`: const-table
-/// keyed on the CONST base working scale on the hot path (`w ==
-/// base_w`, const-folds per monomorphisation — the rung sibling of the
-/// per-tier `ln2_cf`), the runtime-keyed lookup on the Ziv escalation
-/// path. Value-identical either way (same table entry). Mirrors
+/// `ln 2` at `working_scale` in the rung integer `Wk`: const-table
+/// keyed on the CONST base working scale on the hot path
+/// (`working_scale == base_working_scale`, const-folds per
+/// monomorphisation — the rung sibling of the per-tier `ln2_cf`), the
+/// runtime-keyed lookup on the Ziv escalation path. Value-identical
+/// either way (same table entry). Mirrors
 /// `wide_trig_core::pi_at_rung` / `ln_series_g`'s ln2 threading.
 #[cfg(feature = "_wide-support")]
 #[inline]
-fn ln2_at_rung<Wk: crate::int::types::traits::BigInt>(w: u32, base_w: u32) -> Wk {
-    if w == base_w {
-        crate::consts::ln2_by_scale::<Wk>(base_w, crate::support::rounding::DEFAULT_ROUNDING_MODE)
+fn ln2_at_rung<Wk: crate::int::types::traits::BigInt>(
+    working_scale: u32,
+    base_working_scale: u32,
+) -> Wk {
+    if working_scale == base_working_scale {
+        crate::consts::ln2_by_scale::<Wk>(
+            base_working_scale,
+            crate::support::rounding::DEFAULT_ROUNDING_MODE,
+        )
     } else {
         crate::consts::ln2_by_working_scale::<Wk>(
-            w,
+            working_scale,
             crate::support::rounding::DEFAULT_ROUNDING_MODE,
         )
     }
@@ -756,71 +850,103 @@ where
     }
     // The canonical pins — identical to the tier kernel (compressing:
     // asinh(x) = x − x³/6 + …).
-    if let Some(p) = hyper_tiny_pin::<C, SCALE, false>(raw, mode) {
-        return p;
+    if let Some(pinned) = hyper_tiny_pin::<C, SCALE, false>(raw, mode) {
+        return pinned;
     }
-    let neg = raw < C::storage_zero();
+    let is_negative = raw < C::storage_zero();
     // Two-width fall-up to the tier walker width `Wagm` - the second
     // closure is the tier kernel's, verbatim. Retain the `decided` verdict
     // for the deep-band analytic adjust.
-    let (r, decided) = round_to_storage_directed_widening_decided_g::<C::Storage, Wk, C::Wagm>(
-        C::GUARD,
-        SCALE,
-        mode,
-        C::storage_max(),
-        C::storage_min(),
-        |guard| {
-            let w = SCALE + guard;
-            let ln2_w = ln2_at_rung::<Wk>(w, SCALE + C::GUARD);
-            let one_w = eg::one::<Wk>(w);
-            let v = to_work_scaled_g::<C::Storage, Wk>(raw, guard);
-            let ax = if v < eg::zero::<Wk>() { eg::zero::<Wk>() - v } else { v };
-            let inner = if ax >= one_w {
-                let inv = eg::div::<Wk>(one_w, ax, w);
-                let root = eg::sqrt_fixed::<Wk>(one_w + eg::mul::<Wk>(inv, inv, w), w);
-                eg::ln_fixed::<Wk>(ax, w, ln2_w) + eg::ln_fixed::<Wk>(one_w + root, w, ln2_w)
-            } else {
-                let root = eg::sqrt_fixed::<Wk>(eg::mul::<Wk>(ax, ax, w) + one_w, w);
-                eg::ln_fixed::<Wk>(ax + root, w, ln2_w)
-            };
-            if neg { eg::zero::<Wk>() - inner } else { inner }
-        },
-        |guard| {
-            let w = SCALE + guard;
-            let ln2_w = ln2_at_rung::<C::Wagm>(w, SCALE + C::GUARD);
-            let one_w = eg::one::<C::Wagm>(w);
-            let v = to_work_scaled_g::<C::Storage, C::Wagm>(raw, guard);
-            let ax = if v < eg::zero::<C::Wagm>() { eg::zero::<C::Wagm>() - v } else { v };
-            let inner = if ax >= one_w {
-                let inv = eg::div::<C::Wagm>(one_w, ax, w);
-                let root = eg::sqrt_fixed::<C::Wagm>(one_w + eg::mul::<C::Wagm>(inv, inv, w), w);
-                eg::ln_fixed::<C::Wagm>(ax, w, ln2_w) + eg::ln_fixed::<C::Wagm>(one_w + root, w, ln2_w)
-            } else {
-                let root = eg::sqrt_fixed::<C::Wagm>(eg::mul::<C::Wagm>(ax, ax, w) + one_w, w);
-                eg::ln_fixed::<C::Wagm>(ax + root, w, ln2_w)
-            };
-            if neg { eg::zero::<C::Wagm>() - inner } else { inner }
-        },
-    );
+    let (rounded, decided) =
+        round_to_storage_directed_widening_decided_g::<C::Storage, Wk, C::Wagm>(
+            C::GUARD,
+            SCALE,
+            mode,
+            C::storage_max(),
+            C::storage_min(),
+            |guard_digits| {
+                let working_scale = SCALE + guard_digits;
+                let ln2_w = ln2_at_rung::<Wk>(working_scale, SCALE + C::GUARD);
+                let one_w = eg::one::<Wk>(working_scale);
+                let working_value = to_work_scaled_g::<C::Storage, Wk>(raw, guard_digits);
+                let abs_working_value = if working_value < eg::zero::<Wk>() {
+                    eg::zero::<Wk>() - working_value
+                } else {
+                    working_value
+                };
+                let inner = if abs_working_value >= one_w {
+                    let reciprocal = eg::div::<Wk>(one_w, abs_working_value, working_scale);
+                    let root = eg::sqrt_fixed::<Wk>(
+                        one_w + eg::mul::<Wk>(reciprocal, reciprocal, working_scale),
+                        working_scale,
+                    );
+                    eg::ln_fixed::<Wk>(abs_working_value, working_scale, ln2_w)
+                        + eg::ln_fixed::<Wk>(one_w + root, working_scale, ln2_w)
+                } else {
+                    let root = eg::sqrt_fixed::<Wk>(
+                        eg::mul::<Wk>(abs_working_value, abs_working_value, working_scale) + one_w,
+                        working_scale,
+                    );
+                    eg::ln_fixed::<Wk>(abs_working_value + root, working_scale, ln2_w)
+                };
+                if is_negative {
+                    eg::zero::<Wk>() - inner
+                } else {
+                    inner
+                }
+            },
+            |guard_digits| {
+                let working_scale = SCALE + guard_digits;
+                let ln2_w = ln2_at_rung::<C::Wagm>(working_scale, SCALE + C::GUARD);
+                let one_w = eg::one::<C::Wagm>(working_scale);
+                let working_value = to_work_scaled_g::<C::Storage, C::Wagm>(raw, guard_digits);
+                let abs_working_value = if working_value < eg::zero::<C::Wagm>() {
+                    eg::zero::<C::Wagm>() - working_value
+                } else {
+                    working_value
+                };
+                let inner = if abs_working_value >= one_w {
+                    let reciprocal = eg::div::<C::Wagm>(one_w, abs_working_value, working_scale);
+                    let root = eg::sqrt_fixed::<C::Wagm>(
+                        one_w + eg::mul::<C::Wagm>(reciprocal, reciprocal, working_scale),
+                        working_scale,
+                    );
+                    eg::ln_fixed::<C::Wagm>(abs_working_value, working_scale, ln2_w)
+                        + eg::ln_fixed::<C::Wagm>(one_w + root, working_scale, ln2_w)
+                } else {
+                    let root = eg::sqrt_fixed::<C::Wagm>(
+                        eg::mul::<C::Wagm>(abs_working_value, abs_working_value, working_scale)
+                            + one_w,
+                        working_scale,
+                    );
+                    eg::ln_fixed::<C::Wagm>(abs_working_value + root, working_scale, ln2_w)
+                };
+                if is_negative {
+                    eg::zero::<C::Wagm>() - inner
+                } else {
+                    inner
+                }
+            },
+        );
     // Deep sub-resolution band (j* ≥ 5): asinh alternates — see the tier
     // [`asinh_schoolbook`]. The widening walker falls up to `C::Wagm`.
     // The exact alternating-series bracket first: where it closes it PROVES
     // which side of `r` the true value lies on, superseding the `j*`-parity
     // rule whose exactness premise fails for a multi-digit significand.
-    if let Some(v) = crate::algos::support::wide_trig_core::adjust_alternating_bracket::<
+    if let Some(bracketed) = crate::algos::support::wide_trig_core::adjust_alternating_bracket::<
         C::Storage,
         C::Wagm,
         SCALE,
     >(
-        r,
+        rounded,
         raw,
         mode,
         crate::algos::support::wide_trig_core::AlternatingSeries::Asinh,
     ) {
-        return v;
+        return bracketed;
     }
     tiny_x_deep_directed_adjust::<C::Storage, SCALE>(
-        r,
+        rounded,
         decided,
         raw,
         mode,
@@ -850,8 +976,8 @@ where
         round_to_storage_directed_near_special_widening_g, to_work_scaled_g,
     };
     {
-        let w0 = SCALE + C::GUARD;
-        if to_work_scaled_g::<C::Storage, Wk>(raw, C::GUARD) < eg::one::<Wk>(w0) {
+        let base_working_scale = SCALE + C::GUARD;
+        if to_work_scaled_g::<C::Storage, Wk>(raw, C::GUARD) < eg::one::<Wk>(base_working_scale) {
             panic!("schoolbook acosh: argument must be >= 1");
         }
     }
@@ -863,35 +989,49 @@ where
         mode,
         C::storage_max(),
         C::storage_min(),
-        |guard| {
-            let w = SCALE + guard;
-            let ln2_w = ln2_at_rung::<Wk>(w, SCALE + C::GUARD);
-            let one_w = eg::one::<Wk>(w);
-            let v = to_work_scaled_g::<C::Storage, Wk>(raw, guard);
+        |guard_digits| {
+            let working_scale = SCALE + guard_digits;
+            let ln2_w = ln2_at_rung::<Wk>(working_scale, SCALE + C::GUARD);
+            let one_w = eg::one::<Wk>(working_scale);
+            let working_value = to_work_scaled_g::<C::Storage, Wk>(raw, guard_digits);
             let two_w = one_w + one_w;
-            if v >= two_w {
-                let inv = eg::div::<Wk>(one_w, v, w);
-                let root = eg::sqrt_fixed::<Wk>(one_w - eg::mul::<Wk>(inv, inv, w), w);
-                eg::ln_fixed::<Wk>(v, w, ln2_w) + eg::ln_fixed::<Wk>(one_w + root, w, ln2_w)
+            if working_value >= two_w {
+                let reciprocal = eg::div::<Wk>(one_w, working_value, working_scale);
+                let root = eg::sqrt_fixed::<Wk>(
+                    one_w - eg::mul::<Wk>(reciprocal, reciprocal, working_scale),
+                    working_scale,
+                );
+                eg::ln_fixed::<Wk>(working_value, working_scale, ln2_w)
+                    + eg::ln_fixed::<Wk>(one_w + root, working_scale, ln2_w)
             } else {
-                let t = v - one_w;
-                let root = eg::sqrt_fixed::<Wk>(eg::mul::<Wk>(t, t + two_w, w), w);
-                eg::log1p_fixed::<Wk>(t + root, w)
+                let x_minus_one = working_value - one_w;
+                let root = eg::sqrt_fixed::<Wk>(
+                    eg::mul::<Wk>(x_minus_one, x_minus_one + two_w, working_scale),
+                    working_scale,
+                );
+                eg::log1p_fixed::<Wk>(x_minus_one + root, working_scale)
             }
         },
-        |guard| {
-            let w = SCALE + guard;
-            let one_w = eg::one::<C::Wagm>(w);
-            let v = to_work_scaled_g::<C::Storage, C::Wagm>(raw, guard);
+        |guard_digits| {
+            let working_scale = SCALE + guard_digits;
+            let one_w = eg::one::<C::Wagm>(working_scale);
+            let working_value = to_work_scaled_g::<C::Storage, C::Wagm>(raw, guard_digits);
             let two_w = one_w + one_w;
-            if v >= two_w {
-                let inv = eg::div::<C::Wagm>(one_w, v, w);
-                let root = eg::sqrt_fixed::<C::Wagm>(one_w - eg::mul::<C::Wagm>(inv, inv, w), w);
-                C::ln_fixed_routed_agm::<SCALE>(v, w) + C::ln_fixed_routed_agm::<SCALE>(one_w + root, w)
+            if working_value >= two_w {
+                let reciprocal = eg::div::<C::Wagm>(one_w, working_value, working_scale);
+                let root = eg::sqrt_fixed::<C::Wagm>(
+                    one_w - eg::mul::<C::Wagm>(reciprocal, reciprocal, working_scale),
+                    working_scale,
+                );
+                C::ln_fixed_routed_agm::<SCALE>(working_value, working_scale)
+                    + C::ln_fixed_routed_agm::<SCALE>(one_w + root, working_scale)
             } else {
-                let t = v - one_w;
-                let root = eg::sqrt_fixed::<C::Wagm>(eg::mul::<C::Wagm>(t, t + two_w, w), w);
-                eg::log1p_fixed::<C::Wagm>(t + root, w)
+                let x_minus_one = working_value - one_w;
+                let root = eg::sqrt_fixed::<C::Wagm>(
+                    eg::mul::<C::Wagm>(x_minus_one, x_minus_one + two_w, working_scale),
+                    working_scale,
+                );
+                eg::log1p_fixed::<C::Wagm>(x_minus_one + root, working_scale)
             }
         },
     )
@@ -919,17 +1059,21 @@ where
         round_to_storage_directed_near_special_widening_g, to_work_scaled_g,
     };
     {
-        let w0 = SCALE + C::GUARD;
-        let v0 = to_work_scaled_g::<C::Storage, Wk>(raw, C::GUARD);
-        let ax0 = if v0 < eg::zero::<Wk>() { eg::zero::<Wk>() - v0 } else { v0 };
-        if ax0 >= eg::one::<Wk>(w0) {
+        let base_working_scale = SCALE + C::GUARD;
+        let base_working_value = to_work_scaled_g::<C::Storage, Wk>(raw, C::GUARD);
+        let abs_base_working_value = if base_working_value < eg::zero::<Wk>() {
+            eg::zero::<Wk>() - base_working_value
+        } else {
+            base_working_value
+        };
+        if abs_base_working_value >= eg::one::<Wk>(base_working_scale) {
             panic!("schoolbook atanh: argument out of domain (-1, 1)");
         }
     }
     // The canonical pins — identical to the tier kernel (expanding:
     // atanh(x) = x + x³/3 + …).
-    if let Some(p) = hyper_tiny_pin::<C, SCALE, true>(raw, mode) {
-        return p;
+    if let Some(pinned) = hyper_tiny_pin::<C, SCALE, true>(raw, mode) {
+        return pinned;
     }
     // Two-width fall-up (near-special form) to the tier walker width
     // `Wagm` - see [`acosh_schoolbook_g`].
@@ -939,20 +1083,21 @@ where
         mode,
         C::storage_max(),
         C::storage_min(),
-        |guard| {
-            let w = SCALE + guard;
-            let ln2_w = ln2_at_rung::<Wk>(w, SCALE + C::GUARD);
-            let one_w = eg::one::<Wk>(w);
-            let v = to_work_scaled_g::<C::Storage, Wk>(raw, guard);
-            (eg::ln_fixed::<Wk>(one_w + v, w, ln2_w) - eg::ln_fixed::<Wk>(one_w - v, w, ln2_w))
+        |guard_digits| {
+            let working_scale = SCALE + guard_digits;
+            let ln2_w = ln2_at_rung::<Wk>(working_scale, SCALE + C::GUARD);
+            let one_w = eg::one::<Wk>(working_scale);
+            let working_value = to_work_scaled_g::<C::Storage, Wk>(raw, guard_digits);
+            (eg::ln_fixed::<Wk>(one_w + working_value, working_scale, ln2_w)
+                - eg::ln_fixed::<Wk>(one_w - working_value, working_scale, ln2_w))
                 >> 1
         },
-        |guard| {
-            let w = SCALE + guard;
-            let one_w = eg::one::<C::Wagm>(w);
-            let v = to_work_scaled_g::<C::Storage, C::Wagm>(raw, guard);
-            (C::ln_fixed_routed_agm::<SCALE>(one_w + v, w)
-                - C::ln_fixed_routed_agm::<SCALE>(one_w - v, w))
+        |guard_digits| {
+            let working_scale = SCALE + guard_digits;
+            let one_w = eg::one::<C::Wagm>(working_scale);
+            let working_value = to_work_scaled_g::<C::Storage, C::Wagm>(raw, guard_digits);
+            (C::ln_fixed_routed_agm::<SCALE>(one_w + working_value, working_scale)
+                - C::ln_fixed_routed_agm::<SCALE>(one_w - working_value, working_scale))
                 >> 1
         },
     )
@@ -961,8 +1106,8 @@ where
 // -- Narrow tier -- Int<2> storage, math in the 256-bit Fixed ---------
 
 #[inline]
-fn one_fixed(w: u32) -> Fixed {
-    Fixed { negative: false, mag: Fixed::pow10(w) }
+fn one_fixed(working_scale: u32) -> Fixed {
+    Fixed { negative: false, mag: Fixed::pow10(working_scale) }
 }
 
 #[inline]
@@ -971,16 +1116,17 @@ fn sinh_schoolbook_raw<const SCALE: u32>(raw: i128, mode: RoundingMode) -> i128 
     if raw == 0 {
         return 0;
     }
-    let w = SCALE + STRICT_GUARD;
-    let v = to_fixed(raw);
-    let neg = raw < 0;
-    let av = Fixed { negative: false, mag: v.mag };
-    let ex = exp_fixed(av, w);
-    let one_w = one_fixed(w);
-    let enx = one_w.div(ex, w);
-    let sh = ex.sub(enx).halve();
-    let sh = if neg { sh.neg() } else { sh };
-    sh.round_to_i128_with(w, SCALE, mode)
+    let working_scale = SCALE + STRICT_GUARD;
+    let working_value = to_fixed(raw);
+    let is_negative = raw < 0;
+    let abs_working_value = Fixed { negative: false, mag: working_value.mag };
+    let exp_x = exp_fixed(abs_working_value, working_scale);
+    let one_w = one_fixed(working_scale);
+    let exp_neg_x = one_w.div(exp_x, working_scale);
+    let sinh_value = exp_x.sub(exp_neg_x).halve();
+    let sinh_value = if is_negative { sinh_value.neg() } else { sinh_value };
+    sinh_value
+        .round_to_i128_with(working_scale, SCALE, mode)
         .unwrap_or_else(|| crate::support::diagnostics::overflow_panic_with_scale("sinh", SCALE))
 }
 
@@ -990,15 +1136,16 @@ fn cosh_schoolbook_raw<const SCALE: u32>(raw: i128, mode: RoundingMode) -> i128 
     if raw == 0 {
         return 10_i128.pow(SCALE);
     }
-    let w = SCALE + STRICT_GUARD;
-    let v = to_fixed(raw);
-    let av = Fixed { negative: false, mag: v.mag };
-    let ex = exp_fixed(av, w);
-    let one_w = one_fixed(w);
-    let enx = one_w.div(ex, w);
-    ex.add(enx)
+    let working_scale = SCALE + STRICT_GUARD;
+    let working_value = to_fixed(raw);
+    let abs_working_value = Fixed { negative: false, mag: working_value.mag };
+    let exp_x = exp_fixed(abs_working_value, working_scale);
+    let one_w = one_fixed(working_scale);
+    let exp_neg_x = one_w.div(exp_x, working_scale);
+    exp_x
+        .add(exp_neg_x)
         .halve()
-        .round_to_i128_with(w, SCALE, mode)
+        .round_to_i128_with(working_scale, SCALE, mode)
         .unwrap_or_else(|| crate::support::diagnostics::overflow_panic_with_scale("cosh", SCALE))
 }
 
@@ -1008,35 +1155,38 @@ fn tanh_schoolbook_raw<const SCALE: u32>(raw: i128, mode: RoundingMode) -> i128 
     if raw == 0 {
         return 0;
     }
-    let w = SCALE + STRICT_GUARD;
-    let one_w = one_fixed(w);
-    let neg = raw < 0;
+    let working_scale = SCALE + STRICT_GUARD;
+    let one_w = one_fixed(working_scale);
+    let is_negative = raw < 0;
     // Large |x| via the NEGATIVE-exponent identity tanh(|x|) = (1 − m)/(1 + m),
     // m = e^(−2|x|) = (e^|x| − e^−|x|)/(e^|x| + e^−|x|) — exact. Forming e^(+|x|)
-    // directly overflows the 256-bit `Fixed` once |x| ≳ (256·ln2 − w·ln10) (≈ 44
-    // at w = 58), BELOW the all-nines saturation onset |x| ≳ 1.1513·w (`thr_x`),
+    // directly overflows the 256-bit `Fixed` once |x| ≳ (256·ln2 − working_scale·ln10)
+    // (≈ 44 at working_scale = 58), BELOW the all-nines saturation onset
+    // |x| ≳ 1.1513·working_scale (`saturation_bound`),
     // leaving a panic GAP. The identity sidesteps it: m is TINY for large |x|,
     // formed by `exp_fixed` on the NEGATIVE argument −2|x| whose `2^k` reassembly
     // shifts DOWN, never the overflowing up-shift. Mirrors the routed
     // `tanh_with_raw` / wide `exp_generic::tanh_pos`, bit-for-bit.
-    let thr_x = (w as i128) * 1152 / 1000 + 2;
-    // Largest working value below 1 (value 1 − 10^−w): the all-nines saturation.
+    let saturation_bound = (working_scale as i128) * 1152 / 1000 + 2;
+    // Largest working value below 1 (value 1 − 10^−working_scale): the all-nines
+    // saturation.
     let saturated = one_w.sub(Fixed::from_u128_mag(1, false));
-    let th = if raw.abs() / 10_i128.pow(SCALE) > thr_x {
+    let tanh_value = if raw.abs() / 10_i128.pow(SCALE) > saturation_bound {
         saturated
     } else {
-        let v = to_fixed(raw);
-        let av = Fixed { negative: false, mag: v.mag };
-        let m = exp_fixed(av.double().neg(), w);
+        let working_value = to_fixed(raw);
+        let abs_working_value = Fixed { negative: false, mag: working_value.mag };
+        let m = exp_fixed(abs_working_value.double().neg(), working_scale);
         if m.is_zero() {
-            // |x| just under `thr_x`: m underflowed; tanh is all-nines too.
+            // |x| just under `saturation_bound`: m underflowed; tanh is all-nines too.
             saturated
         } else {
-            one_w.sub(m).div(one_w.add(m), w)
+            one_w.sub(m).div(one_w.add(m), working_scale)
         }
     };
-    let th = if neg { th.neg() } else { th };
-    th.round_to_i128_with(w, SCALE, mode)
+    let tanh_value = if is_negative { tanh_value.neg() } else { tanh_value };
+    tanh_value
+        .round_to_i128_with(working_scale, SCALE, mode)
         .unwrap_or_else(|| crate::support::diagnostics::overflow_panic_with_scale("tanh", SCALE))
 }
 
@@ -1046,21 +1196,27 @@ fn asinh_schoolbook_raw<const SCALE: u32>(raw: i128, mode: RoundingMode) -> i128
     if raw == 0 {
         return 0;
     }
-    let w = SCALE + STRICT_GUARD;
-    let one_w = one_fixed(w);
-    let v = to_fixed(raw);
-    let ax = Fixed { negative: false, mag: v.mag };
-    let inner = if ax.ge_mag(one_w) {
-        let inv = one_w.div(ax, w);
-        let root = one_w.add(inv.mul(inv, w)).sqrt(w);
-        ln_fixed(ax, w).add(ln_fixed(one_w.add(root), w))
+    let working_scale = SCALE + STRICT_GUARD;
+    let one_w = one_fixed(working_scale);
+    let working_value = to_fixed(raw);
+    let abs_working_value = Fixed { negative: false, mag: working_value.mag };
+    let inner = if abs_working_value.ge_mag(one_w) {
+        let reciprocal = one_w.div(abs_working_value, working_scale);
+        let root = one_w
+            .add(reciprocal.mul(reciprocal, working_scale))
+            .sqrt(working_scale);
+        ln_fixed(abs_working_value, working_scale)
+            .add(ln_fixed(one_w.add(root), working_scale))
     } else {
-        let root = ax.mul(ax, w).add(one_w).sqrt(w);
-        ln_fixed(ax.add(root), w)
+        let root = abs_working_value
+            .mul(abs_working_value, working_scale)
+            .add(one_w)
+            .sqrt(working_scale);
+        ln_fixed(abs_working_value.add(root), working_scale)
     };
     let signed = if raw < 0 { inner.neg() } else { inner };
     signed
-        .round_to_i128_with(w, SCALE, mode)
+        .round_to_i128_with(working_scale, SCALE, mode)
         .unwrap_or_else(|| crate::support::diagnostics::overflow_panic_with_scale("asinh", SCALE))
 }
 
@@ -1071,21 +1227,29 @@ fn acosh_schoolbook_raw<const SCALE: u32>(raw: i128, mode: RoundingMode) -> i128
     if raw == one_bits {
         return 0;
     }
-    let w = SCALE + STRICT_GUARD;
-    let one_w = one_fixed(w);
-    let v = to_fixed(raw);
-    assert!(!v.negative && v.ge_mag(one_w), "acosh: argument must be >= 1");
+    let working_scale = SCALE + STRICT_GUARD;
+    let one_w = one_fixed(working_scale);
+    let working_value = to_fixed(raw);
+    assert!(
+        !working_value.negative && working_value.ge_mag(one_w),
+        "acosh: argument must be >= 1"
+    );
     let two_w = one_w.double();
-    let inner = if v.ge_mag(two_w) {
-        let inv = one_w.div(v, w);
-        let root = one_w.sub(inv.mul(inv, w)).sqrt(w);
-        ln_fixed(v, w).add(ln_fixed(one_w.add(root), w))
+    let inner = if working_value.ge_mag(two_w) {
+        let reciprocal = one_w.div(working_value, working_scale);
+        let root = one_w
+            .sub(reciprocal.mul(reciprocal, working_scale))
+            .sqrt(working_scale);
+        ln_fixed(working_value, working_scale).add(ln_fixed(one_w.add(root), working_scale))
     } else {
-        let root = v.mul(v, w).sub(one_w).sqrt(w);
-        ln_fixed(v.add(root), w)
+        let root = working_value
+            .mul(working_value, working_scale)
+            .sub(one_w)
+            .sqrt(working_scale);
+        ln_fixed(working_value.add(root), working_scale)
     };
     inner
-        .round_to_i128_with(w, SCALE, mode)
+        .round_to_i128_with(working_scale, SCALE, mode)
         .unwrap_or_else(|| crate::support::diagnostics::overflow_panic_with_scale("acosh", SCALE))
 }
 
@@ -1095,24 +1259,27 @@ fn atanh_schoolbook_raw<const SCALE: u32>(raw: i128, mode: RoundingMode) -> i128
     if raw == 0 {
         return 0;
     }
-    let w = SCALE + STRICT_GUARD;
-    let one_w = one_fixed(w);
-    let v = to_fixed(raw);
-    let ax = Fixed { negative: false, mag: v.mag };
-    assert!(!ax.ge_mag(one_w), "atanh: argument out of domain (-1, 1)");
+    let working_scale = SCALE + STRICT_GUARD;
+    let one_w = one_fixed(working_scale);
+    let working_value = to_fixed(raw);
+    let abs_working_value = Fixed { negative: false, mag: working_value.mag };
+    assert!(
+        !abs_working_value.ge_mag(one_w),
+        "atanh: argument out of domain (-1, 1)"
+    );
     // atanh(x) = ½·ln((1+x)/(1-x)) = ½·(ln(1+x) − ln(1-x)). Computing the two
     // logs SEPARATELY (not ln of the ratio) is essential near |x| = 1: the
     // ratio (1+x)/(1-x) reaches ~10^(2·digits) there and, scaled to the
-    // working scale `w`, overflows the 256-bit `Fixed` — e.g. atanh(1−10⁻²⁸)
-    // at D38 s28 has ratio ≈ 2·10²⁸ which at w = SCALE+30 = 58 is a raw ~10⁸⁶,
-    // far past 2²⁵⁶. `1+x` and `1-x` each fit, and `ln_fixed` handles arguments
-    // below 1 (the x-near-−1 case already relies on it).
-    let ln_num = ln_fixed(one_w.add(v), w);
-    let ln_den = ln_fixed(one_w.sub(v), w);
+    // working scale, overflows the 256-bit `Fixed` — e.g. atanh(1−10⁻²⁸)
+    // at D38 s28 has ratio ≈ 2·10²⁸ which at working_scale = SCALE+30 = 58 is a
+    // raw ~10⁸⁶, far past 2²⁵⁶. `1+x` and `1-x` each fit, and `ln_fixed` handles
+    // arguments below 1 (the x-near-−1 case already relies on it).
+    let ln_num = ln_fixed(one_w.add(working_value), working_scale);
+    let ln_den = ln_fixed(one_w.sub(working_value), working_scale);
     ln_num
         .sub(ln_den)
         .halve()
-        .round_to_i128_with(w, SCALE, mode)
+        .round_to_i128_with(working_scale, SCALE, mode)
         .unwrap_or_else(|| crate::support::diagnostics::overflow_panic_with_scale("atanh", SCALE))
 }
 
@@ -1232,7 +1399,7 @@ mod tests {
         }
     }
 
-    // Large |x| (well past the saturation onset |x| ≳ 1.1513·w): tanh is
+    // Large |x| (well past the saturation onset |x| ≳ 1.1513·working_scale): tanh is
     // BOUNDED in (−1, 1), so these must SATURATE to ±1 (or ±(1−ulp) under the
     // directed modes), never panic by forming e^|x|. Schoolbook and routed
     // must still agree bit-for-bit. Dedicated array (not the shared
@@ -1257,8 +1424,9 @@ mod tests {
     }
 
     // Large |x| at a HIGH scale (28) — the band the `(e^|x| ± e^-|x|)` form
-    // cannot reach. At w = SCALE + 30 = 58 the dominant e^(+|x|) overflows the
-    // 256-bit `Fixed` once |x| ≳ 44, yet the saturation onset sits at |x| ≳ 1.1513·w
+    // cannot reach. At working_scale = SCALE + 30 = 58 the dominant e^(+|x|) overflows
+    // the 256-bit `Fixed` once |x| ≳ 44, yet the saturation onset sits at
+    // |x| ≳ 1.1513·working_scale
     // ≈ 67, so |x| in [44, 67] would PANIC under that form (the 18 D38<28> cells). The
     // negative-exponent form tanh = (1 − e^-2|x|)/(1 + e^-2|x|) never forms e^(+|x|),
     // so these compute (no panic) AND still agree with the routed kernel bit-for-bit.
@@ -1408,32 +1576,35 @@ mod tests {
             // |x| ≥ 257 (257·log10(e) ≈ 111.6).
             let floor_mag = Int::<6>::TEN.pow(110);
             for &x in &[257i128, 259, 263, 264, 265, 266] {
-                let pos = Int::<6>::from_i128(x);
-                let neg = Int::<6>::from_i128(-x);
+                let positive_raw = Int::<6>::from_i128(x);
+                let negative_raw = Int::<6>::from_i128(-x);
                 for &mode in &MODES {
-                    let c = D::<Int<6>, 0>(pos).cosh_strict_with(mode).0;
-                    let s = D::<Int<6>, 0>(pos).sinh_strict_with(mode).0;
-                    assert!(c > floor_mag, "cosh({x}) too small, mode {mode:?}");
-                    assert!(s > floor_mag, "sinh({x}) too small, mode {mode:?}");
-                    assert!(c >= s, "cosh({x}) < sinh({x}), mode {mode:?}");
+                    let cosh_value = D::<Int<6>, 0>(positive_raw).cosh_strict_with(mode).0;
+                    let sinh_value = D::<Int<6>, 0>(positive_raw).sinh_strict_with(mode).0;
+                    assert!(cosh_value > floor_mag, "cosh({x}) too small, mode {mode:?}");
+                    assert!(sinh_value > floor_mag, "sinh({x}) too small, mode {mode:?}");
+                    assert!(
+                        cosh_value >= sinh_value,
+                        "cosh({x}) < sinh({x}), mode {mode:?}"
+                    );
                     // Even / odd symmetry against the negative-argument rows.
                     // cosh is even: same value, same mode, same result. sinh
                     // is odd, so directed modes flip across the negation:
                     // round_Floor(-v) = -round_Ceiling(v); the nearest modes
                     // and Trunc are sign-symmetric.
                     assert_eq!(
-                        D::<Int<6>, 0>(neg).cosh_strict_with(mode).0,
-                        c,
+                        D::<Int<6>, 0>(negative_raw).cosh_strict_with(mode).0,
+                        cosh_value,
                         "cosh(-{x}) != cosh({x}), mode {mode:?}"
                     );
                     let flipped = match mode {
                         RoundingMode::Floor => RoundingMode::Ceiling,
                         RoundingMode::Ceiling => RoundingMode::Floor,
-                        m => m,
+                        other => other,
                     };
-                    let s_flipped = D::<Int<6>, 0>(pos).sinh_strict_with(flipped).0;
+                    let s_flipped = D::<Int<6>, 0>(positive_raw).sinh_strict_with(flipped).0;
                     assert_eq!(
-                        D::<Int<6>, 0>(neg).sinh_strict_with(mode).0,
+                        D::<Int<6>, 0>(negative_raw).sinh_strict_with(mode).0,
                         Int::<6>::ZERO - s_flipped,
                         "sinh(-{x}) != -sinh({x}) under the flipped mode, mode {mode:?}"
                     );
@@ -1451,11 +1622,11 @@ mod tests {
                 * Int::<6>::TEN.pow(32);
             let floor_mag = Int::<6>::TEN.pow(114);
             for &mode in &MODES {
-                let c = D::<Int<6>, 57>(raw).cosh_strict_with(mode).0;
-                assert!(c > floor_mag, "cosh(133.61..) too small, mode {mode:?}");
+                let cosh_value = D::<Int<6>, 57>(raw).cosh_strict_with(mode).0;
+                assert!(cosh_value > floor_mag, "cosh(133.61..) too small, mode {mode:?}");
                 assert_eq!(
                     D::<Int<6>, 57>(Int::<6>::ZERO - raw).cosh_strict_with(mode).0,
-                    c,
+                    cosh_value,
                     "cosh(-133.61..) != cosh(133.61..), mode {mode:?}"
                 );
             }
@@ -1474,26 +1645,26 @@ mod tests {
                         Int::<6>::ZERO
                     };
                     // Scale 0.
-                    let r0 = Int::<6>::from_i128(x);
+                    let raw_s0 = Int::<6>::from_i128(x);
                     assert_eq!(
-                        D::<Int<6>, 0>(r0).exp_strict_with(mode).0,
+                        D::<Int<6>, 0>(raw_s0).exp_strict_with(mode).0,
                         expect,
                         "exp({x}) at s0, mode {mode:?}"
                     );
                     assert_eq!(
-                        D::<Int<6>, 0>(r0).exp2_strict_with(mode).0,
+                        D::<Int<6>, 0>(raw_s0).exp2_strict_with(mode).0,
                         expect,
                         "exp2({x}) at s0, mode {mode:?}"
                     );
                     // Scale 50 (the deep-escalation band).
-                    let r50 = Int::<6>::from_i128(x) * Int::<6>::TEN.pow(50);
+                    let raw_s50 = Int::<6>::from_i128(x) * Int::<6>::TEN.pow(50);
                     assert_eq!(
-                        D::<Int<6>, 50>(r50).exp_strict_with(mode).0,
+                        D::<Int<6>, 50>(raw_s50).exp_strict_with(mode).0,
                         expect,
                         "exp({x}) at s50, mode {mode:?}"
                     );
                     assert_eq!(
-                        D::<Int<6>, 50>(r50).exp2_strict_with(mode).0,
+                        D::<Int<6>, 50>(raw_s50).exp2_strict_with(mode).0,
                         expect,
                         "exp2({x}) at s50, mode {mode:?}"
                     );
@@ -1523,23 +1694,23 @@ mod tests {
                 -1_000_000_000,
                 -2_500_000_000,
             ];
-            for &u in &INPUTS9 {
-                let r = raw9(u);
+            for &units in &INPUTS9 {
+                let raw = raw9(units);
                 for &mode in &MODES {
                     assert_eq!(
-                        sinh_schoolbook::<Core, S>(r, mode),
-                        D::<Int<3>, S>(r).sinh_strict_with(mode).0,
-                        "D57 sinh schoolbook != routed at units={u} mode={mode:?}"
+                        sinh_schoolbook::<Core, S>(raw, mode),
+                        D::<Int<3>, S>(raw).sinh_strict_with(mode).0,
+                        "D57 sinh schoolbook != routed at units={units} mode={mode:?}"
                     );
                     assert_eq!(
-                        cosh_schoolbook::<Core, S>(r, mode),
-                        D::<Int<3>, S>(r).cosh_strict_with(mode).0,
-                        "D57 cosh schoolbook != routed at units={u} mode={mode:?}"
+                        cosh_schoolbook::<Core, S>(raw, mode),
+                        D::<Int<3>, S>(raw).cosh_strict_with(mode).0,
+                        "D57 cosh schoolbook != routed at units={units} mode={mode:?}"
                     );
                     assert_eq!(
-                        tanh_schoolbook::<Core, S>(r, mode),
-                        D::<Int<3>, S>(r).tanh_strict_with(mode).0,
-                        "D57 tanh schoolbook != routed at units={u} mode={mode:?}"
+                        tanh_schoolbook::<Core, S>(raw, mode),
+                        D::<Int<3>, S>(raw).tanh_strict_with(mode).0,
+                        "D57 tanh schoolbook != routed at units={units} mode={mode:?}"
                     );
                 }
             }
@@ -1556,13 +1727,13 @@ mod tests {
                 -1_000_000_000,
                 -2_500_000_000,
             ];
-            for &u in &SINPUTS {
-                let r = raw9(u);
+            for &units in &SINPUTS {
+                let raw = raw9(units);
                 for &mode in &MODES {
                     assert_eq!(
-                        asinh_schoolbook::<Core, S>(r, mode),
-                        D::<Int<3>, S>(r).asinh_strict_with(mode).0,
-                        "D57 asinh schoolbook != routed at units={u} mode={mode:?}"
+                        asinh_schoolbook::<Core, S>(raw, mode),
+                        D::<Int<3>, S>(raw).asinh_strict_with(mode).0,
+                        "D57 asinh schoolbook != routed at units={units} mode={mode:?}"
                     );
                 }
             }
@@ -1573,13 +1744,13 @@ mod tests {
                 900_000_000,
                 -500_000_000,
             ];
-            for &u in &TINPUTS {
-                let r = raw9(u);
+            for &units in &TINPUTS {
+                let raw = raw9(units);
                 for &mode in &MODES {
                     assert_eq!(
-                        atanh_schoolbook::<Core, S>(r, mode),
-                        D::<Int<3>, S>(r).atanh_strict_with(mode).0,
-                        "D57 atanh schoolbook != routed at units={u} mode={mode:?}"
+                        atanh_schoolbook::<Core, S>(raw, mode),
+                        D::<Int<3>, S>(raw).atanh_strict_with(mode).0,
+                        "D57 atanh schoolbook != routed at units={units} mode={mode:?}"
                     );
                 }
             }
@@ -1589,13 +1760,13 @@ mod tests {
                 2_000_000_000,
                 3_000_000_000,
             ];
-            for &u in &AINPUTS {
-                let r = raw9(u);
+            for &units in &AINPUTS {
+                let raw = raw9(units);
                 for &mode in &MODES {
                     assert_eq!(
-                        acosh_schoolbook::<Core, S>(r, mode),
-                        D::<Int<3>, S>(r).acosh_strict_with(mode).0,
-                        "D57 acosh schoolbook != routed at units={u} mode={mode:?}"
+                        acosh_schoolbook::<Core, S>(raw, mode),
+                        D::<Int<3>, S>(raw).acosh_strict_with(mode).0,
+                        "D57 acosh schoolbook != routed at units={units} mode={mode:?}"
                     );
                 }
             }
@@ -1634,33 +1805,46 @@ mod tests {
             let zero = Int::<24>::from_i128(0);
             let one = Int::<24>::from_i128(1);
             // positive, expanding: Ceiling -> G+1, Floor/Trunc -> G.
-            let g = asinh_schoolbook::<Core, S>(raw, RoundingMode::HalfToEven);
+            let grid_value = asinh_schoolbook::<Core, S>(raw, RoundingMode::HalfToEven);
             assert_eq!(
                 asinh_schoolbook::<Core, S>(raw, RoundingMode::Ceiling),
-                g + one,
+                grid_value + one,
                 "asinh(+) Ceiling steps up"
             );
-            assert_eq!(asinh_schoolbook::<Core, S>(raw, RoundingMode::Floor), g, "asinh(+) Floor stays");
-            assert_eq!(asinh_schoolbook::<Core, S>(raw, RoundingMode::Trunc), g, "asinh(+) Trunc stays");
+            assert_eq!(
+                asinh_schoolbook::<Core, S>(raw, RoundingMode::Floor),
+                grid_value,
+                "asinh(+) Floor stays"
+            );
+            assert_eq!(
+                asinh_schoolbook::<Core, S>(raw, RoundingMode::Trunc),
+                grid_value,
+                "asinh(+) Trunc stays"
+            );
             // negative (odd): nearest = -G; expanding -> Floor -> -G-1, Ceiling/Trunc -> -G.
-            let gn = asinh_schoolbook::<Core, S>(zero - raw, RoundingMode::HalfToEven);
-            assert_eq!(gn, zero - g, "asinh(-) nearest = -G");
+            let negative_grid_value =
+                asinh_schoolbook::<Core, S>(zero - raw, RoundingMode::HalfToEven);
+            assert_eq!(negative_grid_value, zero - grid_value, "asinh(-) nearest = -G");
             assert_eq!(
                 asinh_schoolbook::<Core, S>(zero - raw, RoundingMode::Floor),
-                gn - one,
+                negative_grid_value - one,
                 "asinh(-) Floor steps down"
             );
             assert_eq!(
                 asinh_schoolbook::<Core, S>(zero - raw, RoundingMode::Ceiling),
-                gn,
+                negative_grid_value,
                 "asinh(-) Ceiling stays"
             );
-            assert_eq!(asinh_schoolbook::<Core, S>(zero - raw, RoundingMode::Trunc), gn, "asinh(-) Trunc stays");
+            assert_eq!(
+                asinh_schoolbook::<Core, S>(zero - raw, RoundingMode::Trunc),
+                negative_grid_value,
+                "asinh(-) Trunc stays"
+            );
             // public path routes to the same kernel (rung == tier).
-            let x = D::<Int<24>, S>(raw);
+            let value = D::<Int<24>, S>(raw);
             for mode in MODES {
                 assert_eq!(
-                    x.asinh_strict_with(mode).0,
+                    value.asinh_strict_with(mode).0,
                     asinh_schoolbook::<Core, S>(raw, mode),
                     "asinh public == tier {mode:?}"
                 );

--- a/src/algos/trig/inverse_schoolbook.rs
+++ b/src/algos/trig/inverse_schoolbook.rs
@@ -21,23 +21,44 @@ use crate::int::types::Int;
 use crate::support::rounding::RoundingMode;
 
 #[inline]
-fn asin_work<C: WideTrigCore, const SCALE: u32>(v: C::W, w: u32) -> C::W {
-    let one_w = C::one(w);
-    let abs_v = if v < C::zero() { C::zero() - v } else { v };
-    let half_w = one_w >> 1;
-    if abs_v == one_w {
-        let hp = C::half_pi::<SCALE>(w);
-        if v < C::zero() { C::zero() - hp } else { hp }
-    } else if abs_v <= half_w {
-        let denom = C::sqrt_fixed(one_w - C::mul(v, v, w), w);
-        C::atan_fixed::<SCALE>(C::div(v, denom, w), w)
+fn asin_work<C: WideTrigCore, const SCALE: u32>(working_value: C::W, working_scale: u32) -> C::W {
+    let one_w = C::one(working_scale);
+    let abs_working_value = if working_value < C::zero() {
+        C::zero() - working_value
     } else {
-        let inner = (one_w - abs_v) >> 1;
-        let inner_sqrt = C::sqrt_fixed(inner, w);
-        let inner_denom = C::sqrt_fixed(one_w - C::mul(inner_sqrt, inner_sqrt, w), w);
-        let inner_asin = C::atan_fixed::<SCALE>(C::div(inner_sqrt, inner_denom, w), w);
-        let result_abs = C::half_pi::<SCALE>(w) - inner_asin - inner_asin;
-        if v < C::zero() { C::zero() - result_abs } else { result_abs }
+        working_value
+    };
+    let half_w = one_w >> 1;
+    if abs_working_value == one_w {
+        let half_pi = C::half_pi::<SCALE>(working_scale);
+        if working_value < C::zero() {
+            C::zero() - half_pi
+        } else {
+            half_pi
+        }
+    } else if abs_working_value <= half_w {
+        let denom = C::sqrt_fixed(
+            one_w - C::mul(working_value, working_value, working_scale),
+            working_scale,
+        );
+        C::atan_fixed::<SCALE>(C::div(working_value, denom, working_scale), working_scale)
+    } else {
+        let inner = (one_w - abs_working_value) >> 1;
+        let inner_sqrt = C::sqrt_fixed(inner, working_scale);
+        let inner_denom = C::sqrt_fixed(
+            one_w - C::mul(inner_sqrt, inner_sqrt, working_scale),
+            working_scale,
+        );
+        let inner_asin = C::atan_fixed::<SCALE>(
+            C::div(inner_sqrt, inner_denom, working_scale),
+            working_scale,
+        );
+        let result_abs = C::half_pi::<SCALE>(working_scale) - inner_asin - inner_asin;
+        if working_value < C::zero() {
+            C::zero() - result_abs
+        } else {
+            result_abs
+        }
     }
 }
 
@@ -55,36 +76,43 @@ where
     use crate::algos::support::wide_trig_core::{
         round_to_storage_directed_decided_g, tiny_x_deep_directed_adjust, tiny_x_linear_directed,
     };
-    let w0 = SCALE + C::GUARD;
-    let one_w0 = C::one(w0);
-    let v0 = C::to_work(raw);
-    let abs_v0 = if v0 < C::zero() { C::zero() - v0 } else { v0 };
-    if abs_v0 > one_w0 {
+    let base_working_scale = SCALE + C::GUARD;
+    let one_w0 = C::one(base_working_scale);
+    let base_working_value = C::to_work(raw);
+    let abs_base_working_value = if base_working_value < C::zero() {
+        C::zero() - base_working_value
+    } else {
+        base_working_value
+    };
+    if abs_base_working_value > one_w0 {
         panic!("schoolbook asin: argument out of domain [-1, 1]");
     }
     // Analytic tiny-`x` directed decision (relocated from the policy layer) —
     // `asin(x) = x + x³/6 + …` EXPANDS (every Taylor coefficient is positive).
-    if let Some(v) = tiny_x_linear_directed::<C::Storage, SCALE>(raw, mode, true) {
-        return v;
+    if let Some(analytic_result) = tiny_x_linear_directed::<C::Storage, SCALE>(raw, mode, true) {
+        return analytic_result;
     }
     // Ziv-escalated narrowing (NOT a single shot): the composition's true
     // value can sit a sub-resolution distance from a rounding boundary
-    // while the fixed-w partial lands exactly ON it — asin(3·10⁻⁶⁰) at
-    // SCALE 180 has x³/6 = 4.5 ULP EXACT and the deciding +3x⁵/40 tail at
-    // fraction depth ~298, beyond any fixed GUARD. The walker's base
+    // while the partial at a fixed working scale lands exactly ON it —
+    // asin(3·10⁻⁶⁰) at SCALE 180 has x³/6 = 4.5 ULP EXACT and the
+    // deciding +3x⁵/40 tail at fraction depth ~298, beyond any fixed
+    // GUARD. The walker's base
     // probe is this same single evaluation (clear-of-band inputs exit
     // there, no cost added); a near-tie escalates the working scale.
-    let (r, decided) = round_to_storage_directed_decided_g::<C::Storage, C::W>(
+    let (rounded, decided) = round_to_storage_directed_decided_g::<C::Storage, C::W>(
         C::GUARD,
         SCALE,
         mode,
         C::storage_max(),
         C::storage_min(),
-        |guard| asin_work::<C, SCALE>(C::to_work_scaled(raw, guard), SCALE + guard),
+        |guard_digits| {
+            asin_work::<C, SCALE>(C::to_work_scaled(raw, guard_digits), SCALE + guard_digits)
+        },
     );
     // Deep sub-resolution band (`j* ≥ 5`): `asin` always EXPANDS.
     tiny_x_deep_directed_adjust::<C::Storage, SCALE>(
-        r,
+        rounded,
         decided,
         raw,
         mode,
@@ -100,17 +128,22 @@ pub(crate) fn acos_schoolbook<C: WideTrigCore, const SCALE: u32>(
     raw: C::Storage,
     mode: RoundingMode,
 ) -> C::Storage {
-    let w0 = SCALE + C::GUARD;
-    let one_w0 = C::one(w0);
-    let v0 = C::to_work(raw);
-    let abs_v0 = if v0 < C::zero() { C::zero() - v0 } else { v0 };
-    if abs_v0 > one_w0 {
+    let base_working_scale = SCALE + C::GUARD;
+    let one_w0 = C::one(base_working_scale);
+    let base_working_value = C::to_work(raw);
+    let abs_base_working_value = if base_working_value < C::zero() {
+        C::zero() - base_working_value
+    } else {
+        base_working_value
+    };
+    if abs_base_working_value > one_w0 {
         panic!("schoolbook acos: argument out of domain [-1, 1]");
     }
     // Ziv-escalated narrowing — see [`asin_schoolbook`].
-    C::round_to_storage_directed(C::GUARD, SCALE, mode, &mut |guard| {
-        let w = SCALE + guard;
-        C::half_pi::<SCALE>(w) - asin_work::<C, SCALE>(C::to_work_scaled(raw, guard), w)
+    C::round_to_storage_directed(C::GUARD, SCALE, mode, &mut |guard_digits| {
+        let working_scale = SCALE + guard_digits;
+        C::half_pi::<SCALE>(working_scale)
+            - asin_work::<C, SCALE>(C::to_work_scaled(raw, guard_digits), working_scale)
     })
 }
 
@@ -147,114 +180,121 @@ where
         // to `decided == true` via paired exact-zero probes — d307 s120 — yet
         // still needs the analytic step; a genuinely-resolved off-grid cell —
         // d924 s923 — is also `decided == true` but must NOT be stepped).
-        let probe = |m: RoundingMode| {
+        let probe = |probe_mode: RoundingMode| {
             round_to_storage_directed_decided_g::<C::Storage, C::W>(
                 C::GUARD,
                 SCALE,
-                m,
+                probe_mode,
                 C::storage_max(),
                 C::storage_min(),
-                |guard| atan2_work::<C, SCALE>(y_raw, x_raw, guard),
+                |guard_digits| atan2_work::<C, SCALE>(y_raw, x_raw, guard_digits),
             )
             .0
         };
-        let r_f = probe(RoundingMode::Floor);
-        let r_c = probe(RoundingMode::Ceiling);
-        if r_f == r_c {
-            // On grid: G = r_f. SINGLE analytic step from G — `atan z = z − z³/3
-            // + z⁵/5 − …` COMPRESSES (cubic −) and ALTERNATES, so the linear
-            // (j* = 3) and deep (j* ≥ 5, alternating) helpers place the directed
-            // neighbour exactly one ULP from G.
-            let g = r_f;
-            if let Some(v) = tiny_x_linear_directed::<C::Storage, SCALE>(g, mode, false) {
-                return v;
-            }
-            // The exact bracket posed on the RATIO `z = y/x`, which is what
-            // the `g`-as-argument step below cannot do: substituting `g` for
-            // `z` reasons in a circle over `g − z`, the very quantity being
-            // signed. Where it closes it PROVES the side; where it is silent
-            // the `j*`-parity step runs unchanged.
-            if let Some(v) = crate::algos::support::wide_trig_core::adjust_alternating_bracket_ratio::<
-                C::Storage,
-                C::W,
-                SCALE,
-            >(g, y_raw, x_raw, mode)
+        let floor_probe = probe(RoundingMode::Floor);
+        let ceiling_probe = probe(RoundingMode::Ceiling);
+        if floor_probe == ceiling_probe {
+            // On grid: G = floor_probe. SINGLE analytic step from G — `atan z =
+            // z − z³/3 + z⁵/5 − …` COMPRESSES (cubic −) and ALTERNATES, so the
+            // linear (j* = 3) and deep (j* ≥ 5, alternating) helpers place the
+            // directed neighbour exactly one ULP from G.
+            let grid_value = floor_probe;
+            if let Some(adjusted) =
+                tiny_x_linear_directed::<C::Storage, SCALE>(grid_value, mode, false)
             {
-                return v;
+                return adjusted;
+            }
+            // The exact bracket posed on the RATIO `z = y/x`, which is what the
+            // `grid_value`-as-argument step below cannot do: substituting
+            // `grid_value` for `z` reasons in a circle over `grid_value − z`,
+            // the very quantity being signed. Where it closes it PROVES the
+            // side; where it is silent the `j*`-parity step runs unchanged.
+            if let Some(adjusted) =
+                crate::algos::support::wide_trig_core::adjust_alternating_bracket_ratio::<
+                    C::Storage,
+                    C::W,
+                    SCALE,
+                >(grid_value, y_raw, x_raw, mode)
+            {
+                return adjusted;
             }
             let stepped = tiny_x_deep_directed_adjust::<C::Storage, SCALE>(
-                g,
+                grid_value,
                 false,
-                g,
+                grid_value,
                 mode,
                 true,
                 <C::W as crate::int::types::traits::BigInt>::BITS,
             );
-            if stepped != g {
+            if stepped != grid_value {
                 return stepped;
             }
             // On grid but not in the tiny band (the helpers no-op): G is exact.
-            return g;
+            return grid_value;
         }
         // Off grid: the walker resolved the directed rounding. Return its result
         // for `mode` (Trunc is toward zero — x > 0 so the result sign is y's).
         return match mode {
-            RoundingMode::Ceiling => r_c,
-            RoundingMode::Floor => r_f,
+            RoundingMode::Ceiling => ceiling_probe,
+            RoundingMode::Floor => floor_probe,
             RoundingMode::Trunc => {
                 if y_raw >= zero {
-                    r_f
+                    floor_probe
                 } else {
-                    r_c
+                    ceiling_probe
                 }
             }
             _ => unreachable!("directed mode"),
         };
     }
     // Nearest modes, x ≤ 0, or |y| ≥ |x| (non-tiny |result|): ordinary narrowing.
-    C::round_to_storage_directed(C::GUARD, SCALE, mode, &mut |guard| {
-        atan2_work::<C, SCALE>(y_raw, x_raw, guard)
+    C::round_to_storage_directed(C::GUARD, SCALE, mode, &mut |guard_digits| {
+        atan2_work::<C, SCALE>(y_raw, x_raw, guard_digits)
     })
 }
 
-/// One working-scale atan2 evaluation at `w = SCALE + guard` — the
+/// One working-scale atan2 evaluation at `SCALE + guard_digits` — the
 /// quadrant-resolved composition body shared by the walker probes.
 #[inline]
 fn atan2_work<C: WideTrigCore, const SCALE: u32>(
     y_raw: C::Storage,
     x_raw: C::Storage,
-    guard: u32,
+    guard_digits: u32,
 ) -> C::W {
-    let w = SCALE + guard;
-    let z = C::storage_zero();
-    if x_raw == z {
-        return if y_raw > z {
-            C::half_pi::<SCALE>(w)
-        } else if y_raw < z {
-            C::zero() - C::half_pi::<SCALE>(w)
+    let working_scale = SCALE + guard_digits;
+    let zero_storage = C::storage_zero();
+    if x_raw == zero_storage {
+        return if y_raw > zero_storage {
+            C::half_pi::<SCALE>(working_scale)
+        } else if y_raw < zero_storage {
+            C::zero() - C::half_pi::<SCALE>(working_scale)
         } else {
             C::zero()
         };
     }
-    let y = C::to_work_scaled(y_raw, guard);
-    let x = C::to_work_scaled(x_raw, guard);
+    let y = C::to_work_scaled(y_raw, guard_digits);
+    let x = C::to_work_scaled(x_raw, guard_digits);
     let zero_w = C::zero();
     let abs_y = if y < zero_w { zero_w - y } else { y };
     let abs_x = if x < zero_w { zero_w - x } else { x };
     let base = if abs_x >= abs_y {
-        C::atan_fixed::<SCALE>(C::div(y, x, w), w)
+        C::atan_fixed::<SCALE>(C::div(y, x, working_scale), working_scale)
     } else {
-        let inv = C::atan_fixed::<SCALE>(C::div(x, y, w), w);
-        let hp = C::half_pi::<SCALE>(w);
+        let atan_x_over_y = C::atan_fixed::<SCALE>(C::div(x, y, working_scale), working_scale);
+        let half_pi = C::half_pi::<SCALE>(working_scale);
         let same_sign = (y < zero_w) == (x < zero_w);
-        if same_sign { hp - inv } else { (zero_w - hp) - inv }
+        if same_sign {
+            half_pi - atan_x_over_y
+        } else {
+            (zero_w - half_pi) - atan_x_over_y
+        }
     };
-    if x_raw > z {
+    if x_raw > zero_storage {
         base
-    } else if y_raw >= z {
-        base + C::pi::<SCALE>(w)
+    } else if y_raw >= zero_storage {
+        base + C::pi::<SCALE>(working_scale)
     } else {
-        base - C::pi::<SCALE>(w)
+        base - C::pi::<SCALE>(working_scale)
     }
 }
 
@@ -272,33 +312,54 @@ fn atan2_work<C: WideTrigCore, const SCALE: u32>(
 /// (only its `π/2` half is consumed).
 #[cfg(feature = "_wide-support")]
 #[inline]
-fn asin_work_g<Wk: crate::int::types::traits::BigInt>(v: Wk, w: u32, pi_w: Wk) -> Wk
+fn asin_work_g<Wk: crate::int::types::traits::BigInt>(
+    working_value: Wk,
+    working_scale: u32,
+    pi_at_working_scale: Wk,
+) -> Wk
 where
     Wk::Scratch: crate::int::types::compute_limbs::ComputeLimbs,
 {
     use crate::algos::exp::exp_generic as eg;
-    let one_w = eg::one::<Wk>(w);
+    let one_w = eg::one::<Wk>(working_scale);
     let zero = eg::zero::<Wk>();
-    let abs_v = if v < zero { zero - v } else { v };
-    let half_w = one_w >> 1;
-    if abs_v == one_w {
-        let hp = pi_w >> 1;
-        if v < zero { zero - hp } else { hp }
-    } else if abs_v <= half_w {
-        let denom = eg::sqrt_fixed::<Wk>(one_w - eg::mul::<Wk>(v, v, w), w);
-        crate::algos::trig::trig_generic::atan_fixed::<Wk>(eg::div::<Wk>(v, denom, w), w, pi_w)
+    let abs_working_value = if working_value < zero {
+        zero - working_value
     } else {
-        let inner = (one_w - abs_v) >> 1;
-        let inner_sqrt = eg::sqrt_fixed::<Wk>(inner, w);
-        let inner_denom =
-            eg::sqrt_fixed::<Wk>(one_w - eg::mul::<Wk>(inner_sqrt, inner_sqrt, w), w);
-        let inner_asin = crate::algos::trig::trig_generic::atan_fixed::<Wk>(
-            eg::div::<Wk>(inner_sqrt, inner_denom, w),
-            w,
-            pi_w,
+        working_value
+    };
+    let half_w = one_w >> 1;
+    if abs_working_value == one_w {
+        let half_pi = pi_at_working_scale >> 1;
+        if working_value < zero { zero - half_pi } else { half_pi }
+    } else if abs_working_value <= half_w {
+        let denom = eg::sqrt_fixed::<Wk>(
+            one_w - eg::mul::<Wk>(working_value, working_value, working_scale),
+            working_scale,
         );
-        let result_abs = (pi_w >> 1) - inner_asin - inner_asin;
-        if v < zero { zero - result_abs } else { result_abs }
+        crate::algos::trig::trig_generic::atan_fixed::<Wk>(
+            eg::div::<Wk>(working_value, denom, working_scale),
+            working_scale,
+            pi_at_working_scale,
+        )
+    } else {
+        let inner = (one_w - abs_working_value) >> 1;
+        let inner_sqrt = eg::sqrt_fixed::<Wk>(inner, working_scale);
+        let inner_denom = eg::sqrt_fixed::<Wk>(
+            one_w - eg::mul::<Wk>(inner_sqrt, inner_sqrt, working_scale),
+            working_scale,
+        );
+        let inner_asin = crate::algos::trig::trig_generic::atan_fixed::<Wk>(
+            eg::div::<Wk>(inner_sqrt, inner_denom, working_scale),
+            working_scale,
+            pi_at_working_scale,
+        );
+        let result_abs = (pi_at_working_scale >> 1) - inner_asin - inner_asin;
+        if working_value < zero {
+            zero - result_abs
+        } else {
+            result_abs
+        }
     }
 }
 
@@ -323,41 +384,47 @@ where
         pi_at_rung, round_to_storage_directed_widening_decided_g, tiny_x_deep_directed_adjust,
         tiny_x_linear_directed, to_work_scaled_g,
     };
-    let w0 = SCALE + C::GUARD;
-    let one_w0 = eg::one::<Wk>(w0);
+    let base_working_scale = SCALE + C::GUARD;
+    let one_w0 = eg::one::<Wk>(base_working_scale);
     let zero = eg::zero::<Wk>();
-    let v0 = to_work_scaled_g::<C::Storage, Wk>(raw, C::GUARD);
-    let abs_v0 = if v0 < zero { zero - v0 } else { v0 };
-    if abs_v0 > one_w0 {
+    let base_working_value = to_work_scaled_g::<C::Storage, Wk>(raw, C::GUARD);
+    let abs_base_working_value = if base_working_value < zero {
+        zero - base_working_value
+    } else {
+        base_working_value
+    };
+    if abs_base_working_value > one_w0 {
         panic!("schoolbook asin: argument out of domain [-1, 1]");
     }
     // Analytic tiny-`x` directed decision — the SAME pre-empt the tier
     // [`asin_schoolbook`] carries (relocated from the policy layer).
-    if let Some(v) = tiny_x_linear_directed::<C::Storage, SCALE>(raw, mode, true) {
-        return v;
+    if let Some(analytic_result) = tiny_x_linear_directed::<C::Storage, SCALE>(raw, mode, true) {
+        return analytic_result;
     }
     // Ziv-escalated two-width narrowing — see the tier [`asin_schoolbook`]
     // (the asin(3e-60) partial-sum family): rung probes first, an
     // unresolved-at-rung-cap walk falls up to the tier width.
-    let (r, decided) = round_to_storage_directed_widening_decided_g::<C::Storage, Wk, C::W>(
+    let (rounded, decided) = round_to_storage_directed_widening_decided_g::<C::Storage, Wk, C::W>(
         C::GUARD,
         SCALE,
         mode,
         C::storage_max(),
         C::storage_min(),
-        |guard| {
-            let w = SCALE + guard;
+        |guard_digits| {
+            let working_scale = SCALE + guard_digits;
             asin_work_g::<Wk>(
-                to_work_scaled_g::<C::Storage, Wk>(raw, guard),
-                w,
-                pi_at_rung::<Wk>(w, w0),
+                to_work_scaled_g::<C::Storage, Wk>(raw, guard_digits),
+                working_scale,
+                pi_at_rung::<Wk>(working_scale, base_working_scale),
             )
         },
-        |guard| asin_work::<C, SCALE>(C::to_work_scaled(raw, guard), SCALE + guard),
+        |guard_digits| {
+            asin_work::<C, SCALE>(C::to_work_scaled(raw, guard_digits), SCALE + guard_digits)
+        },
     );
     // Deep sub-resolution band (`j* ≥ 5`): `asin` always EXPANDS.
     tiny_x_deep_directed_adjust::<C::Storage, SCALE>(
-        r,
+        rounded,
         decided,
         raw,
         mode,
@@ -384,12 +451,16 @@ where
     use crate::algos::support::wide_trig_core::{
         pi_at_rung, round_to_storage_directed_widening_g, to_work_scaled_g,
     };
-    let w0 = SCALE + C::GUARD;
-    let one_w0 = eg::one::<Wk>(w0);
+    let base_working_scale = SCALE + C::GUARD;
+    let one_w0 = eg::one::<Wk>(base_working_scale);
     let zero = eg::zero::<Wk>();
-    let v0 = to_work_scaled_g::<C::Storage, Wk>(raw, C::GUARD);
-    let abs_v0 = if v0 < zero { zero - v0 } else { v0 };
-    if abs_v0 > one_w0 {
+    let base_working_value = to_work_scaled_g::<C::Storage, Wk>(raw, C::GUARD);
+    let abs_base_working_value = if base_working_value < zero {
+        zero - base_working_value
+    } else {
+        base_working_value
+    };
+    if abs_base_working_value > one_w0 {
         panic!("schoolbook acos: argument out of domain [-1, 1]");
     }
     // Ziv-escalated two-width narrowing — see [`asin_schoolbook_g`].
@@ -399,15 +470,20 @@ where
         mode,
         C::storage_max(),
         C::storage_min(),
-        |guard| {
-            let w = SCALE + guard;
-            let pi_w = pi_at_rung::<Wk>(w, w0);
-            (pi_w >> 1)
-                - asin_work_g::<Wk>(to_work_scaled_g::<C::Storage, Wk>(raw, guard), w, pi_w)
+        |guard_digits| {
+            let working_scale = SCALE + guard_digits;
+            let pi_at_working_scale = pi_at_rung::<Wk>(working_scale, base_working_scale);
+            (pi_at_working_scale >> 1)
+                - asin_work_g::<Wk>(
+                    to_work_scaled_g::<C::Storage, Wk>(raw, guard_digits),
+                    working_scale,
+                    pi_at_working_scale,
+                )
         },
-        |guard| {
-            let w = SCALE + guard;
-            C::half_pi::<SCALE>(w) - asin_work::<C, SCALE>(C::to_work_scaled(raw, guard), w)
+        |guard_digits| {
+            let working_scale = SCALE + guard_digits;
+            C::half_pi::<SCALE>(working_scale)
+                - asin_work::<C, SCALE>(C::to_work_scaled(raw, guard_digits), working_scale)
         },
     )
 }
@@ -430,68 +506,73 @@ where
     use crate::algos::support::wide_trig_core::{
         round_to_storage_directed_widening_g, tiny_x_deep_directed_adjust, tiny_x_linear_directed,
     };
-    let w0 = SCALE + C::GUARD;
+    let base_working_scale = SCALE + C::GUARD;
     let zero = C::storage_zero();
     let abs_y = if y_raw < zero { zero - y_raw } else { y_raw };
     // Two-width directed narrowing (rung-first, fall-up to the tier width C::W).
-    let walk = |m: RoundingMode| {
+    let walk = |walk_mode: RoundingMode| {
         round_to_storage_directed_widening_g::<C::Storage, Wk, C::W>(
             C::GUARD,
             SCALE,
-            m,
+            walk_mode,
             C::storage_max(),
             C::storage_min(),
-            |guard| atan2_work_g::<C, Wk, SCALE>(y_raw, x_raw, guard, w0),
-            |guard| atan2_work::<C, SCALE>(y_raw, x_raw, guard),
+            |guard_digits| {
+                atan2_work_g::<C, Wk, SCALE>(y_raw, x_raw, guard_digits, base_working_scale)
+            },
+            |guard_digits| atan2_work::<C, SCALE>(y_raw, x_raw, guard_digits),
         )
     };
     // Tiny-result directed decision — see the tier [`atan2_schoolbook`]: probe
     // Floor/Ceiling; AGREE ⟺ exactly on grid (mode-blind, deciding odd term
-    // sub-resolution → SINGLE analytic step from G = r_f); DIFFER ⟺ off-grid (a
-    // resolved non-terminating term, j* ≥ 9 → the walker already rounds it
-    // correctly). atan compresses + alternates.
+    // sub-resolution → SINGLE analytic step from G = floor_probe); DIFFER ⟺
+    // off-grid (a resolved non-terminating term, j* ≥ 9 → the walker already
+    // rounds it correctly). atan compresses + alternates.
     if !crate::support::rounding::is_nearest_mode(mode) && x_raw > zero && abs_y < x_raw {
-        let r_f = walk(RoundingMode::Floor);
-        let r_c = walk(RoundingMode::Ceiling);
-        if r_f == r_c {
-            let g = r_f;
-            if let Some(v) = tiny_x_linear_directed::<C::Storage, SCALE>(g, mode, false) {
-                return v;
-            }
-            // The exact bracket posed on the RATIO `z = y/x`, which is what
-            // the `g`-as-argument step below cannot do: substituting `g` for
-            // `z` reasons in a circle over `g − z`, the very quantity being
-            // signed. Where it closes it PROVES the side; where it is silent
-            // the `j*`-parity step runs unchanged.
-            if let Some(v) = crate::algos::support::wide_trig_core::adjust_alternating_bracket_ratio::<
-                C::Storage,
-                C::W,
-                SCALE,
-            >(g, y_raw, x_raw, mode)
+        let floor_probe = walk(RoundingMode::Floor);
+        let ceiling_probe = walk(RoundingMode::Ceiling);
+        if floor_probe == ceiling_probe {
+            let grid_value = floor_probe;
+            if let Some(adjusted) =
+                tiny_x_linear_directed::<C::Storage, SCALE>(grid_value, mode, false)
             {
-                return v;
+                return adjusted;
+            }
+            // The exact bracket posed on the RATIO `z = y/x`, which is what the
+            // `grid_value`-as-argument step below cannot do: substituting
+            // `grid_value` for `z` reasons in a circle over `grid_value − z`,
+            // the very quantity being signed. Where it closes it PROVES the
+            // side; where it is silent the `j*`-parity step runs unchanged.
+            if let Some(adjusted) =
+                crate::algos::support::wide_trig_core::adjust_alternating_bracket_ratio::<
+                    C::Storage,
+                    C::W,
+                    SCALE,
+                >(grid_value, y_raw, x_raw, mode)
+            {
+                return adjusted;
             }
             let stepped = tiny_x_deep_directed_adjust::<C::Storage, SCALE>(
-                g,
+                grid_value,
                 false,
-                g,
+                grid_value,
                 mode,
                 true,
                 <C::W as crate::int::types::traits::BigInt>::BITS,
             );
-            if stepped != g {
+            if stepped != grid_value {
                 return stepped;
             }
-            return g;
+            return grid_value;
         }
         return match mode {
-            RoundingMode::Ceiling => r_c,
-            RoundingMode::Floor => r_f,
+            RoundingMode::Ceiling => ceiling_probe,
+            RoundingMode::Floor => floor_probe,
             RoundingMode::Trunc => {
                 if y_raw >= zero {
-                    r_f
+                    floor_probe
                 } else {
-                    r_c
+                    ceiling_probe
                 }
             }
             _ => unreachable!("directed mode"),
@@ -500,16 +581,16 @@ where
     walk(mode)
 }
 
-/// One rung-width atan2 evaluation at `w = SCALE + guard` — the
+/// One rung-width atan2 evaluation at `SCALE + guard_digits` — the
 /// quadrant-resolved composition body shared by the rung walker probes
-/// (`base_w0` keys the hot-path const-fold of `π`).
+/// (`base_working_scale` keys the hot-path const-fold of `π`).
 #[cfg(feature = "_wide-support")]
 #[inline]
 fn atan2_work_g<C: WideTrigCore, Wk: crate::int::types::traits::BigInt, const SCALE: u32>(
     y_raw: C::Storage,
     x_raw: C::Storage,
-    guard: u32,
-    base_w0: u32,
+    guard_digits: u32,
+    base_working_scale: u32,
 ) -> Wk
 where
     Wk::Scratch: crate::int::types::compute_limbs::ComputeLimbs,
@@ -517,59 +598,73 @@ where
     use crate::algos::exp::exp_generic as eg;
     use crate::algos::support::wide_trig_core::{pi_at_rung, to_work_scaled_g};
     use crate::algos::trig::trig_generic::atan_fixed;
-    let w = SCALE + guard;
-    let z = C::storage_zero();
-    let pi_w = pi_at_rung::<Wk>(w, base_w0);
-    if x_raw == z {
-        return if y_raw > z {
-            pi_w >> 1
-        } else if y_raw < z {
-            eg::zero::<Wk>() - (pi_w >> 1)
+    let working_scale = SCALE + guard_digits;
+    let zero_storage = C::storage_zero();
+    let pi_at_working_scale = pi_at_rung::<Wk>(working_scale, base_working_scale);
+    if x_raw == zero_storage {
+        return if y_raw > zero_storage {
+            pi_at_working_scale >> 1
+        } else if y_raw < zero_storage {
+            eg::zero::<Wk>() - (pi_at_working_scale >> 1)
         } else {
             eg::zero::<Wk>()
         };
     }
-    let y = to_work_scaled_g::<C::Storage, Wk>(y_raw, guard);
-    let x = to_work_scaled_g::<C::Storage, Wk>(x_raw, guard);
+    let y = to_work_scaled_g::<C::Storage, Wk>(y_raw, guard_digits);
+    let x = to_work_scaled_g::<C::Storage, Wk>(x_raw, guard_digits);
     let zero_w = eg::zero::<Wk>();
     let abs_y = if y < zero_w { zero_w - y } else { y };
     let abs_x = if x < zero_w { zero_w - x } else { x };
     let base = if abs_x >= abs_y {
-        atan_fixed::<Wk>(eg::div::<Wk>(y, x, w), w, pi_w)
+        atan_fixed::<Wk>(
+            eg::div::<Wk>(y, x, working_scale),
+            working_scale,
+            pi_at_working_scale,
+        )
     } else {
-        let inv = atan_fixed::<Wk>(eg::div::<Wk>(x, y, w), w, pi_w);
-        let hp = pi_w >> 1;
+        let atan_x_over_y = atan_fixed::<Wk>(
+            eg::div::<Wk>(x, y, working_scale),
+            working_scale,
+            pi_at_working_scale,
+        );
+        let half_pi = pi_at_working_scale >> 1;
         let same_sign = (y < zero_w) == (x < zero_w);
-        if same_sign { hp - inv } else { (zero_w - hp) - inv }
+        if same_sign {
+            half_pi - atan_x_over_y
+        } else {
+            (zero_w - half_pi) - atan_x_over_y
+        }
     };
-    if x_raw > z {
+    if x_raw > zero_storage {
         base
-    } else if y_raw >= z {
-        base + pi_w
+    } else if y_raw >= zero_storage {
+        base + pi_at_working_scale
     } else {
-        base - pi_w
+        base - pi_at_working_scale
     }
 }
 
 #[inline]
-fn asin_work_narrow(v: Fixed, w: u32) -> Fixed {
-    let one_w = Fixed { negative: false, mag: Fixed::pow10(w) };
-    let abs_v = Fixed { negative: false, mag: v.mag };
-    if abs_v == one_w {
-        let hp = wide_half_pi(w);
-        return if v.negative { hp.neg() } else { hp };
+fn asin_work_narrow(working_value: Fixed, working_scale: u32) -> Fixed {
+    let one_w = Fixed { negative: false, mag: Fixed::pow10(working_scale) };
+    let abs_working_value = Fixed { negative: false, mag: working_value.mag };
+    if abs_working_value == one_w {
+        let half_pi = wide_half_pi(working_scale);
+        return if working_value.negative { half_pi.neg() } else { half_pi };
     }
     let half_w = one_w.halve();
-    if !abs_v.ge_mag(half_w) {
-        let denom = one_w.sub(v.mul(v, w)).sqrt(w);
-        atan_fixed(v.div(denom, w), w)
+    if !abs_working_value.ge_mag(half_w) {
+        let denom = one_w
+            .sub(working_value.mul(working_value, working_scale))
+            .sqrt(working_scale);
+        atan_fixed(working_value.div(denom, working_scale), working_scale)
     } else {
-        let inner = one_w.sub(abs_v).halve();
-        let inner_sqrt = inner.sqrt(w);
-        let inner_denom = one_w.sub(inner_sqrt.mul(inner_sqrt, w)).sqrt(w);
-        let inner_asin = atan_fixed(inner_sqrt.div(inner_denom, w), w);
-        let result_abs = wide_half_pi(w).sub(inner_asin).sub(inner_asin);
-        if v.negative { result_abs.neg() } else { result_abs }
+        let inner = one_w.sub(abs_working_value).halve();
+        let inner_sqrt = inner.sqrt(working_scale);
+        let inner_denom = one_w.sub(inner_sqrt.mul(inner_sqrt, working_scale)).sqrt(working_scale);
+        let inner_asin = atan_fixed(inner_sqrt.div(inner_denom, working_scale), working_scale);
+        let result_abs = wide_half_pi(working_scale).sub(inner_asin).sub(inner_asin);
+        if working_value.negative { result_abs.neg() } else { result_abs }
     }
 }
 
@@ -579,24 +674,28 @@ fn asin_schoolbook_raw<const SCALE: u32>(raw: i128, mode: RoundingMode) -> i128 
     if raw == 0 {
         return 0;
     }
-    let w = SCALE + STRICT_GUARD;
-    let one_w = Fixed { negative: false, mag: Fixed::pow10(w) };
-    let v = to_fixed(raw);
-    let abs_v = Fixed { negative: false, mag: v.mag };
+    let working_scale = SCALE + STRICT_GUARD;
+    let one_w = Fixed { negative: false, mag: Fixed::pow10(working_scale) };
+    let working_value = to_fixed(raw);
+    let abs_working_value = Fixed { negative: false, mag: working_value.mag };
     assert!(
-        !(abs_v.ge_mag(one_w) && abs_v != one_w),
+        !(abs_working_value.ge_mag(one_w) && abs_working_value != one_w),
         "asin: argument out of domain [-1, 1]"
     );
     // Near-tie protected terminal, mirroring the routed
     // `trig_series_2limb::asin_strict_raw` (the schoolbook is the
     // bit-exact reference, so it must decide ties the same way).
-    match asin_work_narrow(v, w).round_to_i128_clear_of_tie(w, SCALE, mode) {
-        Some(v) => v.unwrap_or_else(|| {
+    match asin_work_narrow(working_value, working_scale)
+        .round_to_i128_clear_of_tie(working_scale, SCALE, mode)
+    {
+        Some(narrowed) => narrowed.unwrap_or_else(|| {
             crate::support::diagnostics::overflow_panic_with_scale("asin", SCALE)
         }),
-        None => crate::algos::support::narrow_ziv::walk(STRICT_GUARD, SCALE, mode, |g| {
-            crate::algos::trig::trig_series_2limb::asin_ziv(raw, SCALE, g)
-        }),
+        None => {
+            crate::algos::support::narrow_ziv::walk(STRICT_GUARD, SCALE, mode, |guard_digits| {
+                crate::algos::trig::trig_series_2limb::asin_ziv(raw, SCALE, guard_digits)
+            })
+        }
     }
 }
 
@@ -619,42 +718,46 @@ fn acos_schoolbook_raw<const SCALE: u32>(raw: i128, mode: RoundingMode) -> i128 
     if raw == -one_bits && crate::support::rounding::is_nearest_mode(mode) {
         return <crate::D<Int<2>, SCALE> as DecimalConstants>::pi().0.as_i128();
     }
-    let w = SCALE + STRICT_GUARD;
-    let one_w = Fixed { negative: false, mag: Fixed::pow10(w) };
-    let v = to_fixed(raw);
-    let abs_v = Fixed { negative: false, mag: v.mag };
+    let working_scale = SCALE + STRICT_GUARD;
+    let one_w = Fixed { negative: false, mag: Fixed::pow10(working_scale) };
+    let working_value = to_fixed(raw);
+    let abs_working_value = Fixed { negative: false, mag: working_value.mag };
     assert!(
-        !(abs_v.ge_mag(one_w) && abs_v != one_w),
+        !(abs_working_value.ge_mag(one_w) && abs_working_value != one_w),
         "acos: argument out of domain [-1, 1]"
     );
     // Near-tie protected terminal — see `asin_schoolbook_raw`.
-    match wide_half_pi(w)
-        .sub(asin_work_narrow(v, w))
-        .round_to_i128_clear_of_tie(w, SCALE, mode)
+    match wide_half_pi(working_scale)
+        .sub(asin_work_narrow(working_value, working_scale))
+        .round_to_i128_clear_of_tie(working_scale, SCALE, mode)
     {
-        Some(v) => v.unwrap_or_else(|| {
+        Some(narrowed) => narrowed.unwrap_or_else(|| {
             crate::support::diagnostics::overflow_panic_with_scale("acos", SCALE)
         }),
-        None => crate::algos::support::narrow_ziv::walk(STRICT_GUARD, SCALE, mode, |g| {
-            crate::algos::trig::trig_series_2limb::acos_ziv(raw, SCALE, g)
-        }),
+        None => {
+            crate::algos::support::narrow_ziv::walk(STRICT_GUARD, SCALE, mode, |guard_digits| {
+                crate::algos::trig::trig_series_2limb::acos_ziv(raw, SCALE, guard_digits)
+            })
+        }
     }
 }
 
 #[inline]
 #[must_use]
 fn atan2_schoolbook_raw<const SCALE: u32>(y_raw: i128, x_raw: i128, mode: RoundingMode) -> i128 {
-    let w = SCALE + STRICT_GUARD;
+    let working_scale = SCALE + STRICT_GUARD;
     // Near-tie protected terminal — see `asin_schoolbook_raw`.
-    match atan2_kernel(to_fixed(y_raw), to_fixed(x_raw), y_raw, w)
-        .round_to_i128_clear_of_tie(w, SCALE, mode)
+    match atan2_kernel(to_fixed(y_raw), to_fixed(x_raw), y_raw, working_scale)
+        .round_to_i128_clear_of_tie(working_scale, SCALE, mode)
     {
-        Some(v) => v.unwrap_or_else(|| {
+        Some(narrowed) => narrowed.unwrap_or_else(|| {
             crate::support::diagnostics::overflow_panic_with_scale("atan2", SCALE)
         }),
-        None => crate::algos::support::narrow_ziv::walk(STRICT_GUARD, SCALE, mode, |g| {
-            crate::algos::trig::trig_series_2limb::atan2_ziv(y_raw, x_raw, SCALE, g)
-        }),
+        None => {
+            crate::algos::support::narrow_ziv::walk(STRICT_GUARD, SCALE, mode, |guard_digits| {
+                crate::algos::trig::trig_series_2limb::atan2_ziv(y_raw, x_raw, SCALE, guard_digits)
+            })
+        }
     }
 }
 
@@ -855,15 +958,15 @@ mod tests {
                 "tier asin Ceiling"
             );
             // Public path (policy -> rung walker -> tier fall-up).
-            let x = crate::D::<Int<24>, 180>(raw);
+            let value = crate::D::<Int<24>, 180>(raw);
             assert_eq!(
-                x.asin_strict_with(RoundingMode::HalfToEven).0,
+                value.asin_strict_with(RoundingMode::HalfToEven).0,
                 expect_nearest,
                 "public asin HalfToEven"
             );
             for mode in MODES {
                 assert_eq!(
-                    x.asin_strict_with(mode).0,
+                    value.asin_strict_with(mode).0,
                     asin_schoolbook::<Core, 180>(raw, mode),
                     "public == tier at mode {mode:?}"
                 );
@@ -897,14 +1000,14 @@ mod tests {
             crate::int::types::compute_limbs::ComputeLimbs,
     {
         use crate::int::types::traits::BigInt;
-        let p = |n: u32| crate::consts::pow10::dispatch::<C::Storage>(n);
+        let pow10 = |exponent: u32| crate::consts::pow10::dispatch::<C::Storage>(exponent);
         let one = <C::Storage as BigInt>::from_i128(1);
-        let y = <C::Storage as BigInt>::from_i128(coeff) * p(S - big_k);
-        let x = p(S); // 1.0
-        let g = atan2_schoolbook::<C, S>(y, x, RoundingMode::HalfToEven);
+        let y = <C::Storage as BigInt>::from_i128(coeff) * pow10(S - big_k);
+        let x = pow10(S); // 1.0
+        let grid_value = atan2_schoolbook::<C, S>(y, x, RoundingMode::HalfToEven);
         assert_eq!(
             atan2_schoolbook::<C, S>(y, x, RoundingMode::HalfAwayFromZero),
-            g,
+            grid_value,
             "nearest modes agree S={S} k={big_k} coeff={coeff}"
         );
         let j_min = S / big_k + 1;
@@ -914,32 +1017,43 @@ mod tests {
         // atan COMPRESSES (cubic −), then alternates. The directed neighbour per
         // (deciding-term direction, result sign) — mirrors
         // `tiny_odd_{compressing,expanding}_directed`.
-        let (floor_e, trunc_e, ceil_e) = match (expanding, positive) {
-            (true, true) => (g, g, g + one),            // expanding +: Ceil up
-            (true, false) => (g - one, g, g),           // expanding −: Floor down
-            (false, true) => (g - one, g - one, g),     // compress +: Floor/Trunc down
-            (false, false) => (g, g + one, g + one),    // compress −: Trunc/Ceil up
+        let (floor_expected, trunc_expected, ceil_expected) = match (expanding, positive) {
+            // expanding +: Ceil up
+            (true, true) => (grid_value, grid_value, grid_value + one),
+            // expanding −: Floor down
+            (true, false) => (grid_value - one, grid_value, grid_value),
+            // compress +: Floor/Trunc down
+            (false, true) => (grid_value - one, grid_value - one, grid_value),
+            // compress −: Trunc/Ceil up
+            (false, false) => (grid_value, grid_value + one, grid_value + one),
         };
         assert_eq!(
             atan2_schoolbook::<C, S>(y, x, RoundingMode::Floor),
-            floor_e,
+            floor_expected,
             "Floor S={S} k={big_k} coeff={coeff} j*={j_star} exp={expanding}"
         );
         assert_eq!(
             atan2_schoolbook::<C, S>(y, x, RoundingMode::Trunc),
-            trunc_e,
+            trunc_expected,
             "Trunc S={S} k={big_k} coeff={coeff} j*={j_star} exp={expanding}"
         );
         assert_eq!(
             atan2_schoolbook::<C, S>(y, x, RoundingMode::Ceiling),
-            ceil_e,
+            ceil_expected,
             "Ceiling S={S} k={big_k} coeff={coeff} j*={j_star} exp={expanding}"
         );
         // Single-step invariant: every directed result within ONE ULP of G.
-        for m in [RoundingMode::Floor, RoundingMode::Trunc, RoundingMode::Ceiling] {
-            let r = atan2_schoolbook::<C, S>(y, x, m);
-            let d = if r < g { g - r } else { r - g };
-            assert!(d <= one, "single-step |r-G|<=1 S={S} k={big_k} coeff={coeff} mode={m:?}");
+        for mode in [RoundingMode::Floor, RoundingMode::Trunc, RoundingMode::Ceiling] {
+            let directed = atan2_schoolbook::<C, S>(y, x, mode);
+            let delta = if directed < grid_value {
+                grid_value - directed
+            } else {
+                directed - grid_value
+            };
+            assert!(
+                delta <= one,
+                "single-step |r-G|<=1 S={S} k={big_k} coeff={coeff} mode={mode:?}"
+            );
         }
     }
 
@@ -957,19 +1071,19 @@ mod tests {
     {
         use crate::algos::support::wide_trig_core::round_to_storage_directed_decided_g;
         use crate::int::types::traits::BigInt;
-        let p = |n: u32| crate::consts::pow10::dispatch::<C::Storage>(n);
+        let pow10 = |exponent: u32| crate::consts::pow10::dispatch::<C::Storage>(exponent);
         let one = <C::Storage as BigInt>::from_i128(1);
-        let y = <C::Storage as BigInt>::from_i128(coeff) * p(S - big_k);
-        let x = p(S);
-        let g = atan2_schoolbook::<C, S>(y, x, RoundingMode::HalfToEven);
-        let walker = |m: RoundingMode| {
+        let y = <C::Storage as BigInt>::from_i128(coeff) * pow10(S - big_k);
+        let x = pow10(S);
+        let grid_value = atan2_schoolbook::<C, S>(y, x, RoundingMode::HalfToEven);
+        let walker = |walk_mode: RoundingMode| {
             round_to_storage_directed_decided_g::<C::Storage, C::W>(
                 C::GUARD,
                 S,
-                m,
+                walk_mode,
                 C::storage_max(),
                 C::storage_min(),
-                |guard| atan2_work::<C, S>(y, x, guard),
+                |guard_digits| atan2_work::<C, S>(y, x, guard_digits),
             )
             .0
         };
@@ -979,15 +1093,22 @@ mod tests {
             walker(RoundingMode::Ceiling),
             "off-grid Floor != Ceiling S={S} k={big_k} coeff={coeff}"
         );
-        for m in [RoundingMode::Floor, RoundingMode::Trunc, RoundingMode::Ceiling] {
+        for mode in [RoundingMode::Floor, RoundingMode::Trunc, RoundingMode::Ceiling] {
             assert_eq!(
-                atan2_schoolbook::<C, S>(y, x, m),
-                walker(m),
-                "off-grid kernel==walker S={S} k={big_k} coeff={coeff} mode={m:?}"
+                atan2_schoolbook::<C, S>(y, x, mode),
+                walker(mode),
+                "off-grid kernel==walker S={S} k={big_k} coeff={coeff} mode={mode:?}"
             );
-            let r = atan2_schoolbook::<C, S>(y, x, m);
-            let d = if r < g { g - r } else { r - g };
-            assert!(d <= one, "off-grid single-step S={S} k={big_k} coeff={coeff} mode={m:?}");
+            let directed = atan2_schoolbook::<C, S>(y, x, mode);
+            let delta = if directed < grid_value {
+                grid_value - directed
+            } else {
+                directed - grid_value
+            };
+            assert!(
+                delta <= one,
+                "off-grid single-step S={S} k={big_k} coeff={coeff} mode={mode:?}"
+            );
         }
     }
 
@@ -1029,14 +1150,14 @@ mod tests {
             check::<180>(3, 117); // linear
             check::<461>(3, 117); // deep
             fn check<const S: u32>(coeff: i128, big_k: u32) {
-                let p = |n: u32| Int::<24>::from_i128(10).pow(n);
-                let y = Int::<24>::from_i128(coeff) * p(S - big_k);
-                let x = p(S);
-                let yd = crate::D::<Int<24>, S>(y);
-                let xd = crate::D::<Int<24>, S>(x);
+                let pow10 = |exponent: u32| Int::<24>::from_i128(10).pow(exponent);
+                let y = Int::<24>::from_i128(coeff) * pow10(S - big_k);
+                let x = pow10(S);
+                let y_decimal = crate::D::<Int<24>, S>(y);
+                let x_decimal = crate::D::<Int<24>, S>(x);
                 for mode in MODES {
                     assert_eq!(
-                        yd.atan2_strict_with(xd, mode).0,
+                        y_decimal.atan2_strict_with(x_decimal, mode).0,
                         atan2_schoolbook::<Core, S>(y, x, mode),
                         "public==tier S={S} k={big_k} mode={mode:?}"
                     );
@@ -1051,15 +1172,21 @@ mod tests {
         fn atan2_nontiny_no_spurious_step() {
             let one_val = Int::<24>::from_i128(10).pow(461);
             let one = Int::<24>::from_i128(1);
-            let f = atan2_schoolbook::<Core, 461>(one_val, one_val, RoundingMode::Floor);
-            let n = atan2_schoolbook::<Core, 461>(one_val, one_val, RoundingMode::HalfToEven);
-            let c = atan2_schoolbook::<Core, 461>(one_val, one_val, RoundingMode::Ceiling);
-            assert!(f <= n && n <= c, "non-tiny atan2(1,1) directed ordered");
-            assert!(c - f <= one, "non-tiny atan2(1,1) Ceiling-Floor <= 1 ULP (no spurious step)");
-            let d = crate::D::<Int<24>, 461>(one_val);
+            let floored = atan2_schoolbook::<Core, 461>(one_val, one_val, RoundingMode::Floor);
+            let nearest = atan2_schoolbook::<Core, 461>(one_val, one_val, RoundingMode::HalfToEven);
+            let ceiled = atan2_schoolbook::<Core, 461>(one_val, one_val, RoundingMode::Ceiling);
+            assert!(
+                floored <= nearest && nearest <= ceiled,
+                "non-tiny atan2(1,1) directed ordered"
+            );
+            assert!(
+                ceiled - floored <= one,
+                "non-tiny atan2(1,1) Ceiling-Floor <= 1 ULP (no spurious step)"
+            );
+            let operand = crate::D::<Int<24>, 461>(one_val);
             for mode in MODES {
                 assert_eq!(
-                    d.atan2_strict_with(d, mode).0,
+                    operand.atan2_strict_with(operand, mode).0,
                     atan2_schoolbook::<Core, 461>(one_val, one_val, mode),
                     "non-tiny public==tier mode={mode:?}"
                 );
@@ -1128,14 +1255,14 @@ mod tests {
 
             // Public path == tier kernel across all six modes (rung == tier).
             use crate::int::types::Int;
-            let p = |n: u32| Int::<48>::from_i128(10).pow(n);
-            let y = Int::<48>::from_i128(3) * p(923 - 117);
-            let x = p(923);
-            let yd = crate::D::<Int<48>, 923>(y);
-            let xd = crate::D::<Int<48>, 923>(x);
+            let pow10 = |exponent: u32| Int::<48>::from_i128(10).pow(exponent);
+            let y = Int::<48>::from_i128(3) * pow10(923 - 117);
+            let x = pow10(923);
+            let y_decimal = crate::D::<Int<48>, 923>(y);
+            let x_decimal = crate::D::<Int<48>, 923>(x);
             for mode in MODES {
                 assert_eq!(
-                    yd.atan2_strict_with(xd, mode).0,
+                    y_decimal.atan2_strict_with(x_decimal, mode).0,
                     atan2_schoolbook::<Core, 923>(y, x, mode),
                     "d924 s923 public==tier mode={mode:?}"
                 );
@@ -1184,18 +1311,18 @@ mod tests {
 
         #[test]
         fn asin_acos_atan2_schoolbook_match_routed() {
-            for &u in &INPUTS9 {
-                let r = raw9(u);
+            for &units in &INPUTS9 {
+                let raw = raw9(units);
                 for &mode in &MODES {
                     assert_eq!(
-                        asin_schoolbook::<Core, S>(r, mode),
-                        D::<Int<3>, S>(r).asin_strict_with(mode).0,
-                        "D57 asin schoolbook != routed at units={u} mode={mode:?}"
+                        asin_schoolbook::<Core, S>(raw, mode),
+                        D::<Int<3>, S>(raw).asin_strict_with(mode).0,
+                        "D57 asin schoolbook != routed at units={units} mode={mode:?}"
                     );
                     assert_eq!(
-                        acos_schoolbook::<Core, S>(r, mode),
-                        D::<Int<3>, S>(r).acos_strict_with(mode).0,
-                        "D57 acos schoolbook != routed at units={u} mode={mode:?}"
+                        acos_schoolbook::<Core, S>(raw, mode),
+                        D::<Int<3>, S>(raw).acos_strict_with(mode).0,
+                        "D57 acos schoolbook != routed at units={units} mode={mode:?}"
                     );
                 }
             }
@@ -1208,12 +1335,12 @@ mod tests {
                 (500_000_000, 2_000_000_000),
             ];
             for &(y, x) in &PTS {
-                let yr = raw9(y);
-                let xr = raw9(x);
+                let y_raw = raw9(y);
+                let x_raw = raw9(x);
                 for &mode in &MODES {
                     assert_eq!(
-                        atan2_schoolbook::<Core, S>(yr, xr, mode),
-                        D::<Int<3>, S>(yr).atan2_strict_with(D::<Int<3>, S>(xr), mode).0,
+                        atan2_schoolbook::<Core, S>(y_raw, x_raw, mode),
+                        D::<Int<3>, S>(y_raw).atan2_strict_with(D::<Int<3>, S>(x_raw), mode).0,
                         "D57 atan2 schoolbook != routed at y={y} x={x} mode={mode:?}"
                     );
                 }

--- a/src/algos/trig/inverse_tang_3limb_s18_22.rs
+++ b/src/algos/trig/inverse_tang_3limb_s18_22.rs
@@ -27,16 +27,18 @@
 //!
 //! ## Correctness
 //!
-//! Error budget at working scale `w = SCALE + 10`:
+//! Error budget at `working_scale = SCALE + 10`:
 //!
-//! - One `sqrt_fixed`: ≤ 0.5 LSB-of-w.
-//! - One `mul` (for `1 − v²`): ≤ 0.5 LSB-of-w.
-//! - One `div` (for `v / sqrt(...)`): ≤ 0.5 LSB-of-w.
-//! - One `atan_fixed`: ~25 rounded muls @ 0.5 LSB each = ≤ 13 LSB-of-w.
-//! - Final round-to-storage: ≤ 0.5 LSB-of-w.
+//! - One `sqrt_fixed`: ≤ 0.5 LSB-of-`working_scale`.
+//! - One `mul` (for `1 − x²`): ≤ 0.5 LSB-of-`working_scale`.
+//! - One `div` (for `x / sqrt(...)`): ≤ 0.5 LSB-of-`working_scale`.
+//! - One `atan_fixed`: ~25 rounded muls @ 0.5 LSB each = ≤ 13
+//!   LSB-of-`working_scale`.
+//! - Final round-to-storage: ≤ 0.5 LSB-of-`working_scale`.
 //!
 //! Half-angle branch doubles the sqrt + adds an outer sub/double;
-//! cumulative budget is still ≤ ~30 LSB-of-w. With `GUARD_NARROW = 10`
+//! cumulative budget is still ≤ ~30 LSB-of-`working_scale`. With
+//! `GUARD_NARROW = 10`
 //! that's `30·10⁻¹⁰ = 3·10⁻⁹` of a storage ULP — over 8 orders of
 //! magnitude below the half-ULP line for any `SCALE ≤ 22` (and the
 //! near-tie band the wide campaign added walks anything closer).
@@ -51,28 +53,48 @@ use crate::int::types::Int;
 /// narrow-`GUARD` atan slot guard (`wide_trig_core::atan_narrow`).
 const GUARD_NARROW: u32 = 10;
 
-fn asin_fixed<const SCALE: u32>(v: core::W, w: u32) -> core::W {
-    let one_w = core::one(w);
-    let abs_v = if v < core::zero() { -v } else { v };
-    if abs_v > one_w {
+fn asin_fixed<const SCALE: u32>(working_value: core::W, working_scale: u32) -> core::W {
+    let one_w = core::one(working_scale);
+    let abs_working_value = if working_value < core::zero() {
+        -working_value
+    } else {
+        working_value
+    };
+    if abs_working_value > one_w {
         panic!("D57::asin: argument out of domain [-1, 1]");
     }
     let half_w = one_w / core::lit(2);
-    if abs_v == one_w {
-        let hp = core::half_pi::<SCALE>(w);
-        return if v < core::zero() { -hp } else { hp };
+    if abs_working_value == one_w {
+        let half_pi = core::half_pi::<SCALE>(working_scale);
+        return if working_value < core::zero() {
+            -half_pi
+        } else {
+            half_pi
+        };
     }
-    if abs_v <= half_w {
-        let denom = core::sqrt_fixed(one_w - core::mul(v, v, w), w);
-        return core::atan_fixed::<SCALE>(core::div(v, denom, w), w);
+    if abs_working_value <= half_w {
+        let denom = core::sqrt_fixed(
+            one_w - core::mul(working_value, working_value, working_scale),
+            working_scale,
+        );
+        return core::atan_fixed::<SCALE>(
+            core::div(working_value, denom, working_scale),
+            working_scale,
+        );
     }
     // Half-angle: asin(|x|) = π/2 − 2·asin(√((1−|x|)/2)).
-    let inner = (one_w - abs_v) / core::lit(2);
-    let inner_sqrt = core::sqrt_fixed(inner, w);
-    let inner_denom = core::sqrt_fixed(one_w - core::mul(inner_sqrt, inner_sqrt, w), w);
-    let inner_asin = core::atan_fixed::<SCALE>(core::div(inner_sqrt, inner_denom, w), w);
-    let result_abs = core::half_pi::<SCALE>(w) - inner_asin - inner_asin;
-    if v < core::zero() {
+    let inner = (one_w - abs_working_value) / core::lit(2);
+    let inner_sqrt = core::sqrt_fixed(inner, working_scale);
+    let inner_denom = core::sqrt_fixed(
+        one_w - core::mul(inner_sqrt, inner_sqrt, working_scale),
+        working_scale,
+    );
+    let inner_asin = core::atan_fixed::<SCALE>(
+        core::div(inner_sqrt, inner_denom, working_scale),
+        working_scale,
+    );
+    let result_abs = core::half_pi::<SCALE>(working_scale) - inner_asin - inner_asin;
+    if working_value < core::zero() {
         -result_abs
     } else {
         result_abs
@@ -83,17 +105,17 @@ fn asin_fixed<const SCALE: u32>(v: core::W, w: u32) -> core::W {
 #[inline]
 #[must_use]
 pub(crate) fn asin_strict<const SCALE: u32>(raw: Int<3>, mode: RoundingMode) -> Int<3> {
-    let w = SCALE + GUARD_NARROW;
-    let v = core::to_work_scaled(raw, GUARD_NARROW);
-    let r = asin_fixed::<SCALE>(v, w);
+    let working_scale = SCALE + GUARD_NARROW;
+    let working_value = core::to_work_scaled(raw, GUARD_NARROW);
+    let asin_value = asin_fixed::<SCALE>(working_value, working_scale);
     // Near-tie escape — see `wide_trig_core::tan_series` / the asin(3e-60)
-    // family: a fixed-w single shot cannot see a deciding digit below w.
-    // Clear-of-band residuals keep the single-shot cost; the band falls to
-    // the Ziv-escalating generic kernel (rare).
+    // family: a fixed-working-scale single shot cannot see a deciding digit
+    // below the working scale. Clear-of-band residuals keep the single-shot
+    // cost; the band falls to the Ziv-escalating generic kernel (rare).
     match crate::algos::support::wide_trig_core::round_to_storage_clear_of_tie_g::<Int<3>, _>(
-        r, w, SCALE, mode, Int::<3>::MAX, Int::<3>::MIN,
+        asin_value, working_scale, SCALE, mode, Int::<3>::MAX, Int::<3>::MIN,
     ) {
-        Some(st) => st,
+        Some(rounded) => rounded,
         None => crate::algos::trig::inverse_schoolbook::asin_schoolbook::<
             crate::types::widths::wide_trig_d57::Core,
             SCALE,
@@ -105,18 +127,18 @@ pub(crate) fn asin_strict<const SCALE: u32>(raw: Int<3>, mode: RoundingMode) -> 
 #[inline]
 #[must_use]
 pub(crate) fn acos_strict<const SCALE: u32>(raw: Int<3>, mode: RoundingMode) -> Int<3> {
-    let w = SCALE + GUARD_NARROW;
-    let v = core::to_work_scaled(raw, GUARD_NARROW);
-    let asin_w = asin_fixed::<SCALE>(v, w);
-    let r = core::half_pi::<SCALE>(w) - asin_w;
+    let working_scale = SCALE + GUARD_NARROW;
+    let working_value = core::to_work_scaled(raw, GUARD_NARROW);
+    let asin_w = asin_fixed::<SCALE>(working_value, working_scale);
+    let acos_value = core::half_pi::<SCALE>(working_scale) - asin_w;
     // Near-tie escape — see `wide_trig_core::tan_series` / the asin(3e-60)
-    // family: a fixed-w single shot cannot see a deciding digit below w.
-    // Clear-of-band residuals keep the single-shot cost; the band falls to
-    // the Ziv-escalating generic kernel (rare).
+    // family: a fixed-working-scale single shot cannot see a deciding digit
+    // below the working scale. Clear-of-band residuals keep the single-shot
+    // cost; the band falls to the Ziv-escalating generic kernel (rare).
     match crate::algos::support::wide_trig_core::round_to_storage_clear_of_tie_g::<Int<3>, _>(
-        r, w, SCALE, mode, Int::<3>::MAX, Int::<3>::MIN,
+        acos_value, working_scale, SCALE, mode, Int::<3>::MAX, Int::<3>::MIN,
     ) {
-        Some(st) => st,
+        Some(rounded) => rounded,
         None => crate::algos::trig::inverse_schoolbook::acos_schoolbook::<
             crate::types::widths::wide_trig_d57::Core,
             SCALE,
@@ -132,13 +154,13 @@ pub(crate) fn atan2_strict<const SCALE: u32>(
     x_raw: Int<3>,
     mode: RoundingMode,
 ) -> Int<3> {
-    let w = SCALE + GUARD_NARROW;
+    let working_scale = SCALE + GUARD_NARROW;
     let zero_s = Int::<3>::ZERO;
-    let r = if x_raw == zero_s {
+    let atan2_value = if x_raw == zero_s {
         if y_raw > zero_s {
-            core::half_pi::<SCALE>(w)
+            core::half_pi::<SCALE>(working_scale)
         } else if y_raw < zero_s {
-            -core::half_pi::<SCALE>(w)
+            -core::half_pi::<SCALE>(working_scale)
         } else {
             core::zero()
         }
@@ -149,29 +171,40 @@ pub(crate) fn atan2_strict<const SCALE: u32>(
         let abs_y = if y < zero_w { -y } else { y };
         let abs_x = if x < zero_w { -x } else { x };
         let base = if abs_x >= abs_y {
-            core::atan_fixed::<SCALE>(core::div(y, x, w), w)
+            core::atan_fixed::<SCALE>(core::div(y, x, working_scale), working_scale)
         } else {
-            let inv = core::atan_fixed::<SCALE>(core::div(x, y, w), w);
-            let hp = core::half_pi::<SCALE>(w);
+            let atan_x_over_y =
+                core::atan_fixed::<SCALE>(core::div(x, y, working_scale), working_scale);
+            let half_pi = core::half_pi::<SCALE>(working_scale);
             let same_sign = (y < zero_w) == (x < zero_w);
-            if same_sign { hp - inv } else { -hp - inv }
+            if same_sign {
+                half_pi - atan_x_over_y
+            } else {
+                -half_pi - atan_x_over_y
+            }
         };
         if x_raw > zero_s {
             base
         } else if y_raw >= zero_s {
-            base + core::pi_cf::<SCALE>(w, crate::support::rounding::DEFAULT_ROUNDING_MODE)
+            base + core::pi_cf::<SCALE>(
+                working_scale,
+                crate::support::rounding::DEFAULT_ROUNDING_MODE,
+            )
         } else {
-            base - core::pi_cf::<SCALE>(w, crate::support::rounding::DEFAULT_ROUNDING_MODE)
+            base - core::pi_cf::<SCALE>(
+                working_scale,
+                crate::support::rounding::DEFAULT_ROUNDING_MODE,
+            )
         }
     };
     // Near-tie escape — see `wide_trig_core::tan_series` / the asin(3e-60)
-    // family: a fixed-w single shot cannot see a deciding digit below w.
-    // Clear-of-band residuals keep the single-shot cost; the band falls to
-    // the Ziv-escalating generic kernel (rare).
+    // family: a fixed-working-scale single shot cannot see a deciding digit
+    // below the working scale. Clear-of-band residuals keep the single-shot
+    // cost; the band falls to the Ziv-escalating generic kernel (rare).
     match crate::algos::support::wide_trig_core::round_to_storage_clear_of_tie_g::<Int<3>, _>(
-        r, w, SCALE, mode, Int::<3>::MAX, Int::<3>::MIN,
+        atan2_value, working_scale, SCALE, mode, Int::<3>::MAX, Int::<3>::MIN,
     ) {
-        Some(st) => st,
+        Some(rounded) => rounded,
         None => crate::algos::trig::inverse_schoolbook::atan2_schoolbook::<
             crate::types::widths::wide_trig_d57::Core,
             SCALE,

--- a/src/algos/trig/near_pole_tan.rs
+++ b/src/algos/trig/near_pole_tan.rs
@@ -6,7 +6,7 @@
 //! `tan(x)` is computed as `sin(r)/cos(r)` on the range-reduced residue
 //! `r`. When the input lies close to an odd multiple of π/2 the residue
 //! folds toward ±π/2, where `cos(r) → 0` and the quotient diverges. A
-//! division at a fixed working scale `w` then amplifies the per-op
+//! division at a fixed working scale then amplifies the per-op
 //! working-scale rounding error by the quotient magnitude
 //! `1/cos(r) ≈ |tan|`. Holding the 0.5 ULP storage contract therefore
 //! requires the working scale to carry roughly `log10(|tan|)` extra
@@ -21,10 +21,10 @@
 /// Extra working-scale guard digits a near-pole `tan` evaluation needs,
 /// derived from the bit length of a base-width probe quotient.
 ///
-/// The probe `q = sin(r)/cos(r)` is held at working scale `w0`, i.e.
-/// `q ≈ |tan| · 10^{w0}`. Its bit length is
-/// `bit_length(q) ≈ log2(|tan|) + w0 · log2(10)`, so
-/// `log10(|tan|) ≈ bit_length(q) / log2(10) − w0`.
+/// The probe `q = sin(r)/cos(r)` is held at `base_working_scale`, i.e.
+/// `q ≈ |tan| · 10^base_working_scale`. Its bit length is
+/// `bit_length(q) ≈ log2(|tan|) + base_working_scale · log2(10)`, so
+/// `log10(|tan|) ≈ bit_length(q) / log2(10) − base_working_scale`.
 ///
 /// `bit_length / log2(10)` is computed in integers via the rational
 /// `1 / log2(10) ≈ 100_000 / 332_193`. Anything ≤ 0 means the result is
@@ -38,10 +38,10 @@
 /// covering extreme inputs where `|tan|` is many digits large.
 #[inline]
 #[must_use]
-pub(crate) fn tan_extra_digits(probe_bit_length: u32, w0: u32) -> u32 {
+pub(crate) fn tan_extra_digits(probe_bit_length: u32, base_working_scale: u32) -> u32 {
     // Integer `log10` of the probe magnitude: bits / log2(10).
     let log10_probe = (probe_bit_length as u64 * 100_000) / 332_193;
-    let log10_tan = log10_probe as i64 - w0 as i64;
+    let log10_tan = log10_probe as i64 - base_working_scale as i64;
     if log10_tan <= 0 {
         return 0;
     }
@@ -50,15 +50,16 @@ pub(crate) fn tan_extra_digits(probe_bit_length: u32, w0: u32) -> u32 {
     // final `round_to_storage_with` sheds at most a half-LSB. Six
     // decimal digits sits many orders below half a storage ULP.
     //
-    // The lift is bounded so the lifted working scale `w0 + extra` stays
-    // within `2·w0` digits — the work integer is sized for `2·(SCALE +
-    // GUARD)` products, so a lift past `w0` risks overflowing it. An
-    // input that close to the pole rounds to a value too large for
-    // storage anyway, and `round_to_storage_with` panics with an
+    // The lift is bounded so the lifted working scale
+    // `base_working_scale + extra` stays within `2·base_working_scale`
+    // digits — the work integer is sized for `2·(SCALE + GUARD)`
+    // products, so a lift past `base_working_scale` risks overflowing
+    // it. An input that close to the pole rounds to a value too large
+    // for storage anyway, and `round_to_storage_with` panics with an
     // out-of-range message rather than returning a silently-wrong
     // result.
     let extra = log10_tan as u64 + 6;
-    extra.min(w0 as u64) as u32
+    extra.min(base_working_scale as u64) as u32
 }
 
 #[cfg(test)]
@@ -67,18 +68,18 @@ mod tests {
 
     #[test]
     fn magnitude_one_quotient_needs_no_lift() {
-        // |tan| ≈ 1 ⇒ probe ≈ 10^{w0} ⇒ bit_length ≈ w0·log2(10).
-        let w0 = 158u32;
-        let bits = ((w0 as f64) * std::f64::consts::LOG2_10) as u32;
-        assert_eq!(tan_extra_digits(bits, w0), 0);
+        // |tan| ≈ 1 ⇒ probe ≈ 10^base ⇒ bit_length ≈ base·log2(10).
+        let base_working_scale = 158u32;
+        let bits = ((base_working_scale as f64) * std::f64::consts::LOG2_10) as u32;
+        assert_eq!(tan_extra_digits(bits, base_working_scale), 0);
     }
 
     #[test]
     fn five_digit_quotient_lifts_about_five_plus_margin() {
-        // |tan| ≈ 10^5 ⇒ probe bit length ≈ (w0 + 5)·log2(10).
-        let w0 = 158u32;
-        let bits = (((w0 + 5) as f64) * std::f64::consts::LOG2_10).ceil() as u32;
-        let extra = tan_extra_digits(bits, w0);
+        // |tan| ≈ 10^5 ⇒ probe bit length ≈ (base + 5)·log2(10).
+        let base_working_scale = 158u32;
+        let bits = (((base_working_scale + 5) as f64) * std::f64::consts::LOG2_10).ceil() as u32;
+        let extra = tan_extra_digits(bits, base_working_scale);
         // ~5 magnitude digits + 6 margin, allowing ±1 for integer rounding.
         assert!((10..=12).contains(&extra), "extra = {extra}");
     }
@@ -86,9 +87,9 @@ mod tests {
     #[test]
     fn large_quotient_scales_linearly() {
         // |tan| ≈ 10^40 ⇒ ~40 magnitude digits + margin.
-        let w0 = 90u32;
-        let bits = (((w0 + 40) as f64) * std::f64::consts::LOG2_10).ceil() as u32;
-        let extra = tan_extra_digits(bits, w0);
+        let base_working_scale = 90u32;
+        let bits = (((base_working_scale + 40) as f64) * std::f64::consts::LOG2_10).ceil() as u32;
+        let extra = tan_extra_digits(bits, base_working_scale);
         assert!((45..=47).contains(&extra), "extra = {extra}");
     }
 }

--- a/src/algos/trig/sincos_narrow.rs
+++ b/src/algos/trig/sincos_narrow.rs
@@ -54,18 +54,18 @@ fn sin_cos_strict<C: WideTrigCore, const SCALE: u32, const GUARD: u32>(
     // multiple) the working-scale approximation can land on the wrong
     // side. Route through the shared Ziv escalation; nearest modes narrow
     // once.
-    let r = C::round_to_storage_directed(GUARD, SCALE, mode, &mut |guard| {
-        let v_w = C::to_work_scaled(raw, guard);
+    let rounded = C::round_to_storage_directed(GUARD, SCALE, mode, &mut |guard_digits| {
+        let working_value = C::to_work_scaled(raw, guard_digits);
         match which {
-            Which::Sin => C::sin_fixed::<SCALE>(v_w, SCALE + guard),
-            Which::Cos => C::cos_fixed::<SCALE>(v_w, SCALE + guard),
+            Which::Sin => C::sin_fixed::<SCALE>(working_value, SCALE + guard_digits),
+            Which::Cos => C::cos_fixed::<SCALE>(working_value, SCALE + guard_digits),
         }
     });
     // Near an extremum the deviation from ±1 can sit below any reachable
     // working scale, so the kernel rounds to exactly ±10^SCALE and a directed
     // mode lands on the wrong side; sin/cos are strictly interior for raw != 0,
     // so the side is known a priori. See `wide_trig_core::adjust_bounded_extremum`.
-    crate::algos::support::wide_trig_core::adjust_bounded_extremum::<C, SCALE>(r, raw, mode)
+    crate::algos::support::wide_trig_core::adjust_bounded_extremum::<C, SCALE>(rounded, raw, mode)
 }
 
 /// Narrow `sin_strict` for a wide tier — generic over `C`, `SCALE`, the
@@ -98,7 +98,7 @@ pub(crate) fn cos_narrow_with_taylor<C: WideTrigCore, const SCALE: u32, const GU
 /// amplification near an odd multiple of π/2 still lands at ≤ 0.5 ULP at
 /// storage (Muller, *Elementary Functions* 3rd ed., §11.1). When clear,
 /// the band's guard already covers the worst case, so the kernel divides
-/// once at `w = SCALE + GUARD`.
+/// once at the base working scale `SCALE + GUARD`.
 #[inline]
 #[must_use]
 pub(crate) fn tan_narrow_with_taylor<
@@ -117,58 +117,62 @@ where
     if raw == C::storage_zero() {
         return C::storage_zero();
     }
-    let w0 = SCALE + GUARD;
-    let v0 = C::to_work_scaled(raw, GUARD);
-    let (sin0, cos0) = C::sin_cos_fixed::<SCALE>(v0, w0);
-    if cos0 == C::zero() {
+    let base_working_scale = SCALE + GUARD;
+    let base_working_value = C::to_work_scaled(raw, GUARD);
+    let (sin_base, cos_base) = C::sin_cos_fixed::<SCALE>(base_working_value, base_working_scale);
+    if cos_base == C::zero() {
         panic!("wide-tier tan: cosine is zero (argument is an odd multiple of pi/2)");
     }
     // Near-tie escapes — see `wide_trig_core::tan_series`: clear-of-band
-    // residuals keep the single-shot cost; the band escalates through
-    // the ratio walker (a deciding digit can sit below the fixed w).
-    let tie_walker = |base_guard: u32| -> C::Storage {
-        C::round_to_storage_directed(base_guard, SCALE, mode, &mut |guard| {
-            let w = SCALE + guard;
-            let (s, c) = C::sin_cos_fixed::<SCALE>(C::to_work_scaled(raw, guard), w);
-            if c == C::zero() {
+    // residuals keep the single-shot cost; the band escalates through the
+    // ratio walker (a deciding digit can sit below the fixed working scale).
+    let tie_walker = |base_guard_digits: u32| -> C::Storage {
+        C::round_to_storage_directed(base_guard_digits, SCALE, mode, &mut |guard_digits| {
+            let working_scale = SCALE + guard_digits;
+            let (sin_value, cos_value) =
+                C::sin_cos_fixed::<SCALE>(C::to_work_scaled(raw, guard_digits), working_scale);
+            if cos_value == C::zero() {
                 panic!("wide-tier tan: cosine is zero (argument is an odd multiple of pi/2)");
             }
-            C::div(s, c, w)
+            C::div(sin_value, cos_value, working_scale)
         })
     };
     if !NEAR_POLE {
-        let r = C::div(sin0, cos0, w0);
-        if let Some(st) = crate::algos::support::wide_trig_core::round_to_storage_clear_of_tie_g::<
-            C::Storage,
-            C::W,
-        >(r, w0, SCALE, mode, C::storage_max(), C::storage_min())
+        let tan_value = C::div(sin_base, cos_base, base_working_scale);
+        if let Some(rounded) =
+            crate::algos::support::wide_trig_core::round_to_storage_clear_of_tie_g::<
+                C::Storage,
+                C::W,
+            >(tan_value, base_working_scale, SCALE, mode, C::storage_max(), C::storage_min())
         {
-            return st;
+            return rounded;
         }
         return tie_walker(GUARD);
     }
-    let probe = C::div(sin0, cos0, w0);
-    let extra = super::near_pole_tan::tan_extra_digits(C::bit_length(probe), w0);
+    let probe = C::div(sin_base, cos_base, base_working_scale);
+    let extra = super::near_pole_tan::tan_extra_digits(C::bit_length(probe), base_working_scale);
     if extra == 0 {
-        if let Some(st) = crate::algos::support::wide_trig_core::round_to_storage_clear_of_tie_g::<
-            C::Storage,
-            C::W,
-        >(probe, w0, SCALE, mode, C::storage_max(), C::storage_min())
+        if let Some(rounded) =
+            crate::algos::support::wide_trig_core::round_to_storage_clear_of_tie_g::<
+                C::Storage,
+                C::W,
+            >(probe, base_working_scale, SCALE, mode, C::storage_max(), C::storage_min())
         {
-            return st;
+            return rounded;
         }
         return tie_walker(GUARD);
     }
-    let w = w0 + extra;
-    let v_w = C::to_work_scaled(raw, GUARD + extra);
-    let (sin_w, cos_w) = C::sin_cos_fixed::<SCALE>(v_w, w);
-    let r = C::div(sin_w, cos_w, w);
-    if let Some(st) = crate::algos::support::wide_trig_core::round_to_storage_clear_of_tie_g::<
-        C::Storage,
-        C::W,
-    >(r, w, SCALE, mode, C::storage_max(), C::storage_min())
+    let lifted_working_scale = base_working_scale + extra;
+    let working_value = C::to_work_scaled(raw, GUARD + extra);
+    let (sin_w, cos_w) = C::sin_cos_fixed::<SCALE>(working_value, lifted_working_scale);
+    let tan_value = C::div(sin_w, cos_w, lifted_working_scale);
+    if let Some(rounded) =
+        crate::algos::support::wide_trig_core::round_to_storage_clear_of_tie_g::<
+            C::Storage,
+            C::W,
+        >(tan_value, lifted_working_scale, SCALE, mode, C::storage_max(), C::storage_min())
     {
-        return st;
+        return rounded;
     }
     tie_walker(GUARD + extra)
 }

--- a/src/algos/trig/sincos_tang.rs
+++ b/src/algos/trig/sincos_tang.rs
@@ -76,29 +76,35 @@ where
         };
     }
 
-    let w = SCALE + C::GUARD;
-    let v_w = C::to_work(raw);
-    let one_w = C::one(w);
+    let working_scale = SCALE + C::GUARD;
+    let working_value = C::to_work(raw);
+    let one_w = C::one(working_scale);
     let pow10_w = one_w;
-    let pi_w = C::pi::<SCALE>(w);
-    let half_pi_w = C::half_pi::<SCALE>(w);
+    let pi_at_working_scale = C::pi::<SCALE>(working_scale);
+    let half_pi_at_working_scale = C::half_pi::<SCALE>(working_scale);
 
     // Stage 1: x = k·(π/2) + r, |r| ≤ π/4 + small rounding slack.
-    let k = C::round_to_nearest_int(C::div_cached(v_w, half_pi_w, pow10_w), w);
+    let k = C::round_to_nearest_int(
+        C::div_cached(working_value, half_pi_at_working_scale, pow10_w),
+        working_scale,
+    );
     let k_half_pi = if k >= 0 {
-        half_pi_w * C::lit(k as u128)
+        half_pi_at_working_scale * C::lit(k as u128)
     } else {
-        -(half_pi_w * C::lit((-k) as u128))
+        -(half_pi_at_working_scale * C::lit((-k) as u128))
     };
-    let r = v_w - k_half_pi;
+    let r = working_value - k_half_pi;
 
     // Stage 2: r = c_j_signed · π/(4M) + δ, |δ| ≤ π/(8M).
     let four_m = C::lit((4 * M) as u128);
-    let j_signed = C::round_to_nearest_int(C::div_cached(r * four_m, pi_w, pow10_w), w);
+    let j_signed = C::round_to_nearest_int(
+        C::div_cached(r * four_m, pi_at_working_scale, pow10_w),
+        working_scale,
+    );
     let cj_signed_w = if j_signed >= 0 {
-        (pi_w * C::lit(j_signed as u128)) / four_m
+        (pi_at_working_scale * C::lit(j_signed as u128)) / four_m
     } else {
-        -((pi_w * C::lit((-j_signed) as u128)) / four_m)
+        -((pi_at_working_scale * C::lit((-j_signed) as u128)) / four_m)
     };
     let delta = r - cj_signed_w;
 
@@ -107,29 +113,30 @@ where
     let j_abs = j_signed.unsigned_abs() as u32;
     debug_assert!(j_abs <= M, "sin_cos_strict tang: table index {j_abs} > M={M}");
     let j_idx = if j_abs > M { M as usize } else { j_abs as usize };
-    let (sin_cj_abs, cos_cj) = C::sincos_table_entry::<SCALE>(w, j_idx, M);
+    let (sin_cj_abs, cos_cj) = C::sincos_table_entry::<SCALE>(working_scale, j_idx, M);
     let sin_cj = if j_signed < 0 { -sin_cj_abs } else { sin_cj_abs };
 
     // Stage 3: small-residual Taylor for sin(δ) and cos(δ).
-    let delta2 = C::mul(delta, delta, w);
+    let delta_squared = C::mul(delta, delta, working_scale);
 
     // sin(δ) = δ − δ³/3! + δ⁵/5! − …
     let sin_delta = {
         let mut sum = delta;
         let mut term = delta;
-        let mut k_term: u128 = 1;
+        let mut term_index: u128 = 1;
         loop {
-            term = C::mul(term, delta2, w) / C::lit((2 * k_term) * (2 * k_term + 1));
+            term = C::mul(term, delta_squared, working_scale)
+                / C::lit((2 * term_index) * (2 * term_index + 1));
             if term == C::zero() {
                 break;
             }
-            if k_term % 2 == 1 {
+            if term_index % 2 == 1 {
                 sum = sum - term;
             } else {
                 sum = sum + term;
             }
-            k_term += 1;
-            if k_term > 200 {
+            term_index += 1;
+            if term_index > 200 {
                 break;
             }
         }
@@ -140,19 +147,20 @@ where
     let cos_delta = {
         let mut sum = one_w;
         let mut term = one_w;
-        let mut k_term: u128 = 1;
+        let mut term_index: u128 = 1;
         loop {
-            term = C::mul(term, delta2, w) / C::lit((2 * k_term - 1) * (2 * k_term));
+            term = C::mul(term, delta_squared, working_scale)
+                / C::lit((2 * term_index - 1) * (2 * term_index));
             if term == C::zero() {
                 break;
             }
-            if k_term % 2 == 1 {
+            if term_index % 2 == 1 {
                 sum = sum - term;
             } else {
                 sum = sum + term;
             }
-            k_term += 1;
-            if k_term > 200 {
+            term_index += 1;
+            if term_index > 200 {
                 break;
             }
         }
@@ -160,8 +168,8 @@ where
     };
 
     // Stage 4: addition formula to lift (sin δ, cos δ) onto r.
-    let sin_r = C::mul(sin_cj, cos_delta, w) + C::mul(cos_cj, sin_delta, w);
-    let cos_r = C::mul(cos_cj, cos_delta, w) - C::mul(sin_cj, sin_delta, w);
+    let sin_r = C::mul(sin_cj, cos_delta, working_scale) + C::mul(cos_cj, sin_delta, working_scale);
+    let cos_r = C::mul(cos_cj, cos_delta, working_scale) - C::mul(sin_cj, sin_delta, working_scale);
 
     // Stage 5: quadrant permutation. `k mod 4` selects the signed
     // permutation of (sin(r), cos(r)) that becomes (sin(x), cos(x)).
@@ -179,13 +187,13 @@ where
         Which::Cos => cos_x,
     };
     // Near-tie escape — see `wide_trig_core::tan_series` / the asin(3e-60)
-    // family: a fixed-w single shot cannot see a deciding digit below w.
-    // Clear-of-band residuals keep the single-shot cost; the band falls to
-    // the Ziv-escalating generic kernel (rare).
+    // family: a fixed-working-scale single shot cannot see a deciding digit
+    // below the working scale. Clear-of-band residuals keep the single-shot
+    // cost; the band falls to the Ziv-escalating generic kernel (rare).
     match crate::algos::support::wide_trig_core::round_to_storage_clear_of_tie_g::<C::Storage, C::W>(
-        result, w, SCALE, mode, C::storage_max(), C::storage_min(),
+        result, working_scale, SCALE, mode, C::storage_max(), C::storage_min(),
     ) {
-        Some(st) => st,
+        Some(rounded) => rounded,
         None => match which {
             Which::Sin => crate::algos::support::wide_trig_core::sin_series::<C, SCALE>(raw, mode),
             Which::Cos => crate::algos::support::wide_trig_core::cos_series::<C, SCALE>(raw, mode),

--- a/src/algos/trig/sincos_tang_3limb_s18_22.rs
+++ b/src/algos/trig/sincos_tang_3limb_s18_22.rs
@@ -32,10 +32,10 @@
 //!
 //! The shared core's `GUARD = 30` is documented (in
 //! `crate::macros::wide_transcendental`) as supporting `~200 ×
-//! 0.5 = 100 LSB-of-w` accumulated drift across the longest series
+//! 0.5 = 100 LSB-of-working_scale` accumulated drift across the longest series
 //! the wide tiers run. At SCALE 18..=22 the Taylor series on
 //! `r ∈ [0, π/4]` converges in ~20-30 rounded multiplies; the matching
-//! worst-case drift is ~30 × 0.5 = 15 LSB-of-w, many orders of
+//! worst-case drift is ~30 × 0.5 = 15 LSB-of-`working_scale`, many orders of
 //! magnitude below half a storage ULP for any `SCALE ≤ 22` at the
 //! band's guard. The probe set the value empirically: every value
 //! tried in the 8..=14 band held the wide-tier baseline within 1 LSB
@@ -64,21 +64,21 @@ pub(crate) fn tan_strict<const SCALE: u32>(raw: Int<3>, mode: RoundingMode) -> I
     if raw == Int::<3>::ZERO {
         return Int::<3>::ZERO;
     }
-    let w = SCALE + GUARD_NARROW;
-    let v_w = core::to_work_scaled(raw, GUARD_NARROW);
-    let (sin_w, cos_w) = core::sin_cos_fixed::<SCALE>(v_w, w);
+    let working_scale = SCALE + GUARD_NARROW;
+    let working_value = core::to_work_scaled(raw, GUARD_NARROW);
+    let (sin_w, cos_w) = core::sin_cos_fixed::<SCALE>(working_value, working_scale);
     if cos_w == core::zero() {
         panic!("D57::tan: cosine is zero (argument is an odd multiple of pi/2)");
     }
-    let r = core::div(sin_w, cos_w, w);
+    let tan_value = core::div(sin_w, cos_w, working_scale);
     // Near-tie escape — see `wide_trig_core::tan_series` / the asin(3e-60)
-    // family: a fixed-w single shot cannot see a deciding digit below w.
-    // Clear-of-band residuals keep the single-shot cost; the band falls to
-    // the Ziv-escalating generic kernel (rare).
+    // family: a fixed-working-scale single shot cannot see a deciding digit
+    // below the working scale. Clear-of-band residuals keep the single-shot
+    // cost; the band falls to the Ziv-escalating generic kernel (rare).
     match crate::algos::support::wide_trig_core::round_to_storage_clear_of_tie_g::<Int<3>, _>(
-        r, w, SCALE, mode, Int::<3>::MAX, Int::<3>::MIN,
+        tan_value, working_scale, SCALE, mode, Int::<3>::MAX, Int::<3>::MIN,
     ) {
-        Some(st) => st,
+        Some(rounded) => rounded,
         None => crate::algos::support::wide_trig_core::tan_series::<
             crate::types::widths::wide_trig_d57::Core,
             SCALE,

--- a/src/algos/trig/trig_generic.rs
+++ b/src/algos/trig/trig_generic.rs
@@ -17,7 +17,7 @@
 //!
 //! `π` is supplied by the caller as a working-scale value rather than
 //! computed here, so the caller owns the const-fold seam
-//! (`pi_by_scale` on the hot `w == SCALE + GUARD` path,
+//! (`pi_by_scale` on the hot `working_scale == SCALE + GUARD` path,
 //! `pi_by_working_scale` on the Ziv escalation path) — exactly the
 //! `ln2` parameter shape of [`exp_generic::ln_fixed`].
 //!
@@ -32,36 +32,39 @@ use crate::algos::exp::exp_generic as eg;
 use crate::int::types::compute_limbs::ComputeLimbs;
 use crate::int::types::traits::BigInt;
 
-/// Taylor series for `sin` on a reduced `r ∈ [0, π/4]`, at scale `w`.
+/// Taylor series for `sin` on a reduced argument `r ∈ [0, π/4]`, at
+/// `working_scale`.
 ///
 /// `sin(r) = r − r³/3! + r⁵/5! − …`
-fn sin_taylor<S: BigInt>(r: S, w: u32) -> S
+fn sin_taylor<S: BigInt>(reduced_arg: S, working_scale: u32) -> S
 where
     S::Scratch: ComputeLimbs,
 {
-    let r2 = eg::mul::<S>(r, r, w);
-    let mut sum = r;
-    let mut term = r;
-    let mut k: u128 = 1;
+    let reduced_arg_squared = eg::mul::<S>(reduced_arg, reduced_arg, working_scale);
+    let mut sum = reduced_arg;
+    let mut term = reduced_arg;
+    let mut term_index: u128 = 1;
     loop {
-        term = eg::mul::<S>(term, r2, w) / eg::lit::<S>(((2 * k) * (2 * k + 1)) as i128);
+        term = eg::mul::<S>(term, reduced_arg_squared, working_scale)
+            / eg::lit::<S>(((2 * term_index) * (2 * term_index + 1)) as i128);
         if term == eg::zero::<S>() {
             break;
         }
-        if k % 2 == 1 {
+        if term_index % 2 == 1 {
             sum = sum - term;
         } else {
             sum = sum + term;
         }
-        k += 1;
-        if k > eg::SERIES_CAP {
+        term_index += 1;
+        if term_index > eg::SERIES_CAP {
             break;
         }
     }
     sum
 }
 
-/// Taylor series for `cos` on a reduced `r ∈ [0, π/4]`, at scale `w`.
+/// Taylor series for `cos` on a reduced argument `r ∈ [0, π/4]`, at
+/// `working_scale`.
 ///
 /// `cos(r) = 1 − r²/2! + r⁴/4! − r⁶/6! + …`
 ///
@@ -69,35 +72,37 @@ where
 /// leading `1` dominates the small even-power corrections — used as the
 /// "upper-half" branch of [`sin_fixed`] when the reduced argument
 /// exceeds π/4.
-fn cos_taylor<S: BigInt>(r: S, w: u32) -> S
+fn cos_taylor<S: BigInt>(reduced_arg: S, working_scale: u32) -> S
 where
     S::Scratch: ComputeLimbs,
 {
-    let r2 = eg::mul::<S>(r, r, w);
-    let one_w = eg::one::<S>(w);
+    let reduced_arg_squared = eg::mul::<S>(reduced_arg, reduced_arg, working_scale);
+    let one_w = eg::one::<S>(working_scale);
     let mut sum = one_w;
     let mut term = one_w;
-    let mut k: u128 = 1;
+    let mut term_index: u128 = 1;
     loop {
-        term = eg::mul::<S>(term, r2, w) / eg::lit::<S>(((2 * k - 1) * (2 * k)) as i128);
+        term = eg::mul::<S>(term, reduced_arg_squared, working_scale)
+            / eg::lit::<S>(((2 * term_index - 1) * (2 * term_index)) as i128);
         if term == eg::zero::<S>() {
             break;
         }
-        if k % 2 == 1 {
+        if term_index % 2 == 1 {
             sum = sum - term;
         } else {
             sum = sum + term;
         }
-        k += 1;
-        if k > eg::SERIES_CAP {
+        term_index += 1;
+        if term_index > eg::SERIES_CAP {
             break;
         }
     }
     sum
 }
 
-/// Sine of a working-scale value `v_w` (`= x · 10^w`) at scale `w`,
-/// with `π` supplied at the same scale (`pi_w = π · 10^w`).
+/// Sine of a `working_value` (`= x · 10^working_scale`) at
+/// `working_scale`, with `π` supplied at the same scale
+/// (`pi_at_working_scale = π · 10^working_scale`).
 ///
 /// Reduces to `|r| ≤ π/2` via mod-τ; then folds to `r ∈ [0, π/2]` via
 /// `sin(π − x) = sin(x)`; then routes to `sin_taylor` if `r ≤ π/4` or
@@ -108,78 +113,100 @@ where
 ///
 /// ## Argument-magnitude validity (the reduction error)
 ///
-/// `τ = 2π·10^w` is correctly rounded (error ≤ 1 working unit), so the
-/// reduced residue `r = v_w − q·τ` carries an absolute error of up to
-/// `q ≈ |x|/2π` working units — the mod-τ cancellation eats one guard
+/// `τ = 2π·10^working_scale` is correctly rounded (error ≤ 1 working
+/// unit), so the reduced residue `r = working_value − tau_multiple·τ`
+/// carries an absolute error of up to `tau_multiple ≈ |x|/2π` working
+/// units — the mod-τ cancellation eats one guard
 /// digit per integer digit of `|x|`. A caller choosing the work width /
 /// guard must budget `digits(|x|)` on top of the precision it needs
 /// (the work-rung selector's `D_BUDGET` axis; see
-/// `policy::work_rung::trig_rung`). `q` must also fit `i128`
+/// `policy::work_rung::trig_rung`). `tau_multiple` must also fit `i128`
 /// ([`eg::round_to_nearest_int`] truncates past it) — a bound inherited
 /// from the per-tier cores, not introduced here.
-pub(crate) fn sin_fixed<S: BigInt>(v_w: S, w: u32, pi_w: S) -> S
+pub(crate) fn sin_fixed<S: BigInt>(
+    working_value: S,
+    working_scale: u32,
+    pi_at_working_scale: S,
+) -> S
 where
     S::Scratch: ComputeLimbs,
 {
-    let tau = pi_w + pi_w;
-    let hp = pi_w >> 1;
-    let qp = hp >> 1; // π/4
-    let q = eg::round_to_nearest_int::<S>(eg::div::<S>(v_w, tau, w), w);
-    let r = v_w - eg::scale_by_k::<S>(tau, q);
-    let neg = r < eg::zero::<S>();
-    let abs_r = if neg { -r } else { r };
-    let reduced = if abs_r >= hp { pi_w - abs_r } else { abs_r };
-    let s = if reduced > qp {
+    let tau = pi_at_working_scale + pi_at_working_scale;
+    let half_pi = pi_at_working_scale >> 1;
+    let quarter_pi = half_pi >> 1; // π/4
+    let tau_multiple = eg::round_to_nearest_int::<S>(
+        eg::div::<S>(working_value, tau, working_scale),
+        working_scale,
+    );
+    let residue = working_value - eg::scale_by_k::<S>(tau, tau_multiple);
+    let sin_neg = residue < eg::zero::<S>();
+    let abs_residue = if sin_neg { -residue } else { residue };
+    let reduced = if abs_residue >= half_pi {
+        pi_at_working_scale - abs_residue
+    } else {
+        abs_residue
+    };
+    let sin_abs = if reduced > quarter_pi {
         // sin(reduced) = cos(π/2 − reduced); the cos argument lies in
         // [0, π/4].
-        cos_taylor::<S>(hp - reduced, w)
+        cos_taylor::<S>(half_pi - reduced, working_scale)
     } else {
-        sin_taylor::<S>(reduced, w)
+        sin_taylor::<S>(reduced, working_scale)
     };
-    if neg { -s } else { s }
+    if sin_neg { -sin_abs } else { sin_abs }
 }
 
 /// Cosine of a working-scale value via the cofunction identity
 /// `cos(x) = sin(π/2 − x)` — one [`sin_fixed`] evaluation, no sqrt.
-pub(crate) fn cos_fixed<S: BigInt>(v_w: S, w: u32, pi_w: S) -> S
+pub(crate) fn cos_fixed<S: BigInt>(
+    working_value: S,
+    working_scale: u32,
+    pi_at_working_scale: S,
+) -> S
 where
     S::Scratch: ComputeLimbs,
 {
-    sin_fixed::<S>((pi_w >> 1) - v_w, w, pi_w)
+    sin_fixed::<S>(
+        (pi_at_working_scale >> 1) - working_value,
+        working_scale,
+        pi_at_working_scale,
+    )
 }
 
-/// Taylor series for `atan` on a reduced `|x| < 1`, at scale `w`.
+/// Taylor series for `atan` on a reduced argument `|x| < 1`, at
+/// `working_scale`.
 ///
 /// `atan(x) = x − x³/3 + x⁵/5 − …`
-fn atan_taylor<S: BigInt>(x: S, w: u32) -> S
+fn atan_taylor<S: BigInt>(reduced_arg: S, working_scale: u32) -> S
 where
     S::Scratch: ComputeLimbs,
 {
-    let x2 = eg::mul::<S>(x, x, w);
-    let mut sum = x;
-    let mut term = x;
-    let mut k: u128 = 1;
+    let reduced_arg_squared = eg::mul::<S>(reduced_arg, reduced_arg, working_scale);
+    let mut sum = reduced_arg;
+    let mut term = reduced_arg;
+    let mut term_index: u128 = 1;
     loop {
-        term = eg::mul::<S>(term, x2, w);
-        let contrib = term / eg::lit::<S>((2 * k + 1) as i128);
+        term = eg::mul::<S>(term, reduced_arg_squared, working_scale);
+        let contrib = term / eg::lit::<S>((2 * term_index + 1) as i128);
         if contrib == eg::zero::<S>() {
             break;
         }
-        if k % 2 == 1 {
+        if term_index % 2 == 1 {
             sum = sum - contrib;
         } else {
             sum = sum + contrib;
         }
-        k += 1;
-        if k > eg::SERIES_CAP {
+        term_index += 1;
+        if term_index > eg::SERIES_CAP {
             break;
         }
     }
     sum
 }
 
-/// Arctangent of a working-scale value `v_w` (`= x · 10^w`) at scale `w`,
-/// with `π` supplied at the same scale (`pi_w = π · 10^w`) — only the
+/// Arctangent of a `working_value` (`= x · 10^working_scale`) at
+/// `working_scale`, with `π` supplied at the same scale
+/// (`pi_at_working_scale = π · 10^working_scale`) — only the
 /// `π/2` complement of the `|x| > 1` reciprocal fold consumes it.
 /// Result in `(−π/2, π/2)`.
 ///
@@ -193,46 +220,50 @@ where
 /// Unlike [`sin_fixed`]'s mod-τ reduction, the fold loses NO precision
 /// proportional to `digits(|x|)` — the reciprocal's relative error stays
 /// one working ULP, so there is no per-integer-digit guard cost. The
-/// only `|x|` axis is REPRESENTATION: the lifted `v_w` (and the fold's
-/// `10^(2w)` divide numerator) must fit `S` — a caller choosing a narrow
-/// work width must bound `digits(|x|)` so the lift fits (the work-rung
-/// selector's gate; see `policy::work_rung`).
-pub(crate) fn atan_fixed<S: BigInt>(v_w: S, w: u32, pi_w: S) -> S
+/// only `|x|` axis is REPRESENTATION: the lifted `working_value` (and the
+/// fold's `10^(2·working_scale)` divide numerator) must fit `S` — a
+/// caller choosing a narrow work width must bound `digits(|x|)` so the
+/// lift fits (the work-rung selector's gate; see `policy::work_rung`).
+pub(crate) fn atan_fixed<S: BigInt>(
+    working_value: S,
+    working_scale: u32,
+    pi_at_working_scale: S,
+) -> S
 where
     S::Scratch: ComputeLimbs,
 {
-    let one_w = eg::one::<S>(w);
-    let sign = v_w < eg::zero::<S>();
-    let mut x = if sign { -v_w } else { v_w };
+    let one_w = eg::one::<S>(working_scale);
+    let sign_neg = working_value < eg::zero::<S>();
+    let mut x = if sign_neg { -working_value } else { working_value };
     let mut add_half_pi = false;
     if x > one_w {
-        x = eg::div::<S>(one_w, x, w);
+        x = eg::div::<S>(one_w, x, working_scale);
         add_half_pi = true;
     }
     // Argument halvings: atan(x) = 2·atan(x/(1+√(1+x²))). Count keyed on
     // the working scale (the original per-tier kernel's break-even sweet
     // spots — wider working scale → more halvings worth taking).
-    let halvings: u32 = if w < 60 {
+    let halvings: u32 = if working_scale < 60 {
         5
-    } else if w < 110 {
+    } else if working_scale < 110 {
         6
     } else {
         7
     };
     let pow10_w = one_w;
     for _ in 0..halvings {
-        let x2 = eg::mul::<S>(x, x, w);
-        let denom = one_w + eg::sqrt_fixed::<S>(one_w + x2, w);
+        let x_squared = eg::mul::<S>(x, x, working_scale);
+        let denom = one_w + eg::sqrt_fixed::<S>(one_w + x_squared, working_scale);
         x = eg::div_cached::<S>(x, denom, pow10_w);
     }
-    let mut result = atan_taylor::<S>(x, w) << halvings;
+    let mut result = atan_taylor::<S>(x, working_scale) << halvings;
     if add_half_pi {
-        result = (pi_w >> 1) - result;
+        result = (pi_at_working_scale >> 1) - result;
     }
-    if sign { -result } else { result }
+    if sign_neg { -result } else { result }
 }
 
-/// Joint sine + cosine of a working-scale value at scale `w`.
+/// Joint sine + cosine of a working-scale value at `working_scale`.
 ///
 /// One Taylor series + one wide sqrt + one wide mul, vs two independent
 /// Taylor evaluations:
@@ -245,29 +276,40 @@ where
 /// - Recover `|cos(reduced)|` from the Pythagorean identity
 ///   `√(1 − sin²)`.
 /// - Apply the cached signs.
-pub(crate) fn sin_cos_fixed<S: BigInt>(v_w: S, w: u32, pi_w: S) -> (S, S)
+pub(crate) fn sin_cos_fixed<S: BigInt>(
+    working_value: S,
+    working_scale: u32,
+    pi_at_working_scale: S,
+) -> (S, S)
 where
     S::Scratch: ComputeLimbs,
 {
-    let tau = pi_w + pi_w;
-    let hp = pi_w >> 1;
-    let qp = hp >> 1;
-    let q = eg::round_to_nearest_int::<S>(eg::div::<S>(v_w, tau, w), w);
-    let r = v_w - eg::scale_by_k::<S>(tau, q);
-    let sin_neg = r < eg::zero::<S>();
-    let abs_r = if sin_neg { -r } else { r };
-    let cos_neg = abs_r > hp; // |r| > π/2 → cos negative.
-    let reduced = if cos_neg { pi_w - abs_r } else { abs_r };
-    let s_abs = if reduced > qp {
-        cos_taylor::<S>(hp - reduced, w)
+    let tau = pi_at_working_scale + pi_at_working_scale;
+    let half_pi = pi_at_working_scale >> 1;
+    let quarter_pi = half_pi >> 1;
+    let tau_multiple = eg::round_to_nearest_int::<S>(
+        eg::div::<S>(working_value, tau, working_scale),
+        working_scale,
+    );
+    let residue = working_value - eg::scale_by_k::<S>(tau, tau_multiple);
+    let sin_neg = residue < eg::zero::<S>();
+    let abs_residue = if sin_neg { -residue } else { residue };
+    let cos_neg = abs_residue > half_pi; // |r| > π/2 → cos negative.
+    let reduced = if cos_neg {
+        pi_at_working_scale - abs_residue
     } else {
-        sin_taylor::<S>(reduced, w)
+        abs_residue
+    };
+    let sin_abs = if reduced > quarter_pi {
+        cos_taylor::<S>(half_pi - reduced, working_scale)
+    } else {
+        sin_taylor::<S>(reduced, working_scale)
     };
     // cos² + sin² = 1 ⇒ |cos| = √(1 − sin²).
-    let one_w = eg::one::<S>(w);
-    let s2 = eg::mul::<S>(s_abs, s_abs, w);
-    let cos_abs = eg::sqrt_fixed::<S>(one_w - s2, w);
-    let sin_result = if sin_neg { -s_abs } else { s_abs };
+    let one_w = eg::one::<S>(working_scale);
+    let sin_abs_squared = eg::mul::<S>(sin_abs, sin_abs, working_scale);
+    let cos_abs = eg::sqrt_fixed::<S>(one_w - sin_abs_squared, working_scale);
+    let sin_result = if sin_neg { -sin_abs } else { sin_abs };
     let cos_result = if cos_neg { -cos_abs } else { cos_abs };
     (sin_result, cos_result)
 }

--- a/src/algos/trig/trig_schoolbook.rs
+++ b/src/algos/trig/trig_schoolbook.rs
@@ -48,8 +48,8 @@ pub(crate) fn sin_schoolbook<C: WideTrigCore, const SCALE: u32>(
     raw: C::Storage,
     mode: RoundingMode,
 ) -> C::Storage {
-    C::round_to_storage_directed(C::GUARD, SCALE, mode, &mut |guard| {
-        C::sin_fixed::<SCALE>(C::to_work_scaled(raw, guard), SCALE + guard)
+    C::round_to_storage_directed(C::GUARD, SCALE, mode, &mut |guard_digits| {
+        C::sin_fixed::<SCALE>(C::to_work_scaled(raw, guard_digits), SCALE + guard_digits)
     })
 }
 
@@ -61,8 +61,8 @@ pub(crate) fn cos_schoolbook<C: WideTrigCore, const SCALE: u32>(
     raw: C::Storage,
     mode: RoundingMode,
 ) -> C::Storage {
-    C::round_to_storage_directed(C::GUARD, SCALE, mode, &mut |guard| {
-        C::cos_fixed::<SCALE>(C::to_work_scaled(raw, guard), SCALE + guard)
+    C::round_to_storage_directed(C::GUARD, SCALE, mode, &mut |guard_digits| {
+        C::cos_fixed::<SCALE>(C::to_work_scaled(raw, guard_digits), SCALE + guard_digits)
     })
 }
 
@@ -76,13 +76,14 @@ pub(crate) fn tan_schoolbook<C: WideTrigCore, const SCALE: u32>(
     raw: C::Storage,
     mode: RoundingMode,
 ) -> C::Storage {
-    C::round_to_storage_directed(C::GUARD, SCALE, mode, &mut |guard| {
-        let w = SCALE + guard;
-        let (sin_w, cos_w) = C::sin_cos_fixed::<SCALE>(C::to_work_scaled(raw, guard), w);
+    C::round_to_storage_directed(C::GUARD, SCALE, mode, &mut |guard_digits| {
+        let working_scale = SCALE + guard_digits;
+        let (sin_w, cos_w) =
+            C::sin_cos_fixed::<SCALE>(C::to_work_scaled(raw, guard_digits), working_scale);
         if cos_w == C::zero() {
             panic!("schoolbook tan: cosine is zero (argument is an odd multiple of pi/2)");
         }
-        C::div(sin_w, cos_w, w)
+        C::div(sin_w, cos_w, working_scale)
     })
 }
 
@@ -95,8 +96,8 @@ pub(crate) fn atan_schoolbook<C: WideTrigCore, const SCALE: u32>(
     raw: C::Storage,
     mode: RoundingMode,
 ) -> C::Storage {
-    C::round_to_storage_directed(C::GUARD, SCALE, mode, &mut |guard| {
-        C::atan_fixed::<SCALE>(C::to_work_scaled(raw, guard), SCALE + guard)
+    C::round_to_storage_directed(C::GUARD, SCALE, mode, &mut |guard_digits| {
+        C::atan_fixed::<SCALE>(C::to_work_scaled(raw, guard_digits), SCALE + guard_digits)
     })
 }
 
@@ -110,9 +111,9 @@ fn sin_schoolbook_raw<const SCALE: u32>(raw: i128, mode: RoundingMode) -> i128 {
     if raw == 0 {
         return 0;
     }
-    let w = SCALE + STRICT_GUARD;
-    sin_fixed(to_fixed(raw), w)
-        .round_to_i128_with(w, SCALE, mode)
+    let working_scale = SCALE + STRICT_GUARD;
+    sin_fixed(to_fixed(raw), working_scale)
+        .round_to_i128_with(working_scale, SCALE, mode)
         .unwrap_or_else(|| crate::support::diagnostics::overflow_panic_with_scale("sin", SCALE))
 }
 
@@ -121,9 +122,10 @@ fn sin_schoolbook_raw<const SCALE: u32>(raw: i128, mode: RoundingMode) -> i128 {
 #[inline]
 #[must_use]
 fn cos_schoolbook_raw<const SCALE: u32>(raw: i128, mode: RoundingMode) -> i128 {
-    let w = SCALE + STRICT_GUARD;
-    let (_s, c) = sin_cos_fixed(to_fixed(raw), w);
-    c.round_to_i128_with(w, SCALE, mode)
+    let working_scale = SCALE + STRICT_GUARD;
+    let (_sin_value, cos_value) = sin_cos_fixed(to_fixed(raw), working_scale);
+    cos_value
+        .round_to_i128_with(working_scale, SCALE, mode)
         .unwrap_or_else(|| crate::support::diagnostics::overflow_panic_with_scale("cos", SCALE))
 }
 
@@ -136,13 +138,13 @@ fn tan_schoolbook_raw<const SCALE: u32>(raw: i128, mode: RoundingMode) -> i128 {
     if raw == 0 {
         return 0;
     }
-    let w = SCALE + STRICT_GUARD;
-    let (s, c) = sin_cos_fixed(to_fixed(raw), w);
-    if c.is_zero() {
+    let working_scale = SCALE + STRICT_GUARD;
+    let (sin_value, cos_value) = sin_cos_fixed(to_fixed(raw), working_scale);
+    if cos_value.is_zero() {
         panic!("schoolbook tan: cosine is zero (argument is an odd multiple of pi/2)");
     }
-    s.div(c, w)
-        .round_to_i128_with(w, SCALE, mode)
+    sin_value.div(cos_value, working_scale)
+        .round_to_i128_with(working_scale, SCALE, mode)
         .unwrap_or_else(|| crate::support::diagnostics::overflow_panic_with_scale("tan", SCALE))
 }
 
@@ -170,9 +172,9 @@ fn atan_schoolbook_raw<const SCALE: u32>(raw: i128, mode: RoundingMode) -> i128 
             return -<crate::D<Int<2>, SCALE> as DecimalConstants>::quarter_pi().0.as_i128();
         }
     }
-    let w = SCALE + STRICT_GUARD;
-    atan_fixed(to_fixed(raw), w)
-        .round_to_i128_with(w, SCALE, mode)
+    let working_scale = SCALE + STRICT_GUARD;
+    atan_fixed(to_fixed(raw), working_scale)
+        .round_to_i128_with(working_scale, SCALE, mode)
         .unwrap_or_else(|| crate::support::diagnostics::overflow_panic_with_scale("atan", SCALE))
 }
 
@@ -424,28 +426,28 @@ mod tests {
 
         #[test]
         fn sin_cos_tan_atan_schoolbook_match_routed() {
-            for &u in &INPUTS9 {
-                let r = raw(u);
+            for &units in &INPUTS9 {
+                let raw_value = raw(units);
                 for &mode in &MODES {
                     assert_eq!(
-                        sin_schoolbook::<Core, S>(r, mode),
-                        D::<Int<3>, S>(r).sin_strict_with(mode).0,
-                        "D57 sin schoolbook != routed at units={u} mode={mode:?}"
+                        sin_schoolbook::<Core, S>(raw_value, mode),
+                        D::<Int<3>, S>(raw_value).sin_strict_with(mode).0,
+                        "D57 sin schoolbook != routed at units={units} mode={mode:?}"
                     );
                     assert_eq!(
-                        cos_schoolbook::<Core, S>(r, mode),
-                        D::<Int<3>, S>(r).cos_strict_with(mode).0,
-                        "D57 cos schoolbook != routed at units={u} mode={mode:?}"
+                        cos_schoolbook::<Core, S>(raw_value, mode),
+                        D::<Int<3>, S>(raw_value).cos_strict_with(mode).0,
+                        "D57 cos schoolbook != routed at units={units} mode={mode:?}"
                     );
                     assert_eq!(
-                        tan_schoolbook::<Core, S>(r, mode),
-                        D::<Int<3>, S>(r).tan_strict_with(mode).0,
-                        "D57 tan schoolbook != routed at units={u} mode={mode:?}"
+                        tan_schoolbook::<Core, S>(raw_value, mode),
+                        D::<Int<3>, S>(raw_value).tan_strict_with(mode).0,
+                        "D57 tan schoolbook != routed at units={units} mode={mode:?}"
                     );
                     assert_eq!(
-                        atan_schoolbook::<Core, S>(r, mode),
-                        D::<Int<3>, S>(r).atan_strict_with(mode).0,
-                        "D57 atan schoolbook != routed at units={u} mode={mode:?}"
+                        atan_schoolbook::<Core, S>(raw_value, mode),
+                        D::<Int<3>, S>(raw_value).atan_strict_with(mode).0,
+                        "D57 atan schoolbook != routed at units={units} mode={mode:?}"
                     );
                 }
             }
@@ -474,28 +476,28 @@ mod tests {
 
         #[test]
         fn sin_cos_tan_atan_schoolbook_match_routed() {
-            for &u in &INPUTS9 {
-                let r = raw(u);
+            for &units in &INPUTS9 {
+                let raw_value = raw(units);
                 for &mode in &MODES {
                     assert_eq!(
-                        sin_schoolbook::<Core, S>(r, mode),
-                        D::<Int<16>, S>(r).sin_strict_with(mode).0,
-                        "D307 sin schoolbook != routed at units={u} mode={mode:?}"
+                        sin_schoolbook::<Core, S>(raw_value, mode),
+                        D::<Int<16>, S>(raw_value).sin_strict_with(mode).0,
+                        "D307 sin schoolbook != routed at units={units} mode={mode:?}"
                     );
                     assert_eq!(
-                        cos_schoolbook::<Core, S>(r, mode),
-                        D::<Int<16>, S>(r).cos_strict_with(mode).0,
-                        "D307 cos schoolbook != routed at units={u} mode={mode:?}"
+                        cos_schoolbook::<Core, S>(raw_value, mode),
+                        D::<Int<16>, S>(raw_value).cos_strict_with(mode).0,
+                        "D307 cos schoolbook != routed at units={units} mode={mode:?}"
                     );
                     assert_eq!(
-                        tan_schoolbook::<Core, S>(r, mode),
-                        D::<Int<16>, S>(r).tan_strict_with(mode).0,
-                        "D307 tan schoolbook != routed at units={u} mode={mode:?}"
+                        tan_schoolbook::<Core, S>(raw_value, mode),
+                        D::<Int<16>, S>(raw_value).tan_strict_with(mode).0,
+                        "D307 tan schoolbook != routed at units={units} mode={mode:?}"
                     );
                     assert_eq!(
-                        atan_schoolbook::<Core, S>(r, mode),
-                        D::<Int<16>, S>(r).atan_strict_with(mode).0,
-                        "D307 atan schoolbook != routed at units={u} mode={mode:?}"
+                        atan_schoolbook::<Core, S>(raw_value, mode),
+                        D::<Int<16>, S>(raw_value).atan_strict_with(mode).0,
+                        "D307 atan schoolbook != routed at units={units} mode={mode:?}"
                     );
                 }
             }

--- a/src/algos/trig/trig_series_2limb.rs
+++ b/src/algos/trig/trig_series_2limb.rs
@@ -139,18 +139,25 @@ pub(crate) const fn small_x_linear_threshold<const SCALE: u32>() -> i128 {
     if SCALE == 0 {
         return 0;
     }
-    let thresh_exp = SCALE.saturating_sub(SCALE.div_ceil(3));
-    10_i128.pow(thresh_exp)
+    let threshold_exponent = SCALE.saturating_sub(SCALE.div_ceil(3));
+    10_i128.pow(threshold_exponent)
 }
 
-/// π at working scale `w`, sourced DIRECTLY from the per-scale const
-/// table (`consts::pi_const_n`) — `floor(π·10^w)` rounded half-to-even.
+/// π at `working_scale`, sourced DIRECTLY from the per-scale const
+/// table (`consts::pi_const_n`) — `floor(π·10^working_scale)` rounded
+/// half-to-even.
 /// The ungated NARROW band covers `0..=512`, so this reads in every build
 /// (default / no_std included); no per-call rescale, no embedded raw.
-pub(crate) fn wide_pi(w: u32) -> Fixed {
-    debug_assert!(w <= 75, "wide_pi: working scale {w} exceeds Fixed capacity");
-    let words = crate::consts::pi_const_n::<4>(w, crate::support::rounding::RoundingMode::HalfToEven)
-        .limbs_le();
+pub(crate) fn wide_pi(working_scale: u32) -> Fixed {
+    debug_assert!(
+        working_scale <= 75,
+        "wide_pi: working scale {working_scale} exceeds Fixed capacity"
+    );
+    let words = crate::consts::pi_const_n::<4>(
+        working_scale,
+        crate::support::rounding::RoundingMode::HalfToEven,
+    )
+    .limbs_le();
     Fixed {
         negative: false,
         mag: [
@@ -160,14 +167,14 @@ pub(crate) fn wide_pi(w: u32) -> Fixed {
     }
 }
 
-/// τ = 2π at working scale `w`.
-fn wide_tau(w: u32) -> Fixed {
-    wide_pi(w).double()
+/// τ = 2π at `working_scale`.
+fn wide_tau(working_scale: u32) -> Fixed {
+    wide_pi(working_scale).double()
 }
 
-/// π/2 at working scale `w`.
-pub(crate) fn wide_half_pi(w: u32) -> Fixed {
-    wide_pi(w).halve()
+/// π/2 at `working_scale`.
+pub(crate) fn wide_half_pi(working_scale: u32) -> Fixed {
+    wide_pi(working_scale).halve()
 }
 
 /// Builds a working-scale `Fixed` from a signed `D38` raw value `r`:
@@ -180,20 +187,21 @@ pub(crate) fn to_fixed(raw: i128) -> Fixed {
 /// `r · 10^working_digits`, carrying the sign. Used by the `_approx`
 /// variants where the guard width is chosen at runtime.
 pub(crate) fn to_fixed_w(raw: i128, working_digits: u32) -> Fixed {
-    let m = Fixed::from_u128_mag(raw.unsigned_abs(), false).mul_u128(10u128.pow(working_digits));
-    if raw < 0 { m.neg() } else { m }
+    let magnitude =
+        Fixed::from_u128_mag(raw.unsigned_abs(), false).mul_u128(10u128.pow(working_digits));
+    if raw < 0 { magnitude.neg() } else { magnitude }
 }
 
 /// Shared `atan2` body factored out so the `_strict` and `_approx`
-/// dispatchers can compose it at their chosen working scale `w`.
+/// dispatchers can compose it at their chosen `working_scale`.
 /// `y_raw` keeps the original sign of the y-argument for the x-zero
 /// branch where the wide y value would have been signed-zero.
-pub(crate) fn atan2_kernel(y: Fixed, x: Fixed, y_raw: i128, w: u32) -> Fixed {
+pub(crate) fn atan2_kernel(y: Fixed, x: Fixed, y_raw: i128, working_scale: u32) -> Fixed {
     if x.is_zero() {
         return if y_raw > 0 {
-            wide_half_pi(w)
+            wide_half_pi(working_scale)
         } else if y_raw < 0 {
-            wide_half_pi(w).neg()
+            wide_half_pi(working_scale).neg()
         } else {
             Fixed::ZERO
         };
@@ -202,46 +210,48 @@ pub(crate) fn atan2_kernel(y: Fixed, x: Fixed, y_raw: i128, w: u32) -> Fixed {
     // argument-halving cascade doesn't blow up when |y| ≫ |x|.
     let abs_y_ge_abs_x = y.ge_mag(x);
     let base = if !abs_y_ge_abs_x {
-        atan_fixed(y.div(x, w), w)
+        atan_fixed(y.div(x, working_scale), working_scale)
     } else {
-        let inv = atan_fixed(x.div(y, w), w);
-        let hp = wide_half_pi(w);
+        let atan_x_over_y = atan_fixed(x.div(y, working_scale), working_scale);
+        let half_pi = wide_half_pi(working_scale);
         let same_sign = y.negative == x.negative;
         if same_sign {
-            hp.sub(inv)
+            half_pi.sub(atan_x_over_y)
         } else {
-            hp.neg().sub(inv)
+            half_pi.neg().sub(atan_x_over_y)
         }
     };
     if !x.negative {
         base
     } else if !y.negative {
-        base.add(wide_pi(w))
+        base.add(wide_pi(working_scale))
     } else {
-        base.sub(wide_pi(w))
+        base.sub(wide_pi(working_scale))
     }
 }
 
 /// Taylor series for `sin` on a reduced non-negative argument
-/// `r ∈ [0, π/4]`, evaluated at working scale `w`.
-fn sin_taylor(r: Fixed, w: u32) -> Fixed {
-    let r2 = r.mul(r, w);
-    let mut sum = r;
-    let mut term = r; // term = r^(2k-1)
-    let mut k: u128 = 1;
+/// `r ∈ [0, π/4]`, evaluated at `working_scale`.
+fn sin_taylor(reduced_arg: Fixed, working_scale: u32) -> Fixed {
+    let reduced_arg_squared = reduced_arg.mul(reduced_arg, working_scale);
+    let mut sum = reduced_arg;
+    let mut term = reduced_arg; // term = r^(2k-1)
+    let mut term_index: u128 = 1;
     loop {
         // term_k = term_{k-1} · r² / ((2k)(2k+1)); sign alternates.
-        term = term.mul(r2, w).div_small((2 * k) * (2 * k + 1));
+        term = term
+            .mul(reduced_arg_squared, working_scale)
+            .div_small((2 * term_index) * (2 * term_index + 1));
         if term.is_zero() {
             break;
         }
-        if k % 2 == 1 {
+        if term_index % 2 == 1 {
             sum = sum.sub(term);
         } else {
             sum = sum.add(term);
         }
-        k += 1;
-        if k > 200 {
+        term_index += 1;
+        if term_index > 200 {
             break;
         }
     }
@@ -249,7 +259,7 @@ fn sin_taylor(r: Fixed, w: u32) -> Fixed {
 }
 
 /// Taylor series for `cos` on a reduced non-negative argument
-/// `r ∈ [0, π/4]`, evaluated at working scale `w`.
+/// `r ∈ [0, π/4]`, evaluated at `working_scale`.
 ///
 /// `cos(r) = 1 − r²/2! + r⁴/4! − r⁶/6! + …`
 ///
@@ -259,79 +269,83 @@ fn sin_taylor(r: Fixed, w: u32) -> Fixed {
 /// `sin_fixed` and `sin_cos_fixed` when the reduced argument exceeds
 /// π/4 — splitting `[0, π/2]` at π/4 roughly halves the worst-case
 /// Taylor term count.
-fn cos_taylor(r: Fixed, w: u32) -> Fixed {
-    let r2 = r.mul(r, w);
+fn cos_taylor(reduced_arg: Fixed, working_scale: u32) -> Fixed {
+    let reduced_arg_squared = reduced_arg.mul(reduced_arg, working_scale);
     let one_w = Fixed {
         negative: false,
-        mag: Fixed::pow10(w),
+        mag: Fixed::pow10(working_scale),
     };
     let mut sum = one_w;
     let mut term = one_w;
-    let mut k: u128 = 1;
+    let mut term_index: u128 = 1;
     loop {
         // term_k = term_{k-1} · r² / ((2k-1)(2k)); sign alternates.
-        term = term.mul(r2, w).div_small((2 * k - 1) * (2 * k));
+        term = term
+            .mul(reduced_arg_squared, working_scale)
+            .div_small((2 * term_index - 1) * (2 * term_index));
         if term.is_zero() {
             break;
         }
-        if k % 2 == 1 {
+        if term_index % 2 == 1 {
             sum = sum.sub(term);
         } else {
             sum = sum.add(term);
         }
-        k += 1;
-        if k > 200 {
+        term_index += 1;
+        if term_index > 200 {
             break;
         }
     }
     sum
 }
 
-/// Sine of a working-scale value `v_w`, at working scale `w`.
+/// Sine of a `working_value`, at `working_scale`.
 ///
-/// Reduces `v` modulo τ via `q = round(v/τ)`, folds the remainder into
+/// Reduces the value modulo τ via `tau_multiple = round(v/τ)`, folds the
+/// remainder into
 /// `[0, π/2]` tracking sign and the `π − x` reflection, then routes
 /// to `sin_taylor` for `r ≤ π/4` or `cos_taylor(π/2 − r)` for the
 /// upper half — the π/4 split roughly halves the Taylor term count
 /// versus a single `[0, π/2]` series.
-pub(crate) fn sin_fixed(v_w: Fixed, w: u32) -> Fixed {
-    let tau = wide_tau(w);
-    let pi = wide_pi(w);
-    let half_pi = wide_half_pi(w);
+pub(crate) fn sin_fixed(working_value: Fixed, working_scale: u32) -> Fixed {
+    let tau = wide_tau(working_scale);
+    let pi = wide_pi(working_scale);
+    let half_pi = wide_half_pi(working_scale);
     let quarter_pi = half_pi.halve();
 
     // r = v - round(v/τ)·τ ∈ [-π, π].
-    let q = v_w.div(tau, w).round_to_nearest_int(w);
-    let q_tau = if q >= 0 {
-        tau.mul_u128(q as u128)
+    let tau_multiple = working_value
+        .div(tau, working_scale)
+        .round_to_nearest_int(working_scale);
+    let tau_offset = if tau_multiple >= 0 {
+        tau.mul_u128(tau_multiple as u128)
     } else {
-        tau.mul_u128((-q) as u128).neg()
+        tau.mul_u128((-tau_multiple) as u128).neg()
     };
-    let r = v_w.sub(q_tau);
+    let residue = working_value.sub(tau_offset);
 
     // Fold |r| ∈ [0, π] into [0, π/2] via sin(π − x) = sin(x).
-    let sign = r.negative;
-    let abs_r = Fixed {
+    let sin_neg = residue.negative;
+    let abs_residue = Fixed {
         negative: false,
-        mag: r.mag,
+        mag: residue.mag,
     };
-    let reduced = if abs_r.ge_mag(half_pi) {
-        pi.sub(abs_r)
+    let reduced = if abs_residue.ge_mag(half_pi) {
+        pi.sub(abs_residue)
     } else {
-        abs_r
+        abs_residue
     };
     // Pick the faster-converging branch at π/4.
-    let s = if reduced.ge_mag(quarter_pi) {
+    let sin_abs = if reduced.ge_mag(quarter_pi) {
         // sin(reduced) = cos(π/2 − reduced); the cos arg ∈ [0, π/4].
-        cos_taylor(half_pi.sub(reduced), w)
+        cos_taylor(half_pi.sub(reduced), working_scale)
     } else {
-        sin_taylor(reduced, w)
+        sin_taylor(reduced, working_scale)
     };
-    if sign { s.neg() } else { s }
+    if sin_neg { sin_abs.neg() } else { sin_abs }
 }
 
-/// Joint sine + cosine of a working-scale value `v_w`, at working
-/// scale `w`.
+/// Joint sine + cosine of a `working_value`, at `working_scale`.
 ///
 /// Shares the mod-τ argument reduction between sin and cos — one
 /// reduction (1 wide divide + 1 round-to-int + 1 multiply-back +
@@ -342,84 +356,90 @@ pub(crate) fn sin_fixed(v_w: Fixed, w: u32) -> Fixed {
 /// `|cos| = √(1 − sin²)` was tried — a 256-bit Fixed sqrt is far
 /// more expensive than a second Taylor at this width, so the joint
 /// kernel sticks with two Taylors after the shared reduction.
-pub(crate) fn sin_cos_fixed(v_w: Fixed, w: u32) -> (Fixed, Fixed) {
-    let tau = wide_tau(w);
-    let pi = wide_pi(w);
-    let half_pi = wide_half_pi(w);
+pub(crate) fn sin_cos_fixed(working_value: Fixed, working_scale: u32) -> (Fixed, Fixed) {
+    let tau = wide_tau(working_scale);
+    let pi = wide_pi(working_scale);
+    let half_pi = wide_half_pi(working_scale);
     let quarter_pi = half_pi.halve();
 
-    let q = v_w.div(tau, w).round_to_nearest_int(w);
-    let q_tau = if q >= 0 {
-        tau.mul_u128(q as u128)
+    let tau_multiple = working_value
+        .div(tau, working_scale)
+        .round_to_nearest_int(working_scale);
+    let tau_offset = if tau_multiple >= 0 {
+        tau.mul_u128(tau_multiple as u128)
     } else {
-        tau.mul_u128((-q) as u128).neg()
+        tau.mul_u128((-tau_multiple) as u128).neg()
     };
-    let r = v_w.sub(q_tau);
+    let residue = working_value.sub(tau_offset);
 
     // Sin: fold |r| ∈ [0, π] to [0, π/2] via sin(π − x) = sin(x);
     // sign comes from the residue sign.
-    let sin_neg = r.negative;
-    let abs_r = Fixed {
+    let sin_neg = residue.negative;
+    let abs_residue = Fixed {
         negative: false,
-        mag: r.mag,
+        mag: residue.mag,
     };
-    let cos_neg = abs_r.ge_mag(half_pi); // |r| > π/2 ⇒ cos negative.
-    let sin_reduced = if cos_neg { pi.sub(abs_r) } else { abs_r };
-    let s_abs = if sin_reduced.ge_mag(quarter_pi) {
-        cos_taylor(half_pi.sub(sin_reduced), w)
+    let cos_neg = abs_residue.ge_mag(half_pi); // |r| > π/2 ⇒ cos negative.
+    let sin_reduced = if cos_neg {
+        pi.sub(abs_residue)
     } else {
-        sin_taylor(sin_reduced, w)
+        abs_residue
+    };
+    let sin_abs = if sin_reduced.ge_mag(quarter_pi) {
+        cos_taylor(half_pi.sub(sin_reduced), working_scale)
+    } else {
+        sin_taylor(sin_reduced, working_scale)
     };
 
     // Cos: |cos(r)| = sin(π/2 − sin_reduced) — same π/4 split.
     // sin_reduced is in [0, π/2], so π/2 − sin_reduced is also in
     // [0, π/2] and the π/4 branch logic is just inverted.
     let cos_reduced = half_pi.sub(sin_reduced);
-    let c_abs = if cos_reduced.ge_mag(quarter_pi) {
-        cos_taylor(half_pi.sub(cos_reduced), w)
+    let cos_abs = if cos_reduced.ge_mag(quarter_pi) {
+        cos_taylor(half_pi.sub(cos_reduced), working_scale)
     } else {
-        sin_taylor(cos_reduced, w)
+        sin_taylor(cos_reduced, working_scale)
     };
 
-    let sin_result = if sin_neg { s_abs.neg() } else { s_abs };
-    let cos_result = if cos_neg { c_abs.neg() } else { c_abs };
+    let sin_result = if sin_neg { sin_abs.neg() } else { sin_abs };
+    let cos_result = if cos_neg { cos_abs.neg() } else { cos_abs };
     (sin_result, cos_result)
 }
 
 /// Taylor series for `atan` on a reduced non-negative argument
-/// `x ∈ [0, ~1/8]`, evaluated at working scale `w`.
-fn atan_taylor(x: Fixed, w: u32) -> Fixed {
-    let x2 = x.mul(x, w);
-    let mut sum = x;
-    let mut term = x; // term = x^(2k-1)
-    let mut k: u128 = 1;
+/// `x ∈ [0, ~1/8]`, evaluated at `working_scale`.
+fn atan_taylor(reduced_arg: Fixed, working_scale: u32) -> Fixed {
+    let reduced_arg_squared = reduced_arg.mul(reduced_arg, working_scale);
+    let mut sum = reduced_arg;
+    let mut term = reduced_arg; // term = x^(2k-1)
+    let mut term_index: u128 = 1;
     loop {
-        term = term.mul(x2, w);
-        let contrib = term.div_small(2 * k + 1);
+        term = term.mul(reduced_arg_squared, working_scale);
+        let contrib = term.div_small(2 * term_index + 1);
         if contrib.is_zero() {
             break;
         }
-        if k % 2 == 1 {
+        if term_index % 2 == 1 {
             sum = sum.sub(contrib);
         } else {
             sum = sum.add(contrib);
         }
-        k += 1;
-        if k > 300 {
+        term_index += 1;
+        if term_index > 300 {
             break;
         }
     }
     sum
 }
 
-/// Arctangent of a working-scale value `v_w`, at working scale `w`,
+/// Arctangent of a `working_value`, at `working_scale`,
 /// result in `(−π/2, π/2)`.
 ///
 /// Odd-function fold to `x ≥ 0`; reciprocal reduction
 /// `atan(x) = π/2 − atan(1/x)` for `x > 1`; up to 8 rounds of
 /// argument halving `atan(x) = 2·atan(x / (1 + √(1+x²)))`; then the
 /// series.
-pub(crate) fn atan_fixed(v_w: Fixed, w: u32) -> Fixed {
+pub(crate) fn atan_fixed(working_value: Fixed, working_scale: u32) -> Fixed {
     #[cfg(feature = "perf-trace")]
     let _atan_span = ::tracing::info_span!("atan_fixed").entered();
 
@@ -427,16 +447,16 @@ pub(crate) fn atan_fixed(v_w: Fixed, w: u32) -> Fixed {
     let _setup_span = ::tracing::info_span!("setup").entered();
     let one_w = Fixed {
         negative: false,
-        mag: Fixed::pow10(w),
+        mag: Fixed::pow10(working_scale),
     };
-    let sign = v_w.negative;
+    let sign_neg = working_value.negative;
     let mut x = Fixed {
         negative: false,
-        mag: v_w.mag,
+        mag: working_value.mag,
     };
     let mut add_half_pi = false;
     if x.ge_mag(one_w) && x != one_w {
-        x = one_w.div(x, w); // atan(x) = π/2 − atan(1/x)
+        x = one_w.div(x, working_scale); // atan(x) = π/2 − atan(1/x)
         add_half_pi = true;
     }
     #[cfg(feature = "perf-trace")]
@@ -449,12 +469,12 @@ pub(crate) fn atan_fixed(v_w: Fixed, w: u32) -> Fixed {
     // as a safety net against pathological edge cases.
     #[cfg(feature = "perf-trace")]
     let _halvings_span = ::tracing::info_span!("halvings").entered();
-    let halving_threshold = one_w.div_small(5); // 0.2 at scale w
+    let halving_threshold = one_w.div_small(5); // 0.2 at the working scale
     let mut halvings: u32 = 0;
     while x.ge_mag(halving_threshold) && halvings < 8 {
-        let x2 = x.mul(x, w);
-        let denom = one_w.add(one_w.add(x2).sqrt(w));
-        x = x.div(denom, w);
+        let x_squared = x.mul(x, working_scale);
+        let denom = one_w.add(one_w.add(x_squared).sqrt(working_scale));
+        x = x.div(denom, working_scale);
         halvings += 1;
     }
     #[cfg(feature = "perf-trace")]
@@ -462,7 +482,7 @@ pub(crate) fn atan_fixed(v_w: Fixed, w: u32) -> Fixed {
 
     #[cfg(feature = "perf-trace")]
     let _taylor_span = ::tracing::info_span!("taylor").entered();
-    let mut result = atan_taylor(x, w);
+    let mut result = atan_taylor(x, working_scale);
     #[cfg(feature = "perf-trace")]
     drop(_taylor_span);
 
@@ -470,9 +490,9 @@ pub(crate) fn atan_fixed(v_w: Fixed, w: u32) -> Fixed {
     let _reasm_span = ::tracing::info_span!("reassemble").entered();
     result = result.shl(halvings);
     if add_half_pi {
-        result = wide_half_pi(w).sub(result);
+        result = wide_half_pi(working_scale).sub(result);
     }
-    if sign { result.neg() } else { result }
+    if sign_neg { result.neg() } else { result }
 }
 
 // ── Near-tie Ziv escalation (the narrow walker recomputes) ─────────
@@ -493,102 +513,139 @@ pub(crate) fn atan_fixed(v_w: Fixed, w: u32) -> Fixed {
 // ~192 digits, past every constructible narrow-tier deciding depth
 // (≤ 3·38 = 114); see `narrow_ziv`.
 
-/// One `WZiv` sin probe at working scale `SCALE + g`.
-fn sin_ziv(raw: i128, scale: u32, g: u32) -> WZiv {
-    let w = scale + g;
-    tg::sin_fixed::<WZiv>(narrow_ziv::lift(raw, g), w, narrow_ziv::pi_w(w))
+/// One `WZiv` sin probe at working scale `SCALE + guard_digits`.
+fn sin_ziv(raw: i128, scale: u32, guard_digits: u32) -> WZiv {
+    let working_scale = scale + guard_digits;
+    tg::sin_fixed::<WZiv>(
+        narrow_ziv::lift(raw, guard_digits),
+        working_scale,
+        narrow_ziv::pi_w(working_scale),
+    )
 }
 
-/// One `WZiv` cos probe at working scale `SCALE + g`.
-fn cos_ziv(raw: i128, scale: u32, g: u32) -> WZiv {
-    let w = scale + g;
-    tg::cos_fixed::<WZiv>(narrow_ziv::lift(raw, g), w, narrow_ziv::pi_w(w))
+/// One `WZiv` cos probe at working scale `SCALE + guard_digits`.
+fn cos_ziv(raw: i128, scale: u32, guard_digits: u32) -> WZiv {
+    let working_scale = scale + guard_digits;
+    tg::cos_fixed::<WZiv>(
+        narrow_ziv::lift(raw, guard_digits),
+        working_scale,
+        narrow_ziv::pi_w(working_scale),
+    )
 }
 
-/// One `WZiv` tan probe (the sin/cos ratio) at working scale `SCALE + g`.
-fn tan_ziv(raw: i128, scale: u32, g: u32) -> WZiv {
-    let w = scale + g;
-    let (s, c) = tg::sin_cos_fixed::<WZiv>(narrow_ziv::lift(raw, g), w, narrow_ziv::pi_w(w));
+/// One `WZiv` tan probe (the sin/cos ratio) at working scale
+/// `SCALE + guard_digits`.
+fn tan_ziv(raw: i128, scale: u32, guard_digits: u32) -> WZiv {
+    let working_scale = scale + guard_digits;
+    let (sin_value, cos_value) = tg::sin_cos_fixed::<WZiv>(
+        narrow_ziv::lift(raw, guard_digits),
+        working_scale,
+        narrow_ziv::pi_w(working_scale),
+    );
     assert!(
-        c != WZiv::from_i128(0),
+        cos_value != WZiv::from_i128(0),
         "tan: cosine is zero (argument is an odd multiple of pi/2)"
     );
-    eg::div::<WZiv>(s, c, w)
+    eg::div::<WZiv>(sin_value, cos_value, working_scale)
 }
 
-/// One `WZiv` atan probe at working scale `SCALE + g`.
-fn atan_ziv(raw: i128, scale: u32, g: u32) -> WZiv {
-    let w = scale + g;
-    tg::atan_fixed::<WZiv>(narrow_ziv::lift(raw, g), w, narrow_ziv::pi_w(w))
+/// One `WZiv` atan probe at working scale `SCALE + guard_digits`.
+fn atan_ziv(raw: i128, scale: u32, guard_digits: u32) -> WZiv {
+    let working_scale = scale + guard_digits;
+    tg::atan_fixed::<WZiv>(
+        narrow_ziv::lift(raw, guard_digits),
+        working_scale,
+        narrow_ziv::pi_w(working_scale),
+    )
 }
 
 /// The asin composition on a `WZiv` working value — the generic mirror
 /// of the `Fixed` body (`atan(x/√(1−x²))` below ½, the half-angle
 /// reduction above).
-pub(crate) fn asin_work_ziv(v: WZiv, w: u32) -> WZiv {
+pub(crate) fn asin_work_ziv(working_value: WZiv, working_scale: u32) -> WZiv {
     let zero = WZiv::from_i128(0);
-    let one_w = eg::one::<WZiv>(w);
-    let pi = narrow_ziv::pi_w(w);
-    let hp = pi >> 1;
-    let neg = v < zero;
-    let av = if neg { -v } else { v };
-    if av == one_w {
-        return if neg { -hp } else { hp };
+    let one_w = eg::one::<WZiv>(working_scale);
+    let pi = narrow_ziv::pi_w(working_scale);
+    let half_pi = pi >> 1;
+    let is_negative = working_value < zero;
+    let abs_working_value = if is_negative { -working_value } else { working_value };
+    if abs_working_value == one_w {
+        return if is_negative { -half_pi } else { half_pi };
     }
     let half_w = one_w >> 1;
-    let r = if av < half_w {
-        let denom = eg::sqrt_fixed::<WZiv>(one_w - eg::mul::<WZiv>(av, av, w), w);
-        tg::atan_fixed::<WZiv>(eg::div::<WZiv>(av, denom, w), w, pi)
+    let asin_abs = if abs_working_value < half_w {
+        let denom = eg::sqrt_fixed::<WZiv>(
+            one_w - eg::mul::<WZiv>(abs_working_value, abs_working_value, working_scale),
+            working_scale,
+        );
+        tg::atan_fixed::<WZiv>(
+            eg::div::<WZiv>(abs_working_value, denom, working_scale),
+            working_scale,
+            pi,
+        )
     } else {
-        let inner = (one_w - av) >> 1;
-        let inner_sqrt = eg::sqrt_fixed::<WZiv>(inner, w);
-        let inner_denom =
-            eg::sqrt_fixed::<WZiv>(one_w - eg::mul::<WZiv>(inner_sqrt, inner_sqrt, w), w);
-        let inner_asin =
-            tg::atan_fixed::<WZiv>(eg::div::<WZiv>(inner_sqrt, inner_denom, w), w, pi);
-        hp - inner_asin - inner_asin
+        let inner = (one_w - abs_working_value) >> 1;
+        let inner_sqrt = eg::sqrt_fixed::<WZiv>(inner, working_scale);
+        let inner_denom = eg::sqrt_fixed::<WZiv>(
+            one_w - eg::mul::<WZiv>(inner_sqrt, inner_sqrt, working_scale),
+            working_scale,
+        );
+        let inner_asin = tg::atan_fixed::<WZiv>(
+            eg::div::<WZiv>(inner_sqrt, inner_denom, working_scale),
+            working_scale,
+            pi,
+        );
+        half_pi - inner_asin - inner_asin
     };
-    if neg { -r } else { r }
+    if is_negative { -asin_abs } else { asin_abs }
 }
 
-/// One `WZiv` asin probe at working scale `SCALE + g`.
-pub(crate) fn asin_ziv(raw: i128, scale: u32, g: u32) -> WZiv {
-    let w = scale + g;
-    asin_work_ziv(narrow_ziv::lift(raw, g), w)
+/// One `WZiv` asin probe at working scale `SCALE + guard_digits`.
+pub(crate) fn asin_ziv(raw: i128, scale: u32, guard_digits: u32) -> WZiv {
+    let working_scale = scale + guard_digits;
+    asin_work_ziv(narrow_ziv::lift(raw, guard_digits), working_scale)
 }
 
-/// One `WZiv` acos probe (`π/2 − asin`) at working scale `SCALE + g`.
-pub(crate) fn acos_ziv(raw: i128, scale: u32, g: u32) -> WZiv {
-    let w = scale + g;
-    (narrow_ziv::pi_w(w) >> 1) - asin_work_ziv(narrow_ziv::lift(raw, g), w)
+/// One `WZiv` acos probe (`π/2 − asin`) at working scale
+/// `SCALE + guard_digits`.
+pub(crate) fn acos_ziv(raw: i128, scale: u32, guard_digits: u32) -> WZiv {
+    let working_scale = scale + guard_digits;
+    (narrow_ziv::pi_w(working_scale) >> 1)
+        - asin_work_ziv(narrow_ziv::lift(raw, guard_digits), working_scale)
 }
 
 /// One `WZiv` atan2 probe (quadrant-resolved max-branch ratio) at
-/// working scale `SCALE + g` — the generic mirror of [`atan2_kernel`].
-pub(crate) fn atan2_ziv(y_raw: i128, x_raw: i128, scale: u32, g: u32) -> WZiv {
-    let w = scale + g;
+/// working scale `SCALE + guard_digits` — the generic mirror of
+/// [`atan2_kernel`].
+pub(crate) fn atan2_ziv(y_raw: i128, x_raw: i128, scale: u32, guard_digits: u32) -> WZiv {
+    let working_scale = scale + guard_digits;
     let zero = WZiv::from_i128(0);
-    let pi = narrow_ziv::pi_w(w);
-    let hp = pi >> 1;
+    let pi = narrow_ziv::pi_w(working_scale);
+    let half_pi = pi >> 1;
     if x_raw == 0 {
         return if y_raw > 0 {
-            hp
+            half_pi
         } else if y_raw < 0 {
-            -hp
+            -half_pi
         } else {
             zero
         };
     }
-    let y = narrow_ziv::lift(y_raw, g);
-    let x = narrow_ziv::lift(x_raw, g);
-    let ay = if y < zero { -y } else { y };
-    let ax = if x < zero { -x } else { x };
-    let base = if ax >= ay {
-        tg::atan_fixed::<WZiv>(eg::div::<WZiv>(y, x, w), w, pi)
+    let y = narrow_ziv::lift(y_raw, guard_digits);
+    let x = narrow_ziv::lift(x_raw, guard_digits);
+    let abs_y = if y < zero { -y } else { y };
+    let abs_x = if x < zero { -x } else { x };
+    let base = if abs_x >= abs_y {
+        tg::atan_fixed::<WZiv>(eg::div::<WZiv>(y, x, working_scale), working_scale, pi)
     } else {
-        let inv = tg::atan_fixed::<WZiv>(eg::div::<WZiv>(x, y, w), w, pi);
+        let atan_x_over_y =
+            tg::atan_fixed::<WZiv>(eg::div::<WZiv>(x, y, working_scale), working_scale, pi);
         let same_sign = (y < zero) == (x < zero);
-        if same_sign { hp - inv } else { (-hp) - inv }
+        if same_sign {
+            half_pi - atan_x_over_y
+        } else {
+            (-half_pi) - atan_x_over_y
+        }
     };
     if x_raw > 0 {
         base
@@ -638,14 +695,18 @@ pub(crate) fn sin_strict_raw<const SCALE: u32>(raw: i128, mode: RoundingMode) ->
     if raw.abs() <= small_x_linear_threshold::<SCALE>() && is_nearest_mode(mode) {
         return raw;
     }
-    let w = SCALE + STRICT_GUARD;
-    let r = match sin_fixed(to_fixed(raw), w).round_to_i128_clear_of_tie(w, SCALE, mode) {
-        Some(v) => v.unwrap_or_else(|| {
+    let working_scale = SCALE + STRICT_GUARD;
+    let rounded = match sin_fixed(to_fixed(raw), working_scale)
+        .round_to_i128_clear_of_tie(working_scale, SCALE, mode)
+    {
+        Some(narrowed) => narrowed.unwrap_or_else(|| {
             crate::support::diagnostics::overflow_panic_with_scale("sin", SCALE)
         }),
-        None => narrow_ziv::walk(STRICT_GUARD, SCALE, mode, |g| sin_ziv(raw, SCALE, g)),
+        None => narrow_ziv::walk(STRICT_GUARD, SCALE, mode, |guard_digits| {
+            sin_ziv(raw, SCALE, guard_digits)
+        }),
     };
-    adjust_bounded_extremum_raw(r, SCALE, mode)
+    adjust_bounded_extremum_raw(rounded, SCALE, mode)
 }
 
 #[inline]
@@ -661,9 +722,9 @@ pub(crate) fn sin_with_raw<const SCALE: u32>(
     if raw.abs() <= small_x_linear_threshold::<SCALE>() && is_nearest_mode(mode) {
         return raw;
     }
-    let w = SCALE + working_digits;
-    sin_fixed(to_fixed_w(raw, working_digits), w)
-        .round_to_i128_with(w, SCALE, mode)
+    let working_scale = SCALE + working_digits;
+    sin_fixed(to_fixed_w(raw, working_digits), working_scale)
+        .round_to_i128_with(working_scale, SCALE, mode)
         .unwrap_or_else(|| crate::support::diagnostics::overflow_panic_with_scale("sin", SCALE))
 }
 
@@ -675,15 +736,20 @@ pub(crate) fn cos_strict_raw<const SCALE: u32>(raw: i128, mode: RoundingMode) ->
     if raw == 0 {
         return 10_i128.pow(SCALE);
     }
-    let w = SCALE + STRICT_GUARD;
-    let v = sin_fixed(to_fixed(raw).add(wide_half_pi(w)), w);
-    let r = match v.round_to_i128_clear_of_tie(w, SCALE, mode) {
-        Some(v) => v.unwrap_or_else(|| {
+    let working_scale = SCALE + STRICT_GUARD;
+    let cos_value = sin_fixed(
+        to_fixed(raw).add(wide_half_pi(working_scale)),
+        working_scale,
+    );
+    let rounded = match cos_value.round_to_i128_clear_of_tie(working_scale, SCALE, mode) {
+        Some(narrowed) => narrowed.unwrap_or_else(|| {
             crate::support::diagnostics::overflow_panic_with_scale("cos", SCALE)
         }),
-        None => narrow_ziv::walk(STRICT_GUARD, SCALE, mode, |g| cos_ziv(raw, SCALE, g)),
+        None => narrow_ziv::walk(STRICT_GUARD, SCALE, mode, |guard_digits| {
+            cos_ziv(raw, SCALE, guard_digits)
+        }),
     };
-    adjust_bounded_extremum_raw(r, SCALE, mode)
+    adjust_bounded_extremum_raw(rounded, SCALE, mode)
 }
 
 #[inline]
@@ -696,10 +762,10 @@ pub(crate) fn cos_with_raw<const SCALE: u32>(
     if raw == 0 {
         return 10_i128.pow(SCALE);
     }
-    let w = SCALE + working_digits;
-    let arg = to_fixed_w(raw, working_digits).add(wide_half_pi(w));
-    sin_fixed(arg, w)
-        .round_to_i128_with(w, SCALE, mode)
+    let working_scale = SCALE + working_digits;
+    let arg = to_fixed_w(raw, working_digits).add(wide_half_pi(working_scale));
+    sin_fixed(arg, working_scale)
+        .round_to_i128_with(working_scale, SCALE, mode)
         .unwrap_or_else(|| crate::support::diagnostics::overflow_panic_with_scale("cos", SCALE))
 }
 
@@ -714,17 +780,22 @@ pub(crate) fn tan_strict_raw<const SCALE: u32>(raw: i128, mode: RoundingMode) ->
     if raw.abs() <= small_x_linear_threshold::<SCALE>() && is_nearest_mode(mode) {
         return raw;
     }
-    let w = SCALE + STRICT_GUARD;
-    let (sin_w, cos_w) = sin_cos_fixed(to_fixed(raw), w);
+    let working_scale = SCALE + STRICT_GUARD;
+    let (sin_w, cos_w) = sin_cos_fixed(to_fixed(raw), working_scale);
     assert!(
         !cos_w.is_zero(),
         "tan: cosine is zero (argument is an odd multiple of pi/2)"
     );
-    match sin_w.div(cos_w, w).round_to_i128_clear_of_tie(w, SCALE, mode) {
-        Some(v) => v.unwrap_or_else(|| {
+    match sin_w
+        .div(cos_w, working_scale)
+        .round_to_i128_clear_of_tie(working_scale, SCALE, mode)
+    {
+        Some(narrowed) => narrowed.unwrap_or_else(|| {
             crate::support::diagnostics::overflow_panic_with_scale("tan", SCALE)
         }),
-        None => narrow_ziv::walk(STRICT_GUARD, SCALE, mode, |g| tan_ziv(raw, SCALE, g)),
+        None => narrow_ziv::walk(STRICT_GUARD, SCALE, mode, |guard_digits| {
+            tan_ziv(raw, SCALE, guard_digits)
+        }),
     }
 }
 
@@ -741,15 +812,15 @@ pub(crate) fn tan_with_raw<const SCALE: u32>(
     if raw.abs() <= small_x_linear_threshold::<SCALE>() && is_nearest_mode(mode) {
         return raw;
     }
-    let w = SCALE + working_digits;
-    let (sin_w, cos_w) = sin_cos_fixed(to_fixed_w(raw, working_digits), w);
+    let working_scale = SCALE + working_digits;
+    let (sin_w, cos_w) = sin_cos_fixed(to_fixed_w(raw, working_digits), working_scale);
     assert!(
         !cos_w.is_zero(),
         "tan: cosine is zero (argument is an odd multiple of pi/2)"
     );
     sin_w
-        .div(cos_w, w)
-        .round_to_i128_with(w, SCALE, mode)
+        .div(cos_w, working_scale)
+        .round_to_i128_with(working_scale, SCALE, mode)
         .unwrap_or_else(|| crate::support::diagnostics::overflow_panic_with_scale("tan", SCALE))
 }
 
@@ -777,12 +848,16 @@ pub(crate) fn atan_strict_raw<const SCALE: u32>(raw: i128, mode: RoundingMode) -
     if raw.abs() <= small_x_linear_threshold::<SCALE>() && is_nearest_mode(mode) {
         return raw;
     }
-    let w = SCALE + STRICT_GUARD;
-    match atan_fixed(to_fixed(raw), w).round_to_i128_clear_of_tie(w, SCALE, mode) {
-        Some(v) => v.unwrap_or_else(|| {
+    let working_scale = SCALE + STRICT_GUARD;
+    match atan_fixed(to_fixed(raw), working_scale)
+        .round_to_i128_clear_of_tie(working_scale, SCALE, mode)
+    {
+        Some(narrowed) => narrowed.unwrap_or_else(|| {
             crate::support::diagnostics::overflow_panic_with_scale("atan", SCALE)
         }),
-        None => narrow_ziv::walk(STRICT_GUARD, SCALE, mode, |g| atan_ziv(raw, SCALE, g)),
+        None => narrow_ziv::walk(STRICT_GUARD, SCALE, mode, |guard_digits| {
+            atan_ziv(raw, SCALE, guard_digits)
+        }),
     }
 }
 
@@ -809,9 +884,9 @@ pub(crate) fn atan_with_raw<const SCALE: u32>(
     if raw.abs() <= small_x_linear_threshold::<SCALE>() && is_nearest_mode(mode) {
         return raw;
     }
-    let w = SCALE + working_digits;
-    atan_fixed(to_fixed_w(raw, working_digits), w)
-        .round_to_i128_with(w, SCALE, mode)
+    let working_scale = SCALE + working_digits;
+    atan_fixed(to_fixed_w(raw, working_digits), working_scale)
+        .round_to_i128_with(working_scale, SCALE, mode)
         .unwrap_or_else(|| crate::support::diagnostics::overflow_panic_with_scale("atan", SCALE))
 }
 
@@ -826,46 +901,55 @@ pub(crate) fn asin_strict_raw<const SCALE: u32>(raw: i128, mode: RoundingMode) -
     if raw.abs() <= small_x_linear_threshold::<SCALE>() && is_nearest_mode(mode) {
         return raw;
     }
-    let w = SCALE + STRICT_GUARD;
+    let working_scale = SCALE + STRICT_GUARD;
     let one_w = Fixed {
         negative: false,
-        mag: Fixed::pow10(w),
+        mag: Fixed::pow10(working_scale),
     };
-    let v = to_fixed(raw);
-    let abs_v = Fixed {
+    let working_value = to_fixed(raw);
+    let abs_working_value = Fixed {
         negative: false,
-        mag: v.mag,
+        mag: working_value.mag,
     };
     assert!(
-        !(abs_v.ge_mag(one_w) && abs_v != one_w),
+        !(abs_working_value.ge_mag(one_w) && abs_working_value != one_w),
         "asin: argument out of domain [-1, 1]"
     );
-    let asin_w = if abs_v == one_w {
-        let hp = wide_half_pi(w);
-        if v.negative { hp.neg() } else { hp }
+    let asin_w = if abs_working_value == one_w {
+        let half_pi = wide_half_pi(working_scale);
+        if working_value.negative { half_pi.neg() } else { half_pi }
     } else {
         let half_w = one_w.halve();
-        if !abs_v.ge_mag(half_w) {
-            let denom = one_w.sub(v.mul(v, w)).sqrt(w);
-            atan_fixed(v.div(denom, w), w)
+        if !abs_working_value.ge_mag(half_w) {
+            let denom = one_w
+                .sub(working_value.mul(working_value, working_scale))
+                .sqrt(working_scale);
+            atan_fixed(working_value.div(denom, working_scale), working_scale)
         } else {
-            let inner = one_w.sub(abs_v).halve();
-            let inner_sqrt = inner.sqrt(w);
-            let inner_denom = one_w.sub(inner_sqrt.mul(inner_sqrt, w)).sqrt(w);
-            let inner_asin = atan_fixed(inner_sqrt.div(inner_denom, w), w);
-            let result_abs = wide_half_pi(w).sub(inner_asin).sub(inner_asin);
-            if v.negative {
+            let inner = one_w.sub(abs_working_value).halve();
+            let inner_sqrt = inner.sqrt(working_scale);
+            let inner_denom = one_w
+                .sub(inner_sqrt.mul(inner_sqrt, working_scale))
+                .sqrt(working_scale);
+            let inner_asin =
+                atan_fixed(inner_sqrt.div(inner_denom, working_scale), working_scale);
+            let result_abs = wide_half_pi(working_scale)
+                .sub(inner_asin)
+                .sub(inner_asin);
+            if working_value.negative {
                 result_abs.neg()
             } else {
                 result_abs
             }
         }
     };
-    match asin_w.round_to_i128_clear_of_tie(w, SCALE, mode) {
-        Some(v) => v.unwrap_or_else(|| {
+    match asin_w.round_to_i128_clear_of_tie(working_scale, SCALE, mode) {
+        Some(narrowed) => narrowed.unwrap_or_else(|| {
             crate::support::diagnostics::overflow_panic_with_scale("asin", SCALE)
         }),
-        None => narrow_ziv::walk(STRICT_GUARD, SCALE, mode, |g| asin_ziv(raw, SCALE, g)),
+        None => narrow_ziv::walk(STRICT_GUARD, SCALE, mode, |guard_digits| {
+            asin_ziv(raw, SCALE, guard_digits)
+        }),
     }
 }
 
@@ -882,45 +966,53 @@ pub(crate) fn asin_with_raw<const SCALE: u32>(
     if raw.abs() <= small_x_linear_threshold::<SCALE>() && is_nearest_mode(mode) {
         return raw;
     }
-    let w = SCALE + working_digits;
+    let working_scale = SCALE + working_digits;
     let one_w = Fixed {
         negative: false,
-        mag: Fixed::pow10(w),
+        mag: Fixed::pow10(working_scale),
     };
-    let v = to_fixed_w(raw, working_digits);
-    let abs_v = Fixed {
+    let working_value = to_fixed_w(raw, working_digits);
+    let abs_working_value = Fixed {
         negative: false,
-        mag: v.mag,
+        mag: working_value.mag,
     };
     assert!(
-        !(abs_v.ge_mag(one_w) && abs_v != one_w),
+        !(abs_working_value.ge_mag(one_w) && abs_working_value != one_w),
         "asin: argument out of domain [-1, 1]"
     );
-    if abs_v == one_w {
-        let hp = wide_half_pi(w);
-        let hp = if v.negative { hp.neg() } else { hp };
-        return hp.round_to_i128_with(w, SCALE, mode).unwrap_or_else(|| {
-            crate::support::diagnostics::overflow_panic_with_scale("asin", SCALE)
-        });
+    if abs_working_value == one_w {
+        let half_pi = wide_half_pi(working_scale);
+        let half_pi = if working_value.negative { half_pi.neg() } else { half_pi };
+        return half_pi
+            .round_to_i128_with(working_scale, SCALE, mode)
+            .unwrap_or_else(|| {
+                crate::support::diagnostics::overflow_panic_with_scale("asin", SCALE)
+            });
     }
     let half_w = one_w.halve();
-    let asin_w = if !abs_v.ge_mag(half_w) {
-        let denom = one_w.sub(v.mul(v, w)).sqrt(w);
-        atan_fixed(v.div(denom, w), w)
+    let asin_w = if !abs_working_value.ge_mag(half_w) {
+        let denom = one_w
+            .sub(working_value.mul(working_value, working_scale))
+            .sqrt(working_scale);
+        atan_fixed(working_value.div(denom, working_scale), working_scale)
     } else {
-        let inner = one_w.sub(abs_v).halve();
-        let inner_sqrt = inner.sqrt(w);
-        let inner_denom = one_w.sub(inner_sqrt.mul(inner_sqrt, w)).sqrt(w);
-        let inner_asin = atan_fixed(inner_sqrt.div(inner_denom, w), w);
-        let result_abs = wide_half_pi(w).sub(inner_asin).sub(inner_asin);
-        if v.negative {
+        let inner = one_w.sub(abs_working_value).halve();
+        let inner_sqrt = inner.sqrt(working_scale);
+        let inner_denom = one_w
+            .sub(inner_sqrt.mul(inner_sqrt, working_scale))
+            .sqrt(working_scale);
+        let inner_asin = atan_fixed(inner_sqrt.div(inner_denom, working_scale), working_scale);
+        let result_abs = wide_half_pi(working_scale)
+            .sub(inner_asin)
+            .sub(inner_asin);
+        if working_value.negative {
             result_abs.neg()
         } else {
             result_abs
         }
     };
     asin_w
-        .round_to_i128_with(w, SCALE, mode)
+        .round_to_i128_with(working_scale, SCALE, mode)
         .unwrap_or_else(|| crate::support::diagnostics::overflow_panic_with_scale("asin", SCALE))
 }
 
@@ -943,47 +1035,55 @@ pub(crate) fn acos_strict_raw<const SCALE: u32>(raw: i128, mode: RoundingMode) -
     if raw == -one_bits && is_nearest_mode(mode) {
         return <crate::D<crate::int::types::Int<2>, SCALE> as DecimalConstants>::pi().0.as_i128();
     }
-    let w = SCALE + STRICT_GUARD;
+    let working_scale = SCALE + STRICT_GUARD;
     let one_w = Fixed {
         negative: false,
-        mag: Fixed::pow10(w),
+        mag: Fixed::pow10(working_scale),
     };
-    let v = to_fixed(raw);
-    let abs_v = Fixed {
+    let working_value = to_fixed(raw);
+    let abs_working_value = Fixed {
         negative: false,
-        mag: v.mag,
+        mag: working_value.mag,
     };
     assert!(
-        !(abs_v.ge_mag(one_w) && abs_v != one_w),
+        !(abs_working_value.ge_mag(one_w) && abs_working_value != one_w),
         "acos: argument out of domain [-1, 1]"
     );
     let half_w = one_w.halve();
-    let asin_w = if abs_v == one_w {
-        let hp = wide_half_pi(w);
-        if v.negative { hp.neg() } else { hp }
-    } else if !abs_v.ge_mag(half_w) {
-        let denom = one_w.sub(v.mul(v, w)).sqrt(w);
-        atan_fixed(v.div(denom, w), w)
+    let asin_w = if abs_working_value == one_w {
+        let half_pi = wide_half_pi(working_scale);
+        if working_value.negative { half_pi.neg() } else { half_pi }
+    } else if !abs_working_value.ge_mag(half_w) {
+        let denom = one_w
+            .sub(working_value.mul(working_value, working_scale))
+            .sqrt(working_scale);
+        atan_fixed(working_value.div(denom, working_scale), working_scale)
     } else {
-        let inner = one_w.sub(abs_v).halve();
-        let inner_sqrt = inner.sqrt(w);
-        let inner_denom = one_w.sub(inner_sqrt.mul(inner_sqrt, w)).sqrt(w);
-        let inner_asin = atan_fixed(inner_sqrt.div(inner_denom, w), w);
-        let result_abs = wide_half_pi(w).sub(inner_asin).sub(inner_asin);
-        if v.negative {
+        let inner = one_w.sub(abs_working_value).halve();
+        let inner_sqrt = inner.sqrt(working_scale);
+        let inner_denom = one_w
+            .sub(inner_sqrt.mul(inner_sqrt, working_scale))
+            .sqrt(working_scale);
+        let inner_asin = atan_fixed(inner_sqrt.div(inner_denom, working_scale), working_scale);
+        let result_abs = wide_half_pi(working_scale)
+            .sub(inner_asin)
+            .sub(inner_asin);
+        if working_value.negative {
             result_abs.neg()
         } else {
             result_abs
         }
     };
-    match wide_half_pi(w)
+    match wide_half_pi(working_scale)
         .sub(asin_w)
-        .round_to_i128_clear_of_tie(w, SCALE, mode)
+        .round_to_i128_clear_of_tie(working_scale, SCALE, mode)
     {
-        Some(v) => v.unwrap_or_else(|| {
+        Some(narrowed) => narrowed.unwrap_or_else(|| {
             crate::support::diagnostics::overflow_panic_with_scale("acos", SCALE)
         }),
-        None => narrow_ziv::walk(STRICT_GUARD, SCALE, mode, |g| acos_ziv(raw, SCALE, g)),
+        None => narrow_ziv::walk(STRICT_GUARD, SCALE, mode, |guard_digits| {
+            acos_ziv(raw, SCALE, guard_digits)
+        }),
     }
 }
 
@@ -1005,42 +1105,48 @@ pub(crate) fn acos_with_raw<const SCALE: u32>(
     if raw == -one_bits && is_nearest_mode(mode) {
         return <crate::D<crate::int::types::Int<2>, SCALE> as DecimalConstants>::pi().0.as_i128();
     }
-    let w = SCALE + working_digits;
+    let working_scale = SCALE + working_digits;
     let one_w = Fixed {
         negative: false,
-        mag: Fixed::pow10(w),
+        mag: Fixed::pow10(working_scale),
     };
-    let v = to_fixed_w(raw, working_digits);
-    let abs_v = Fixed {
+    let working_value = to_fixed_w(raw, working_digits);
+    let abs_working_value = Fixed {
         negative: false,
-        mag: v.mag,
+        mag: working_value.mag,
     };
     assert!(
-        !(abs_v.ge_mag(one_w) && abs_v != one_w),
+        !(abs_working_value.ge_mag(one_w) && abs_working_value != one_w),
         "acos: argument out of domain [-1, 1]"
     );
     let half_w = one_w.halve();
-    let asin_w = if abs_v == one_w {
-        let hp = wide_half_pi(w);
-        if v.negative { hp.neg() } else { hp }
-    } else if !abs_v.ge_mag(half_w) {
-        let denom = one_w.sub(v.mul(v, w)).sqrt(w);
-        atan_fixed(v.div(denom, w), w)
+    let asin_w = if abs_working_value == one_w {
+        let half_pi = wide_half_pi(working_scale);
+        if working_value.negative { half_pi.neg() } else { half_pi }
+    } else if !abs_working_value.ge_mag(half_w) {
+        let denom = one_w
+            .sub(working_value.mul(working_value, working_scale))
+            .sqrt(working_scale);
+        atan_fixed(working_value.div(denom, working_scale), working_scale)
     } else {
-        let inner = one_w.sub(abs_v).halve();
-        let inner_sqrt = inner.sqrt(w);
-        let inner_denom = one_w.sub(inner_sqrt.mul(inner_sqrt, w)).sqrt(w);
-        let inner_asin = atan_fixed(inner_sqrt.div(inner_denom, w), w);
-        let result_abs = wide_half_pi(w).sub(inner_asin).sub(inner_asin);
-        if v.negative {
+        let inner = one_w.sub(abs_working_value).halve();
+        let inner_sqrt = inner.sqrt(working_scale);
+        let inner_denom = one_w
+            .sub(inner_sqrt.mul(inner_sqrt, working_scale))
+            .sqrt(working_scale);
+        let inner_asin = atan_fixed(inner_sqrt.div(inner_denom, working_scale), working_scale);
+        let result_abs = wide_half_pi(working_scale)
+            .sub(inner_asin)
+            .sub(inner_asin);
+        if working_value.negative {
             result_abs.neg()
         } else {
             result_abs
         }
     };
-    wide_half_pi(w)
+    wide_half_pi(working_scale)
         .sub(asin_w)
-        .round_to_i128_with(w, SCALE, mode)
+        .round_to_i128_with(working_scale, SCALE, mode)
         .unwrap_or_else(|| crate::support::diagnostics::overflow_panic_with_scale("acos", SCALE))
 }
 
@@ -1049,15 +1155,15 @@ pub(crate) fn acos_with_raw<const SCALE: u32>(
 #[inline]
 #[must_use]
 pub(crate) fn atan2_strict_raw<const SCALE: u32>(y_raw: i128, x_raw: i128, mode: RoundingMode) -> i128 {
-    let w = SCALE + STRICT_GUARD;
-    match atan2_kernel(to_fixed(y_raw), to_fixed(x_raw), y_raw, w)
-        .round_to_i128_clear_of_tie(w, SCALE, mode)
+    let working_scale = SCALE + STRICT_GUARD;
+    match atan2_kernel(to_fixed(y_raw), to_fixed(x_raw), y_raw, working_scale)
+        .round_to_i128_clear_of_tie(working_scale, SCALE, mode)
     {
-        Some(v) => v.unwrap_or_else(|| {
+        Some(narrowed) => narrowed.unwrap_or_else(|| {
             crate::support::diagnostics::overflow_panic_with_scale("atan2", SCALE)
         }),
-        None => narrow_ziv::walk(STRICT_GUARD, SCALE, mode, |g| {
-            atan2_ziv(y_raw, x_raw, SCALE, g)
+        None => narrow_ziv::walk(STRICT_GUARD, SCALE, mode, |guard_digits| {
+            atan2_ziv(y_raw, x_raw, SCALE, guard_digits)
         }),
     }
 }
@@ -1070,14 +1176,14 @@ pub(crate) fn atan2_with_raw<const SCALE: u32>(
     working_digits: u32,
     mode: RoundingMode,
 ) -> i128 {
-    let w = SCALE + working_digits;
+    let working_scale = SCALE + working_digits;
     atan2_kernel(
         to_fixed_w(y_raw, working_digits),
         to_fixed_w(x_raw, working_digits),
         y_raw,
-        w,
+        working_scale,
     )
-    .round_to_i128_with(w, SCALE, mode)
+    .round_to_i128_with(working_scale, SCALE, mode)
     .unwrap_or_else(|| crate::support::diagnostics::overflow_panic_with_scale("atan2", SCALE))
 }
 
@@ -1094,7 +1200,8 @@ pub(crate) fn sinh_strict<const SCALE: u32>(raw: Int<2>, mode: RoundingMode) -> 
     Int::<2>::from_i128(sinh_strict_raw(raw.as_i128(), SCALE, mode))
 }
 
-/// One signed `Fixed` sinh evaluation at `w = scale + working_digits` —
+/// One signed `Fixed` sinh evaluation at
+/// `working_scale = scale + working_digits` —
 /// the `(e^|x| − e^-|x|)/2` identity body shared by the strict and
 /// approx terminals. Evaluates at `|v|` so the dominant `e^|x|` term is
 /// computed directly and accurately; the reciprocal gives the tiny
@@ -1102,29 +1209,33 @@ pub(crate) fn sinh_strict<const SCALE: u32>(raw: Int<2>, mode: RoundingMode) -> 
 /// amplify the small term's relative error into a large absolute
 /// error). sinh is odd: the input sign is reapplied to the non-negative
 /// `sinh(|x|)`.
-fn sinh_eval_fixed(raw: i128, working_digits: u32, w: u32) -> Fixed {
-    let v = to_fixed_w(raw, working_digits);
-    let av = Fixed {
+fn sinh_eval_fixed(raw: i128, working_digits: u32, working_scale: u32) -> Fixed {
+    let working_value = to_fixed_w(raw, working_digits);
+    let abs_working_value = Fixed {
         negative: false,
-        mag: v.mag,
+        mag: working_value.mag,
     };
-    let ex = exp_fixed(av, w);
+    let exp_x = exp_fixed(abs_working_value, working_scale);
     let one_w = Fixed {
         negative: false,
-        mag: Fixed::pow10(w),
+        mag: Fixed::pow10(working_scale),
     };
-    let enx = one_w.div(ex, w);
-    let sh = ex.sub(enx).halve();
-    if raw < 0 { sh.neg() } else { sh }
+    let exp_neg_x = one_w.div(exp_x, working_scale);
+    let sinh_value = exp_x.sub(exp_neg_x).halve();
+    if raw < 0 { sinh_value.neg() } else { sinh_value }
 }
 
-/// One `WZiv` sinh probe at working scale `scale + g`.
-fn sinh_ziv(raw: i128, scale: u32, g: u32) -> WZiv {
-    let w = scale + g;
-    let v = narrow_ziv::lift(raw, g);
-    let av = if v < WZiv::from_i128(0) { -v } else { v };
-    let sh = eg::sinh_pos::<WZiv>(av, w);
-    if raw < 0 { -sh } else { sh }
+/// One `WZiv` sinh probe at working scale `scale + guard_digits`.
+fn sinh_ziv(raw: i128, scale: u32, guard_digits: u32) -> WZiv {
+    let working_scale = scale + guard_digits;
+    let working_value = narrow_ziv::lift(raw, guard_digits);
+    let abs_working_value = if working_value < WZiv::from_i128(0) {
+        -working_value
+    } else {
+        working_value
+    };
+    let sinh_value = eg::sinh_pos::<WZiv>(abs_working_value, working_scale);
+    if raw < 0 { -sinh_value } else { sinh_value }
 }
 
 /// Strict-path `i128` core of [`sinh_strict`]: the `Fixed` fast shot
@@ -1142,15 +1253,21 @@ fn sinh_strict_raw(raw: i128, scale: u32, mode: RoundingMode) -> i128 {
         // decision, exact at every depth.
         return crate::support::rounding::tiny_odd_expanding_directed(raw, 0, 1, mode);
     }
-    let w = scale + STRICT_GUARD;
-    if crate::algos::exp::exp_series_2limb::hyper_needs_wide_narrow(raw, scale, w) {
-        return narrow_ziv::walk(STRICT_GUARD, scale, mode, |g| sinh_ziv(raw, scale, g));
+    let working_scale = scale + STRICT_GUARD;
+    if crate::algos::exp::exp_series_2limb::hyper_needs_wide_narrow(raw, scale, working_scale) {
+        return narrow_ziv::walk(STRICT_GUARD, scale, mode, |guard_digits| {
+            sinh_ziv(raw, scale, guard_digits)
+        });
     }
-    match sinh_eval_fixed(raw, STRICT_GUARD, w).round_to_i128_clear_of_tie(w, scale, mode) {
-        Some(v) => v.unwrap_or_else(|| {
+    match sinh_eval_fixed(raw, STRICT_GUARD, working_scale)
+        .round_to_i128_clear_of_tie(working_scale, scale, mode)
+    {
+        Some(narrowed) => narrowed.unwrap_or_else(|| {
             crate::support::diagnostics::overflow_panic_with_scale("D38::sinh", scale)
         }),
-        None => narrow_ziv::walk(STRICT_GUARD, scale, mode, |g| sinh_ziv(raw, scale, g)),
+        None => narrow_ziv::walk(STRICT_GUARD, scale, mode, |guard_digits| {
+            sinh_ziv(raw, scale, guard_digits)
+        }),
     }
 }
 
@@ -1168,11 +1285,11 @@ pub(crate) fn sinh_with_raw(raw: i128, scale: u32, working_digits: u32, mode: Ro
         // no finite-precision exp path can resolve the sub-ULP cubic.
         return crate::support::rounding::tiny_odd_expanding_directed(raw, 0, 1, mode);
     }
-    let w = scale + working_digits;
+    let working_scale = scale + working_digits;
     // Integer-regime: the result carries too many integer digits for the
     // 256-bit `Fixed`'s `e^|x|` reassembly — route through the wider
     // `WNarrow` work integer (correctly-rounded, never-exact directed).
-    if crate::algos::exp::exp_series_2limb::hyper_needs_wide_narrow(raw, scale, w) {
+    if crate::algos::exp::exp_series_2limb::hyper_needs_wide_narrow(raw, scale, working_scale) {
         return crate::algos::exp::exp_series_2limb::sinh_wide_narrow_raw(
             raw,
             scale,
@@ -1180,8 +1297,8 @@ pub(crate) fn sinh_with_raw(raw: i128, scale: u32, working_digits: u32, mode: Ro
             mode,
         );
     }
-    sinh_eval_fixed(raw, working_digits, w)
-        .round_to_i128_with(w, scale, mode)
+    sinh_eval_fixed(raw, working_digits, working_scale)
+        .round_to_i128_with(working_scale, scale, mode)
         .unwrap_or_else(|| {
             crate::support::diagnostics::overflow_panic_with_scale("D38::sinh", scale)
         })
@@ -1193,31 +1310,36 @@ pub(crate) fn cosh_strict<const SCALE: u32>(raw: Int<2>, mode: RoundingMode) -> 
     Int::<2>::from_i128(cosh_strict_raw(raw.as_i128(), SCALE, mode))
 }
 
-/// One non-negative `Fixed` cosh evaluation at `w = scale +
-/// working_digits` — the `(e^|x| + e^-|x|)/2` identity body shared by
+/// One non-negative `Fixed` cosh evaluation at
+/// `working_scale = scale + working_digits` — the `(e^|x| + e^-|x|)/2`
+/// identity body shared by
 /// the strict and approx terminals. cosh is even; evaluating at `|v|`
 /// keeps the dominant `e^|x|` term direct (see [`sinh_eval_fixed`]).
-fn cosh_eval_fixed(raw: i128, working_digits: u32, w: u32) -> Fixed {
-    let v = to_fixed_w(raw, working_digits);
-    let av = Fixed {
+fn cosh_eval_fixed(raw: i128, working_digits: u32, working_scale: u32) -> Fixed {
+    let working_value = to_fixed_w(raw, working_digits);
+    let abs_working_value = Fixed {
         negative: false,
-        mag: v.mag,
+        mag: working_value.mag,
     };
-    let ex = exp_fixed(av, w);
+    let exp_x = exp_fixed(abs_working_value, working_scale);
     let one_w = Fixed {
         negative: false,
-        mag: Fixed::pow10(w),
+        mag: Fixed::pow10(working_scale),
     };
-    let enx = one_w.div(ex, w);
-    ex.add(enx).halve()
+    let exp_neg_x = one_w.div(exp_x, working_scale);
+    exp_x.add(exp_neg_x).halve()
 }
 
-/// One `WZiv` cosh probe at working scale `scale + g`.
-fn cosh_ziv(raw: i128, scale: u32, g: u32) -> WZiv {
-    let w = scale + g;
-    let v = narrow_ziv::lift(raw, g);
-    let av = if v < WZiv::from_i128(0) { -v } else { v };
-    eg::cosh_pos::<WZiv>(av, w)
+/// One `WZiv` cosh probe at working scale `scale + guard_digits`.
+fn cosh_ziv(raw: i128, scale: u32, guard_digits: u32) -> WZiv {
+    let working_scale = scale + guard_digits;
+    let working_value = narrow_ziv::lift(raw, guard_digits);
+    let abs_working_value = if working_value < WZiv::from_i128(0) {
+        -working_value
+    } else {
+        working_value
+    };
+    eg::cosh_pos::<WZiv>(abs_working_value, working_scale)
 }
 
 /// Strict-path `i128` core of [`cosh_strict`]. `cosh(x) > 1` is
@@ -1232,18 +1354,20 @@ fn cosh_strict_raw(raw: i128, scale: u32, mode: RoundingMode) -> i128 {
     if raw == 0 {
         return 10_i128.pow(scale);
     }
-    let w = scale + STRICT_GUARD;
-    if crate::algos::exp::exp_series_2limb::hyper_needs_wide_narrow(raw, scale, w) {
-        return narrow_ziv::walk_never_exact(STRICT_GUARD, scale, mode, |g| {
-            cosh_ziv(raw, scale, g)
+    let working_scale = scale + STRICT_GUARD;
+    if crate::algos::exp::exp_series_2limb::hyper_needs_wide_narrow(raw, scale, working_scale) {
+        return narrow_ziv::walk_never_exact(STRICT_GUARD, scale, mode, |guard_digits| {
+            cosh_ziv(raw, scale, guard_digits)
         });
     }
-    match cosh_eval_fixed(raw, STRICT_GUARD, w).round_to_i128_clear_of_tie(w, scale, mode) {
-        Some(v) => v.unwrap_or_else(|| {
+    match cosh_eval_fixed(raw, STRICT_GUARD, working_scale)
+        .round_to_i128_clear_of_tie(working_scale, scale, mode)
+    {
+        Some(narrowed) => narrowed.unwrap_or_else(|| {
             crate::support::diagnostics::overflow_panic_with_scale("D38::cosh", scale)
         }),
-        None => narrow_ziv::walk_never_exact(STRICT_GUARD, scale, mode, |g| {
-            cosh_ziv(raw, scale, g)
+        None => narrow_ziv::walk_never_exact(STRICT_GUARD, scale, mode, |guard_digits| {
+            cosh_ziv(raw, scale, guard_digits)
         }),
     }
 }
@@ -1254,7 +1378,7 @@ pub(crate) fn cosh_with_raw(raw: i128, scale: u32, working_digits: u32, mode: Ro
     if raw == 0 {
         return 10_i128.pow(scale);
     }
-    let w = scale + working_digits;
+    let working_scale = scale + working_digits;
     // The wider `WNarrow` work integer is needed for:
     //  1. integer-regime — the result exceeds the 256-bit `Fixed`'s headroom
     //     (see `sinh_with_raw`); and
@@ -1266,7 +1390,7 @@ pub(crate) fn cosh_with_raw(raw: i128, scale: u32, working_digits: u32, mode: Ro
     //     misses the Ceiling bump the never-exact treatment supplies. Mirrors
     //     the `exp_with_raw` directed gate; directed cosh is not the
     //     common/benched cell, so the hot path is unaffected.
-    if crate::algos::exp::exp_series_2limb::hyper_needs_wide_narrow(raw, scale, w)
+    if crate::algos::exp::exp_series_2limb::hyper_needs_wide_narrow(raw, scale, working_scale)
         || !crate::support::rounding::is_nearest_mode(mode)
     {
         return crate::algos::exp::exp_series_2limb::cosh_wide_narrow_raw(
@@ -1276,8 +1400,8 @@ pub(crate) fn cosh_with_raw(raw: i128, scale: u32, working_digits: u32, mode: Ro
             mode,
         );
     }
-    cosh_eval_fixed(raw, working_digits, w)
-        .round_to_i128_with(w, scale, mode)
+    cosh_eval_fixed(raw, working_digits, working_scale)
+        .round_to_i128_with(working_scale, scale, mode)
         .unwrap_or_else(|| {
             crate::support::diagnostics::overflow_panic_with_scale("D38::cosh", scale)
         })
@@ -1289,13 +1413,17 @@ pub(crate) fn tanh_strict<const SCALE: u32>(raw: Int<2>, mode: RoundingMode) -> 
     Int::<2>::from_i128(tanh_strict_raw(raw.as_i128(), SCALE, mode))
 }
 
-/// One `WZiv` tanh probe at working scale `scale + g`.
-fn tanh_ziv(raw: i128, scale: u32, g: u32) -> WZiv {
-    let w = scale + g;
-    let v = narrow_ziv::lift(raw, g);
-    let av = if v < WZiv::from_i128(0) { -v } else { v };
-    let th = eg::tanh_pos::<WZiv>(av, w);
-    if raw < 0 { -th } else { th }
+/// One `WZiv` tanh probe at working scale `scale + guard_digits`.
+fn tanh_ziv(raw: i128, scale: u32, guard_digits: u32) -> WZiv {
+    let working_scale = scale + guard_digits;
+    let working_value = narrow_ziv::lift(raw, guard_digits);
+    let abs_working_value = if working_value < WZiv::from_i128(0) {
+        -working_value
+    } else {
+        working_value
+    };
+    let tanh_value = eg::tanh_pos::<WZiv>(abs_working_value, working_scale);
+    if raw < 0 { -tanh_value } else { tanh_value }
 }
 
 /// Strict-path `i128` core of [`tanh_strict`]: the linear band and the
@@ -1312,55 +1440,71 @@ fn tanh_strict_raw(raw: i128, scale: u32, mode: RoundingMode) -> i128 {
         // `tanh_with_raw`).
         return crate::support::rounding::tiny_odd_compressing_directed(raw, 0, 1, mode);
     }
-    let w = scale + STRICT_GUARD;
-    match tanh_eval_fixed(raw, STRICT_GUARD, w) {
-        // Saturated all-nines: tanh(|x|) ∈ (1 − 10^-w, 1) analytically —
-        // every mode rounds the all-nines value correctly (nearest → 1,
-        // Floor/Trunc → 1 − 10^-S, Ceiling → 1); no tie to resolve.
-        (th, true) => th.round_to_i128_with(w, scale, mode).unwrap_or_else(|| {
-            crate::support::diagnostics::overflow_panic_with_scale("D38::tanh", scale)
-        }),
-        (th, false) => match th.round_to_i128_clear_of_tie(w, scale, mode) {
-            Some(v) => v.unwrap_or_else(|| {
+    let working_scale = scale + STRICT_GUARD;
+    match tanh_eval_fixed(raw, STRICT_GUARD, working_scale) {
+        // Saturated all-nines: tanh(|x|) ∈ (1 − 10^-working_scale, 1)
+        // analytically — every mode rounds the all-nines value correctly
+        // (nearest → 1, Floor/Trunc → 1 − 10^-S, Ceiling → 1); no tie to
+        // resolve.
+        (tanh_value, true) => tanh_value
+            .round_to_i128_with(working_scale, scale, mode)
+            .unwrap_or_else(|| {
                 crate::support::diagnostics::overflow_panic_with_scale("D38::tanh", scale)
             }),
-            None => narrow_ziv::walk(STRICT_GUARD, scale, mode, |g| tanh_ziv(raw, scale, g)),
-        },
+        (tanh_value, false) => {
+            match tanh_value.round_to_i128_clear_of_tie(working_scale, scale, mode) {
+                Some(narrowed) => narrowed.unwrap_or_else(|| {
+                    crate::support::diagnostics::overflow_panic_with_scale("D38::tanh", scale)
+                }),
+                None => narrow_ziv::walk(STRICT_GUARD, scale, mode, |guard_digits| {
+                    tanh_ziv(raw, scale, guard_digits)
+                }),
+            }
+        }
     }
 }
 
-/// One signed `Fixed` tanh evaluation at `w = scale + working_digits`,
+/// One signed `Fixed` tanh evaluation at
+/// `working_scale = scale + working_digits`,
 /// returning `(value, saturated)` — `saturated == true` is the analytic
-/// all-nines region (`|x|` past the `2·e^(−2|x|) < 10^-w` onset, or the
+/// all-nines region (`|x|` past the `2·e^(−2|x|) < 10^-working_scale`
+/// onset, or the
 /// `m` underflow just inside it), where the value is exactly the
 /// largest working value below 1 and needs no tie analysis.
-fn tanh_eval_fixed(raw: i128, working_digits: u32, w: u32) -> (Fixed, bool) {
+fn tanh_eval_fixed(raw: i128, working_digits: u32, working_scale: u32) -> (Fixed, bool) {
     let one_w = Fixed {
         negative: false,
-        mag: Fixed::pow10(w),
+        mag: Fixed::pow10(working_scale),
     };
-    let neg = raw < 0;
+    let is_negative = raw < 0;
     // Large |x| via the NEGATIVE-exponent identity tanh(|x|) = (1 − m)/(1 + m),
     // m = e^(−2|x|) — see `tanh_with_raw` for the overflow-gap derivation.
-    let scale = w - working_digits;
-    let thr_x = (w as i128) * 1152 / 1000 + 2;
+    let scale = working_scale - working_digits;
+    let saturation_bound = (working_scale as i128) * 1152 / 1000 + 2;
     let saturated = one_w.sub(Fixed::from_u128_mag(1, false));
-    let (th, sat) = if raw.abs() / 10_i128.pow(scale) > thr_x {
+    let (tanh_value, is_saturated) = if raw.abs() / 10_i128.pow(scale) > saturation_bound {
         (saturated, true)
     } else {
-        let v = to_fixed_w(raw, working_digits);
-        let av = Fixed {
+        let working_value = to_fixed_w(raw, working_digits);
+        let abs_working_value = Fixed {
             negative: false,
-            mag: v.mag,
+            mag: working_value.mag,
         };
-        let m = exp_fixed(av.double().neg(), w);
+        let m = exp_fixed(abs_working_value.double().neg(), working_scale);
         if m.is_zero() {
             (saturated, true)
         } else {
-            (one_w.sub(m).div(one_w.add(m), w), false)
+            (one_w.sub(m).div(one_w.add(m), working_scale), false)
         }
     };
-    (if neg { th.neg() } else { th }, sat)
+    (
+        if is_negative {
+            tanh_value.neg()
+        } else {
+            tanh_value
+        },
+        is_saturated,
+    )
 }
 
 #[inline]
@@ -1377,17 +1521,19 @@ pub(crate) fn tanh_with_raw(raw: i128, scale: u32, working_digits: u32, mode: Ro
         // finite-precision exp path can resolve the sub-ULP cubic.
         return crate::support::rounding::tiny_odd_compressing_directed(raw, 0, 1, mode);
     }
-    let w = scale + working_digits;
+    let working_scale = scale + working_digits;
     // The body lives in `tanh_eval_fixed`: the NEGATIVE-exponent identity
     // tanh(|x|) = (1 − m)/(1 + m), m = e^(−2|x|) — exact and overflow-safe
     // across the whole large-|x| range (forming e^(+|x|) directly
-    // overflows the 256-bit `Fixed` once |x| ≳ 256·ln2 − w·ln10, BELOW
-    // the all-nines saturation onset |x| ≳ 1.1513·w);
+    // overflows the 256-bit `Fixed` once |x| ≳ 256·ln2 − working_scale·ln10,
+    // BELOW the all-nines saturation onset |x| ≳ 1.1513·working_scale);
     // mirrors `exp_generic::tanh_pos` (the wide path).
-    let (th, _saturated) = tanh_eval_fixed(raw, working_digits, w);
-    th.round_to_i128_with(w, scale, mode).unwrap_or_else(|| {
-        crate::support::diagnostics::overflow_panic_with_scale("D38::tanh", scale)
-    })
+    let (tanh_value, _saturated) = tanh_eval_fixed(raw, working_digits, working_scale);
+    tanh_value
+        .round_to_i128_with(working_scale, scale, mode)
+        .unwrap_or_else(|| {
+            crate::support::diagnostics::overflow_panic_with_scale("D38::tanh", scale)
+        })
 }
 
 #[inline]
@@ -1396,46 +1542,64 @@ pub(crate) fn asinh_strict<const SCALE: u32>(raw: Int<2>, mode: RoundingMode) ->
     Int::<2>::from_i128(asinh_strict_raw(raw.as_i128(), SCALE, mode))
 }
 
-/// One signed `Fixed` asinh evaluation at `w = scale + working_digits`
+/// One signed `Fixed` asinh evaluation at
+/// `working_scale = scale + working_digits`
 /// — `ln(|x| + √(x²+1))` (the reciprocal form above 1 keeps the `x²`
 /// product inside the 256-bit `Fixed`), shared by the strict and approx
 /// terminals. asinh is odd; the sign is reapplied.
-fn asinh_eval_fixed(raw: i128, working_digits: u32, w: u32) -> Fixed {
+fn asinh_eval_fixed(raw: i128, working_digits: u32, working_scale: u32) -> Fixed {
     let one_w = Fixed {
         negative: false,
-        mag: Fixed::pow10(w),
+        mag: Fixed::pow10(working_scale),
     };
-    let v = to_fixed_w(raw, working_digits);
-    let ax = Fixed {
+    let working_value = to_fixed_w(raw, working_digits);
+    let abs_working_value = Fixed {
         negative: false,
-        mag: v.mag,
+        mag: working_value.mag,
     };
-    let inner = if ax.ge_mag(one_w) {
-        let inv = one_w.div(ax, w);
-        let root = one_w.add(inv.mul(inv, w)).sqrt(w);
-        ln_fixed(ax, w).add(ln_fixed(one_w.add(root), w))
+    let inner = if abs_working_value.ge_mag(one_w) {
+        let reciprocal = one_w.div(abs_working_value, working_scale);
+        let root = one_w
+            .add(reciprocal.mul(reciprocal, working_scale))
+            .sqrt(working_scale);
+        ln_fixed(abs_working_value, working_scale)
+            .add(ln_fixed(one_w.add(root), working_scale))
     } else {
-        let root = ax.mul(ax, w).add(one_w).sqrt(w);
-        ln_fixed(ax.add(root), w)
+        let root = abs_working_value
+            .mul(abs_working_value, working_scale)
+            .add(one_w)
+            .sqrt(working_scale);
+        ln_fixed(abs_working_value.add(root), working_scale)
     };
     if raw < 0 { inner.neg() } else { inner }
 }
 
-/// One `WZiv` asinh probe at working scale `scale + g`.
-fn asinh_ziv(raw: i128, scale: u32, g: u32) -> WZiv {
-    let w = scale + g;
+/// One `WZiv` asinh probe at working scale `scale + guard_digits`.
+fn asinh_ziv(raw: i128, scale: u32, guard_digits: u32) -> WZiv {
+    let working_scale = scale + guard_digits;
     let zero = WZiv::from_i128(0);
-    let one_w = eg::one::<WZiv>(w);
-    let ln2 = narrow_ziv::ln2_w(w);
-    let v = narrow_ziv::lift(raw, g);
-    let av = if v < zero { -v } else { v };
-    let inner = if av >= one_w {
-        let inv = eg::div::<WZiv>(one_w, av, w);
-        let root = eg::sqrt_fixed::<WZiv>(one_w + eg::mul::<WZiv>(inv, inv, w), w);
-        eg::ln_fixed::<WZiv>(av, w, ln2) + eg::ln_fixed::<WZiv>(one_w + root, w, ln2)
+    let one_w = eg::one::<WZiv>(working_scale);
+    let ln2 = narrow_ziv::ln2_w(working_scale);
+    let working_value = narrow_ziv::lift(raw, guard_digits);
+    let abs_working_value = if working_value < zero {
+        -working_value
     } else {
-        let root = eg::sqrt_fixed::<WZiv>(eg::mul::<WZiv>(av, av, w) + one_w, w);
-        eg::ln_fixed::<WZiv>(av + root, w, ln2)
+        working_value
+    };
+    let inner = if abs_working_value >= one_w {
+        let reciprocal = eg::div::<WZiv>(one_w, abs_working_value, working_scale);
+        let root = eg::sqrt_fixed::<WZiv>(
+            one_w + eg::mul::<WZiv>(reciprocal, reciprocal, working_scale),
+            working_scale,
+        );
+        eg::ln_fixed::<WZiv>(abs_working_value, working_scale, ln2)
+            + eg::ln_fixed::<WZiv>(one_w + root, working_scale, ln2)
+    } else {
+        let root = eg::sqrt_fixed::<WZiv>(
+            eg::mul::<WZiv>(abs_working_value, abs_working_value, working_scale) + one_w,
+            working_scale,
+        );
+        eg::ln_fixed::<WZiv>(abs_working_value + root, working_scale, ln2)
     };
     if raw < 0 { -inner } else { inner }
 }
@@ -1449,12 +1613,16 @@ fn asinh_strict_raw(raw: i128, scale: u32, mode: RoundingMode) -> i128 {
     if raw.abs() <= small_x_linear_threshold_scale(scale) && is_nearest_mode(mode) {
         return raw;
     }
-    let w = scale + STRICT_GUARD;
-    match asinh_eval_fixed(raw, STRICT_GUARD, w).round_to_i128_clear_of_tie(w, scale, mode) {
-        Some(v) => v.unwrap_or_else(|| {
+    let working_scale = scale + STRICT_GUARD;
+    match asinh_eval_fixed(raw, STRICT_GUARD, working_scale)
+        .round_to_i128_clear_of_tie(working_scale, scale, mode)
+    {
+        Some(narrowed) => narrowed.unwrap_or_else(|| {
             crate::support::diagnostics::overflow_panic_with_scale("D38::asinh", scale)
         }),
-        None => narrow_ziv::walk(STRICT_GUARD, scale, mode, |g| asinh_ziv(raw, scale, g)),
+        None => narrow_ziv::walk(STRICT_GUARD, scale, mode, |guard_digits| {
+            asinh_ziv(raw, scale, guard_digits)
+        }),
     }
 }
 
@@ -1467,9 +1635,9 @@ pub(crate) fn asinh_with_raw(raw: i128, scale: u32, working_digits: u32, mode: R
     if raw.abs() <= small_x_linear_threshold_scale(scale) && is_nearest_mode(mode) {
         return raw;
     }
-    let w = scale + working_digits;
-    asinh_eval_fixed(raw, working_digits, w)
-        .round_to_i128_with(w, scale, mode)
+    let working_scale = scale + working_digits;
+    asinh_eval_fixed(raw, working_digits, working_scale)
+        .round_to_i128_with(working_scale, scale, mode)
         .unwrap_or_else(|| {
             crate::support::diagnostics::overflow_panic_with_scale("D38::asinh", scale)
         })
@@ -1481,44 +1649,57 @@ pub(crate) fn acosh_strict<const SCALE: u32>(raw: Int<2>, mode: RoundingMode) ->
     Int::<2>::from_i128(acosh_strict_raw(raw.as_i128(), SCALE, mode))
 }
 
-/// One `Fixed` acosh evaluation at `w = scale + working_digits` —
+/// One `Fixed` acosh evaluation at
+/// `working_scale = scale + working_digits` —
 /// `ln(x + √(x²−1))` (reciprocal form above 2), shared by the strict
 /// and approx terminals. Asserts the `x ≥ 1` domain.
-fn acosh_eval_fixed(raw: i128, working_digits: u32, w: u32) -> Fixed {
+fn acosh_eval_fixed(raw: i128, working_digits: u32, working_scale: u32) -> Fixed {
     let one_w = Fixed {
         negative: false,
-        mag: Fixed::pow10(w),
+        mag: Fixed::pow10(working_scale),
     };
-    let v = to_fixed_w(raw, working_digits);
+    let working_value = to_fixed_w(raw, working_digits);
     assert!(
-        !v.negative && v.ge_mag(one_w),
+        !working_value.negative && working_value.ge_mag(one_w),
         "D38::acosh: argument must be >= 1"
     );
     let two_w = one_w.double();
-    if v.ge_mag(two_w) {
-        let inv = one_w.div(v, w);
-        let root = one_w.sub(inv.mul(inv, w)).sqrt(w);
-        ln_fixed(v, w).add(ln_fixed(one_w.add(root), w))
+    if working_value.ge_mag(two_w) {
+        let reciprocal = one_w.div(working_value, working_scale);
+        let root = one_w
+            .sub(reciprocal.mul(reciprocal, working_scale))
+            .sqrt(working_scale);
+        ln_fixed(working_value, working_scale).add(ln_fixed(one_w.add(root), working_scale))
     } else {
-        let root = v.mul(v, w).sub(one_w).sqrt(w);
-        ln_fixed(v.add(root), w)
+        let root = working_value
+            .mul(working_value, working_scale)
+            .sub(one_w)
+            .sqrt(working_scale);
+        ln_fixed(working_value.add(root), working_scale)
     }
 }
 
-/// One `WZiv` acosh probe at working scale `scale + g`.
-fn acosh_ziv(raw: i128, scale: u32, g: u32) -> WZiv {
-    let w = scale + g;
-    let one_w = eg::one::<WZiv>(w);
-    let ln2 = narrow_ziv::ln2_w(w);
-    let v = narrow_ziv::lift(raw, g);
+/// One `WZiv` acosh probe at working scale `scale + guard_digits`.
+fn acosh_ziv(raw: i128, scale: u32, guard_digits: u32) -> WZiv {
+    let working_scale = scale + guard_digits;
+    let one_w = eg::one::<WZiv>(working_scale);
+    let ln2 = narrow_ziv::ln2_w(working_scale);
+    let working_value = narrow_ziv::lift(raw, guard_digits);
     let two_w = one_w + one_w;
-    if v >= two_w {
-        let inv = eg::div::<WZiv>(one_w, v, w);
-        let root = eg::sqrt_fixed::<WZiv>(one_w - eg::mul::<WZiv>(inv, inv, w), w);
-        eg::ln_fixed::<WZiv>(v, w, ln2) + eg::ln_fixed::<WZiv>(one_w + root, w, ln2)
+    if working_value >= two_w {
+        let reciprocal = eg::div::<WZiv>(one_w, working_value, working_scale);
+        let root = eg::sqrt_fixed::<WZiv>(
+            one_w - eg::mul::<WZiv>(reciprocal, reciprocal, working_scale),
+            working_scale,
+        );
+        eg::ln_fixed::<WZiv>(working_value, working_scale, ln2)
+            + eg::ln_fixed::<WZiv>(one_w + root, working_scale, ln2)
     } else {
-        let root = eg::sqrt_fixed::<WZiv>(eg::mul::<WZiv>(v, v, w) - one_w, w);
-        eg::ln_fixed::<WZiv>(v + root, w, ln2)
+        let root = eg::sqrt_fixed::<WZiv>(
+            eg::mul::<WZiv>(working_value, working_value, working_scale) - one_w,
+            working_scale,
+        );
+        eg::ln_fixed::<WZiv>(working_value + root, working_scale, ln2)
     }
 }
 
@@ -1530,13 +1711,15 @@ fn acosh_strict_raw(raw: i128, scale: u32, mode: RoundingMode) -> i128 {
     if raw == one_bits {
         return 0;
     }
-    let w = scale + STRICT_GUARD;
-    match acosh_eval_fixed(raw, STRICT_GUARD, w).round_to_i128_clear_of_tie(w, scale, mode) {
-        Some(v) => v.unwrap_or_else(|| {
+    let working_scale = scale + STRICT_GUARD;
+    match acosh_eval_fixed(raw, STRICT_GUARD, working_scale)
+        .round_to_i128_clear_of_tie(working_scale, scale, mode)
+    {
+        Some(narrowed) => narrowed.unwrap_or_else(|| {
             crate::support::diagnostics::overflow_panic_with_scale("D38::acosh", scale)
         }),
-        None => narrow_ziv::walk_near_special(STRICT_GUARD, scale, mode, |g| {
-            acosh_ziv(raw, scale, g)
+        None => narrow_ziv::walk_near_special(STRICT_GUARD, scale, mode, |guard_digits| {
+            acosh_ziv(raw, scale, guard_digits)
         }),
     }
 }
@@ -1548,9 +1731,9 @@ pub(crate) fn acosh_with_raw(raw: i128, scale: u32, working_digits: u32, mode: R
     if raw == one_bits {
         return 0;
     }
-    let w = scale + working_digits;
-    acosh_eval_fixed(raw, working_digits, w)
-        .round_to_i128_with(w, scale, mode)
+    let working_scale = scale + working_digits;
+    acosh_eval_fixed(raw, working_digits, working_scale)
+        .round_to_i128_with(working_scale, scale, mode)
         .unwrap_or_else(|| {
             crate::support::diagnostics::overflow_panic_with_scale("D38::acosh", scale)
         })
@@ -1562,18 +1745,23 @@ pub(crate) fn atanh_strict<const SCALE: u32>(raw: Int<2>, mode: RoundingMode) ->
     Int::<2>::from_i128(atanh_strict_raw(raw.as_i128(), SCALE, mode))
 }
 
-/// One `WZiv` atanh probe at working scale `scale + g` — the
+/// One `WZiv` atanh probe at working scale `scale + guard_digits` — the
 /// overflow-safe two-log GAP form `½·(ln(1+|x|) − ln(1−|x|))` (the
 /// near-±1 ratio overflow never arises), sign reapplied.
-fn atanh_ziv(raw: i128, scale: u32, g: u32) -> WZiv {
-    let w = scale + g;
+fn atanh_ziv(raw: i128, scale: u32, guard_digits: u32) -> WZiv {
+    let working_scale = scale + guard_digits;
     let zero = WZiv::from_i128(0);
-    let one_w = eg::one::<WZiv>(w);
-    let ln2 = narrow_ziv::ln2_w(w);
-    let v = narrow_ziv::lift(raw, g);
-    let av = if v < zero { -v } else { v };
-    let inner =
-        (eg::ln_fixed::<WZiv>(one_w + av, w, ln2) - eg::ln_fixed::<WZiv>(one_w - av, w, ln2)) >> 1;
+    let one_w = eg::one::<WZiv>(working_scale);
+    let ln2 = narrow_ziv::ln2_w(working_scale);
+    let working_value = narrow_ziv::lift(raw, guard_digits);
+    let abs_working_value = if working_value < zero {
+        -working_value
+    } else {
+        working_value
+    };
+    let inner = (eg::ln_fixed::<WZiv>(one_w + abs_working_value, working_scale, ln2)
+        - eg::ln_fixed::<WZiv>(one_w - abs_working_value, working_scale, ln2))
+        >> 1;
     if raw < 0 { -inner } else { inner }
 }
 
@@ -1589,41 +1777,46 @@ fn atanh_strict_raw(raw: i128, scale: u32, mode: RoundingMode) -> i128 {
     if raw.abs() <= small_x_linear_threshold_scale(scale) && is_nearest_mode(mode) {
         return raw;
     }
-    let w = scale + STRICT_GUARD;
-    match atanh_eval_fixed(raw, STRICT_GUARD, w).round_to_i128_clear_of_tie(w, scale, mode) {
-        Some(v) => v.unwrap_or_else(|| {
+    let working_scale = scale + STRICT_GUARD;
+    match atanh_eval_fixed(raw, STRICT_GUARD, working_scale)
+        .round_to_i128_clear_of_tie(working_scale, scale, mode)
+    {
+        Some(narrowed) => narrowed.unwrap_or_else(|| {
             crate::support::diagnostics::overflow_panic_with_scale("D38::atanh", scale)
         }),
-        None => narrow_ziv::walk_near_special(STRICT_GUARD, scale, mode, |g| {
-            atanh_ziv(raw, scale, g)
+        None => narrow_ziv::walk_near_special(STRICT_GUARD, scale, mode, |guard_digits| {
+            atanh_ziv(raw, scale, guard_digits)
         }),
     }
 }
 
-/// One signed `Fixed` atanh evaluation at `w = scale + working_digits`
+/// One signed `Fixed` atanh evaluation at
+/// `working_scale = scale + working_digits`
 /// — the value-gated ratio/gap split shared by the strict and approx
 /// terminals (see the gate derivation in the body).
-fn atanh_eval_fixed(raw: i128, working_digits: u32, w: u32) -> Fixed {
+fn atanh_eval_fixed(raw: i128, working_digits: u32, working_scale: u32) -> Fixed {
     let one_w = Fixed {
         negative: false,
-        mag: Fixed::pow10(w),
+        mag: Fixed::pow10(working_scale),
     };
-    let v = to_fixed_w(raw, working_digits);
-    let ax = Fixed {
+    let working_value = to_fixed_w(raw, working_digits);
+    let abs_working_value = Fixed {
         negative: false,
-        mag: v.mag,
+        mag: working_value.mag,
     };
     assert!(
-        !ax.ge_mag(one_w),
+        !abs_working_value.ge_mag(one_w),
         "D38::atanh: argument out of domain (-1, 1)"
     );
     // Ratio form below |x| ≤ 0.98, gap form near ±1 — see `atanh_with_raw`.
-    if one_w.sub(ax).mul_u128(50).ge_mag(one_w) {
-        let r = one_w.add(v).div(one_w.sub(v), w);
-        ln_fixed(r, w).halve()
+    if one_w.sub(abs_working_value).mul_u128(50).ge_mag(one_w) {
+        let ratio = one_w
+            .add(working_value)
+            .div(one_w.sub(working_value), working_scale);
+        ln_fixed(ratio, working_scale).halve()
     } else {
-        let ln_num = ln_fixed(one_w.add(v), w);
-        let ln_den = ln_fixed(one_w.sub(v), w);
+        let ln_num = ln_fixed(one_w.add(working_value), working_scale);
+        let ln_den = ln_fixed(one_w.sub(working_value), working_scale);
         ln_num.sub(ln_den).halve()
     }
 }
@@ -1637,15 +1830,17 @@ pub(crate) fn atanh_with_raw(raw: i128, scale: u32, working_digits: u32, mode: R
     if raw.abs() <= small_x_linear_threshold_scale(scale) && is_nearest_mode(mode) {
         return raw;
     }
-    let w = scale + working_digits;
+    let working_scale = scale + working_digits;
     // atanh(x) = ½·ln((1+x)/(1-x)), value-gated on |x|:
     //
     //  - |x| ≤ 0.98 (1−|x| ≥ 0.02): the 1-log RATIO form ½·ln((1+x)/(1-x)) —
     //    ONE `ln_fixed` (~2× cheaper than the two-log gap form). The ratio
-    //    R = (1+|x|)/(1-|x|) ≤ 99 there, so `R·10^w` fits the 256-bit `Fixed`
+    //    R = (1+|x|)/(1-|x|) ≤ 99 there, so `R·10^ws` (ws = the working scale)
+    //    fits the 256-bit `Fixed`
     //    at any working scale up to the 75-digit ceiling (R < 2²⁵⁶/10⁷⁵ ≈ 115;
-    //    the strict path's w = SCALE+30 ≤ 68 has ~10⁷× more headroom). The
-    //    division's ≤0.5-ULP-at-w error propagates to atanh as ≤0.25·10⁻ʷ,
+    //    the strict path's working_scale = SCALE+30 ≤ 68 has ~10⁷× more
+    //    headroom). The division's ≤0.5-ULP-at-working-scale error propagates
+    //    to atanh as ≤0.25·10⁻ʷ,
     //    absorbed by the ≥30 guard digits, so every mode rounds correctly.
     //
     //  - |x| > 0.98 (near ±1): the GAP form ½·(ln(1+x) − ln(1-x)) — TWO logs,
@@ -1654,11 +1849,12 @@ pub(crate) fn atanh_with_raw(raw: i128, scale: u32, working_digits: u32, mode: R
     //    e.g. atanh(1−10⁻²⁸) at D38 s28 → ~10⁸⁶, past 2²⁵⁶). `1+x` and `1-x`
     //    each lie in (0, 2) and fit; `ln_fixed` handles arguments below 1.
     //
-    // Gate in `Fixed` magnitudes: `50·(1−|x|)·10^w ≥ 10^w` ⟺ `1−|x| ≥ 0.02`
-    // (the `50·(1−|x|)·10^w ≤ 5·10⁷⁶` intermediate fits 2²⁵⁶). The split
-    // body is shared with the strict terminal in [`atanh_eval_fixed`].
-    atanh_eval_fixed(raw, working_digits, w)
-        .round_to_i128_with(w, scale, mode)
+    // Gate in `Fixed` magnitudes: `50·(1−|x|)·10^ws ≥ 10^ws` ⟺ `1−|x| ≥ 0.02`
+    // (the `50·(1−|x|)·10^ws ≤ 5·10⁷⁶` intermediate fits 2²⁵⁶, where `ws` is
+    // the working scale). The split body is shared with the strict terminal
+    // in [`atanh_eval_fixed`].
+    atanh_eval_fixed(raw, working_digits, working_scale)
+        .round_to_i128_with(working_scale, scale, mode)
         .unwrap_or_else(|| {
             crate::support::diagnostics::overflow_panic_with_scale("D38::atanh", scale)
         })
@@ -1683,11 +1879,11 @@ pub(crate) fn to_degrees_with_raw(
     if raw == 0 {
         return 0;
     }
-    let w = scale + working_digits;
+    let working_scale = scale + working_digits;
     to_fixed_w(raw, working_digits)
         .mul_u128(180)
-        .div(wide_pi(w), w)
-        .round_to_i128_with(w, scale, mode)
+        .div(wide_pi(working_scale), working_scale)
+        .round_to_i128_with(working_scale, scale, mode)
         .unwrap_or_else(|| {
             crate::support::diagnostics::overflow_panic_with_scale("D38::to_degrees", scale)
         })
@@ -1710,11 +1906,11 @@ pub(crate) fn to_radians_with_raw(
     if raw == 0 {
         return 0;
     }
-    let w = scale + working_digits;
+    let working_scale = scale + working_digits;
     to_fixed_w(raw, working_digits)
-        .mul(wide_pi(w), w)
+        .mul(wide_pi(working_scale), working_scale)
         .div_small(180)
-        .round_to_i128_with(w, scale, mode)
+        .round_to_i128_with(working_scale, scale, mode)
         .unwrap_or_else(|| {
             crate::support::diagnostics::overflow_panic_with_scale("D38::to_radians", scale)
         })
@@ -1727,8 +1923,8 @@ pub(crate) fn to_radians_with_raw(
 /// a const generic.
 #[inline]
 fn small_x_linear_threshold_scale(scale: u32) -> i128 {
-    let thresh_exp = scale.saturating_sub(scale.div_ceil(3));
-    10_i128.pow(thresh_exp)
+    let threshold_exponent = scale.saturating_sub(scale.div_ceil(3));
+    10_i128.pow(threshold_exponent)
 }
 
 // ── Near-tie pins: the narrow single-shot / capped-escalation defect ──
@@ -1736,7 +1932,7 @@ fn small_x_linear_threshold_scale(scale: u32) -> i128 {
 // tiers (asin(3e-60) D462<180>): an EXACT input whose Taylor partial lands
 // exactly ON a rounding boundary (the grid line for directed modes, the
 // half for nearest) with the deciding transcendental tail BELOW the fixed
-// working scale w = SCALE + 30 (and, for sin/cos, below the 75-digit
+// working scale SCALE + 30 (and, for sin/cos, below the 75-digit
 // escalation cap). Oracle for every expected value: the exact rational
 // Taylor partial + the strict tail sign (mpmath-confirmed,
 // trace/narrow_tie_derive.py derivations):
@@ -1942,26 +2138,26 @@ mod hyper_fast_path_validity {
 
     /// FAST sinh/cosh in `Fixed`, no gate — catching any overflow panic.
     fn fast_hyper_raw(raw: i128, scale: u32, mode: RoundingMode, is_cosh: bool) -> Option<i128> {
-        let w = scale + STRICT_GUARD;
+        let working_scale = scale + STRICT_GUARD;
         std::panic::catch_unwind(|| {
-            let v = to_fixed_w(raw, STRICT_GUARD);
-            let av = Fixed {
+            let working_value = to_fixed_w(raw, STRICT_GUARD);
+            let abs_working_value = Fixed {
                 negative: false,
-                mag: v.mag,
+                mag: working_value.mag,
             };
-            let ex = exp_fixed(av, w);
+            let exp_x = exp_fixed(abs_working_value, working_scale);
             let one_w = Fixed {
                 negative: false,
-                mag: Fixed::pow10(w),
+                mag: Fixed::pow10(working_scale),
             };
-            let enx = one_w.div(ex, w);
-            let res = if is_cosh {
-                ex.add(enx).halve()
+            let exp_neg_x = one_w.div(exp_x, working_scale);
+            let result = if is_cosh {
+                exp_x.add(exp_neg_x).halve()
             } else {
-                let sh = ex.sub(enx).halve();
-                if raw < 0 { sh.neg() } else { sh }
+                let sinh_value = exp_x.sub(exp_neg_x).halve();
+                if raw < 0 { sinh_value.neg() } else { sinh_value }
             };
-            res.round_to_i128_with(w, scale, mode)
+            result.round_to_i128_with(working_scale, scale, mode)
         })
         .unwrap_or(None)
     }
@@ -1984,9 +2180,13 @@ mod hyper_fast_path_validity {
                     if raw == 0 || raw.abs() <= small_x_linear_threshold_scale(scale) {
                         continue; // linear band handled separately
                     }
-                    let w = scale + STRICT_GUARD;
+                    let working_scale = scale + STRICT_GUARD;
                     // Gate: stays fast unless the integer-regime digit gate fires.
-                    if crate::algos::exp::exp_series_2limb::hyper_needs_wide_narrow(raw, scale, w) {
+                    if crate::algos::exp::exp_series_2limb::hyper_needs_wide_narrow(
+                        raw,
+                        scale,
+                        working_scale,
+                    ) {
                         continue;
                     }
                     for mode in MODES {
@@ -2007,7 +2207,7 @@ mod hyper_fast_path_validity {
                                 )
                             }
                         }) {
-                            Ok(v) => v,
+                            Ok(value) => value,
                             Err(_) => continue,
                         };
                         let fast = fast_hyper_raw(raw, scale, mode, is_cosh);

--- a/src/consts/pow10.rs
+++ b/src/consts/pow10.rs
@@ -3,22 +3,26 @@
 
 //! `pow10` — `10^exp` in a work integer, **TABLE-FIRST**.
 //!
-//! Producing `10^exp` is a one-op "constant generation": the baked POW10
+//! Producing `10^exponent` is a one-op "constant generation": the baked POW10
 //! table ([`super::table::pow10_limbs`]) holds every in-range power as
 //! `&'static [u64]` limbs; beyond the (feature-gated) baked range the
-//! square-and-multiply `W::TEN.pow(exp)` is the fallback. The only decision
-//! is "is `exp` in the baked range", which the `Option` from a single table
+//! square-and-multiply `W::TEN.pow(exponent)` is the fallback. The only
+//! decision
+//! is "is `exponent` in the baked range", which the `Option` from a single
+//! table
 //! lookup already answers — so each door **matches that lookup directly**,
 //! with no `select`/`Algorithm` pre-lookup that would only re-fetch the same
-//! entry. `const fn`, so a const `exp` folds to the entry and a runtime `exp`
+//! entry. `const fn`, so a const `exponent` folds to the entry and a runtime
+//! `exponent`
 //! is one in-range branch then the single read.
 //!
 //! Three doors over the one table, by result type:
 //!
 //! * [`dispatch`] — generic over the work integer `W: BigInt`, `#[inline]`.
-//!   The everyday door for kernels that hold a `W`: a const-known `exp` folds
+//!   The everyday door for kernels that hold a `W`: a const-known `exponent`
+//!   folds
 //!   to the baked entry (zero-extended into `W`) or a const `TEN.pow`; a
-//!   runtime `exp` is one in-range branch then the single table read.
+//!   runtime `exponent` is one in-range branch then the single table read.
 //! * [`dispatch_int`] — a `const fn` returning `Int<N>`, for the const-`EXP`
 //!   sites needing a `const { Int::<N>::TEN.pow(EXP) }` value:
 //!   **table-sourced** while still folding to a compile-time constant.
@@ -28,55 +32,59 @@
 use crate::int::types::traits::BigInt;
 use crate::int::types::Int;
 
-/// `10^exp` in the work integer `W`, **table-first**. `#[inline]`: a
-/// const-known `exp` folds to the baked entry or a const `W::TEN.pow`; a
-/// runtime `exp` is one in-range branch then the single table read. The
+/// `10^exponent` in the work integer `W`, **table-first**. `#[inline]`: a
+/// const-known `exponent` folds to the baked entry or a const `W::TEN.pow`; a
+/// runtime `exponent` is one in-range branch then the single table read. The
 /// generic (`W: BigInt`) door — what kernels holding a work integer call.
 ///
 /// Matches the baked entry directly — no `select` pre-lookup that would
 /// re-fetch the same entry — mirroring [`dispatch_int`] / [`dispatch_i128`].
 #[inline]
-pub(crate) fn dispatch<W: BigInt>(exp: u32) -> W {
-    match super::table::pow10_limbs(exp) {
+pub(crate) fn dispatch<W: BigInt>(exponent: u32) -> W {
+    match super::table::pow10_limbs(exponent) {
         // Baked entry present (in range): zero-extend the limbs into `W`.
         Some(limbs) => super::table::limbs_to_w::<W>(limbs),
         // Out of the baked range: square-and-multiply fallback.
-        None => W::TEN.pow(exp),
+        None => W::TEN.pow(exponent),
     }
 }
 
-/// `10^exp` as `Int<N>`, **table-first**, in a `const fn` — the const-`EXP`
+/// `10^exponent` as `Int<N>`, **table-first**, in a `const fn` — the
+/// const-`EXP`
 /// door. Replaces `const { Int::<N>::TEN.pow(EXP) }` so the value is sourced
 /// from the baked table (Table) rather than recomputed by square-and-multiply
 /// (Function) at compile time; out-of-range still folds via the const
 /// `Int::<N>::TEN.pow`. Zero-extends the narrowest-fit table limbs into
-/// `[u64; N]` (the entry never exceeds `N` for an in-range `10^exp` that fits
-/// `Int<N>`).
+/// `[u64; N]` (the entry never exceeds `N` for an in-range `10^exponent` that
+/// fits `Int<N>`).
 #[inline]
-pub(crate) const fn dispatch_int<const N: usize>(exp: u32) -> Int<N> {
-    match super::table::pow10_limbs(exp) {
+pub(crate) const fn dispatch_int<const N: usize>(exponent: u32) -> Int<N> {
+    match super::table::pow10_limbs(exponent) {
         Some(limbs) => {
-            let mut arr = [0u64; N];
+            let mut limb_array = [0u64; N];
             let mut i = 0;
             while i < limbs.len() {
-                arr[i] = limbs[i];
+                limb_array[i] = limbs[i];
                 i += 1;
             }
-            Int::<N>::from_limbs(arr)
+            Int::<N>::from_limbs(limb_array)
         }
-        None => Int::<N>::TEN.pow(exp),
+        None => Int::<N>::TEN.pow(exponent),
     }
 }
 
-/// `10^exp` as `i128`, **table-first** — the narrow-`i128` door for the
+/// `10^exponent` as `i128`, **table-first** — the narrow-`i128` door for the
 /// D18/D38 hardware paths. Sources the value from the baked table (its low
-/// one or two u64 limbs) when in range, else the const `10i128.pow(exp)`.
-/// `const fn`, so a const `exp` folds. Valid only where `10^exp` fits `i128`
-/// (`exp <= 38`), which every narrow caller guarantees; a larger `exp`
+/// one or two u64 limbs) when in range, else the const
+/// `10i128.pow(exponent)`.
+/// `const fn`, so a const `exponent` folds. Valid only where `10^exponent`
+/// fits `i128`
+/// (`exponent <= 38`), which every narrow caller guarantees; a larger
+/// `exponent`
 /// overflows exactly as the original `10i128.pow(exp)` did.
 #[inline]
-pub(crate) const fn dispatch_i128(exp: u32) -> i128 {
-    match super::table::pow10_limbs(exp) {
+pub(crate) const fn dispatch_i128(exponent: u32) -> i128 {
+    match super::table::pow10_limbs(exponent) {
         Some(limbs) if limbs.len() <= 2 => {
             let lo = limbs[0] as u128;
             let hi = if limbs.len() == 2 { limbs[1] as u128 } else { 0 };
@@ -84,6 +92,6 @@ pub(crate) const fn dispatch_i128(exp: u32) -> i128 {
         }
         // Beyond `i128` range (or beyond the table): the square-and-multiply
         // Function — overflows identically to the prior `10i128.pow(exp)`.
-        _ => 10i128.pow(exp),
+        _ => 10i128.pow(exponent),
     }
 }

--- a/src/cross_scale.rs
+++ b/src/cross_scale.rs
@@ -37,8 +37,8 @@ use crate::types::unified::D;
 /// `const fn` `max` for `u32`, usable inside a
 /// `generic_const_exprs` clause.
 #[inline]
-pub const fn max_const(a: u32, b: u32) -> u32 {
-    if a >= b { a } else { b }
+pub const fn max_const(lhs: u32, rhs: u32) -> u32 {
+    if lhs >= rhs { lhs } else { rhs }
 }
 
 /// Same-width cross-scale multiply. Returns a decimal at the wider
@@ -52,16 +52,16 @@ pub const fn max_const(a: u32, b: u32) -> u32 {
 /// let c = cross::mul(a, b); // D38<12>, value = 77
 /// ```
 #[inline]
-pub fn mul<W, const S1: u32, const S2: u32>(a: D<W, S1>, b: D<W, S2>) -> D<W, { max_const(S1, S2) }>
+pub fn mul<W, const S1: u32, const S2: u32>(lhs: D<W, S1>, rhs: D<W, S2>) -> D<W, { max_const(S1, S2) }>
 where
     W: Copy,
     D<W, S1>: WidenScale<W, S1, { max_const(S1, S2) }>,
     D<W, S2>: WidenScale<W, S2, { max_const(S1, S2) }>,
     D<W, { max_const(S1, S2) }>: core::ops::Mul<Output = D<W, { max_const(S1, S2) }>>,
 {
-    let a_t = <D<W, S1> as WidenScale<W, S1, { max_const(S1, S2) }>>::widen_scale(a);
-    let b_t = <D<W, S2> as WidenScale<W, S2, { max_const(S1, S2) }>>::widen_scale(b);
-    a_t * b_t
+    let lhs_at_target = <D<W, S1> as WidenScale<W, S1, { max_const(S1, S2) }>>::widen_scale(lhs);
+    let rhs_at_target = <D<W, S2> as WidenScale<W, S2, { max_const(S1, S2) }>>::widen_scale(rhs);
+    lhs_at_target * rhs_at_target
 }
 
 /// Like [`mul`] but with explicit rounding mode for the
@@ -70,8 +70,8 @@ where
 /// crate; rescaling to `max_const(S1, S2)` is exact for both inputs.
 #[inline]
 pub fn mul_with<W, const S1: u32, const S2: u32>(
-    a: D<W, S1>,
-    b: D<W, S2>,
+    lhs: D<W, S1>,
+    rhs: D<W, S2>,
     _mode: RoundingMode,
 ) -> D<W, { max_const(S1, S2) }>
 where
@@ -80,63 +80,63 @@ where
     D<W, S2>: WidenScale<W, S2, { max_const(S1, S2) }>,
     D<W, { max_const(S1, S2) }>: core::ops::Mul<Output = D<W, { max_const(S1, S2) }>>,
 {
-    mul(a, b)
+    mul(lhs, rhs)
 }
 
 /// Same-width cross-scale add.
 #[inline]
-pub fn add<W, const S1: u32, const S2: u32>(a: D<W, S1>, b: D<W, S2>) -> D<W, { max_const(S1, S2) }>
+pub fn add<W, const S1: u32, const S2: u32>(lhs: D<W, S1>, rhs: D<W, S2>) -> D<W, { max_const(S1, S2) }>
 where
     W: Copy,
     D<W, S1>: WidenScale<W, S1, { max_const(S1, S2) }>,
     D<W, S2>: WidenScale<W, S2, { max_const(S1, S2) }>,
     D<W, { max_const(S1, S2) }>: core::ops::Add<Output = D<W, { max_const(S1, S2) }>>,
 {
-    let a_t = <D<W, S1> as WidenScale<W, S1, { max_const(S1, S2) }>>::widen_scale(a);
-    let b_t = <D<W, S2> as WidenScale<W, S2, { max_const(S1, S2) }>>::widen_scale(b);
-    a_t + b_t
+    let lhs_at_target = <D<W, S1> as WidenScale<W, S1, { max_const(S1, S2) }>>::widen_scale(lhs);
+    let rhs_at_target = <D<W, S2> as WidenScale<W, S2, { max_const(S1, S2) }>>::widen_scale(rhs);
+    lhs_at_target + rhs_at_target
 }
 
 /// Same-width cross-scale subtract.
 #[inline]
-pub fn sub<W, const S1: u32, const S2: u32>(a: D<W, S1>, b: D<W, S2>) -> D<W, { max_const(S1, S2) }>
+pub fn sub<W, const S1: u32, const S2: u32>(lhs: D<W, S1>, rhs: D<W, S2>) -> D<W, { max_const(S1, S2) }>
 where
     W: Copy,
     D<W, S1>: WidenScale<W, S1, { max_const(S1, S2) }>,
     D<W, S2>: WidenScale<W, S2, { max_const(S1, S2) }>,
     D<W, { max_const(S1, S2) }>: core::ops::Sub<Output = D<W, { max_const(S1, S2) }>>,
 {
-    let a_t = <D<W, S1> as WidenScale<W, S1, { max_const(S1, S2) }>>::widen_scale(a);
-    let b_t = <D<W, S2> as WidenScale<W, S2, { max_const(S1, S2) }>>::widen_scale(b);
-    a_t - b_t
+    let lhs_at_target = <D<W, S1> as WidenScale<W, S1, { max_const(S1, S2) }>>::widen_scale(lhs);
+    let rhs_at_target = <D<W, S2> as WidenScale<W, S2, { max_const(S1, S2) }>>::widen_scale(rhs);
+    lhs_at_target - rhs_at_target
 }
 
 /// Same-width cross-scale divide.
 #[inline]
-pub fn div<W, const S1: u32, const S2: u32>(a: D<W, S1>, b: D<W, S2>) -> D<W, { max_const(S1, S2) }>
+pub fn div<W, const S1: u32, const S2: u32>(lhs: D<W, S1>, rhs: D<W, S2>) -> D<W, { max_const(S1, S2) }>
 where
     W: Copy,
     D<W, S1>: WidenScale<W, S1, { max_const(S1, S2) }>,
     D<W, S2>: WidenScale<W, S2, { max_const(S1, S2) }>,
     D<W, { max_const(S1, S2) }>: core::ops::Div<Output = D<W, { max_const(S1, S2) }>>,
 {
-    let a_t = <D<W, S1> as WidenScale<W, S1, { max_const(S1, S2) }>>::widen_scale(a);
-    let b_t = <D<W, S2> as WidenScale<W, S2, { max_const(S1, S2) }>>::widen_scale(b);
-    a_t / b_t
+    let lhs_at_target = <D<W, S1> as WidenScale<W, S1, { max_const(S1, S2) }>>::widen_scale(lhs);
+    let rhs_at_target = <D<W, S2> as WidenScale<W, S2, { max_const(S1, S2) }>>::widen_scale(rhs);
+    lhs_at_target / rhs_at_target
 }
 
 /// Same-width cross-scale remainder.
 #[inline]
-pub fn rem<W, const S1: u32, const S2: u32>(a: D<W, S1>, b: D<W, S2>) -> D<W, { max_const(S1, S2) }>
+pub fn rem<W, const S1: u32, const S2: u32>(lhs: D<W, S1>, rhs: D<W, S2>) -> D<W, { max_const(S1, S2) }>
 where
     W: Copy,
     D<W, S1>: WidenScale<W, S1, { max_const(S1, S2) }>,
     D<W, S2>: WidenScale<W, S2, { max_const(S1, S2) }>,
     D<W, { max_const(S1, S2) }>: core::ops::Rem<Output = D<W, { max_const(S1, S2) }>>,
 {
-    let a_t = <D<W, S1> as WidenScale<W, S1, { max_const(S1, S2) }>>::widen_scale(a);
-    let b_t = <D<W, S2> as WidenScale<W, S2, { max_const(S1, S2) }>>::widen_scale(b);
-    a_t % b_t
+    let lhs_at_target = <D<W, S1> as WidenScale<W, S1, { max_const(S1, S2) }>>::widen_scale(lhs);
+    let rhs_at_target = <D<W, S2> as WidenScale<W, S2, { max_const(S1, S2) }>>::widen_scale(rhs);
+    lhs_at_target % rhs_at_target
 }
 
 /// Trait shim: "widen the SCALE of a same-width decimal".

--- a/src/int/algos/add/add_ripple_carry.rs
+++ b/src/int/algos/add/add_ripple_carry.rs
@@ -15,9 +15,9 @@ use crate::int::types::Int;
 /// [`add_assign_fixed`], discarding the carry-out so the result wraps
 /// modulo `2^BITS` (two's-complement wrapping semantics).
 #[inline]
-pub(crate) const fn add_ripple_carry<const N: usize>(a: Int<N>, b: Int<N>) -> Int<N> {
-    let mut limbs = *a.as_limbs();
-    add_assign_fixed(&mut limbs, b.as_limbs());
+pub(crate) const fn add_ripple_carry<const N: usize>(lhs: Int<N>, rhs: Int<N>) -> Int<N> {
+    let mut limbs = *lhs.as_limbs();
+    add_assign_fixed(&mut limbs, rhs.as_limbs());
     Int::<N>::from_limbs(limbs)
 }
 
@@ -32,25 +32,25 @@ pub(crate) const fn add_ripple_carry<const N: usize>(a: Int<N>, b: Int<N>) -> In
 /// layers; fusing removes them.
 #[inline]
 pub(crate) const fn add_ripple_carry_checked<const N: usize>(
-    a: Int<N>,
-    b: Int<N>,
+    lhs: Int<N>,
+    rhs: Int<N>,
 ) -> Option<Int<N>> {
-    let av = a.as_limbs();
-    let bv = b.as_limbs();
+    let lhs_limbs = lhs.as_limbs();
+    let rhs_limbs = rhs.as_limbs();
     let mut out = [0u64; N];
     let mut carry = 0u64;
     let mut i = 0;
     while i < N {
-        let (s1, c1) = av[i].overflowing_add(bv[i]);
+        let (s1, c1) = lhs_limbs[i].overflowing_add(rhs_limbs[i]);
         let (s2, c2) = s1.overflowing_add(carry);
         out[i] = s2;
         carry = (c1 as u64) + (c2 as u64);
         i += 1;
     }
-    let sa = av[N - 1] >> 63;
-    let sb = bv[N - 1] >> 63;
-    let sr = out[N - 1] >> 63;
-    if sa == sb && sr != sa {
+    let lhs_sign = lhs_limbs[N - 1] >> 63;
+    let rhs_sign = rhs_limbs[N - 1] >> 63;
+    let result_sign = out[N - 1] >> 63;
+    if lhs_sign == rhs_sign && result_sign != lhs_sign {
         None
     } else {
         Some(Int::<N>::from_limbs(out))

--- a/src/int/algos/cmp/cmp_limbwise.rs
+++ b/src/int/algos/cmp/cmp_limbwise.rs
@@ -21,24 +21,24 @@ use core::cmp::Ordering;
 /// Reuses the `cmp_fixed` kernel from [`crate::int::algos::support::limbs`] so
 /// the comparison loop is not duplicated here.
 #[inline]
-pub(crate) const fn cmp_limbwise<const N: usize>(a: Int<N>, b: Int<N>) -> Ordering {
-    let sn = a.is_negative();
-    let so = b.is_negative();
-    if sn && !so {
+pub(crate) const fn cmp_limbwise<const N: usize>(lhs: Int<N>, rhs: Int<N>) -> Ordering {
+    let lhs_is_negative = lhs.is_negative();
+    let rhs_is_negative = rhs.is_negative();
+    if lhs_is_negative && !rhs_is_negative {
         return Ordering::Less;
     }
-    if !sn && so {
+    if !lhs_is_negative && rhs_is_negative {
         return Ordering::Greater;
     }
     // Same sign: compare magnitudes. `cmp_fixed` returns -1 / 0 / 1.
-    let a_mag = a.unsigned_abs();
-    let b_mag = b.unsigned_abs();
-    let c = cmp_fixed(a_mag.as_limbs(), b_mag.as_limbs());
+    let lhs_magnitude = lhs.unsigned_abs();
+    let rhs_magnitude = rhs.unsigned_abs();
+    let comparison = cmp_fixed(lhs_magnitude.as_limbs(), rhs_magnitude.as_limbs());
     // For two negatives the larger magnitude is the smaller value.
-    let c = if sn { -c } else { c };
-    if c < 0 {
+    let comparison = if lhs_is_negative { -comparison } else { comparison };
+    if comparison < 0 {
         Ordering::Less
-    } else if c > 0 {
+    } else if comparison > 0 {
         Ordering::Greater
     } else {
         Ordering::Equal
@@ -51,24 +51,24 @@ pub(crate) const fn cmp_limbwise<const N: usize>(a: Int<N>, b: Int<N>) -> Orderi
 /// general `M != N` case.
 #[inline]
 pub(crate) const fn cmp_limbwise_cross<const N: usize, const M: usize>(
-    a: Int<N>,
-    b: Int<M>,
+    lhs: Int<N>,
+    rhs: Int<M>,
 ) -> Ordering {
-    let sn = a.is_negative();
-    let so = b.is_negative();
-    if sn && !so {
+    let lhs_is_negative = lhs.is_negative();
+    let rhs_is_negative = rhs.is_negative();
+    if lhs_is_negative && !rhs_is_negative {
         return Ordering::Less;
     }
-    if !sn && so {
+    if !lhs_is_negative && rhs_is_negative {
         return Ordering::Greater;
     }
-    let a_mag = a.unsigned_abs();
-    let b_mag = b.unsigned_abs();
-    let c = cmp_cross(a_mag.as_limbs(), b_mag.as_limbs());
-    let c = if sn { -c } else { c };
-    if c < 0 {
+    let lhs_magnitude = lhs.unsigned_abs();
+    let rhs_magnitude = rhs.unsigned_abs();
+    let comparison = cmp_cross(lhs_magnitude.as_limbs(), rhs_magnitude.as_limbs());
+    let comparison = if lhs_is_negative { -comparison } else { comparison };
+    if comparison < 0 {
         Ordering::Less
-    } else if c > 0 {
+    } else if comparison > 0 {
         Ordering::Greater
     } else {
         Ordering::Equal

--- a/src/int/algos/cube/cube_fused_comba.rs
+++ b/src/int/algos/cube/cube_fused_comba.rs
@@ -137,10 +137,10 @@ mod tests {
     fn diff_at<const N: usize>(seeds: &[u64]) {
         for &seed in seeds {
             let mut limbs = [0u64; N];
-            let mut s = seed;
+            let mut state = seed;
             for limb in limbs.iter_mut() {
-                s = s.wrapping_add(0x9E37_79B9_7F4A_7C15);
-                let mut z = s;
+                state = state.wrapping_add(0x9E37_79B9_7F4A_7C15);
+                let mut z = state;
                 z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
                 z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
                 *limb = z ^ (z >> 31);

--- a/src/int/algos/div/div_burnikel_ziegler_with_knuth.rs
+++ b/src/int/algos/div/div_burnikel_ziegler_with_knuth.rs
@@ -49,8 +49,8 @@ const BZ_BASECASE: usize = 16;
 /// tiers: the decimal `÷10^w` rescale and the wide-transcendental slice roots
 /// (`isqrt_newton` / `icbrt_newton` / `newton_reciprocal`) present **working**
 /// numerators that exceed the widest storage width — at the supported build the
-/// effective divisor `den_n` reaches ~67 limbs (≥ `BZ_THRESHOLD`, so BZ DOES
-/// engage there) over a `~2·den_n` ≈ 134-limb dividend. Every recursive
+/// effective `divisor_len` reaches ~67 limbs (≥ `BZ_THRESHOLD`, so BZ DOES
+/// engage there) over a `~2·divisor_len` ≈ 134-limb dividend. Every recursive
 /// sub-buffer (`u`, the `2n` block dividend, the `3s` sub-dividend, the `2s+2`
 /// correction window) is bounded by that widest working dividend, which
 /// [`MAX_QUADRUPLE_LIMBS`] (`4·MAX_WORK_N + ⌈MAX_WORK_N/2⌉`, the build-max
@@ -66,39 +66,40 @@ const BZ_BASECASE: usize = 16;
 const BZ_MAX: usize = MAX_QUADRUPLE_LIMBS;
 
 /// Burnikel–Ziegler recursive fast-division entry. Strips the operand shapes,
-/// applies the engagement guard (the same `n < BZ_THRESHOLD || top < 2·n`
-/// short-circuit to Knuth the policy threshold encodes), then runs the
-/// recursion. The chosen-engine `match` in
+/// applies the engagement guard (the same
+/// `n < BZ_THRESHOLD || dividend_len < 2·n` short-circuit to Knuth the policy
+/// threshold encodes), then runs the recursion. The chosen-engine `match` in
 /// [`crate::int::policy::div_rem::dispatch`] only reaches here for a divisor of
 /// at least `BZ_THRESHOLD` effective limbs whose dividend is at least twice as
 /// wide.
 pub(crate) fn div_burnikel_ziegler_with_knuth(
-    num: &[u64],
-    den: &[u64],
-    quot: &mut [u64],
-    rem: &mut [u64],
+    dividend: &[u64],
+    divisor: &[u64],
+    quotient: &mut [u64],
+    remainder: &mut [u64],
 ) {
-    let mut n = den.len();
-    while n > 0 && den[n - 1] == 0 {
+    let mut n = divisor.len();
+    while n > 0 && divisor[n - 1] == 0 {
         n -= 1;
     }
     assert!(n > 0, "div_burnikel_ziegler_with_knuth: divide by zero");
 
-    let mut top = num.len();
-    while top > 0 && num[top - 1] == 0 {
-        top -= 1;
+    let mut dividend_len = dividend.len();
+    while dividend_len > 0 && dividend[dividend_len - 1] == 0 {
+        dividend_len -= 1;
     }
 
-    if n < crate::int::policy::div_rem::BZ_THRESHOLD || top < 2 * n {
-        div_knuth(num, den, quot, rem);
+    if n < crate::int::policy::div_rem::BZ_THRESHOLD || dividend_len < 2 * n {
+        div_knuth(dividend, divisor, quotient, remainder);
         return;
     }
 
-    bz_recursive_core(num, den, quot, rem, n, top);
+    bz_recursive_core(dividend, divisor, quotient, remainder, n, dividend_len);
 }
 
-/// The recursive core. Callers pass the stripped effective shape `(n, top)`;
-/// the public entry above applies the engagement guard first.
+/// The recursive core. Callers pass the stripped effective shape
+/// `(n, dividend_len)`; the public entry above applies the engagement guard
+/// first.
 ///
 /// Normalises the divisor to a full top limb (Knuth's shift), runs the
 /// block-recursive divide ([`div_blocks`]) so the dividend is consumed in
@@ -107,119 +108,124 @@ pub(crate) fn div_burnikel_ziegler_with_knuth(
 /// the production engagement threshold without an engagement branch in the
 /// timed path.
 pub(crate) fn bz_recursive_core(
-    num: &[u64],
-    den: &[u64],
-    quot: &mut [u64],
-    rem: &mut [u64],
+    dividend: &[u64],
+    divisor: &[u64],
+    quotient: &mut [u64],
+    remainder: &mut [u64],
     n: usize,
-    top: usize,
+    dividend_len: usize,
 ) {
-    for q in quot.iter_mut() {
-        *q = 0;
+    for slot in quotient.iter_mut() {
+        *slot = 0;
     }
-    for r in rem.iter_mut() {
-        *r = 0;
+    for slot in remainder.iter_mut() {
+        *slot = 0;
     }
 
     // Normalise so the divisor's top limb has its high bit set (Knuth's
     // shift); the recursion's `D_{3n/2n}` quotient estimate relies on a
     // normalised divisor exactly as Knuth does.
-    let shift = den[n - 1].leading_zeros();
+    let shift = divisor[n - 1].leading_zeros();
 
     let mut v = [0u64; BZ_MAX];
     let mut u = [0u64; BZ_MAX + 2];
-    debug_assert!(n <= BZ_MAX && top + 1 < BZ_MAX + 2);
+    debug_assert!(n <= BZ_MAX && dividend_len + 1 < BZ_MAX + 2);
 
     if shift == 0 {
-        v[..n].copy_from_slice(&den[..n]);
-        u[..top].copy_from_slice(&num[..top]);
+        v[..n].copy_from_slice(&divisor[..n]);
+        u[..dividend_len].copy_from_slice(&dividend[..dividend_len]);
     } else {
         let mut carry: u64 = 0;
         for i in 0..n {
-            let val = den[i];
-            v[i] = (val << shift) | carry;
-            carry = val >> (64 - shift);
+            let limb = divisor[i];
+            v[i] = (limb << shift) | carry;
+            carry = limb >> (64 - shift);
         }
         carry = 0;
-        for i in 0..top {
-            let val = num[i];
-            u[i] = (val << shift) | carry;
-            carry = val >> (64 - shift);
+        for i in 0..dividend_len {
+            let limb = dividend[i];
+            u[i] = (limb << shift) | carry;
+            carry = limb >> (64 - shift);
         }
-        u[top] = carry;
+        u[dividend_len] = carry;
     }
-    // The normalised dividend occupies `top + 1` limbs (the extra carry limb).
-    let u_len = top + 1;
+    // The normalised dividend occupies `dividend_len + 1` limbs (the extra
+    // carry limb).
+    let u_len = dividend_len + 1;
 
     // Block-recursive divide of the normalised `u` by the normalised `v[..n]`.
     let mut r_norm = [0u64; BZ_MAX];
-    div_blocks(&u[..u_len], &v[..n], n, quot, &mut r_norm[..n]);
+    div_blocks(&u[..u_len], &v[..n], n, quotient, &mut r_norm[..n]);
 
     // De-normalise the remainder (shift right by `shift`).
     if shift == 0 {
-        let copy_n = n.min(rem.len());
-        rem[..copy_n].copy_from_slice(&r_norm[..copy_n]);
+        let copy_len = n.min(remainder.len());
+        remainder[..copy_len].copy_from_slice(&r_norm[..copy_len]);
     } else {
         for i in 0..n {
-            if i < rem.len() {
+            if i < remainder.len() {
                 let lo = r_norm[i] >> shift;
                 let hi_into_lo = if i + 1 < n {
                     r_norm[i + 1] << (64 - shift)
                 } else {
                     0
                 };
-                rem[i] = lo | hi_into_lo;
+                remainder[i] = lo | hi_into_lo;
             }
         }
     }
 }
 
 /// Block-recursive driver: divide a (normalised) dividend `u` by a
-/// (normalised) `n`-limb divisor `v`, producing the full quotient in `quot`
-/// and the `n`-limb remainder in `rem`.
+/// (normalised) `n`-limb divisor `v`, producing the full quotient in
+/// `quotient` and the `n`-limb remainder in `remainder`.
 ///
 /// Burnikel–Ziegler's outer loop: walk the dividend in `n`-limb blocks from the
-/// most-significant end, maintaining a running `n`-limb remainder `r` (`< v`).
-/// Each block forms the `2n`-limb dividend `r ‖ block` and runs ONE
-/// [`div_2n_1n`] (the recursive `D_{2n/1n}`), whose `n`-limb quotient is that
-/// block's quotient digits and whose `n`-limb remainder carries into the next
-/// block. For the `2n`/`n` `div` shape there is exactly one block beyond the
-/// initial zero `r`; a wider dividend generalises to `⌈top/n⌉` blocks.
-fn div_blocks(u: &[u64], v: &[u64], n: usize, quot: &mut [u64], rem: &mut [u64]) {
+/// most-significant end, maintaining a `running_remainder` of `n` limbs
+/// (`< v`). Each block forms the `2n`-limb dividend `running_remainder ‖ block`
+/// and runs ONE [`div_2n_1n`] (the recursive `D_{2n/1n}`), whose `n`-limb
+/// quotient is that block's quotient digits and whose `n`-limb remainder
+/// carries into the next block. For the `2n`/`n` `div` shape there is exactly
+/// one block beyond the initial zero `running_remainder`; a wider dividend
+/// generalises to `⌈u_len/n⌉` blocks.
+fn div_blocks(u: &[u64], v: &[u64], n: usize, quotient: &mut [u64], remainder: &mut [u64]) {
     let u_len = u.len();
     let blocks = u_len.div_ceil(n);
 
-    let mut r = [0u64; BZ_MAX]; // running n-limb remainder (< v)
-    let mut dividend = [0u64; BZ_MAX]; // r ‖ block, 2n limbs
+    let mut running_remainder = [0u64; BZ_MAX]; // running n-limb remainder (< v)
+    let mut dividend = [0u64; BZ_MAX]; // running_remainder ‖ block, 2n limbs
     let mut q_block = [0u64; BZ_MAX]; // n-limb quotient digits
 
     let mut idx = blocks;
     while idx > 0 {
         idx -= 1;
-        let lo = idx * n;
-        let hi = ((idx + 1) * n).min(u_len);
-        let block_len = hi - lo;
+        let block_start = idx * n;
+        let block_end = ((idx + 1) * n).min(u_len);
+        let block_len = block_end - block_start;
 
-        // Build the `2n`-limb dividend = r·2^(64n) + block. The low `block_len`
-        // limbs are the block; limbs `[block_len, n)` (if any) are zero; the
-        // high `n` limbs are `r`.
-        dividend[..block_len].copy_from_slice(&u[lo..lo + block_len]);
-        for d in dividend[block_len..n].iter_mut() {
-            *d = 0;
+        // Build the `2n`-limb dividend = running_remainder·2^(64n) + block. The
+        // low `block_len` limbs are the block; limbs `[block_len, n)` (if any)
+        // are zero; the high `n` limbs are `running_remainder`.
+        dividend[..block_len]
+            .copy_from_slice(&u[block_start..block_start + block_len]);
+        for slot in dividend[block_len..n].iter_mut() {
+            *slot = 0;
         }
-        dividend[n..2 * n].copy_from_slice(&r[..n]);
+        dividend[n..2 * n].copy_from_slice(&running_remainder[..n]);
 
-        div_2n_1n(&dividend[..2 * n], v, n, &mut q_block[..n], &mut r[..n]);
+        div_2n_1n(&dividend[..2 * n], v, n, &mut q_block[..n],
+            &mut running_remainder[..n]);
 
-        let store_end = (lo + n).min(quot.len());
-        let store_len = store_end.saturating_sub(lo);
+        let store_end = (block_start + n).min(quotient.len());
+        let store_len = store_end.saturating_sub(block_start);
         if store_len > 0 {
-            quot[lo..lo + store_len].copy_from_slice(&q_block[..store_len]);
+            quotient[block_start..block_start + store_len]
+                .copy_from_slice(&q_block[..store_len]);
         }
     }
 
-    let rem_n = n.min(rem.len());
-    rem[..rem_n].copy_from_slice(&r[..rem_n]);
+    let copy_len = n.min(remainder.len());
+    remainder[..copy_len].copy_from_slice(&running_remainder[..copy_len]);
 }
 
 /// `D_{2n/1n}` — divide a `2n`-limb dividend `a` by an `n`-limb (normalised)
@@ -293,8 +299,8 @@ fn div_3n_2n(a: &[u64], b: &[u64], s: usize, q: &mut [u64], r: &mut [u64]) {
         // a < b·2^(64s) gives a1 <= b_hi, so `>=` means a1 == b_hi and
         //   r1 = a_top2 - q_hat·b_hi = a_top2 + b_hi - b_hi·2^(64s) = a2 + b_hi
         // (an s-limb value plus a possible carry limb).
-        for x in q_hat[..s].iter_mut() {
-            *x = u64::MAX;
+        for slot in q_hat[..s].iter_mut() {
+            *slot = u64::MAX;
         }
         r1[..s].copy_from_slice(&a[s..2 * s]); // a2 = a_top2's low s limbs
         if add_assign(&mut r1[..s], b_hi) {
@@ -344,21 +350,22 @@ fn div_3n_2n(a: &[u64], b: &[u64], s: usize, q: &mut [u64], r: &mut [u64]) {
 /// production engagement guard, so the Knuth-vs-BZ crossover can be timed at
 /// sub-threshold widths. Not used in production routing.
 #[cfg(feature = "bench-alt")]
-pub(crate) fn bz_chunk_core_forced(num: &[u64], den: &[u64], quot: &mut [u64], rem: &mut [u64]) {
-    let mut n = den.len();
-    while n > 0 && den[n - 1] == 0 {
+pub(crate) fn bz_chunk_core_forced(dividend: &[u64], divisor: &[u64], quotient: &mut [u64],
+    remainder: &mut [u64]) {
+    let mut n = divisor.len();
+    while n > 0 && divisor[n - 1] == 0 {
         n -= 1;
     }
     assert!(n > 0, "bz_chunk_core_forced: divide by zero");
-    let mut top = num.len();
-    while top > 0 && num[top - 1] == 0 {
-        top -= 1;
+    let mut dividend_len = dividend.len();
+    while dividend_len > 0 && dividend[dividend_len - 1] == 0 {
+        dividend_len -= 1;
     }
-    bz_recursive_core(num, den, quot, rem, n, top);
+    bz_recursive_core(dividend, divisor, quotient, remainder, n, dividend_len);
 }
 
 // The differentials below all drive the recursion at the widest WORKING widths
-// (`den_n` up to ~69), so they require the xx-wide divide
+// (`divisor_len` up to ~69), so they require the xx-wide divide
 // scratch and are gated on it — gating the whole module keeps the narrow default
 // build free of unused-import / dead-helper warnings.
 #[cfg(all(test, feature = "xx-wide"))]
@@ -378,50 +385,53 @@ mod tests {
         }
     }
 
-    // Build a `(num, den)` pair: `den` exactly `den_n` nonzero-top limbs, `num`
-    // exactly `top` limbs (top limb forced nonzero). The recursion + Knuth both
-    // strip leading zeros, so the EFFECTIVE shape is `(top, den_n)`.
-    fn make(next: &mut impl FnMut() -> u64, top: usize, den_n: usize) -> (Vec<u64>, Vec<u64>) {
-        let mut num = vec![0u64; top];
-        let mut den = vec![0u64; den_n];
-        for x in num.iter_mut() {
-            *x = next();
+    // Build a `(dividend, divisor)` pair: `divisor` exactly `divisor_len`
+    // nonzero-top limbs, `dividend` exactly `dividend_len` limbs (top limb
+    // forced nonzero). The recursion + Knuth both strip leading zeros, so the
+    // EFFECTIVE shape is `(dividend_len, divisor_len)`.
+    fn make(next: &mut impl FnMut() -> u64, dividend_len: usize, divisor_len: usize)
+        -> (Vec<u64>, Vec<u64>) {
+        let mut dividend = vec![0u64; dividend_len];
+        let mut divisor = vec![0u64; divisor_len];
+        for slot in dividend.iter_mut() {
+            *slot = next();
         }
-        for x in den.iter_mut() {
-            *x = next();
+        for slot in divisor.iter_mut() {
+            *slot = next();
         }
-        num[top - 1] |= 0x8000_0000_0000_0000;
-        den[den_n - 1] |= 0x8000_0000_0000_0000;
-        (num, den)
+        dividend[dividend_len - 1] |= 0x8000_0000_0000_0000;
+        divisor[divisor_len - 1] |= 0x8000_0000_0000_0000;
+        (dividend, divisor)
     }
 
     // Drive the forced recursive core and assert bit-identity with the Knuth
     // reference (the exact-quotient oracle for an integer divide).
-    fn assert_recursive_matches_knuth(num: &[u64], den: &[u64], label: &str) {
-        let len = num.len();
-        let mut q_ref = vec![0u64; len + 1];
-        let mut r_ref = vec![0u64; len + 1];
-        div_knuth(num, den, &mut q_ref, &mut r_ref);
+    fn assert_recursive_matches_knuth(dividend: &[u64], divisor: &[u64], label: &str) {
+        let len = dividend.len();
+        let mut quotient_reference = vec![0u64; len + 1];
+        let mut remainder_reference = vec![0u64; len + 1];
+        div_knuth(dividend, divisor, &mut quotient_reference, &mut remainder_reference);
 
         // Strip the divisor / dividend to their effective lengths, then run the
         // recursive core directly (bypasses the engagement guard so the
         // recursion is exercised at every width, not only routed ones).
-        let mut den_n = den.len();
-        while den_n > 0 && den[den_n - 1] == 0 {
-            den_n -= 1;
+        let mut divisor_len = divisor.len();
+        while divisor_len > 0 && divisor[divisor_len - 1] == 0 {
+            divisor_len -= 1;
         }
-        let mut top = num.len();
-        while top > 0 && num[top - 1] == 0 {
-            top -= 1;
+        let mut dividend_len = dividend.len();
+        while dividend_len > 0 && dividend[dividend_len - 1] == 0 {
+            dividend_len -= 1;
         }
-        let mut q_bz = vec![0u64; len + 1];
-        let mut r_bz = vec![0u64; len + 1];
-        bz_recursive_core(num, den, &mut q_bz, &mut r_bz, den_n, top);
+        let mut quotient_bz = vec![0u64; len + 1];
+        let mut remainder_bz = vec![0u64; len + 1];
+        bz_recursive_core(dividend, divisor, &mut quotient_bz, &mut remainder_bz,
+            divisor_len, dividend_len);
 
-        assert_eq!(q_bz, q_ref, "BZ recursive quot mismatch [{label}]");
+        assert_eq!(quotient_bz, quotient_reference, "BZ recursive quot mismatch [{label}]");
         assert_eq!(
-            r_bz[..den_n],
-            r_ref[..den_n],
+            remainder_bz[..divisor_len],
+            remainder_reference[..divisor_len],
             "BZ recursive rem mismatch [{label}]"
         );
     }
@@ -431,43 +441,52 @@ mod tests {
     // transcendental golden cells (`index out of bounds: len 134 idx 134`).
     // Production presents a divide at WORKING widths exceeding storage — the
     // `÷10^w` rescale + the wide-transcendental slice roots give an effective
-    // `den_n` up to ~67 over a `~2·den_n` dividend — and BZ engages there
-    // (`den_n ≥ BZ_THRESHOLD`). These are the exact 2n/n shapes that arise
-    // in practice (134/67, 138/69, 96/48) plus neighbours, each bit-identical to
-    // Knuth. xx-wide so the build-max recursive scratch is the widest tier.
+    // `divisor_len` up to ~67 over a `~2·divisor_len` dividend — and BZ engages
+    // there (`divisor_len ≥ BZ_THRESHOLD`). These are the exact 2n/n shapes that
+    // arise in practice (134/67, 138/69, 96/48) plus neighbours, each
+    // bit-identical to Knuth. xx-wide so the build-max recursive scratch is the
+    // widest tier.
     #[test]
     fn bz_recursive_matches_knuth_working_width_2n_over_n() {
         let mut next = rng(0x5DEE_CE66_D1B5_4A32);
-        // The named regression shapes (den_n ≥ 65, dividend = 2·den_n).
-        for &(top, den_n) in &[(134usize, 67usize), (138, 69), (96, 48), (130, 65)] {
+        // The named regression shapes (divisor_len ≥ 65, dividend = 2·divisor_len).
+        for &(dividend_len, divisor_len) in
+            &[(134usize, 67usize), (138, 69), (96, 48), (130, 65)]
+        {
             for _ in 0..40 {
-                let (num, den) = make(&mut next, top, den_n);
-                assert_recursive_matches_knuth(&num, &den, &format!("2n/n {top}/{den_n}"));
+                let (dividend, divisor) = make(&mut next, dividend_len, divisor_len);
+                assert_recursive_matches_knuth(&dividend, &divisor,
+                    &format!("2n/n {dividend_len}/{divisor_len}"));
             }
         }
     }
 
     // The PRODUCTION ROUTED path: the public entry (engagement guard intact)
-    // at `den_n ≥ BZ_THRESHOLD(65)`, `num ≥ 2·den_n` — exactly where the
-    // matcher routes to BZ — must equal Knuth. Confirms the routed engine, not
-    // just the forced core.
+    // at `divisor_len ≥ BZ_THRESHOLD(65)`, `dividend ≥ 2·divisor_len` — exactly
+    // where the matcher routes to BZ — must equal Knuth. Confirms the routed
+    // engine, not just the forced core.
     #[test]
     fn bz_routed_entry_matches_knuth_at_engagement_widths() {
         let mut next = rng(0xA0761D64_78BD_642F);
-        for &(top, den_n) in &[(134usize, 67usize), (138, 69), (130, 65), (128, 64)] {
-            let (num, den) = make(&mut next, top, den_n);
-            let len = num.len();
-            let mut q_ref = vec![0u64; len + 1];
-            let mut r_ref = vec![0u64; len + 1];
-            div_knuth(&num, &den, &mut q_ref, &mut r_ref);
-            let mut q_bz = vec![0u64; len + 1];
-            let mut r_bz = vec![0u64; len + 1];
-            div_burnikel_ziegler_with_knuth(&num, &den, &mut q_bz, &mut r_bz);
-            assert_eq!(q_bz, q_ref, "routed BZ quot mismatch {top}/{den_n}");
+        for &(dividend_len, divisor_len) in
+            &[(134usize, 67usize), (138, 69), (130, 65), (128, 64)]
+        {
+            let (dividend, divisor) = make(&mut next, dividend_len, divisor_len);
+            let len = dividend.len();
+            let mut quotient_reference = vec![0u64; len + 1];
+            let mut remainder_reference = vec![0u64; len + 1];
+            div_knuth(&dividend, &divisor, &mut quotient_reference,
+                &mut remainder_reference);
+            let mut quotient_bz = vec![0u64; len + 1];
+            let mut remainder_bz = vec![0u64; len + 1];
+            div_burnikel_ziegler_with_knuth(&dividend, &divisor, &mut quotient_bz,
+                &mut remainder_bz);
+            assert_eq!(quotient_bz, quotient_reference,
+                "routed BZ quot mismatch {dividend_len}/{divisor_len}");
             assert_eq!(
-                r_bz[..den_n],
-                r_ref[..den_n],
-                "routed BZ rem mismatch {top}/{den_n}"
+                remainder_bz[..divisor_len],
+                remainder_reference[..divisor_len],
+                "routed BZ rem mismatch {dividend_len}/{divisor_len}"
             );
         }
     }
@@ -480,19 +499,22 @@ mod tests {
     #[test]
     fn bz_recursive_matches_knuth_spread() {
         let mut next = rng(0x2545_F491_4F6C_DD1D);
-        for &den_n in &[17usize, 24, 32, 33, 48, 64, 65, 67, 69] {
-            for &mul in &[2usize, 3] {
-                let top = mul * den_n;
+        for &divisor_len in &[17usize, 24, 32, 33, 48, 64, 65, 67, 69] {
+            for &multiple in &[2usize, 3] {
+                let dividend_len = multiple * divisor_len;
                 for _ in 0..30 {
-                    let (num, den) = make(&mut next, top, den_n);
-                    assert_recursive_matches_knuth(&num, &den, &format!("spread {top}/{den_n}"));
-                    // Ragged dividend (top - a few limbs) to vary the block split.
-                    if top > den_n + 1 {
-                        let (num2, den2) = make(&mut next, top - 1, den_n);
+                    let (dividend, divisor) = make(&mut next, dividend_len, divisor_len);
+                    assert_recursive_matches_knuth(&dividend, &divisor,
+                        &format!("spread {dividend_len}/{divisor_len}"));
+                    // Ragged dividend (dividend_len - a few limbs) to vary the
+                    // block split.
+                    if dividend_len > divisor_len + 1 {
+                        let (dividend2, divisor2) =
+                            make(&mut next, dividend_len - 1, divisor_len);
                         assert_recursive_matches_knuth(
-                            &num2,
-                            &den2,
-                            &format!("ragged {}/{den_n}", top - 1),
+                            &dividend2,
+                            &divisor2,
+                            &format!("ragged {}/{divisor_len}", dividend_len - 1),
                         );
                     }
                 }

--- a/src/int/algos/div/div_fixed.rs
+++ b/src/int/algos/div/div_fixed.rs
@@ -11,9 +11,10 @@ use crate::int::policy::div_rem::dispatch as div_rem_dispatch;
 
 /// Const-`N` fast-arm divmod over little-endian u64 magnitude limbs.
 ///
-/// `num`, `den`, `quot`, `rem` are all `N`-limb magnitudes (sign handling
-/// is the caller's; this is an unsigned division of the magnitudes). The
-/// quotient and remainder are written into `quot` / `rem`.
+/// `dividend`, `divisor`, `quotient`, `remainder` are all `N`-limb
+/// magnitudes (sign handling is the caller's; this is an unsigned division
+/// of the magnitudes). The quotient and remainder are written into
+/// `quotient` / `remainder`.
 ///
 /// Because `N` is a compile-time constant, the `if N == …` ladder
 /// const-folds per monomorphisation:
@@ -29,27 +30,27 @@ use crate::int::policy::div_rem::dispatch as div_rem_dispatch;
 /// caller guards this before delegating).
 #[inline]
 pub(crate) fn div_rem_mag_fixed<const N: usize>(
-    num: &[u64; N],
-    den: &[u64; N],
-    quot: &mut [u64; N],
-    rem: &mut [u64; N],
+    dividend: &[u64; N],
+    divisor: &[u64; N],
+    quotient: &mut [u64; N],
+    remainder: &mut [u64; N],
 ) {
     if N == 1 {
-        let n0 = num[0];
-        let d0 = den[0];
-        quot[0] = n0 / d0;
-        rem[0] = n0 % d0;
+        let dividend_limb = dividend[0];
+        let divisor_limb = divisor[0];
+        quotient[0] = dividend_limb / divisor_limb;
+        remainder[0] = dividend_limb % divisor_limb;
     } else if N == 2 {
-        let n = (num[0] as u128) | ((num[1] as u128) << 64);
-        let d = (den[0] as u128) | ((den[1] as u128) << 64);
-        let q = n / d;
-        let r = n % d;
-        quot[0] = q as u64;
-        quot[1] = (q >> 64) as u64;
-        rem[0] = r as u64;
-        rem[1] = (r >> 64) as u64;
+        let dividend_u128 = (dividend[0] as u128) | ((dividend[1] as u128) << 64);
+        let divisor_u128 = (divisor[0] as u128) | ((divisor[1] as u128) << 64);
+        let quotient_u128 = dividend_u128 / divisor_u128;
+        let remainder_u128 = dividend_u128 % divisor_u128;
+        quotient[0] = quotient_u128 as u64;
+        quotient[1] = (quotient_u128 >> 64) as u64;
+        remainder[0] = remainder_u128 as u64;
+        remainder[1] = (remainder_u128 >> 64) as u64;
     } else {
-        div_rem_dispatch(num, den, quot, rem);
+        div_rem_dispatch(dividend, divisor, quotient, remainder);
     }
 }
 
@@ -64,7 +65,8 @@ pub(crate) fn div_rem_mag_fixed<const N: usize>(
 /// `int::policy` layer directly. Fixed-width `Int<N>` callers take
 /// [`div_rem_mag_fixed`] instead. The divisor must be non-zero.
 #[inline]
-pub(crate) fn div_rem_mag_slice(num: &[u64], den: &[u64], quot: &mut [u64], rem: &mut [u64]) {
-    div_rem_dispatch(num, den, quot, rem);
+pub(crate) fn div_rem_mag_slice(dividend: &[u64], divisor: &[u64], quotient: &mut [u64],
+    remainder: &mut [u64]) {
+    div_rem_dispatch(dividend, divisor, quotient, remainder);
 }
 

--- a/src/int/algos/div/div_knuth.rs
+++ b/src/int/algos/div/div_knuth.rs
@@ -23,79 +23,80 @@ use crate::int::types::compute_limbs::max_single_limbs;
 /// `Int<N>: ComputeLimbs` context) call `div_knuth_into` directly with their
 /// own buffer (`single_buffered_u64` for a value divide, `quad_buffered_u64` for the cbrt
 /// radicand divide), skipping the build-max zeroing.
-pub(crate) fn div_knuth(num: &[u64], den: &[u64], quot: &mut [u64], rem: &mut [u64]) {
+pub(crate) fn div_knuth(dividend: &[u64], divisor: &[u64], quotient: &mut [u64],
+    remainder: &mut [u64]) {
     let mut u = max_single_limbs();
     let mut v = max_single_limbs();
-    div_knuth_into(num, den, quot, rem, &mut u, &mut v);
+    div_knuth_into(dividend, divisor, quotient, remainder, &mut u, &mut v);
 }
 
 /// Knuth Algorithm D at base 2^64, in caller-provided normalised `u`/`v`
 /// scratch. `u` and `v` must be **zeroed** on entry and at least
-/// `num.len() + 2` / `den.len()` u64 limbs respectively (the divide reads
-/// one limb above the live dividend, relying on the zero there).
+/// `dividend.len() + 2` / `divisor.len()` u64 limbs respectively (the divide
+/// reads one limb above the live dividend, relying on the zero there).
 ///
 /// Every limb is a u64 and the q̂ estimator uses [`Mg2By1`]. The
 /// multiply-subtract pass uses native `u64 × u64 → u128`, which keeps the
 /// carry-merge to a single layer.
 pub(crate) fn div_knuth_into(
-    num: &[u64],
-    den: &[u64],
-    quot: &mut [u64],
-    rem: &mut [u64],
+    dividend: &[u64],
+    divisor: &[u64],
+    quotient: &mut [u64],
+    remainder: &mut [u64],
     u: &mut [u64],
     v: &mut [u64],
 ) {
-    for q in quot.iter_mut() {
-        *q = 0;
+    for slot in quotient.iter_mut() {
+        *slot = 0;
     }
-    for r in rem.iter_mut() {
-        *r = 0;
+    for slot in remainder.iter_mut() {
+        *slot = 0;
     }
 
-    let mut n = den.len();
-    while n > 0 && den[n - 1] == 0 {
+    let mut n = divisor.len();
+    while n > 0 && divisor[n - 1] == 0 {
         n -= 1;
     }
     assert!(n > 0, "div_knuth: divide by zero");
 
-    let mut top = num.len();
-    while top > 0 && num[top - 1] == 0 {
-        top -= 1;
+    let mut dividend_len = dividend.len();
+    while dividend_len > 0 && dividend[dividend_len - 1] == 0 {
+        dividend_len -= 1;
     }
-    if top < n {
-        let copy_n = num.len().min(rem.len());
+    if dividend_len < n {
+        let copy_len = dividend.len().min(remainder.len());
         let mut i = 0;
-        while i < copy_n {
-            rem[i] = num[i];
+        while i < copy_len {
+            remainder[i] = dividend[i];
             i += 1;
         }
         return;
     }
 
-    let shift = den[n - 1].leading_zeros();
-    debug_assert!(top < u.len() && n <= v.len());
+    let shift = divisor[n - 1].leading_zeros();
+    debug_assert!(dividend_len < u.len() && n <= v.len());
 
     if shift == 0 {
-        u[..top].copy_from_slice(&num[..top]);
-        u[top] = 0;
-        v[..n].copy_from_slice(&den[..n]);
+        u[..dividend_len].copy_from_slice(&dividend[..dividend_len]);
+        u[dividend_len] = 0;
+        v[..n].copy_from_slice(&divisor[..n]);
     } else {
         let mut carry: u64 = 0;
-        for i in 0..top {
-            let val = num[i];
-            u[i] = (val << shift) | carry;
-            carry = val >> (64 - shift);
+        for i in 0..dividend_len {
+            let limb = dividend[i];
+            u[i] = (limb << shift) | carry;
+            carry = limb >> (64 - shift);
         }
-        u[top] = carry;
+        u[dividend_len] = carry;
         carry = 0;
         for i in 0..n {
-            let val = den[i];
-            v[i] = (val << shift) | carry;
-            carry = val >> (64 - shift);
+            let limb = divisor[i];
+            v[i] = (limb << shift) | carry;
+            carry = limb >> (64 - shift);
         }
     }
 
-    let m_plus_n = if u[top] != 0 { top + 1 } else { top };
+    let m_plus_n = if u[dividend_len] != 0 { dividend_len + 1 } else { dividend_len };
     debug_assert!(m_plus_n >= n);
     let m = m_plus_n - n;
 
@@ -103,29 +104,29 @@ pub(crate) fn div_knuth_into(
     // divisors have a much faster hardware divide path; route them out
     // here so the hot loop below can assume n >= 2.
     if n == 1 {
-        div_rem(num, den, quot, rem);
+        div_rem(dividend, divisor, quotient, remainder);
         return;
     }
 
     // Knuth D6/D4: emit the `m + 1` quotient digits and reduce `u` in place to
     // the remainder. The base-2⁶⁴ (`L = u64`) monomorphisation of the
-    // limb-generic [`knuth_d_core`]; the u64 quotient slice IS `quot` (no
+    // limb-generic [`knuth_d_core`]; the u64 quotient slice IS `quotient` (no
     // pack/unpack).
-    knuth_d_core::<u64>(u, v, n, m, quot);
+    knuth_d_core::<u64>(u, v, n, m, quotient);
 
     if shift == 0 {
-        let copy_n = n.min(rem.len());
-        rem[..copy_n].copy_from_slice(&u[..copy_n]);
+        let copy_len = n.min(remainder.len());
+        remainder[..copy_len].copy_from_slice(&u[..copy_len]);
     } else {
         for i in 0..n {
-            if i < rem.len() {
+            if i < remainder.len() {
                 let lo = u[i] >> shift;
                 let hi_into_lo = if i + 1 < n {
                     u[i + 1] << (64 - shift)
                 } else {
                     0
                 };
-                rem[i] = lo | hi_into_lo;
+                remainder[i] = lo | hi_into_lo;
             }
         }
     }
@@ -147,14 +148,15 @@ pub(crate) fn div_knuth_into(
 /// - at each step `u[j+n] <= v[n-1]` (the Knuth normalisation invariant — the
 ///   leading dividend limb never exceeds the leading divisor limb).
 ///
-/// On return `quot` (little-endian **u64** — the engine's external quotient
-/// type) holds the `m + 1` quotient digits (each `L` digit serialised at its
-/// u64 limb offset via [`DivLimb::store_quot_digit`], bounds-guarded) and
-/// `u[..n]` holds the remainder (still normalised — the caller denormalises by
-/// the same shift). The quotient is exact and UNIQUE, so the output is
+/// On return `quotient` (little-endian **u64** — the engine's external
+/// quotient type) holds the `m + 1` quotient digits (each `L` digit serialised
+/// at its u64 limb offset via [`DivLimb::store_quot_digit`], bounds-guarded)
+/// and `u[..n]` holds the remainder (still normalised — the caller denormalises
+/// by the same shift). The quotient is exact and UNIQUE, so the output is
 /// **bit-identical** for any conforming [`DivLimb`].
 #[inline]
-pub(crate) fn knuth_d_core<L: DivLimb>(u: &mut [L], v: &[L], n: usize, m: usize, quot: &mut [u64]) {
+pub(crate) fn knuth_d_core<L: DivLimb>(u: &mut [L], v: &[L], n: usize, m: usize,
+    quotient: &mut [u64]) {
     let v_top = v[n - 1]; // normalised: top bit set
     let v_below = v[n - 2];
     // The q̂ 2-by-1 reciprocal of the (constant) top divisor limb, built ONCE.
@@ -165,9 +167,9 @@ pub(crate) fn knuth_d_core<L: DivLimb>(u: &mut [L], v: &[L], n: usize, m: usize,
         j_plus_one -= 1;
         let j = j_plus_one;
 
-        let jn = j + n;
-        let u_top = u[jn];
-        let u_next = u[jn - 1];
+        let j_plus_n = j + n;
+        let u_top = u[j_plus_n];
+        let u_next = u[j_plus_n - 1];
         debug_assert!(u_top <= v_top, "knuth_d_core: dividend window top exceeds divisor top");
 
         // D3. q̂ = min(floor((u_top·B + u_next) / v_top), B − 1). The
@@ -176,27 +178,27 @@ pub(crate) fn knuth_d_core<L: DivLimb>(u: &mut [L], v: &[L], n: usize, m: usize,
         // remainder estimate r̂ = u_next + v_top already ran past `B` (a wrapped
         // r̂ ⇒ no D3 refinement is needed).
         let (mut q_hat, mut r_hat, overflow) = if u_top >= v_top {
-            let (r, of) = u_next.overflowing_add(v_top);
-            (L::MAX, r, of)
+            let (r, overflowed) = u_next.overflowing_add(v_top);
+            (L::MAX, r, overflowed)
         } else {
             let (q, r) = L::est_2by1(&recip, u_top, u_next);
             (q, r, false)
         };
 
-        // D3 refinement against v[n-2]: while q̂·v_below > r̂·B + u[jn-2],
+        // D3 refinement against v[n-2]: while q̂·v_below > r̂·B + u[j_plus_n-2],
         // decrement q̂ (and bump r̂ by v_top), until r̂ runs past B.
         if !overflow {
             loop {
                 let (p_lo, p_hi) = q_hat.widening_mul(v_below);
-                if p_hi < r_hat || (p_hi == r_hat && p_lo <= u[jn - 2]) {
+                if p_hi < r_hat || (p_hi == r_hat && p_lo <= u[j_plus_n - 2]) {
                     break;
                 }
                 q_hat = q_hat.overflowing_sub(L::ONE).0;
-                let (new_r, of) = r_hat.overflowing_add(v_top);
-                if of {
+                let (new_r_hat, overflowed) = r_hat.overflowing_add(v_top);
+                if overflowed {
                     break;
                 }
-                r_hat = new_r;
+                r_hat = new_r_hat;
             }
         }
 
@@ -211,32 +213,33 @@ pub(crate) fn knuth_d_core<L: DivLimb>(u: &mut [L], v: &[L], n: usize, m: usize,
         let mut carry = L::ACC_ZERO;
         let mut i = 0;
         while i < n {
-            let (res, c) = L::mul_sub_step(q_hat, v[i], u[j + i], carry);
-            u[j + i] = res;
-            carry = c;
+            let (new_limb, new_carry) = L::mul_sub_step(q_hat, v[i], u[j + i], carry);
+            u[j + i] = new_limb;
+            carry = new_carry;
             i += 1;
         }
-        let (s2, b1) = L::mul_sub_final(u[jn], carry);
-        u[jn] = s2;
+        let (final_limb, borrowed) = L::mul_sub_final(u[j_plus_n], carry);
+        u[j_plus_n] = final_limb;
 
         // D5/D6. If the final subtraction borrowed, q̂ was 1 too big: add the
         // divisor back once and decrement q̂.
-        if b1 {
+        if borrowed {
             q_hat = q_hat.overflowing_sub(L::ONE).0;
             let mut carry = L::ZERO;
             let mut i = 0;
             while i < n {
-                let (s1, c1) = u[j + i].overflowing_add(v[i]);
-                let (s2, c2) = s1.overflowing_add(carry);
-                u[j + i] = s2;
-                // c1, c2 are never both set (`u[j+i]+v[i] ≤ 2B−2 < 2B−1`), so
-                // `0 + c1 + c2 ∈ {0, 1}` — the schoolbook carry merge.
-                carry = L::ZERO.add_carries(c1, c2);
+                let (sum1, carry1) = u[j + i].overflowing_add(v[i]);
+                let (sum2, carry2) = sum1.overflowing_add(carry);
+                u[j + i] = sum2;
+                // carry1, carry2 are never both set (`u[j+i]+v[i] ≤ 2B−2 <
+                // 2B−1`), so `0 + carry1 + carry2 ∈ {0, 1}` — the schoolbook
+                // carry merge.
+                carry = L::ZERO.add_carries(carry1, carry2);
                 i += 1;
             }
-            u[jn] = u[jn].overflowing_add(carry).0;
+            u[j_plus_n] = u[j_plus_n].overflowing_add(carry).0;
         }
 
-        L::store_quot_digit(quot, j, q_hat);
+        L::store_quot_digit(quotient, j, q_hat);
     }
 }

--- a/src/int/algos/div/div_knuth_u128_limb.rs
+++ b/src/int/algos/div/div_knuth_u128_limb.rs
@@ -7,7 +7,7 @@
 //! ## Why base 2¹²⁸ (and why NOT a u64-`q̂` hybrid)
 //!
 //! The wide-tier rem/div runs [`div_knuth`] at base 2⁶⁴: its hot
-//! `O(m·n)` multiply-subtract walks `n = den.len()` u64 limbs. Storing the
+//! `O(m·n)` multiply-subtract walks `n = divisor.len()` u64 limbs. Storing the
 //! running dividend/divisor in **u128 limbs** halves the limb-slot count
 //! and the carry-chain hops — the same lever that makes the u128
 //! truncated-low multiply win (`mul_low_limb`).
@@ -57,77 +57,80 @@ const SCRATCH_LIMBS_128: usize = MAX_SINGLE_LIMBS / 2 + 2;
 /// concrete-`N` caller that can size the scratch exactly
 /// (`Int<N>: ComputeLimbs`) calls `div_knuth_u128_limb_into` directly with its
 /// own buffer family.
-pub(crate) fn div_knuth_u128_limb(num: &[u64], den: &[u64], quot: &mut [u64], rem: &mut [u64]) {
+pub(crate) fn div_knuth_u128_limb(dividend: &[u64], divisor: &[u64], quotient: &mut [u64],
+    remainder: &mut [u64]) {
     let mut u64buf = [0u64; MAX_SINGLE_LIMBS];
     let mut v64buf = [0u64; MAX_SINGLE_LIMBS];
     let mut u = [0u128; SCRATCH_LIMBS_128];
     let mut v = [0u128; SCRATCH_LIMBS_128];
     div_knuth_u128_limb_into(
-        num, den, quot, rem, &mut u64buf, &mut v64buf, &mut u, &mut v,
+        dividend, divisor, quotient, remainder, &mut u64buf, &mut v64buf, &mut u, &mut v,
     );
 }
 
 /// Base-2¹²⁸ Knuth Algorithm D in caller-provided scratch — the exact-scratch
-/// sibling of [`div_knuth_u128_limb`]. `num` / `den` are little-endian u64
-/// slices; `quot` / `rem` are written in u64 limbs to match [`div_knuth`]'s
-/// contract bit-for-bit. Even effective limb counts run the u128 core; odd /
-/// single-limb / `num < den` shapes fall back to [`div_knuth_into`].
+/// sibling of [`div_knuth_u128_limb`]. `dividend` / `divisor` are little-endian
+/// u64 slices; `quotient` / `remainder` are written in u64 limbs to match
+/// [`div_knuth`]'s contract bit-for-bit. Even effective limb counts run the
+/// u128 core; odd / single-limb / `dividend < divisor` shapes fall back to
+/// [`div_knuth_into`].
 ///
 /// A concrete-`N` caller sources the four scratch buffers from its
 /// `ComputeLimbs` family — for the decimal `/` wide shape (`2N`-dividend,
 /// `N`-divisor): `u64buf` = `double_buffered_u64`, `v64buf` =
 /// `single_buffered_u64`, `u` = `double_buffered_u128`, `v` = `single_u128`.
 /// All four slices are **zeroed here**, so the caller may reuse them across
-/// calls. Required minimum lengths: `u64buf ≥ num.len() + 2`,
-/// `v64buf ≥ den.len()`, `u ≥ ⌈(num.len()+2)/2⌉ + 1`, `v ≥ ⌈den.len()/2⌉`.
+/// calls. Required minimum lengths: `u64buf ≥ dividend.len() + 2`,
+/// `v64buf ≥ divisor.len()`, `u ≥ ⌈(dividend.len()+2)/2⌉ + 1`,
+/// `v ≥ ⌈divisor.len()/2⌉`.
 /// `u64buf` is reused as the remainder unpack scratch after the dividend has
 /// been packed into `u`.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn div_knuth_u128_limb_into(
-    num: &[u64],
-    den: &[u64],
-    quot: &mut [u64],
-    rem: &mut [u64],
+    dividend: &[u64],
+    divisor: &[u64],
+    quotient: &mut [u64],
+    remainder: &mut [u64],
     u64buf: &mut [u64],
     v64buf: &mut [u64],
     u: &mut [u128],
     v: &mut [u128],
 ) {
-    for q in quot.iter_mut() {
-        *q = 0;
+    for slot in quotient.iter_mut() {
+        *slot = 0;
     }
-    for r in rem.iter_mut() {
-        *r = 0;
+    for slot in remainder.iter_mut() {
+        *slot = 0;
     }
     // Zero the caller's scratch — the pack relies on the high limbs being
     // zero (the window-top `u[u_len128]`, the dividend's even-rounding limb),
     // and the caller may have reused these buffers.
-    for x in u64buf.iter_mut() {
-        *x = 0;
+    for slot in u64buf.iter_mut() {
+        *slot = 0;
     }
-    for x in v64buf.iter_mut() {
-        *x = 0;
+    for slot in v64buf.iter_mut() {
+        *slot = 0;
     }
-    for x in u.iter_mut() {
-        *x = 0;
+    for slot in u.iter_mut() {
+        *slot = 0;
     }
-    for x in v.iter_mut() {
-        *x = 0;
+    for slot in v.iter_mut() {
+        *slot = 0;
     }
 
     // Effective u64 limb counts (strip leading zeros).
-    let mut n64 = den.len();
-    while n64 > 0 && den[n64 - 1] == 0 {
+    let mut n64 = divisor.len();
+    while n64 > 0 && divisor[n64 - 1] == 0 {
         n64 -= 1;
     }
     assert!(n64 > 0, "div_knuth_u128_limb: divide by zero");
-    let mut top64 = num.len();
-    while top64 > 0 && num[top64 - 1] == 0 {
-        top64 -= 1;
+    let mut dividend_len64 = dividend.len();
+    while dividend_len64 > 0 && dividend[dividend_len64 - 1] == 0 {
+        dividend_len64 -= 1;
     }
-    if top64 < n64 {
-        let copy = num.len().min(rem.len());
-        rem[..copy].copy_from_slice(&num[..copy]);
+    if dividend_len64 < n64 {
+        let copy_len = dividend.len().min(remainder.len());
+        remainder[..copy_len].copy_from_slice(&dividend[..copy_len]);
         return;
     }
 
@@ -137,7 +140,8 @@ pub(crate) fn div_knuth_u128_limb_into(
     // u128 form), or `n64 < 4` — defers to base-2⁶⁴ Knuth, reusing the
     // caller's (now zeroed) u64 scratch as Knuth's `u`/`v`.
     if n64 < 4 || !n64.is_multiple_of(2) {
-        crate::int::algos::div::div_knuth::div_knuth_into(num, den, quot, rem, u64buf, v64buf);
+        crate::int::algos::div::div_knuth::div_knuth_into(dividend, divisor, quotient,
+            remainder, u64buf, v64buf);
         return;
     }
 
@@ -145,31 +149,35 @@ pub(crate) fn div_knuth_u128_limb_into(
     // normalises the top u128 limb (its bit 127 = the top u64 limb's bit
     // 63), so the packed divisor is base-2¹²⁸ normalised. Shift in u64
     // space (div_knuth's proven path), then pack pairs of u64 into u128.
-    let shift = den[n64 - 1].leading_zeros();
-    debug_assert!(top64 < u64buf.len() && n64 <= v64buf.len());
+    let shift = divisor[n64 - 1].leading_zeros();
+    debug_assert!(dividend_len64 < u64buf.len() && n64 <= v64buf.len());
 
     if shift == 0 {
-        u64buf[..top64].copy_from_slice(&num[..top64]);
-        v64buf[..n64].copy_from_slice(&den[..n64]);
+        u64buf[..dividend_len64].copy_from_slice(&dividend[..dividend_len64]);
+        v64buf[..n64].copy_from_slice(&divisor[..n64]);
     } else {
         let mut carry = 0u64;
-        for i in 0..top64 {
-            let val = num[i];
-            u64buf[i] = (val << shift) | carry;
-            carry = val >> (64 - shift);
+        for i in 0..dividend_len64 {
+            let limb = dividend[i];
+            u64buf[i] = (limb << shift) | carry;
+            carry = limb >> (64 - shift);
         }
-        u64buf[top64] = carry;
+        u64buf[dividend_len64] = carry;
         carry = 0;
         for i in 0..n64 {
-            let val = den[i];
-            v64buf[i] = (val << shift) | carry;
-            carry = val >> (64 - shift);
+            let limb = divisor[i];
+            v64buf[i] = (limb << shift) | carry;
+            carry = limb >> (64 - shift);
         }
     }
 
     // Round the dividend up to an even u64 length (so it packs cleanly),
-    // including the normalisation carry limb at `u64buf[top64]`.
-    let mut u_len64 = if u64buf[top64] != 0 { top64 + 1 } else { top64 };
+    // including the normalisation carry limb at `u64buf[dividend_len64]`.
+    let mut u_len64 = if u64buf[dividend_len64] != 0 {
+        dividend_len64 + 1
+    } else {
+        dividend_len64
+    };
     u_len64 += u_len64 & 1; // round up to even
     let n128 = n64 / 2;
     let u_len128 = u_len64 / 2;
@@ -182,26 +190,30 @@ pub(crate) fn div_knuth_u128_limb_into(
     // Base-2¹²⁸ Knuth D — the `L = u128` monomorphisation of the limb-generic
     // [`knuth_d_core`](crate::int::algos::div::div_knuth::knuth_d_core) (ONE
     // kernel shared with the base-2⁶⁴ `div_knuth`). The quotient has `m128 + 1`
-    // u128 digits, written into `quot` as little-endian u64 pairs by
+    // u128 digits, written into `quotient` as little-endian u64 pairs by
     // [`DivLimb::store_quot_digit`]; `u` has a zeroed limb above the live
     // dividend (`u[u_len128]`) for the window top.
     let m128 = u_len128 - n128;
-    knuth_d_core::<u128>(&mut u[..=u_len128], &v[..n128], n128, m128, quot);
+    knuth_d_core::<u128>(&mut u[..=u_len128], &v[..n128], n128, m128, quotient);
 
     // Unpack the remainder (low `n128` u128 limbs of `u` → `n64` u64 limbs)
-    // into `u64buf` (reused as `r64` now the dividend is consumed), then
-    // denormalise by `shift`.
-    let r64 = u64buf;
-    <u128 as Limb>::unpack(&u[..n128], &mut r64[..n64]);
+    // into `u64buf` (reused as `remainder64` now the dividend is consumed),
+    // then denormalise by `shift`.
+    let remainder64 = u64buf;
+    <u128 as Limb>::unpack(&u[..n128], &mut remainder64[..n64]);
     if shift == 0 {
-        let copy = n64.min(rem.len());
-        rem[..copy].copy_from_slice(&r64[..copy]);
+        let copy_len = n64.min(remainder.len());
+        remainder[..copy_len].copy_from_slice(&remainder64[..copy_len]);
     } else {
         for i in 0..n64 {
-            if i < rem.len() {
-                let lo = r64[i] >> shift;
-                let hi = if i + 1 < n64 { r64[i + 1] << (64 - shift) } else { 0 };
-                rem[i] = lo | hi;
+            if i < remainder.len() {
+                let lo = remainder64[i] >> shift;
+                let hi = if i + 1 < n64 {
+                    remainder64[i + 1] << (64 - shift)
+                } else {
+                    0
+                };
+                remainder[i] = lo | hi;
             }
         }
     }
@@ -234,29 +246,32 @@ mod tests {
         for &n64 in &[2usize, 4, 6, 8, 12, 16, 24, 32, 48, 64] {
             for _ in 0..400 {
                 let extra = 1 + (next() % (n64 as u64 + 2)) as usize; // 1..=n64+2 u64
-                let top64 = n64 + extra;
-                let mut num = vec![0u64; top64];
-                let mut den = vec![0u64; n64];
-                for x in num.iter_mut() {
-                    *x = next();
+                let dividend_len64 = n64 + extra;
+                let mut dividend = vec![0u64; dividend_len64];
+                let mut divisor = vec![0u64; n64];
+                for slot in dividend.iter_mut() {
+                    *slot = next();
                 }
-                for x in den.iter_mut() {
-                    *x = next();
+                for slot in divisor.iter_mut() {
+                    *slot = next();
                 }
-                if den[n64 - 1] == 0 {
-                    den[n64 - 1] = 1; // ensure effective top limb
+                if divisor[n64 - 1] == 0 {
+                    divisor[n64 - 1] = 1; // ensure effective top limb
                 }
-                let mut q_ref = vec![0u64; top64 + 1];
-                let mut r_ref = vec![0u64; top64 + 1];
-                div_knuth(&num, &den, &mut q_ref, &mut r_ref);
-                let mut q_c = vec![0u64; top64 + 1];
-                let mut r_c = vec![0u64; top64 + 1];
-                div_knuth_u128_limb(&num, &den, &mut q_c, &mut r_c);
-                assert_eq!(q_c, q_ref, "quot mismatch n64={n64} num={num:?} den={den:?}");
+                let mut quotient_reference = vec![0u64; dividend_len64 + 1];
+                let mut remainder_reference = vec![0u64; dividend_len64 + 1];
+                div_knuth(&dividend, &divisor, &mut quotient_reference,
+                    &mut remainder_reference);
+                let mut quotient_candidate = vec![0u64; dividend_len64 + 1];
+                let mut remainder_candidate = vec![0u64; dividend_len64 + 1];
+                div_knuth_u128_limb(&dividend, &divisor, &mut quotient_candidate,
+                    &mut remainder_candidate);
+                assert_eq!(quotient_candidate, quotient_reference,
+                    "quot mismatch n64={n64} num={dividend:?} den={divisor:?}");
                 assert_eq!(
-                    r_c[..n64],
-                    r_ref[..n64],
-                    "rem mismatch n64={n64} num={num:?} den={den:?}"
+                    remainder_candidate[..n64],
+                    remainder_reference[..n64],
+                    "rem mismatch n64={n64} num={dividend:?} den={divisor:?}"
                 );
             }
         }
@@ -265,19 +280,23 @@ mod tests {
     // The odd / single-limb fallback returns div_knuth's exact result.
     #[test]
     fn u128_limb_knuth_odd_falls_back() {
-        let num = vec![0x1234u64, 0x5678, 0x9abc, 0xdef0, 0x1111];
-        for den in [
+        let dividend = vec![0x1234u64, 0x5678, 0x9abc, 0xdef0, 0x1111];
+        for divisor in [
             vec![0x3u64],                 // single limb
             vec![0x7u64, 0x9, 0xb],       // odd (3) limbs
         ] {
-            let mut q_ref = vec![0u64; num.len() + 1];
-            let mut r_ref = vec![0u64; num.len() + 1];
-            div_knuth(&num, &den, &mut q_ref, &mut r_ref);
-            let mut q_c = vec![0u64; num.len() + 1];
-            let mut r_c = vec![0u64; num.len() + 1];
-            div_knuth_u128_limb(&num, &den, &mut q_c, &mut r_c);
-            assert_eq!(q_c, q_ref, "fallback quot mismatch den={den:?}");
-            assert_eq!(r_c, r_ref, "fallback rem mismatch den={den:?}");
+            let mut quotient_reference = vec![0u64; dividend.len() + 1];
+            let mut remainder_reference = vec![0u64; dividend.len() + 1];
+            div_knuth(&dividend, &divisor, &mut quotient_reference,
+                &mut remainder_reference);
+            let mut quotient_candidate = vec![0u64; dividend.len() + 1];
+            let mut remainder_candidate = vec![0u64; dividend.len() + 1];
+            div_knuth_u128_limb(&dividend, &divisor, &mut quotient_candidate,
+                &mut remainder_candidate);
+            assert_eq!(quotient_candidate, quotient_reference,
+                "fallback quot mismatch den={divisor:?}");
+            assert_eq!(remainder_candidate, remainder_reference,
+                "fallback rem mismatch den={divisor:?}");
         }
     }
 
@@ -300,45 +319,51 @@ mod tests {
             state ^= state << 17;
             state
         };
-        for &n in &[24usize, 32, 48, 64] {
+        for &storage_width in &[24usize, 32, 48, 64] {
             // Exact-scratch sizes — the `ComputeLimbs` family formulas.
-            let u64buf_len = 2 * n + n.div_ceil(2); // double_buffered_u64
-            let v64buf_len = n + 2; // single_buffered_u64
-            let u128_u_len = (2 * n + n.div_ceil(2)).div_ceil(2); // double_buffered_u128
-            let u128_v_len = n.div_ceil(2); // single_u128
+            let u64buf_len = 2 * storage_width + storage_width.div_ceil(2); // double_buffered_u64
+            let v64buf_len = storage_width + 2; // single_buffered_u64
+            let u128_u_len =
+                (2 * storage_width + storage_width.div_ceil(2)).div_ceil(2); // double_buffered_u128
+            let u128_v_len = storage_width.div_ceil(2); // single_u128
             for _ in 0..200 {
-                let top = 2 * n; // full wide `2N` dividend
-                let mut num = vec![0u64; top];
-                let mut den = vec![0u64; n];
-                for x in num.iter_mut() {
-                    *x = next();
+                let dividend_len = 2 * storage_width; // full wide `2N` dividend
+                let mut dividend = vec![0u64; dividend_len];
+                let mut divisor = vec![0u64; storage_width];
+                for slot in dividend.iter_mut() {
+                    *slot = next();
                 }
-                for x in den.iter_mut() {
-                    *x = next();
+                for slot in divisor.iter_mut() {
+                    *slot = next();
                 }
-                den[n - 1] |= 1 << 63; // full-width even divisor (`den_n == n`)
-                let mut q_ref = vec![0u64; top + 1];
-                let mut r_ref = vec![0u64; top + 1];
-                div_knuth(&num, &den, &mut q_ref, &mut r_ref);
+                // full-width even divisor (`divisor_len == storage_width`)
+                divisor[storage_width - 1] |= 1 << 63;
+                let mut quotient_reference = vec![0u64; dividend_len + 1];
+                let mut remainder_reference = vec![0u64; dividend_len + 1];
+                div_knuth(&dividend, &divisor, &mut quotient_reference,
+                    &mut remainder_reference);
 
-                let mut q_c = vec![0u64; top + 1];
-                let mut r_c = vec![0u64; n];
+                let mut quotient_candidate = vec![0u64; dividend_len + 1];
+                let mut remainder_candidate = vec![0u64; storage_width];
                 let mut u64buf = vec![0u64; u64buf_len];
                 let mut v64buf = vec![0u64; v64buf_len];
                 let mut u128_u = vec![0u128; u128_u_len];
                 let mut u128_v = vec![0u128; u128_v_len];
                 div_knuth_u128_limb_into(
-                    &num,
-                    &den,
-                    &mut q_c,
-                    &mut r_c,
+                    &dividend,
+                    &divisor,
+                    &mut quotient_candidate,
+                    &mut remainder_candidate,
                     &mut u64buf,
                     &mut v64buf,
                     &mut u128_u,
                     &mut u128_v,
                 );
-                assert_eq!(q_c, q_ref, "into quot mismatch n={n}");
-                assert_eq!(r_c[..n], r_ref[..n], "into rem mismatch n={n}");
+                assert_eq!(quotient_candidate, quotient_reference,
+                    "into quot mismatch n={storage_width}");
+                assert_eq!(remainder_candidate[..storage_width],
+                    remainder_reference[..storage_width],
+                    "into rem mismatch n={storage_width}");
             }
         }
     }

--- a/src/int/algos/div/div_mg.rs
+++ b/src/int/algos/div/div_mg.rs
@@ -36,8 +36,8 @@ impl Mg2By1 {
     pub(crate) const fn new(d: u64) -> Self {
         debug_assert!(d >> 63 == 1, "Mg2By1::new: divisor must be normalised");
         // v = floor((B² - 1 - d·B) / d) where B = 2^64.
-        let num = ((!d as u128) << 64) | (u64::MAX as u128);
-        let v = (num / (d as u128)) as u64;
+        let numerator = ((!d as u128) << 64) | (u64::MAX as u128);
+        let v = (numerator / (d as u128)) as u64;
         Self { d, v }
     }
 
@@ -94,8 +94,8 @@ impl Mg3By2 {
             "Mg3By2::new: top divisor limb must be normalised"
         );
         // Step 1: 2-by-1 reciprocal of d1 alone.
-        let num = ((!d1 as u128) << 64) | (u64::MAX as u128);
-        let mut v = (num / (d1 as u128)) as u64;
+        let numerator = ((!d1 as u128) << 64) | (u64::MAX as u128);
+        let mut v = (numerator / (d1 as u128)) as u64;
 
         // Step 2: refine for d0. `p = d1·v + d0` (mod B). If the sum
         // overflows, v was over-estimated → decrement.
@@ -145,16 +145,16 @@ impl Mg3By2 {
         let mut r1 = n1.wrapping_sub(q.wrapping_mul(self.d1));
 
         // Step 2b: (r1, r0) = (r1, n0) - (d1, d0).
-        let r256 = (((r1 as u128) << 64) | (n0 as u128))
+        let remainder_pair = (((r1 as u128) << 64) | (n0 as u128))
             .wrapping_sub(((self.d1 as u128) << 64) | (self.d0 as u128));
-        r1 = (r256 >> 64) as u64;
-        let mut r0 = r256 as u64;
+        r1 = (remainder_pair >> 64) as u64;
+        let mut r0 = remainder_pair as u64;
 
         // Step 2c: (r1, r0) -= d0·q (mod B²).
         let t = (self.d0 as u128).wrapping_mul(q as u128);
-        let r256 = (((r1 as u128) << 64) | (r0 as u128)).wrapping_sub(t);
-        r1 = (r256 >> 64) as u64;
-        r0 = r256 as u64;
+        let remainder_pair = (((r1 as u128) << 64) | (r0 as u128)).wrapping_sub(t);
+        r1 = (remainder_pair >> 64) as u64;
+        r0 = remainder_pair as u64;
 
         // Step 3: q += 1; provisional.
         q = q.wrapping_add(1);
@@ -162,18 +162,18 @@ impl Mg3By2 {
         // Step 4a: first conditional correction.
         let mask = if r1 >= q_lo { u64::MAX } else { 0 };
         q = q.wrapping_add(mask); // adds u64::MAX = -1.
-        let add = ((mask & self.d1) as u128) << 64 | ((mask & self.d0) as u128);
-        let r256 = (((r1 as u128) << 64) | (r0 as u128)).wrapping_add(add);
-        r1 = (r256 >> 64) as u64;
-        r0 = r256 as u64;
+        let correction = ((mask & self.d1) as u128) << 64 | ((mask & self.d0) as u128);
+        let remainder_pair = (((r1 as u128) << 64) | (r0 as u128)).wrapping_add(correction);
+        r1 = (remainder_pair >> 64) as u64;
+        r0 = remainder_pair as u64;
 
         // Step 4b: final correction (rare).
         if r1 > self.d1 || (r1 == self.d1 && r0 >= self.d0) {
             q = q.wrapping_add(1);
-            let r256 = (((r1 as u128) << 64) | (r0 as u128))
+            let remainder_pair = (((r1 as u128) << 64) | (r0 as u128))
                 .wrapping_sub(((self.d1 as u128) << 64) | (self.d0 as u128));
-            r1 = (r256 >> 64) as u64;
-            r0 = r256 as u64;
+            r1 = (remainder_pair >> 64) as u64;
+            r0 = remainder_pair as u64;
         }
 
         (q, r1, r0)
@@ -226,13 +226,14 @@ pub(crate) trait DivLimb: Limb {
     /// whether it borrowed (q̂ was 1 too big ⇒ the D6 add-back fires).
     fn mul_sub_final(u_top: Self, carry: Self::Acc) -> (Self, bool);
     /// Serialise one quotient digit (the `L` value at quotient position `j`)
-    /// into the little-endian u64 output `quot` — the output is always u64
+    /// into the little-endian u64 output `quotient` — the output is always u64
     /// (the engine's external contract), so the digit is written at its u64
-    /// limb offset: `quot[j]` for `u64`, `quot[2j] | quot[2j+1] << 64` for
-    /// `u128`. Bounds-guarded (a digit beyond `quot.len()` is dropped, matching
-    /// both engines' prior `if … < quot.len()` writes), so the generic core
-    /// needs no separate `L`-typed quotient buffer.
-    fn store_quot_digit(quot: &mut [u64], j: usize, digit: Self);
+    /// limb offset: `quotient[j]` for `u64`,
+    /// `quotient[2j] | quotient[2j+1] << 64` for `u128`. Bounds-guarded (a
+    /// digit beyond `quotient.len()` is dropped, matching both engines' prior
+    /// `if … < quotient.len()` writes), so the generic core needs no separate
+    /// `L`-typed quotient buffer.
+    fn store_quot_digit(quotient: &mut [u64], j: usize, digit: Self);
 }
 
 impl DivLimb for u64 {
@@ -257,19 +258,19 @@ impl DivLimb for u64 {
         // generic loop body so the monomorphisation matches the hand-inlined
         // base-2⁶⁴ loop with no call/abstraction overhead.
         let acc = carry + (q_hat as u128) * (v_i as u128);
-        let (res, b) = u_ji.overflowing_sub(acc as u64);
-        (res, (acc >> 64) + (b as u128))
+        let (reduced_limb, borrowed) = u_ji.overflowing_sub(acc as u64);
+        (reduced_limb, (acc >> 64) + (borrowed as u128))
     }
     #[inline(always)]
     fn mul_sub_final(u_top: Self, carry: u128) -> (Self, bool) {
-        let (s, b1) = u_top.overflowing_sub(carry as u64);
+        let (reduced_limb, borrowed) = u_top.overflowing_sub(carry as u64);
         // The borrow is the subtraction borrow OR a non-zero high carry word.
-        (s, b1 || (carry >> 64) != 0)
+        (reduced_limb, borrowed || (carry >> 64) != 0)
     }
     #[inline]
-    fn store_quot_digit(quot: &mut [u64], j: usize, digit: Self) {
-        if j < quot.len() {
-            quot[j] = digit;
+    fn store_quot_digit(quotient: &mut [u64], j: usize, digit: Self) {
+        if j < quotient.len() {
+            quotient[j] = digit;
         }
     }
 }
@@ -308,22 +309,22 @@ impl DivLimb for u128 {
         // (which fits one u128 by the same bound as the u64 double-width form).
         // `inline(always)`: the O(m·n) hot step — see the u64 sibling.
         let (p_lo, p_hi) = <u128 as Limb>::widening_mul(q_hat, v_i);
-        let (sub_lo, c0) = p_lo.overflowing_add(carry);
-        let (res, b) = u_ji.overflowing_sub(sub_lo);
-        (res, p_hi + (c0 as u128) + (b as u128))
+        let (sub_lo, carried) = p_lo.overflowing_add(carry);
+        let (reduced_limb, borrowed) = u_ji.overflowing_sub(sub_lo);
+        (reduced_limb, p_hi + (carried as u128) + (borrowed as u128))
     }
     #[inline(always)]
     fn mul_sub_final(u_top: Self, carry: u128) -> (Self, bool) {
         u_top.overflowing_sub(carry)
     }
     #[inline]
-    fn store_quot_digit(quot: &mut [u64], j: usize, digit: Self) {
+    fn store_quot_digit(quotient: &mut [u64], j: usize, digit: Self) {
         // The u128 digit is two little-endian u64 limbs at offset 2j / 2j+1.
-        if 2 * j < quot.len() {
-            quot[2 * j] = digit as u64;
+        if 2 * j < quotient.len() {
+            quotient[2 * j] = digit as u64;
         }
-        if 2 * j + 1 < quot.len() {
-            quot[2 * j + 1] = (digit >> 64) as u64;
+        if 2 * j + 1 < quotient.len() {
+            quotient[2 * j + 1] = (digit >> 64) as u64;
         }
     }
 }

--- a/src/int/algos/div/div_native_direct.rs
+++ b/src/int/algos/div/div_native_direct.rs
@@ -50,19 +50,20 @@ use crate::int::types::Int;
 /// primitives do), so it is bit-identical to the shipped magnitude path.
 #[inline]
 #[allow(dead_code)]
-pub(crate) fn div_rem_native_direct<const N: usize>(a: Int<N>, b: Int<N>) -> (Int<N>, Int<N>) {
-    assert!(!b.is_zero(), "attempt to divide by zero");
-    let ai = a.to_i128();
-    let bi = b.to_i128();
+pub(crate) fn div_rem_native_direct<const N: usize>(dividend: Int<N>, divisor: Int<N>)
+    -> (Int<N>, Int<N>) {
+    assert!(!divisor.is_zero(), "attempt to divide by zero");
+    let dividend_i128 = dividend.to_i128();
+    let divisor_i128 = divisor.to_i128();
     // i128::MIN / -1 (and the matching `%`) is the sole overflow trap of
     // signed `/`/`%`; the magnitude path can't hit it (unsigned operands).
     // wrapping semantics: quotient wraps to MIN, remainder is 0.
-    let (q, r) = if bi == -1 {
-        (ai.wrapping_neg(), 0)
+    let (quotient, remainder) = if divisor_i128 == -1 {
+        (dividend_i128.wrapping_neg(), 0)
     } else {
-        (ai / bi, ai % bi)
+        (dividend_i128 / divisor_i128, dividend_i128 % divisor_i128)
     };
-    (Int::<N>::from_i128(q), Int::<N>::from_i128(r))
+    (Int::<N>::from_i128(quotient), Int::<N>::from_i128(remainder))
 }
 
 #[cfg(test)]
@@ -87,13 +88,13 @@ mod tests {
             (i64::MIN, -1),
             (i64::MIN, 1),
         ];
-        for &(a, b) in cases {
-            let ia = Int::<1>::from_i64(a);
-            let ib = Int::<1>::from_i64(b);
+        for &(dividend, divisor) in cases {
+            let dividend_int = Int::<1>::from_i64(dividend);
+            let divisor_int = Int::<1>::from_i64(divisor);
             assert_eq!(
-                div_rem_native_direct::<1>(ia, ib),
-                ia.div_rem(ib),
-                "n1 ({a} / {b})"
+                div_rem_native_direct::<1>(dividend_int, divisor_int),
+                dividend_int.div_rem(divisor_int),
+                "n1 ({dividend} / {divisor})"
             );
         }
     }
@@ -111,13 +112,13 @@ mod tests {
             (i128::MIN, -1),
             (i128::MIN, 1),
         ];
-        for &(a, b) in cases {
-            let ia = Int::<2>::from_i128(a);
-            let ib = Int::<2>::from_i128(b);
+        for &(dividend, divisor) in cases {
+            let dividend_int = Int::<2>::from_i128(dividend);
+            let divisor_int = Int::<2>::from_i128(divisor);
             assert_eq!(
-                div_rem_native_direct::<2>(ia, ib),
-                ia.div_rem(ib),
-                "n2 ({a} / {b})"
+                div_rem_native_direct::<2>(dividend_int, divisor_int),
+                dividend_int.div_rem(divisor_int),
+                "n2 ({dividend} / {divisor})"
             );
         }
     }

--- a/src/int/algos/div/div_rem.rs
+++ b/src/int/algos/div/div_rem.rs
@@ -12,7 +12,8 @@
 use crate::int::algos::div::div_mg::Mg2By1;
 use crate::int::algos::support::limbs::{bit_len, cmp, fit_one, shl1, sub_assign};
 
-/// `quot = num / den`, `rem = num % den`, u64 limbs. `const fn`.
+/// `quotient = dividend / divisor`, `remainder = dividend % divisor`, u64
+/// limbs. `const fn`.
 ///
 /// Hardware fast paths:
 /// - both fit a single u64 → one native `u64 / u64`
@@ -21,27 +22,28 @@ use crate::int::algos::support::limbs::{bit_len, cmp, fit_one, shl1, sub_assign}
 ///   mul/shift/correct per limb — see [`single_limb_div_rem`])
 /// - otherwise → bit shift-subtract (only reached when divisor is
 ///   multi-limb; the dispatcher routes those to Knuth instead)
-pub(crate) const fn div_rem(num: &[u64], den: &[u64], quot: &mut [u64], rem: &mut [u64]) {
+pub(crate) const fn div_rem(dividend: &[u64], divisor: &[u64], quotient: &mut [u64],
+    remainder: &mut [u64]) {
     let mut z = 0;
-    while z < quot.len() {
-        quot[z] = 0;
+    while z < quotient.len() {
+        quotient[z] = 0;
         z += 1;
     }
     z = 0;
-    while z < rem.len() {
-        rem[z] = 0;
+    while z < remainder.len() {
+        remainder[z] = 0;
         z += 1;
     }
 
-    let den_one_limb = fit_one(den);
+    let divisor_fits_one_limb = fit_one(divisor);
 
     // Fast path A: both fit a single u64 → hardware divide.
-    if den_one_limb && fit_one(num) {
-        if !quot.is_empty() {
-            quot[0] = num[0] / den[0];
+    if divisor_fits_one_limb && fit_one(dividend) {
+        if !quotient.is_empty() {
+            quotient[0] = dividend[0] / divisor[0];
         }
-        if !rem.is_empty() {
-            rem[0] = num[0] % den[0];
+        if !remainder.is_empty() {
+            remainder[0] = dividend[0] % divisor[0];
         }
         return;
     }
@@ -50,93 +52,104 @@ pub(crate) const fn div_rem(num: &[u64], den: &[u64], quot: &mut [u64], rem: &mu
     // divide. Each step is a normalised 2-by-1 reciprocal divide (one
     // precompute, then mul/shift/correct per limb) rather than a software
     // `u128 ÷ u64` (`__udivti3`); see [`single_limb_div_rem`].
-    if den_one_limb {
-        single_limb_div_rem(num, den[0], quot, rem);
+    if divisor_fits_one_limb {
+        single_limb_div_rem(dividend, divisor[0], quotient, remainder);
         return;
     }
 
     // General path: binary shift-subtract. Only reached for multi-limb
     // divisors when the dispatcher isn't routing to Knuth (i.e. in const
     // contexts where Knuth isn't available).
-    let bits = bit_len(num);
-    let mut i = bits;
+    let dividend_bits = bit_len(dividend);
+    let mut i = dividend_bits;
     while i > 0 {
         i -= 1;
-        shl1(rem);
-        let bit = (num[(i / 64) as usize] >> (i % 64)) & 1;
-        rem[0] |= bit;
-        shl1(quot);
-        if cmp(rem, den) >= 0 {
-            sub_assign(rem, den);
-            quot[0] |= 1;
+        shl1(remainder);
+        let bit = (dividend[(i / 64) as usize] >> (i % 64)) & 1;
+        remainder[0] |= bit;
+        shl1(quotient);
+        if cmp(remainder, divisor) >= 0 {
+            sub_assign(remainder, divisor);
+            quotient[0] |= 1;
         }
     }
 }
 
-/// `quot = num / d`, `rem = num % d` for a single non-zero u64 divisor `d`,
-/// little-endian u64 limbs. Computes one quotient limb per dividend limb
-/// (high → low) via the Möller–Granlund 2-by-1 invariant-divisor reciprocal
-/// ([`Mg2By1`]) instead of a per-limb software `u128 ÷ u64`.
+/// `quotient = dividend / divisor`, `remainder = dividend % divisor` for a
+/// single non-zero u64 `divisor`, little-endian u64 limbs. Computes one
+/// quotient limb per dividend limb (high → low) via the Möller–Granlund
+/// 2-by-1 invariant-divisor reciprocal ([`Mg2By1`]) instead of a per-limb
+/// software `u128 ÷ u64`.
 ///
-/// On x86_64 the obvious `acc / (d as u128)` (`acc < d·2^64`, quotient fits
-/// a u64) does NOT lower to one hardware `DIV r/m64`; LLVM/compiler-builtins
-/// emit a full 128÷128 software routine (`__udivti3`). `const fn` rules out
-/// inline `asm!` to reach the hardware instruction, so this keeps the divide
-/// const-evaluable by replacing the per-limb division with a reciprocal
-/// **multiplication**: precompute `d`'s reciprocal once (amortised over every
-/// dividend limb), then each limb is a 64×64→128 multiply, a shift and a small
-/// correction — no software `__udivti3`.
+/// On x86_64 the obvious `acc / (divisor as u128)` (`acc < divisor·2^64`,
+/// quotient fits a u64) does NOT lower to one hardware `DIV r/m64`;
+/// LLVM/compiler-builtins emit a full 128÷128 software routine (`__udivti3`).
+/// `const fn` rules out inline `asm!` to reach the hardware instruction, so
+/// this keeps the divide const-evaluable by replacing the per-limb division
+/// with a reciprocal **multiplication**: precompute `divisor`'s reciprocal
+/// once (amortised over every dividend limb), then each limb is a 64×64→128
+/// multiply, a shift and a small correction — no software `__udivti3`.
 ///
 /// `Mg2By1` requires a *normalised* divisor (top bit set) and a high word
-/// strictly below it. So `d` is normalised by `s = d.leading_zeros()` into
-/// `dn = d << s`; the dividend is streamed in the matching left-shifted
-/// domain (each window word `(num[i] << s) | (num[i-1] >> (64-s))`), the
-/// running remainder `r` stays `< dn` (the `Mg2By1` precondition), and the
-/// true remainder is recovered as `r >> s`. The quotient is unchanged by the
-/// common left shift of dividend and divisor.
+/// strictly below it. So `divisor` is normalised by
+/// `shift = divisor.leading_zeros()` into
+/// `divisor_normalised = divisor << shift`; the dividend is streamed in the
+/// matching left-shifted domain (each window word
+/// `(dividend[i] << shift) | (dividend[i-1] >> (64-shift))`), the
+/// `running_remainder` stays `< divisor_normalised` (the `Mg2By1`
+/// precondition), and the true remainder is recovered as
+/// `running_remainder >> shift`. The quotient is unchanged by the common left
+/// shift of dividend and divisor.
 ///
-/// Bit-identical to the prior `u128`-division loop for every `(num, d)`.
-const fn single_limb_div_rem(num: &[u64], d: u64, quot: &mut [u64], rem: &mut [u64]) {
+/// Bit-identical to the prior `u128`-division loop for every
+/// `(dividend, divisor)`.
+const fn single_limb_div_rem(dividend: &[u64], divisor: u64, quotient: &mut [u64],
+    remainder: &mut [u64]) {
     // Live dividend extent (skip leading zero limbs).
-    let mut top = num.len();
-    while top > 0 && num[top - 1] == 0 {
-        top -= 1;
+    let mut dividend_len = dividend.len();
+    while dividend_len > 0 && dividend[dividend_len - 1] == 0 {
+        dividend_len -= 1;
     }
 
     // Empty / zero dividend: quotient and remainder are already zeroed.
-    if top == 0 {
+    if dividend_len == 0 {
         return;
     }
 
-    let s = d.leading_zeros();
-    let dn = d << s;
-    let recip = Mg2By1::new(dn);
+    let shift = divisor.leading_zeros();
+    let divisor_normalised = divisor << shift;
+    let recip = Mg2By1::new(divisor_normalised);
 
-    // `r` is the running remainder in the normalised (left-shifted by `s`)
-    // domain; it stays `< dn`, satisfying the `Mg2By1::div_rem` high-word
-    // precondition. Seed it with the bits the top limb shifts out (0 when
-    // `s == 0`, since `x >> 64` is undefined and there is no overflow word).
-    let mut r: u64 = if s == 0 { 0 } else { num[top - 1] >> (64 - s) };
+    // `running_remainder` is the running remainder in the normalised
+    // (left-shifted by `shift`) domain; it stays `< divisor_normalised`,
+    // satisfying the `Mg2By1::div_rem` high-word precondition. Seed it with the
+    // bits the top limb shifts out (0 when `shift == 0`, since `x >> 64` is
+    // undefined and there is no overflow word).
+    let mut running_remainder: u64 = if shift == 0 {
+        0
+    } else {
+        dividend[dividend_len - 1] >> (64 - shift)
+    };
 
-    let mut i = top;
+    let mut i = dividend_len;
     while i > 0 {
         i -= 1;
         // The dividend limb at position `i` in the left-shifted domain.
-        let w = if s == 0 {
-            num[i]
+        let window_word = if shift == 0 {
+            dividend[i]
         } else {
-            let lo_from_below = if i > 0 { num[i - 1] >> (64 - s) } else { 0 };
-            (num[i] << s) | lo_from_below
+            let lo_from_below = if i > 0 { dividend[i - 1] >> (64 - shift) } else { 0 };
+            (dividend[i] << shift) | lo_from_below
         };
-        let (q, r_next) = recip.div_rem(r, w);
-        r = r_next;
-        if i < quot.len() {
-            quot[i] = q;
+        let (quotient_limb, next_remainder) = recip.div_rem(running_remainder, window_word);
+        running_remainder = next_remainder;
+        if i < quotient.len() {
+            quotient[i] = quotient_limb;
         }
     }
 
     // De-normalise the remainder back out of the shifted domain.
-    if !rem.is_empty() {
-        rem[0] = r >> s;
+    if !remainder.is_empty() {
+        remainder[0] = running_remainder >> shift;
     }
 }

--- a/src/int/algos/div/div_rem_schoolbook.rs
+++ b/src/int/algos/div/div_rem_schoolbook.rs
@@ -6,8 +6,8 @@
 //! [`div_rem_schoolbook`] is the generic naive reference algorithm for
 //! unsigned big-integer division, operating over little-endian `u64` limb
 //! slices. It uses the classical bit-by-bit shift-subtract method: the
-//! invariant is that the running remainder in `rem` is always less than the
-//! divisor after each subtraction step.
+//! invariant is that the running remainder in `remainder` is always less than
+//! the divisor after each subtraction step.
 //!
 //! The algorithm: for each bit of the dividend from most-significant to
 //! least-significant, shift the running remainder left by one, bring in the
@@ -24,33 +24,35 @@ use crate::int::algos::support::limbs::{bit_len, cmp, shl1, sub_assign};
 
 /// Binary shift-subtract long division — schoolbook reference.
 ///
-/// Computes `quot = num / den` and `rem = num % den` (unsigned, truncating)
-/// over little-endian `u64` limb slices. Both `quot` and `rem` are
-/// zeroed before use; their lengths must each be at least as long as `num`.
+/// Computes `quotient = dividend / divisor` and
+/// `remainder = dividend % divisor` (unsigned, truncating) over little-endian
+/// `u64` limb slices. Both `quotient` and `remainder` are zeroed before use;
+/// their lengths must each be at least as long as `dividend`.
 ///
-/// The divisor must be non-zero; if `den` is zero the outputs are left as
+/// The divisor must be non-zero; if `divisor` is zero the outputs are left as
 /// zero (the shift-subtract loop produces no subtractions and no quotient
 /// bits, which is consistent with this).
 #[allow(dead_code)]
-pub(crate) fn div_rem_schoolbook(num: &[u64], den: &[u64], quot: &mut [u64], rem: &mut [u64]) {
-    for slot in quot.iter_mut() {
+pub(crate) fn div_rem_schoolbook(dividend: &[u64], divisor: &[u64], quotient: &mut [u64],
+    remainder: &mut [u64]) {
+    for slot in quotient.iter_mut() {
         *slot = 0;
     }
-    for slot in rem.iter_mut() {
+    for slot in remainder.iter_mut() {
         *slot = 0;
     }
 
-    let bits = bit_len(num);
-    let mut i = bits;
+    let dividend_bits = bit_len(dividend);
+    let mut i = dividend_bits;
     while i > 0 {
         i -= 1;
-        shl1(rem);
-        let bit = (num[(i / 64) as usize] >> (i % 64)) & 1;
-        rem[0] |= bit;
-        shl1(quot);
-        if cmp(rem, den) >= 0 {
-            sub_assign(rem, den);
-            quot[0] |= 1;
+        shl1(remainder);
+        let bit = (dividend[(i / 64) as usize] >> (i % 64)) & 1;
+        remainder[0] |= bit;
+        shl1(quotient);
+        if cmp(remainder, divisor) >= 0 {
+            sub_assign(remainder, divisor);
+            quotient[0] |= 1;
         }
     }
 }
@@ -63,23 +65,23 @@ mod tests {
     /// arithmetic (external oracle).
     #[test]
     fn schoolbook_single_limb_oracle() {
-        let vals: &[u64] = &[
+        let values: &[u64] = &[
             0, 1, 2, 3, 7, 10, 13, 100, 1_000_000,
             u64::MAX, u64::MAX - 1, 1u64 << 63,
             0xDEAD_BEEF_CAFE_F00D, 0x0102_0304_0506_0708,
         ];
-        for &num in vals {
-            for &den in vals {
-                if den == 0 {
+        for &dividend in values {
+            for &divisor in values {
+                if divisor == 0 {
                     continue;
                 }
-                let mut q = [0u64; 1];
-                let mut r = [0u64; 1];
-                div_rem_schoolbook(&[num], &[den], &mut q, &mut r);
-                assert_eq!(q[0], num / den,
-                    "schoolbook quot mismatch: {num} / {den}");
-                assert_eq!(r[0], num % den,
-                    "schoolbook rem mismatch: {num} % {den}");
+                let mut quotient = [0u64; 1];
+                let mut remainder = [0u64; 1];
+                div_rem_schoolbook(&[dividend], &[divisor], &mut quotient, &mut remainder);
+                assert_eq!(quotient[0], dividend / divisor,
+                    "schoolbook quot mismatch: {dividend} / {divisor}");
+                assert_eq!(remainder[0], dividend % divisor,
+                    "schoolbook rem mismatch: {dividend} % {divisor}");
             }
         }
     }
@@ -88,29 +90,30 @@ mod tests {
     /// oracle).
     #[test]
     fn schoolbook_double_limb_oracle() {
-        let wide: &[u128] = &[
+        let values: &[u128] = &[
             0, 1, u128::MAX, u128::MAX - 1,
             1u128 << 64, (1u128 << 64) - 1,
             0x0123_4567_89ab_cdef_fedc_ba98_7654_3210_u128,
             0xDEAD_BEEF_DEAD_BEEF_CAFE_F00D_CAFE_F00D_u128,
         ];
-        let to_limbs = |v: u128| [v as u64, (v >> 64) as u64];
-        for &num in wide {
-            for &den in wide {
-                if den == 0 {
+        let to_limbs = |value: u128| [value as u64, (value >> 64) as u64];
+        for &dividend in values {
+            for &divisor in values {
+                if divisor == 0 {
                     continue;
                 }
-                let n = to_limbs(num);
-                let d = to_limbs(den);
-                let mut q = [0u64; 2];
-                let mut r = [0u64; 2];
-                div_rem_schoolbook(&n, &d, &mut q, &mut r);
-                let want_q = to_limbs(num / den);
-                let want_r = to_limbs(num % den);
-                assert_eq!(q, want_q,
-                    "schoolbook quot mismatch: {num:#x} / {den:#x}");
-                assert_eq!(r, want_r,
-                    "schoolbook rem mismatch: {num:#x} % {den:#x}");
+                let dividend_limbs = to_limbs(dividend);
+                let divisor_limbs = to_limbs(divisor);
+                let mut quotient = [0u64; 2];
+                let mut remainder = [0u64; 2];
+                div_rem_schoolbook(&dividend_limbs, &divisor_limbs, &mut quotient,
+                    &mut remainder);
+                let expected_quotient = to_limbs(dividend / divisor);
+                let expected_remainder = to_limbs(dividend % divisor);
+                assert_eq!(quotient, expected_quotient,
+                    "schoolbook quot mismatch: {dividend:#x} / {divisor:#x}");
+                assert_eq!(remainder, expected_remainder,
+                    "schoolbook rem mismatch: {dividend:#x} % {divisor:#x}");
             }
         }
     }
@@ -131,22 +134,24 @@ mod tests {
             (&[100, 0, 0], &[200, 0, 1]),
             (&[0, 0, u64::MAX, u64::MAX], &[1, 2, u64::MAX]),
         ];
-        for (num, den) in cases {
-            if is_zero(den) {
+        for (dividend, divisor) in cases {
+            if is_zero(divisor) {
                 continue;
             }
-            let mut q_ref = [0u64; 8];
-            let mut r_ref = [0u64; 8];
-            div_rem_dispatch(num, den, &mut q_ref, &mut r_ref);
+            let mut quotient_dispatch = [0u64; 8];
+            let mut remainder_dispatch = [0u64; 8];
+            div_rem_dispatch(dividend, divisor, &mut quotient_dispatch,
+                &mut remainder_dispatch);
 
-            let mut q_sb = [0u64; 8];
-            let mut r_sb = [0u64; 8];
-            div_rem_schoolbook(num, den, &mut q_sb, &mut r_sb);
+            let mut quotient_schoolbook = [0u64; 8];
+            let mut remainder_schoolbook = [0u64; 8];
+            div_rem_schoolbook(dividend, divisor, &mut quotient_schoolbook,
+                &mut remainder_schoolbook);
 
-            assert_eq!(q_sb, q_ref,
-                "schoolbook quot differs from dispatch on {:?} / {:?}", num, den);
-            assert_eq!(r_sb, r_ref,
-                "schoolbook rem differs from dispatch on {:?} / {:?}", num, den);
+            assert_eq!(quotient_schoolbook, quotient_dispatch,
+                "schoolbook quot differs from dispatch on {:?} / {:?}", dividend, divisor);
+            assert_eq!(remainder_schoolbook, remainder_dispatch,
+                "schoolbook rem differs from dispatch on {:?} / {:?}", dividend, divisor);
         }
     }
 }

--- a/src/int/algos/div/mod.rs
+++ b/src/int/algos/div/mod.rs
@@ -62,9 +62,9 @@ mod tests {
     /// Pack a `[u128; N]` little-endian limb array into `[u64; 2*N]`.
     fn pack(limbs: &[u128]) -> Vec<u64> {
         let mut out = vec![0u64; 2 * limbs.len()];
-        for (i, &l) in limbs.iter().enumerate() {
-            out[2 * i] = l as u64;
-            out[2 * i + 1] = (l >> 64) as u64;
+        for (i, &limb) in limbs.iter().enumerate() {
+            out[2 * i] = limb as u64;
+            out[2 * i + 1] = (limb >> 64) as u64;
         }
         out
     }
@@ -92,23 +92,27 @@ mod tests {
     fn div_rem_satisfies_identity() {
         use crate::int::algos::support::limbs::{add_assign, cmp, is_zero};
         use crate::int::algos::mul::mul_schoolbook::mul_schoolbook;
-        for num in corpus() {
-            for den in corpus() {
-                let n64 = pack(&num);
-                let d64 = pack(&den);
-                if is_zero(&d64) {
+        for dividend in corpus() {
+            for divisor in corpus() {
+                let dividend_limbs = pack(&dividend);
+                let divisor_limbs = pack(&divisor);
+                if is_zero(&divisor_limbs) {
                     continue;
                 }
-                let mut q64 = vec![0u64; n64.len()];
-                let mut r64 = vec![0u64; n64.len()];
-                div_rem(&n64, &d64, &mut q64, &mut r64);
+                let mut quotient_limbs = vec![0u64; dividend_limbs.len()];
+                let mut remainder_limbs = vec![0u64; dividend_limbs.len()];
+                div_rem(&dividend_limbs, &divisor_limbs, &mut quotient_limbs,
+                    &mut remainder_limbs);
 
-                let mut recon = vec![0u64; q64.len() + d64.len() + 1];
-                mul_schoolbook(&q64, &d64, &mut recon);
-                let _ = add_assign(&mut recon, &r64);
-                assert_eq!(&recon[..n64.len()], &n64[..], "q·den + r != num");
-                assert!(recon[n64.len()..].iter().all(|&x| x == 0), "recon overflow");
-                assert!(cmp(&r64, &d64) < 0, "remainder >= divisor");
+                let mut reconstructed =
+                    vec![0u64; quotient_limbs.len() + divisor_limbs.len() + 1];
+                mul_schoolbook(&quotient_limbs, &divisor_limbs, &mut reconstructed);
+                let _ = add_assign(&mut reconstructed, &remainder_limbs);
+                assert_eq!(&reconstructed[..dividend_limbs.len()], &dividend_limbs[..],
+                    "q·den + r != num");
+                assert!(reconstructed[dividend_limbs.len()..].iter().all(|&limb| limb == 0),
+                    "recon overflow");
+                assert!(cmp(&remainder_limbs, &divisor_limbs) < 0, "remainder >= divisor");
             }
         }
     }
@@ -116,27 +120,29 @@ mod tests {
     /// `div_knuth` agrees with the dispatch path on the corpus.
     #[test]
     fn knuth_matches_dispatch() {
-        for num in corpus() {
-            for den in corpus() {
-                let n64 = pack(&num);
-                let d64 = pack(&den);
-                let mut dn = d64.len();
-                while dn > 0 && d64[dn - 1] == 0 {
-                    dn -= 1;
+        for dividend in corpus() {
+            for divisor in corpus() {
+                let dividend_limbs = pack(&dividend);
+                let divisor_limbs = pack(&divisor);
+                let mut divisor_len = divisor_limbs.len();
+                while divisor_len > 0 && divisor_limbs[divisor_len - 1] == 0 {
+                    divisor_len -= 1;
                 }
-                if dn < 2 {
+                if divisor_len < 2 {
                     continue;
                 }
-                let mut q_ref = vec![0u64; n64.len()];
-                let mut r_ref = vec![0u64; n64.len()];
-                div_rem_dispatch(&n64, &d64, &mut q_ref, &mut r_ref);
+                let mut quotient_reference = vec![0u64; dividend_limbs.len()];
+                let mut remainder_reference = vec![0u64; dividend_limbs.len()];
+                div_rem_dispatch(&dividend_limbs, &divisor_limbs,
+                    &mut quotient_reference, &mut remainder_reference);
 
-                let mut q_knuth = vec![0u64; n64.len()];
-                let mut r_knuth = vec![0u64; n64.len()];
-                div_knuth(&n64, &d64, &mut q_knuth, &mut r_knuth);
+                let mut quotient_knuth = vec![0u64; dividend_limbs.len()];
+                let mut remainder_knuth = vec![0u64; dividend_limbs.len()];
+                div_knuth(&dividend_limbs, &divisor_limbs, &mut quotient_knuth,
+                    &mut remainder_knuth);
 
-                assert_eq!(q_knuth, q_ref, "knuth q mismatch");
-                assert_eq!(r_knuth, r_ref, "knuth r mismatch");
+                assert_eq!(quotient_knuth, quotient_reference, "knuth q mismatch");
+                assert_eq!(remainder_knuth, remainder_reference, "knuth r mismatch");
             }
         }
     }
@@ -168,17 +174,18 @@ mod tests {
             let mg = Mg3By2::new(d1, d0);
             let (q, r1, r0) = mg.div_rem(n2, n1, n0);
 
-            let num = vec![n0, n1, n2];
-            let den = vec![d0, d1];
-            let mut q_ref = vec![0u64; 3];
-            let mut r_ref = vec![0u64; 3];
-            div_rem(&num, &den, &mut q_ref, &mut r_ref);
+            let dividend = vec![n0, n1, n2];
+            let divisor = vec![d0, d1];
+            let mut quotient_reference = vec![0u64; 3];
+            let mut remainder_reference = vec![0u64; 3];
+            div_rem(&dividend, &divisor, &mut quotient_reference,
+                &mut remainder_reference);
 
-            assert_eq!(q_ref[0], q, "Mg3By2 q mismatch");
-            assert_eq!(q_ref[1], 0, "Mg3By2 q higher limb non-zero");
-            assert_eq!(q_ref[2], 0, "Mg3By2 q higher limb non-zero");
-            assert_eq!(r_ref[0], r0, "Mg3By2 r0 mismatch");
-            assert_eq!(r_ref[1], r1, "Mg3By2 r1 mismatch");
+            assert_eq!(quotient_reference[0], q, "Mg3By2 q mismatch");
+            assert_eq!(quotient_reference[1], 0, "Mg3By2 q higher limb non-zero");
+            assert_eq!(quotient_reference[2], 0, "Mg3By2 q higher limb non-zero");
+            assert_eq!(remainder_reference[0], r0, "Mg3By2 r0 mismatch");
+            assert_eq!(remainder_reference[1], r1, "Mg3By2 r1 mismatch");
         }
     }
 
@@ -199,10 +206,10 @@ mod tests {
             assert!(u1 < d);
             let mg = Mg2By1::new(d);
             let (q, r) = mg.div_rem(u1, u0);
-            let num = ((u1 as u128) << 64) | (u0 as u128);
-            let exp_q = (num / (d as u128)) as u64;
-            let exp_r = (num % (d as u128)) as u64;
-            assert_eq!((q, r), (exp_q, exp_r), "Mg2By1 mismatch");
+            let dividend = ((u1 as u128) << 64) | (u0 as u128);
+            let expected_quotient = (dividend / (d as u128)) as u64;
+            let expected_remainder = (dividend % (d as u128)) as u64;
+            assert_eq!((q, r), (expected_quotient, expected_remainder), "Mg2By1 mismatch");
         }
     }
 
@@ -218,15 +225,18 @@ mod tests {
             (&[100, 0, 0], &[200, 0, 1]),
             (&[0, 0, u64::MAX, u64::MAX], &[1, 2, u64::MAX]),
         ];
-        for (num, den) in cases {
-            let mut q_canon = [0u64; 8];
-            let mut r_canon = [0u64; 8];
-            div_rem_dispatch(num, den, &mut q_canon, &mut r_canon);
-            let mut q_knuth = [0u64; 8];
-            let mut r_knuth = [0u64; 8];
-            div_knuth(num, den, &mut q_knuth, &mut r_knuth);
-            assert_eq!(q_canon, q_knuth, "quotient mismatch on {:?} / {:?}", num, den);
-            assert_eq!(r_canon, r_knuth, "remainder mismatch on {:?} / {:?}", num, den);
+        for (dividend, divisor) in cases {
+            let mut quotient_canonical = [0u64; 8];
+            let mut remainder_canonical = [0u64; 8];
+            div_rem_dispatch(dividend, divisor, &mut quotient_canonical,
+                &mut remainder_canonical);
+            let mut quotient_knuth = [0u64; 8];
+            let mut remainder_knuth = [0u64; 8];
+            div_knuth(dividend, divisor, &mut quotient_knuth, &mut remainder_knuth);
+            assert_eq!(quotient_canonical, quotient_knuth,
+                "quotient mismatch on {:?} / {:?}", dividend, divisor);
+            assert_eq!(remainder_canonical, remainder_knuth,
+                "remainder mismatch on {:?} / {:?}", dividend, divisor);
         }
     }
 
@@ -237,49 +247,53 @@ mod tests {
     #[cfg(any(feature = "x-wide", feature = "xx-wide"))]
     #[test]
     fn bz_matches_knuth() {
-        let mut num = [0u64; 40];
-        for (i, slot) in num.iter_mut().enumerate() {
+        let mut dividend = [0u64; 40];
+        for (i, slot) in dividend.iter_mut().enumerate() {
             *slot = (i as u64)
                 .wrapping_mul(0x9E37_79B9_7F4A_7C15)
                 .wrapping_add(i as u64);
         }
-        let mut den = [0u64; 20];
-        for (i, slot) in den.iter_mut().enumerate() {
+        let mut divisor = [0u64; 20];
+        for (i, slot) in divisor.iter_mut().enumerate() {
             *slot = ((i + 1) as u64).wrapping_mul(0xBF58_476D_1CE4_E5B9);
         }
-        let mut q_canon = [0u64; 40];
-        let mut r_canon = [0u64; 40];
-        div_knuth(&num, &den, &mut q_canon, &mut r_canon);
-        let mut q_bz = [0u64; 40];
-        let mut r_bz = [0u64; 40];
-        // Drive the recursive core directly (num=40 limbs, den=20 limbs, so
-        // top=40, n=20): this exercises the BZ recursive-division path
-        // regardless of the production `BZ_THRESHOLD` engagement value, so
-        // the differential survives a threshold that gates the engine off.
-        bz_recursive_core(&num, &den, &mut q_bz, &mut r_bz, 20, 40);
-        assert_eq!(q_canon, q_bz, "BZ quotient mismatch");
-        assert_eq!(r_canon, r_bz, "BZ remainder mismatch");
+        let mut quotient_canonical = [0u64; 40];
+        let mut remainder_canonical = [0u64; 40];
+        div_knuth(&dividend, &divisor, &mut quotient_canonical, &mut remainder_canonical);
+        let mut quotient_bz = [0u64; 40];
+        let mut remainder_bz = [0u64; 40];
+        // Drive the recursive core directly (dividend=40 limbs, divisor=20
+        // limbs, so dividend_len=40, n=20): this exercises the BZ
+        // recursive-division path regardless of the production `BZ_THRESHOLD`
+        // engagement value, so the differential survives a threshold that gates
+        // the engine off.
+        bz_recursive_core(&dividend, &divisor, &mut quotient_bz, &mut remainder_bz, 20, 40);
+        assert_eq!(quotient_canonical, quotient_bz, "BZ quotient mismatch");
+        assert_eq!(remainder_canonical, remainder_bz, "BZ remainder mismatch");
         // The public engine entry still agrees (whatever it dispatches to).
-        let mut q_pub = [0u64; 40];
-        let mut r_pub = [0u64; 40];
-        div_burnikel_ziegler_with_knuth(&num, &den, &mut q_pub, &mut r_pub);
-        assert_eq!(q_canon, q_pub, "BZ public-entry quotient mismatch");
-        assert_eq!(r_canon, r_pub, "BZ public-entry remainder mismatch");
+        let mut quotient_public = [0u64; 40];
+        let mut remainder_public = [0u64; 40];
+        div_burnikel_ziegler_with_knuth(&dividend, &divisor, &mut quotient_public,
+            &mut remainder_public);
+        assert_eq!(quotient_canonical, quotient_public, "BZ public-entry quotient mismatch");
+        assert_eq!(remainder_canonical, remainder_public,
+            "BZ public-entry remainder mismatch");
     }
 
     /// Knuth's q̂-cap path fires when `u_top >= v_top`.
     #[test]
     fn knuth_q_hat_cap_branch_matches_canonical() {
-        let num: [u64; 4] = [0, 0, u64::MAX, u64::MAX >> 1];
-        let den: [u64; 3] = [1, 2, u64::MAX >> 1];
-        let mut q_canon = [0u64; 4];
-        let mut r_canon = [0u64; 4];
-        div_rem_dispatch(&num, &den, &mut q_canon, &mut r_canon);
-        let mut q_knuth = [0u64; 4];
-        let mut r_knuth = [0u64; 4];
-        div_knuth(&num, &den, &mut q_knuth, &mut r_knuth);
-        assert_eq!(q_canon, q_knuth);
-        assert_eq!(r_canon, r_knuth);
+        let dividend: [u64; 4] = [0, 0, u64::MAX, u64::MAX >> 1];
+        let divisor: [u64; 3] = [1, 2, u64::MAX >> 1];
+        let mut quotient_canonical = [0u64; 4];
+        let mut remainder_canonical = [0u64; 4];
+        div_rem_dispatch(&dividend, &divisor, &mut quotient_canonical,
+            &mut remainder_canonical);
+        let mut quotient_knuth = [0u64; 4];
+        let mut remainder_knuth = [0u64; 4];
+        div_knuth(&dividend, &divisor, &mut quotient_knuth, &mut remainder_knuth);
+        assert_eq!(quotient_canonical, quotient_knuth);
+        assert_eq!(remainder_canonical, remainder_knuth);
     }
 
     /// `div_knuth` matches the independent `div_rem` shift-subtract oracle
@@ -289,13 +303,13 @@ mod tests {
     #[test]
     fn knuth_limb_count_boundaries_match_oracle() {
         let cases: &[(&[u64], &[u64])] = &[
-            // even num / even den
+            // even dividend / even divisor
             (&[1, 2, 3, 4], &[5, 6]),
-            // odd num / even den
+            // odd dividend / even divisor
             (&[1, 2, 3, 4, 5], &[5, 6]),
-            // even num / odd den
+            // even dividend / odd divisor
             (&[1, 2, 3, 4, 5, 6], &[7, 8, 9]),
-            // odd num / odd den
+            // odd dividend / odd divisor
             (&[1, 2, 3, 4, 5], &[7, 8, 9]),
             // 2-u64-limb divisor (single wide-digit edge)
             (&[u64::MAX, u64::MAX, u64::MAX, 0], &[3, 7]),
@@ -304,20 +318,22 @@ mod tests {
             (&[u64::MAX, u64::MAX, u64::MAX, u64::MAX, 1], &[1, u64::MAX]),
             // 3-u64-limb divisor
             (&[u64::MAX, u64::MAX, u64::MAX, u64::MAX, u64::MAX, 0], &[1, 2, 3]),
-            // divisor with a zero top limb (den[3] == 0)
+            // divisor with a zero top limb (divisor[3] == 0)
             (&[1, 2, 3, 4, 5, 6, 7, 8], &[9, 10, 11, 0]),
-            // num exactly divisible (zero remainder)
+            // dividend exactly divisible (zero remainder)
             (&[0, 0, 6, 0], &[0, 3]),
         ];
-        for (num, den) in cases {
-            let mut q_ref = [0u64; 12];
-            let mut r_ref = [0u64; 12];
-            div_rem(num, den, &mut q_ref, &mut r_ref);
-            let mut q_k = [0u64; 12];
-            let mut r_k = [0u64; 12];
-            div_knuth(num, den, &mut q_k, &mut r_k);
-            assert_eq!(q_k, q_ref, "quot mismatch {:?} / {:?}", num, den);
-            assert_eq!(r_k, r_ref, "rem mismatch {:?} / {:?}", num, den);
+        for (dividend, divisor) in cases {
+            let mut quotient_reference = [0u64; 12];
+            let mut remainder_reference = [0u64; 12];
+            div_rem(dividend, divisor, &mut quotient_reference, &mut remainder_reference);
+            let mut quotient_knuth = [0u64; 12];
+            let mut remainder_knuth = [0u64; 12];
+            div_knuth(dividend, divisor, &mut quotient_knuth, &mut remainder_knuth);
+            assert_eq!(quotient_knuth, quotient_reference,
+                "quot mismatch {:?} / {:?}", dividend, divisor);
+            assert_eq!(remainder_knuth, remainder_reference,
+                "rem mismatch {:?} / {:?}", dividend, divisor);
         }
     }
 
@@ -338,28 +354,32 @@ mod tests {
             state
         };
         for _ in 0..3000 {
-            let num_len = 2 + (next() % 9) as usize; // 2..=10 u64 limbs
-            let den_len = 2 + (next() % (num_len as u64 - 1)) as usize; // 2..=num_len
-            let mut num = vec![0u64; num_len];
-            let mut den = vec![0u64; den_len];
-            for x in num.iter_mut() {
-                *x = next();
+            let dividend_len = 2 + (next() % 9) as usize; // 2..=10 u64 limbs
+            // 2..=dividend_len
+            let divisor_len = 2 + (next() % (dividend_len as u64 - 1)) as usize;
+            let mut dividend = vec![0u64; dividend_len];
+            let mut divisor = vec![0u64; divisor_len];
+            for slot in dividend.iter_mut() {
+                *slot = next();
             }
-            for x in den.iter_mut() {
-                *x = next();
+            for slot in divisor.iter_mut() {
+                *slot = next();
             }
             // Ensure divisor non-zero and has an effective high limb.
-            if den.iter().all(|&x| x == 0) {
-                den[0] = 1;
+            if divisor.iter().all(|&limb| limb == 0) {
+                divisor[0] = 1;
             }
-            let mut q_ref = vec![0u64; num_len];
-            let mut r_ref = vec![0u64; num_len];
-            div_rem(&num, &den, &mut q_ref, &mut r_ref);
-            let mut q_k = vec![0u64; num_len];
-            let mut r_k = vec![0u64; num_len];
-            div_knuth(&num, &den, &mut q_k, &mut r_k);
-            assert_eq!(q_k, q_ref, "quot mismatch num={:?} den={:?}", num, den);
-            assert_eq!(r_k, r_ref, "rem mismatch num={:?} den={:?}", num, den);
+            let mut quotient_reference = vec![0u64; dividend_len];
+            let mut remainder_reference = vec![0u64; dividend_len];
+            div_rem(&dividend, &divisor, &mut quotient_reference,
+                &mut remainder_reference);
+            let mut quotient_knuth = vec![0u64; dividend_len];
+            let mut remainder_knuth = vec![0u64; dividend_len];
+            div_knuth(&dividend, &divisor, &mut quotient_knuth, &mut remainder_knuth);
+            assert_eq!(quotient_knuth, quotient_reference,
+                "quot mismatch num={:?} den={:?}", dividend, divisor);
+            assert_eq!(remainder_knuth, remainder_reference,
+                "rem mismatch num={:?} den={:?}", dividend, divisor);
         }
     }
 
@@ -369,28 +389,29 @@ mod tests {
     #[cfg(any(feature = "x-wide", feature = "xx-wide"))]
     #[test]
     fn bz_strips_numerator_trailing_zeros() {
-        let mut num = [0u64; 32];
-        for slot in &mut num[..16] {
+        let mut dividend = [0u64; 32];
+        for slot in &mut dividend[..16] {
             *slot = 0xCAFE_F00D;
         }
-        let mut den = [0u64; 20];
-        den[0] = 7;
-        let mut q_canon = [0u64; 32];
-        let mut r_canon = [0u64; 32];
-        div_knuth(&num, &den, &mut q_canon, &mut r_canon);
-        let mut q_bz = [0u64; 32];
-        let mut r_bz = [0u64; 32];
-        // Effective shape after stripping: num=16 limbs over den=1 limb.
-        // Drive the recursive core directly so the trailing-zero stripping +
-        // single-limb base-case path is tested independent of `BZ_THRESHOLD`.
-        bz_recursive_core(&num, &den, &mut q_bz, &mut r_bz, 1, 16);
-        assert_eq!(q_canon, q_bz);
-        assert_eq!(r_canon, r_bz);
-        let mut q_pub = [0u64; 32];
-        let mut r_pub = [0u64; 32];
-        div_burnikel_ziegler_with_knuth(&num, &den, &mut q_pub, &mut r_pub);
-        assert_eq!(q_canon, q_pub);
-        assert_eq!(r_canon, r_pub);
+        let mut divisor = [0u64; 20];
+        divisor[0] = 7;
+        let mut quotient_canonical = [0u64; 32];
+        let mut remainder_canonical = [0u64; 32];
+        div_knuth(&dividend, &divisor, &mut quotient_canonical, &mut remainder_canonical);
+        let mut quotient_bz = [0u64; 32];
+        let mut remainder_bz = [0u64; 32];
+        // Effective shape after stripping: dividend=16 limbs over divisor=1
+        // limb. Drive the recursive core directly so the trailing-zero stripping
+        // + single-limb base-case path is tested independent of `BZ_THRESHOLD`.
+        bz_recursive_core(&dividend, &divisor, &mut quotient_bz, &mut remainder_bz, 1, 16);
+        assert_eq!(quotient_canonical, quotient_bz);
+        assert_eq!(remainder_canonical, remainder_bz);
+        let mut quotient_public = [0u64; 32];
+        let mut remainder_public = [0u64; 32];
+        div_burnikel_ziegler_with_knuth(&dividend, &divisor, &mut quotient_public,
+            &mut remainder_public);
+        assert_eq!(quotient_canonical, quotient_public);
+        assert_eq!(remainder_canonical, remainder_public);
     }
 
     // ── fast-arm wrappers ──────────────────────────────────────────────
@@ -399,7 +420,7 @@ mod tests {
     /// the generic dispatch path over the divmod edge cases.
     #[test]
     fn fast_arm_div_rem_matches_generic() {
-        let vals1: [u64; 8] = [
+        let values1: [u64; 8] = [
             0,
             1,
             2,
@@ -409,25 +430,29 @@ mod tests {
             0x8000_0000_0000_0000,
             123_456_789,
         ];
-        for &num in &vals1 {
-            for &den in &vals1 {
-                if den == 0 {
+        for &dividend in &values1 {
+            for &divisor in &values1 {
+                if divisor == 0 {
                     continue;
                 }
-                let mut fq = [0u64; 1];
-                let mut fr = [0u64; 1];
-                div_rem_mag_fixed::<1>(&[num], &[den], &mut fq, &mut fr);
-                let mut gq = [0u64; 1];
-                let mut gr = [0u64; 1];
-                div_rem_dispatch(&[num], &[den], &mut gq, &mut gr);
-                assert_eq!(fq, gq, "N=1 quot mismatch {num}/{den}");
-                assert_eq!(fr, gr, "N=1 rem mismatch {num}%{den}");
-                assert_eq!(fq[0], num / den);
-                assert_eq!(fr[0], num % den);
+                let mut fixed_quotient = [0u64; 1];
+                let mut fixed_remainder = [0u64; 1];
+                div_rem_mag_fixed::<1>(&[dividend], &[divisor], &mut fixed_quotient,
+                    &mut fixed_remainder);
+                let mut generic_quotient = [0u64; 1];
+                let mut generic_remainder = [0u64; 1];
+                div_rem_dispatch(&[dividend], &[divisor], &mut generic_quotient,
+                    &mut generic_remainder);
+                assert_eq!(fixed_quotient, generic_quotient,
+                    "N=1 quot mismatch {dividend}/{divisor}");
+                assert_eq!(fixed_remainder, generic_remainder,
+                    "N=1 rem mismatch {dividend}%{divisor}");
+                assert_eq!(fixed_quotient[0], dividend / divisor);
+                assert_eq!(fixed_remainder[0], dividend % divisor);
             }
         }
 
-        let vals2: [u128; 8] = [
+        let values2: [u128; 8] = [
             0,
             1,
             u128::MAX,
@@ -437,24 +462,28 @@ mod tests {
             1u128 << 64,
             0x0123_4567_89ab_cdef_fedc_ba98_7654_3210,
         ];
-        let to_limbs = |v: u128| [v as u64, (v >> 64) as u64];
-        for &num in &vals2 {
-            for &den in &vals2 {
-                if den == 0 {
+        let to_limbs = |value: u128| [value as u64, (value >> 64) as u64];
+        for &dividend in &values2 {
+            for &divisor in &values2 {
+                if divisor == 0 {
                     continue;
                 }
-                let n = to_limbs(num);
-                let d = to_limbs(den);
-                let mut fq = [0u64; 2];
-                let mut fr = [0u64; 2];
-                div_rem_mag_fixed::<2>(&n, &d, &mut fq, &mut fr);
-                let mut gq = [0u64; 2];
-                let mut gr = [0u64; 2];
-                div_rem_dispatch(&n, &d, &mut gq, &mut gr);
-                assert_eq!(fq, gq, "N=2 quot mismatch {num}/{den}");
-                assert_eq!(fr, gr, "N=2 rem mismatch {num}%{den}");
-                assert_eq!(fq, to_limbs(num / den));
-                assert_eq!(fr, to_limbs(num % den));
+                let dividend_limbs = to_limbs(dividend);
+                let divisor_limbs = to_limbs(divisor);
+                let mut fixed_quotient = [0u64; 2];
+                let mut fixed_remainder = [0u64; 2];
+                div_rem_mag_fixed::<2>(&dividend_limbs, &divisor_limbs,
+                    &mut fixed_quotient, &mut fixed_remainder);
+                let mut generic_quotient = [0u64; 2];
+                let mut generic_remainder = [0u64; 2];
+                div_rem_dispatch(&dividend_limbs, &divisor_limbs, &mut generic_quotient,
+                    &mut generic_remainder);
+                assert_eq!(fixed_quotient, generic_quotient,
+                    "N=2 quot mismatch {dividend}/{divisor}");
+                assert_eq!(fixed_remainder, generic_remainder,
+                    "N=2 rem mismatch {dividend}%{divisor}");
+                assert_eq!(fixed_quotient, to_limbs(dividend / divisor));
+                assert_eq!(fixed_remainder, to_limbs(dividend % divisor));
             }
         }
     }
@@ -462,7 +491,7 @@ mod tests {
     /// The native isqrt fast arms match the generic limb isqrt.
     #[test]
     fn fast_arm_isqrt_matches_generic() {
-        let vals1: [u64; 9] = [
+        let values1: [u64; 9] = [
             0,
             1,
             2,
@@ -473,16 +502,16 @@ mod tests {
             u64::MAX,
             (u32::MAX as u64) * (u32::MAX as u64),
         ];
-        for &v in &vals1 {
-            let mut f = [0u64; 1];
-            isqrt_mag_fixed::<1>(&[v], &mut f);
-            let mut g = [0u64; 1];
-            isqrt_newton(&[v], &mut g);
-            assert_eq!(f, g, "N=1 isqrt mismatch sqrt({v})");
-            assert_eq!(f[0], v.isqrt());
+        for &value in &values1 {
+            let mut fixed_sqrt = [0u64; 1];
+            isqrt_mag_fixed::<1>(&[value], &mut fixed_sqrt);
+            let mut generic_sqrt = [0u64; 1];
+            isqrt_newton(&[value], &mut generic_sqrt);
+            assert_eq!(fixed_sqrt, generic_sqrt, "N=1 isqrt mismatch sqrt({value})");
+            assert_eq!(fixed_sqrt[0], value.isqrt());
         }
 
-        let vals2: [u128; 8] = [
+        let values2: [u128; 8] = [
             0,
             1,
             u128::MAX,
@@ -492,15 +521,15 @@ mod tests {
             (u64::MAX as u128) * (u64::MAX as u128),
             0x0123_4567_89ab_cdef_fedc_ba98_7654_3210,
         ];
-        for &v in &vals2 {
-            let n = [v as u64, (v >> 64) as u64];
-            let mut f = [0u64; 2];
-            isqrt_mag_fixed::<2>(&n, &mut f);
-            let mut g = [0u64; 2];
-            isqrt_newton(&n, &mut g);
-            assert_eq!(f, g, "N=2 isqrt mismatch sqrt({v})");
-            let r = v.isqrt();
-            assert_eq!(f, [r as u64, (r >> 64) as u64]);
+        for &value in &values2 {
+            let value_limbs = [value as u64, (value >> 64) as u64];
+            let mut fixed_sqrt = [0u64; 2];
+            isqrt_mag_fixed::<2>(&value_limbs, &mut fixed_sqrt);
+            let mut generic_sqrt = [0u64; 2];
+            isqrt_newton(&value_limbs, &mut generic_sqrt);
+            assert_eq!(fixed_sqrt, generic_sqrt, "N=2 isqrt mismatch sqrt({value})");
+            let expected_sqrt = value.isqrt();
+            assert_eq!(fixed_sqrt, [expected_sqrt as u64, (expected_sqrt >> 64) as u64]);
         }
     }
 }

--- a/src/int/algos/eq/eq_limbwise.rs
+++ b/src/int/algos/eq/eq_limbwise.rs
@@ -15,8 +15,8 @@ use crate::int::types::Int;
 /// equal iff their `cmp_fixed` result is `0`. Reuses the comparison
 /// kernel so the limb loop is not duplicated here.
 #[inline]
-pub(crate) const fn eq_limbwise<const N: usize>(a: Int<N>, b: Int<N>) -> bool {
-    cmp_fixed(a.as_limbs(), b.as_limbs()) == 0
+pub(crate) const fn eq_limbwise<const N: usize>(lhs: Int<N>, rhs: Int<N>) -> bool {
+    cmp_fixed(lhs.as_limbs(), rhs.as_limbs()) == 0
 }
 
 #[cfg(test)]

--- a/src/int/algos/eq/eq_xor_fold.rs
+++ b/src/int/algos/eq/eq_xor_fold.rs
@@ -36,13 +36,13 @@ use crate::int::types::Int;
 /// equality is a value equality — no sign special-case is needed.) `const fn`.
 #[allow(dead_code)]
 #[inline]
-pub(crate) const fn eq_xor_fold<const N: usize>(a: Int<N>, b: Int<N>) -> bool {
-    let al = a.as_limbs();
-    let bl = b.as_limbs();
+pub(crate) const fn eq_xor_fold<const N: usize>(lhs: Int<N>, rhs: Int<N>) -> bool {
+    let lhs_limbs = lhs.as_limbs();
+    let rhs_limbs = rhs.as_limbs();
     let mut diff: u64 = 0;
     let mut i = 0;
     while i < N {
-        diff |= al[i] ^ bl[i];
+        diff |= lhs_limbs[i] ^ rhs_limbs[i];
         i += 1;
     }
     diff == 0
@@ -61,32 +61,32 @@ mod tests {
     /// limb, and sign-boundary values.
     fn diff_at<const N: usize>(seeds: &[u64]) {
         for &seed in seeds {
-            let mut la = [0u64; N];
-            let mut s = seed;
-            for limb in la.iter_mut() {
-                s = s.wrapping_add(0x9E37_79B9_7F4A_7C15);
-                let mut z = s;
+            let mut a_limbs = [0u64; N];
+            let mut state = seed;
+            for limb in a_limbs.iter_mut() {
+                state = state.wrapping_add(0x9E37_79B9_7F4A_7C15);
+                let mut z = state;
                 z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
                 z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
                 *limb = z ^ (z >> 31);
             }
-            let a = Int::<N>::from_limbs(la);
+            let a = Int::<N>::from_limbs(a_limbs);
 
             // equal to itself
             assert_eq!(eq_xor_fold::<N>(a, a), eq_limbwise::<N>(a, a));
             assert!(eq_xor_fold::<N>(a, a));
 
             // differ in the bottom limb
-            let mut lb = la;
-            lb[0] ^= 1;
-            let b = Int::<N>::from_limbs(lb);
+            let mut b_limbs = a_limbs;
+            b_limbs[0] ^= 1;
+            let b = Int::<N>::from_limbs(b_limbs);
             assert_eq!(eq_xor_fold::<N>(a, b), eq_limbwise::<N>(a, b));
             assert!(!eq_xor_fold::<N>(a, b));
 
             // differ in the top limb
-            let mut lc = la;
-            lc[N - 1] ^= 1 << 63;
-            let c = Int::<N>::from_limbs(lc);
+            let mut c_limbs = a_limbs;
+            c_limbs[N - 1] ^= 1 << 63;
+            let c = Int::<N>::from_limbs(c_limbs);
             assert_eq!(eq_xor_fold::<N>(a, c), eq_limbwise::<N>(a, c));
             assert!(!eq_xor_fold::<N>(a, c));
         }

--- a/src/int/algos/hypot/hypot_pythagoras.rs
+++ b/src/int/algos/hypot/hypot_pythagoras.rs
@@ -40,32 +40,35 @@ pub(crate) fn hypot_pythagoras<const N: usize>(a: Int<N>, b: Int<N>, mode: Round
 where
     Limbs<N>: ComputeLimbs,
 {
-    // -- n = a^2 + b^2 (magnitudes; sign drops out of squaring) ----------
-    // The radicand former is shared with `sum_sq`; hypot roots `n` rather
-    // than fit-checking it, so it keeps every representable hypot.
-    let ma = a.unsigned_abs();
-    let mb = b.unsigned_abs();
-    let mut n_buf = Limbs::<N>::double_buffered_u64();
-    let n = n_buf.as_mut();
-    let nl = sum_sq_radicand::<N>(ma.as_limbs(), mb.as_limbs(), n);
-    if nl == 1 && n[0] == 0 {
+    // -- radicand = a^2 + b^2 (magnitudes; sign drops out of squaring) ---
+    // The radicand former is shared with `sum_sq`; hypot roots the radicand
+    // rather than fit-checking it, so it keeps every representable hypot.
+    let a_magnitude = a.unsigned_abs();
+    let b_magnitude = b.unsigned_abs();
+    let mut radicand_buf = Limbs::<N>::double_buffered_u64();
+    let radicand = radicand_buf.as_mut();
+    let radicand_len =
+        sum_sq_radicand::<N>(a_magnitude.as_limbs(), b_magnitude.as_limbs(), radicand);
+    if radicand_len == 1 && radicand[0] == 0 {
         return Some(Int::<N>::ZERO);
     }
 
-    // -- q = floor(sqrt(n)) ----------------------------------------------
-    let mut q_buf = Limbs::<N>::double_buffered_u64();
-    let q = q_buf.as_mut();
-    isqrt_newton(&n[..nl], &mut q[..nl]);
-    let ql = sig_len(&q[..nl]);
+    // -- root = floor(sqrt(radicand)) ------------------------------------
+    let mut root_buf = Limbs::<N>::double_buffered_u64();
+    let root = root_buf.as_mut();
+    isqrt_newton(&radicand[..radicand_len], &mut root[..radicand_len]);
+    let root_len = sig_len(&root[..radicand_len]);
 
-    // -- diff = n - q^2  (reuse `n` in place as the remainder) -----------
-    let mut qsq_buf = Limbs::<N>::double_buffered_u64();
-    let qsq = qsq_buf.as_mut();
-    let qsq_cap = qsq.len();
-    mul_schoolbook(&q[..ql], &q[..ql], &mut qsq[..(2 * ql).min(qsq_cap)]);
-    sub_assign(&mut n[..nl], &qsq[..nl]);
-    let halfway_round_up = cmp_cross(&n[..nl], &q[..ql]) > 0;
-    let diff_nonzero = !is_zero(&n[..nl]);
+    // -- diff = radicand - root^2  (reuse `radicand` in place as the
+    //    remainder) -----------------------------------------------------
+    let mut root_sq_buf = Limbs::<N>::double_buffered_u64();
+    let root_sq = root_sq_buf.as_mut();
+    let root_sq_cap = root_sq.len();
+    mul_schoolbook(&root[..root_len], &root[..root_len],
+        &mut root_sq[..(2 * root_len).min(root_sq_cap)]);
+    sub_assign(&mut radicand[..radicand_len], &root_sq[..radicand_len]);
+    let halfway_round_up = cmp_cross(&radicand[..radicand_len], &root[..root_len]) > 0;
+    let diff_nonzero = !is_zero(&radicand[..radicand_len]);
     let bump = match mode {
         RoundingMode::HalfToEven
         | RoundingMode::HalfAwayFromZero
@@ -76,9 +79,9 @@ where
     if bump {
         let mut i = 0;
         loop {
-            let (v, c) = q[i].overflowing_add(1);
-            q[i] = v;
-            if !c {
+            let (sum, carry) = root[i].overflowing_add(1);
+            root[i] = sum;
+            if !carry {
                 break;
             }
             i += 1;
@@ -86,12 +89,12 @@ where
     }
 
     // -- fit check: positive magnitude must be < 2^(64N-1) (signed range) -
-    let qfl = sig_len(&q[..(N + 2).min(qsq_cap)]);
-    if qfl > N || (qfl == N && (q[N - 1] >> 63) != 0) {
+    let root_fit_len = sig_len(&root[..(N + 2).min(root_sq_cap)]);
+    if root_fit_len > N || (root_fit_len == N && (root[N - 1] >> 63) != 0) {
         return None;
     }
     let mut out = [0u64; N];
-    out.copy_from_slice(&q[..N]);
+    out.copy_from_slice(&root[..N]);
     Some(Int::<N>::from_limbs(out))
 }
 

--- a/src/int/algos/hypot/hypot_u128_fast.rs
+++ b/src/int/algos/hypot/hypot_u128_fast.rs
@@ -48,7 +48,8 @@ use crate::int::types::compute_limbs::{ComputeLimbs, Limbs};
 use crate::int::types::Int;
 use crate::support::rounding::RoundingMode;
 
-/// `(floor(sqrt(n)), n - floor(sqrt(n))²)` for a `u128`, exact.
+/// `(floor(sqrt(radicand)), radicand - floor(sqrt(radicand))²)` for a `u128`,
+/// exact.
 ///
 /// Seeds from the shared seed library's `u128` over-estimate
 /// ([`sqrt_seed_u128`]), then runs the integer Newton averaging step
@@ -74,24 +75,24 @@ use crate::support::rounding::RoundingMode;
 ///
 /// [`sqrt_seed_u128`]: crate::algo_x_support::seed::sqrt_seed_u128
 #[inline]
-fn isqrt_u128(n: u128) -> (u128, u128) {
-    if n == 0 {
+fn isqrt_u128(radicand: u128) -> (u128, u128) {
+    if radicand == 0 {
         return (0, 0);
     }
-    let bits = 128 - n.leading_zeros();
-    let mut x: u128 = crate::algo_x_support::seed::sqrt_seed_u128(n, bits);
+    let bits = 128 - radicand.leading_zeros();
+    let mut x: u128 = crate::algo_x_support::seed::sqrt_seed_u128(radicand, bits);
     loop {
         // Floor test by squaring (`x >= floor` invariant => `x² <= n` iff
         // `x == floor`). `checked_mul`: `x >= 2^64` means `x² >= 2^128 > n`,
         // so an overflowing square can never be the floor.
         if let Some(xx) = x.checked_mul(x) {
-            if xx <= n {
-                return (x, n - xx);
+            if xx <= radicand {
+                return (x, radicand - xx);
             }
         }
         // Newton averaging step; on a stall (`y >= x`, x = floor+1 here
         // since the square test above excluded the floor) step down once.
-        let y = (x + n / x) >> 1;
+        let y = (x + radicand / x) >> 1;
         x = if y >= x { x - 1 } else { y };
     }
 }
@@ -108,21 +109,21 @@ fn isqrt_u128(n: u128) -> (u128, u128) {
 /// squaring logic stays single-sourced in the leaf (not re-hand-rolled here).
 #[inline]
 fn sq_u256(x: u128) -> [u64; 4] {
-    let xw = [x as u64, (x >> 64) as u64, 0, 0];
+    let x_limbs = [x as u64, (x >> 64) as u64, 0, 0];
     let mut out = [0u64; 4];
-    crate::int::algos::sqr::sqr_low_fixed::sqr_low_fixed::<4>(&xw, &mut out);
+    crate::int::algos::sqr::sqr_low_fixed::sqr_low_fixed::<4>(&x_limbs, &mut out);
     out
 }
 
-/// `a + b` for two `u256` (`[u64; 4]`) values, returning the 257-bit sum as
-/// `([u64; 4], carry)` where `carry` is the bit-256 overflow.
+/// `lhs + rhs` for two `u256` (`[u64; 4]`) values, returning the 257-bit sum
+/// as `([u64; 4], carry)` where `carry` is the bit-256 overflow.
 #[inline]
-fn add_u256(a: [u64; 4], b: [u64; 4]) -> ([u64; 4], bool) {
+fn add_u256(lhs: [u64; 4], rhs: [u64; 4]) -> ([u64; 4], bool) {
     let mut out = [0u64; 4];
     let mut carry = 0u128;
     let mut i = 0;
     while i < 4 {
-        let s = a[i] as u128 + b[i] as u128 + carry;
+        let s = lhs[i] as u128 + rhs[i] as u128 + carry;
         out[i] = s as u64;
         carry = s >> 64;
         i += 1;
@@ -130,37 +131,39 @@ fn add_u256(a: [u64; 4], b: [u64; 4]) -> ([u64; 4], bool) {
     (out, carry != 0)
 }
 
-/// `n / d` for a `u256` dividend `n` (`[u64; 4]`) and a `u128` divisor `d >= 1`,
-/// returning the quotient as a `u128`. The caller guarantees the quotient fits
-/// a `u128` (in the Newton loop `x` is an over-estimate of `sqrt(n)`, so
-/// `n / x <= x <= 2^128`). FIXED scalar long division with `u64` base digits,
-/// using the *hardware* `u128 / u64` divide for each quotient-digit estimate
-/// (NOT a bit-by-bit loop, and NOT the multi-precision `div_rem` dispatcher).
+/// `dividend / divisor` for a `u256` dividend (`[u64; 4]`) and a `u128`
+/// `divisor >= 1`, returning the quotient as a `u128`. The caller guarantees
+/// the quotient fits a `u128` (in the Newton loop `x` is an over-estimate of
+/// `sqrt(n)`, so `n / x <= x <= 2^128`). FIXED scalar long division with `u64`
+/// base digits, using the *hardware* `u128 / u64` divide for each
+/// quotient-digit estimate (NOT a bit-by-bit loop, and NOT the
+/// multi-precision `div_rem` dispatcher).
 ///
-/// Strategy. When `d` fits one `u64` limb, do a straight 4-digit base-`2^64`
-/// long division by the `u64` divisor (four hardware `u128 / u64` steps). When
-/// `d` is a genuine 2-limb divisor, fall back to Knuth Algorithm D over the
-/// two normalised divisor limbs ([`knuth_d_256_by_128`]). Both are fixed,
-/// branch-light scalar routines.
+/// Strategy. When `divisor` fits one `u64` limb, do a straight 4-digit
+/// base-`2^64` long division by the `u64` divisor (four hardware `u128 / u64`
+/// steps). When `divisor` is a genuine 2-limb divisor, fall back to Knuth
+/// Algorithm D over the two normalised divisor limbs
+/// ([`knuth_d_256_by_128`]). Both are fixed, branch-light scalar routines.
 #[inline]
-fn div_u256_by_u128(n: [u64; 4], d: u128) -> u128 {
-    let d_hi = (d >> 64) as u64;
-    if d_hi == 0 {
+fn div_u256_by_u128(dividend: [u64; 4], divisor: u128) -> u128 {
+    let divisor_hi = (divisor >> 64) as u64;
+    if divisor_hi == 0 {
         // Single-limb divisor: classic base-2^64 long division, MSB limb first.
-        let d0 = d as u64; // != 0 (caller guarantees d >= 1)
-        let mut q = [0u64; 4];
-        let mut rem: u64 = 0;
+        let divisor_limb = divisor as u64; // != 0 (caller guarantees >= 1)
+        let mut quotient = [0u64; 4];
+        let mut remainder: u64 = 0;
         let mut i = 4;
         while i > 0 {
             i -= 1;
-            let cur = ((rem as u128) << 64) | n[i] as u128; // < d0·2^64 (rem < d0)
-            q[i] = (cur / d0 as u128) as u64;
-            rem = (cur % d0 as u128) as u64;
+            // < divisor_limb·2^64 (remainder < divisor_limb)
+            let cur = ((remainder as u128) << 64) | dividend[i] as u128;
+            quotient[i] = (cur / divisor_limb as u128) as u64;
+            remainder = (cur % divisor_limb as u128) as u64;
         }
         // quotient fits u128 by the caller's invariant (top two limbs zero).
-        (q[0] as u128) | ((q[1] as u128) << 64)
+        (quotient[0] as u128) | ((quotient[1] as u128) << 64)
     } else {
-        knuth_d_256_by_128(n, d)
+        knuth_d_256_by_128(dividend, divisor)
     }
 }
 
@@ -169,48 +172,48 @@ fn div_u256_by_u128(n: [u64; 4], d: u128) -> u128 {
 /// estimate uses one hardware `u128 / u64` divide per digit with the standard
 /// two-term correction. A fixed scalar routine (no recursion, no dispatcher).
 #[inline]
-fn knuth_d_256_by_128(n: [u64; 4], d: u128) -> u128 {
-    // Normalise so the divisor's top limb has its MSB set. `d_hi != 0` here,
-    // so its u64 leading-zero count is in 0..=63 -- the correct normalising
-    // shift (taking it on the full u128 would count the 64 high zero bits and
-    // over-shift the divisor).
-    let d_hi = (d >> 64) as u64;
-    let shift = d_hi.leading_zeros(); // 0..=63
-    let dn: u128 = d << shift;
-    let v1 = (dn >> 64) as u64; // top limb, MSB set
-    let v0 = dn as u64;
+fn knuth_d_256_by_128(dividend: [u64; 4], divisor: u128) -> u128 {
+    // Normalise so the divisor's top limb has its MSB set. `divisor_hi != 0`
+    // here, so its u64 leading-zero count is in 0..=63 -- the correct
+    // normalising shift (taking it on the full u128 would count the 64 high
+    // zero bits and over-shift the divisor).
+    let divisor_hi = (divisor >> 64) as u64;
+    let shift = divisor_hi.leading_zeros(); // 0..=63
+    let normalized_divisor: u128 = divisor << shift;
+    let v1 = (normalized_divisor >> 64) as u64; // top limb, MSB set
+    let v0 = normalized_divisor as u64;
 
     // Shifted dividend, 5 limbs (the shift can spill into a 5th).
     let mut u = [0u64; 5];
     if shift == 0 {
-        u[0] = n[0];
-        u[1] = n[1];
-        u[2] = n[2];
-        u[3] = n[3];
+        u[0] = dividend[0];
+        u[1] = dividend[1];
+        u[2] = dividend[2];
+        u[3] = dividend[3];
     } else {
         let s = shift;
-        u[0] = n[0] << s;
-        u[1] = (n[1] << s) | (n[0] >> (64 - s));
-        u[2] = (n[2] << s) | (n[1] >> (64 - s));
-        u[3] = (n[3] << s) | (n[2] >> (64 - s));
-        u[4] = n[3] >> (64 - s);
+        u[0] = dividend[0] << s;
+        u[1] = (dividend[1] << s) | (dividend[0] >> (64 - s));
+        u[2] = (dividend[2] << s) | (dividend[1] >> (64 - s));
+        u[3] = (dividend[3] << s) | (dividend[2] >> (64 - s));
+        u[4] = dividend[3] >> (64 - s);
     }
 
     // Two quotient digits (q1 at 2^64, q0 at 2^0); higher digits are zero by
     // the caller's "quotient fits u128" guarantee.
-    let mut q = [0u64; 2];
+    let mut quotient = [0u64; 2];
     let mut j = 2; // process positions j = 1, 0 (dividend limbs [j+2..j])
     while j > 0 {
         j -= 1;
         // Estimate qhat = (u[j+2]·2^64 + u[j+1]) / v1, capped to a u64 digit.
-        let num = ((u[j + 2] as u128) << 64) | u[j + 1] as u128;
-        let mut qhat = num / v1 as u128;
-        let mut rhat = num % v1 as u128;
+        let numerator = ((u[j + 2] as u128) << 64) | u[j + 1] as u128;
+        let mut qhat = numerator / v1 as u128;
+        let mut rhat = numerator % v1 as u128;
         // Cap qhat at the base digit max (b - 1) so `qhat·v0` stays < 2^128 for
         // the correction test below (standard Knuth-D guard).
         if qhat >= (1u128 << 64) {
             qhat = (1u128 << 64) - 1;
-            rhat = num - qhat * v1 as u128;
+            rhat = numerator - qhat * v1 as u128;
         }
         // Correct the over-estimate (at most twice): qhat·v0 > rhat·b + u[j].
         while rhat < (1u128 << 64) && qhat * v0 as u128 > (rhat << 64) + u[j] as u128 {
@@ -220,9 +223,9 @@ fn knuth_d_256_by_128(n: [u64; 4], d: u128) -> u128 {
         // Multiply-subtract qhat·(v1:v0) from u[j..j+3]. The product spans 3
         // limbs (qhat·v0 at limb j, qhat·v1 at limb j+1), formed via two
         // u64×u64 -> u128 products so nothing truncates.
-        let qh = qhat as u64;
-        let m0 = qh as u128 * v0 as u128; // weight 2^(64j)
-        let m1 = qh as u128 * v1 as u128; // weight 2^(64(j+1))
+        let qhat_limb = qhat as u64;
+        let m0 = qhat_limb as u128 * v0 as u128; // weight 2^(64j)
+        let m1 = qhat_limb as u128 * v1 as u128; // weight 2^(64(j+1))
         let p_lo = m0 as u64;
         let p_mid = (m0 >> 64) + (m1 as u64 as u128); // limb j+1 column
         let p_hi = (p_mid >> 64) + (m1 >> 64); // limb j+2 column
@@ -240,39 +243,39 @@ fn knuth_d_256_by_128(n: [u64; 4], d: u128) -> u128 {
         u[j + 2] = s2 as u64;
         borrow = if s2 < 0 { 1 } else { 0 };
         // If we over-subtracted, add the divisor back once and decrement qhat.
-        let mut qd = qh;
+        let mut quotient_digit = qhat_limb;
         if borrow != 0 {
-            qd = qd.wrapping_sub(1);
+            quotient_digit = quotient_digit.wrapping_sub(1);
             let a0 = u[j] as u128 + v0 as u128;
             u[j] = a0 as u64;
             let a1 = u[j + 1] as u128 + v1 as u128 + (a0 >> 64);
             u[j + 1] = a1 as u64;
             u[j + 2] = u[j + 2].wrapping_add((a1 >> 64) as u64);
         }
-        q[j] = qd;
+        quotient[j] = quotient_digit;
     }
-    (q[0] as u128) | ((q[1] as u128) << 64)
+    (quotient[0] as u128) | ((quotient[1] as u128) << 64)
 }
 
-/// `(floor(sqrt(n)), n - floor(sqrt(n))²)` for a `u256` radicand `n`
-/// (`[u64; 4]`, `n < 2^256`), exact. The floor root is a `u128` (it is
-/// `< 2^128`); the remainder is a `u256` (it can reach `2·root < 2^129`).
+/// `(floor(sqrt(radicand)), radicand - floor(sqrt(radicand))²)` for a `u256`
+/// `radicand` (`[u64; 4]`, `< 2^256`), exact. The floor root is a `u128` (it
+/// is `< 2^128`); the remainder is a `u256` (it can reach `2·root < 2^129`).
 /// Same seeded over-estimate Newton structure and square-test exit as
 /// [`isqrt_u128`] (same invariant, same two-divides-saved rationale -- here
 /// each saved divide is a full [`div_u256_by_u128`] Knuth step, the dominant
 /// cost of the routine), but `n / x` is the fixed scalar
 /// [`div_u256_by_u128`] (hardware `u128 / u64` digit estimates).
 #[inline]
-fn isqrt_u256(n: [u64; 4]) -> (u128, [u64; 4]) {
+fn isqrt_u256(radicand: [u64; 4]) -> (u128, [u64; 4]) {
     // Bit length of the 256-bit magnitude.
-    let bits: u32 = if n[3] != 0 {
-        192 + (64 - n[3].leading_zeros())
-    } else if n[2] != 0 {
-        128 + (64 - n[2].leading_zeros())
-    } else if n[1] != 0 {
-        64 + (64 - n[1].leading_zeros())
+    let bits: u32 = if radicand[3] != 0 {
+        192 + (64 - radicand[3].leading_zeros())
+    } else if radicand[2] != 0 {
+        128 + (64 - radicand[2].leading_zeros())
+    } else if radicand[1] != 0 {
+        64 + (64 - radicand[1].leading_zeros())
     } else {
-        64 - n[0].leading_zeros()
+        64 - radicand[0].leading_zeros()
     };
     if bits == 0 {
         return (0, [0u64; 4]);
@@ -287,7 +290,7 @@ fn isqrt_u256(n: [u64; 4]) -> (u128, [u64; 4]) {
     // over-estimate that touches `2^128` still fits; we read it back as a u128,
     // saturating to `u128::MAX` if the headroom limb is non-zero.
     let mut seed_out = [0u64; 3];
-    crate::algo_x_support::seed::sqrt_seed(&n, bits, &mut seed_out);
+    crate::algo_x_support::seed::sqrt_seed(&radicand, bits, &mut seed_out);
     let mut x: u128 = if seed_out[2] != 0 {
         u128::MAX
     } else {
@@ -310,8 +313,8 @@ fn isqrt_u256(n: [u64; 4]) -> (u128, [u64; 4]) {
     // `>= floor(sqrt(n))` for any `n < 2^256`, so admit it. `x` is a `u128`
     // (`<= 2^128-1`) so `x²` fits a `u256` exactly -- compare against `n`.
     debug_assert!(
-        x == u128::MAX || cmp_u256(sq_u256(x), n) >= 0,
-        "isqrt_u256 seed under-estimate: seed={x} n={n:?}"
+        x == u128::MAX || cmp_u256(sq_u256(x), radicand) >= 0,
+        "isqrt_u256 seed under-estimate: seed={x} n={radicand:?}"
     );
     // Newton averaging with the square-test exit (see [`isqrt_u128`]): the
     // iterates hold `x >= floor(sqrt(n))`, so `x² <= n` iff `x == floor`,
@@ -320,36 +323,38 @@ fn isqrt_u256(n: [u64; 4]) -> (u128, [u64; 4]) {
     loop {
         // `x <= u128::MAX`, so `x²` fits the u256 exactly.
         let xsq = sq_u256(x);
-        if cmp_u256(xsq, n) <= 0 {
-            let (rem, _borrow) = sub_u256(n, xsq); // n >= x², no borrow
-            return (x, rem);
+        if cmp_u256(xsq, radicand) <= 0 {
+            // n >= x², no borrow
+            let (remainder, _borrow) = sub_u256(radicand, xsq);
+            return (x, remainder);
         }
-        let nx = div_u256_by_u128(n, x);
+        let quotient = div_u256_by_u128(radicand, x);
         // (x + n/x)/2 -- both < 2^129 here only transiently; x <= 2^128 and
-        // nx <= x, so x + nx <= 2^129. Compute the average without overflow.
-        let y = avg_u128(x, nx);
+        // n/x <= x, so x + n/x <= 2^129. Compute the average without overflow.
+        let y = avg_u128(x, quotient);
         // Stall (`y >= x`) with `x² > n` means x = floor+1: one step down
         // lands on the floor; the square test exits on the next pass.
         x = if y >= x { x - 1 } else { y };
     }
 }
 
-/// `(a + b) / 2` for two `u128` without overflowing the intermediate sum
-/// (`a + b` can reach `2^129`). Standard average-without-overflow identity.
+/// `(lhs + rhs) / 2` for two `u128` without overflowing the intermediate sum
+/// (`lhs + rhs` can reach `2^129`). Standard average-without-overflow
+/// identity.
 #[inline]
-fn avg_u128(a: u128, b: u128) -> u128 {
-    (a & b) + ((a ^ b) >> 1)
+fn avg_u128(lhs: u128, rhs: u128) -> u128 {
+    (lhs & rhs) + ((lhs ^ rhs) >> 1)
 }
 
 /// Three-way compare of two `u256` (`[u64; 4]`) values: `-1`/`0`/`1` for
-/// `a < b` / `a == b` / `a > b`. Most-significant limb first.
+/// `lhs < rhs` / `lhs == rhs` / `lhs > rhs`. Most-significant limb first.
 #[inline]
-fn cmp_u256(a: [u64; 4], b: [u64; 4]) -> i32 {
+fn cmp_u256(lhs: [u64; 4], rhs: [u64; 4]) -> i32 {
     let mut i = 4;
     while i > 0 {
         i -= 1;
-        if a[i] != b[i] {
-            return if a[i] < b[i] { -1 } else { 1 };
+        if lhs[i] != rhs[i] {
+            return if lhs[i] < rhs[i] { -1 } else { 1 };
         }
     }
     0
@@ -366,26 +371,27 @@ pub(crate) fn hypot_u128_fast<const N: usize>(a: Int<N>, b: Int<N>, mode: Roundi
 where
     Limbs<N>: ComputeLimbs,
 {
-    let ma = a.unsigned_abs();
-    let mb = b.unsigned_abs();
-    let la = ma.as_limbs();
-    let lb = mb.as_limbs();
+    let a_magnitude = a.unsigned_abs();
+    let b_magnitude = b.unsigned_abs();
+    let a_limbs = a_magnitude.as_limbs();
+    let b_limbs = b_magnitude.as_limbs();
 
     // -- u128 fast path: both magnitudes fit one u64 limb -----------------
     // Then each square fits u128 and the sum fits u128 iff no carry past bit
     // 128 (checked). Kept as a distinct branch because the hardware u128
     // divide in `isqrt_u128` is cheaper than the u256/u128 long division.
-    if fit_one(la) && fit_one(lb) {
-        let av = la[0] as u128;
-        let bv = lb[0] as u128;
-        let asq = av * av;
-        let bsq = bv * bv;
-        if let Some(n) = asq.checked_add(bsq) {
-            if n == 0 {
+    if fit_one(a_limbs) && fit_one(b_limbs) {
+        let a_value = a_limbs[0] as u128;
+        let b_value = b_limbs[0] as u128;
+        let a_squared = a_value * a_value;
+        let b_squared = b_value * b_value;
+        if let Some(radicand) = a_squared.checked_add(b_squared) {
+            if radicand == 0 {
                 return Some(Int::<N>::ZERO);
             }
-            let (q, rem) = isqrt_u128(n); // rem = n - floor(sqrt n)², exact
-            return finish::<N>(q, rem != 0, rem > q, mode);
+            // remainder = n - floor(sqrt n)², exact
+            let (root, remainder) = isqrt_u128(radicand);
+            return finish::<N>(root, remainder != 0, remainder > root, mode);
         }
         // sum carried past bit 128: fall through to the u256 / wide paths.
     }
@@ -396,23 +402,23 @@ where
     // is fixed scalar u256 arithmetic (no multi-precision div_rem). Covers all
     // of D38 and the entire low magnitude band of every wider tier -- the
     // decimal `s >= 19` slow band the `fit_one`-only gate cliffed on.
-    if fit_k(la, 2) && fit_k(lb, 2) {
-        let av = (la[0] as u128) | ((la[1] as u128) << 64);
-        let bv = (lb[0] as u128) | ((lb[1] as u128) << 64);
-        let (n, carry) = add_u256(sq_u256(av), sq_u256(bv));
+    if fit_k(a_limbs, 2) && fit_k(b_limbs, 2) {
+        let a_value = (a_limbs[0] as u128) | ((a_limbs[1] as u128) << 64);
+        let b_value = (b_limbs[0] as u128) | ((b_limbs[1] as u128) << 64);
+        let (radicand, carry) = add_u256(sq_u256(a_value), sq_u256(b_value));
         if !carry {
-            // n < 2^256, so q = floor(sqrt(n)) < 2^128.
-            if n == [0u64; 4] {
+            // n < 2^256, so the floor root is < 2^128.
+            if radicand == [0u64; 4] {
                 return Some(Int::<N>::ZERO);
             }
-            // The exact remainder rem = n - q² comes fused out of the root
-            // (its square-test exit already computed q²). rem <= 2q, which may
-            // reach 2^129-2 (> u128) when q ~ 2^128 -- compare via the 256-bit
-            // value directly.
-            let (q, rem) = isqrt_u256(n);
-            let rem_nonzero = rem != [0u64; 4];
-            let rem_gt_q = cmp_u256_u128(rem, q) > 0;
-            return finish::<N>(q, rem_nonzero, rem_gt_q, mode);
+            // The exact remainder n - root² comes fused out of the root (its
+            // square-test exit already computed root²). The remainder is
+            // <= 2·root, which may reach 2^129-2 (> u128) when root ~ 2^128 --
+            // compare via the 256-bit value directly.
+            let (root, remainder) = isqrt_u256(radicand);
+            let remainder_nonzero = remainder != [0u64; 4];
+            let remainder_gt_root = cmp_u256_u128(remainder, root) > 0;
+            return finish::<N>(root, remainder_nonzero, remainder_gt_root, mode);
         }
         // bit-256 carry (operands near 2^128): fall through to the wide path.
     }
@@ -421,15 +427,16 @@ where
     hypot_pythagoras::<N>(a, b, mode)
 }
 
-/// `a - b` for two `u256` (`[u64; 4]`), returning `(diff, borrow)`. Used for
-/// the exact remainder `n - q²` (where `n >= q²`, so `borrow` is `false`).
+/// `lhs - rhs` for two `u256` (`[u64; 4]`), returning `(diff, borrow)`. Used
+/// for the exact remainder `n - root²` (where `n >= root²`, so `borrow` is
+/// `false`).
 #[inline]
-fn sub_u256(a: [u64; 4], b: [u64; 4]) -> ([u64; 4], bool) {
+fn sub_u256(lhs: [u64; 4], rhs: [u64; 4]) -> ([u64; 4], bool) {
     let mut out = [0u64; 4];
     let mut borrow = 0i128;
     let mut i = 0;
     while i < 4 {
-        let d = a[i] as i128 - b[i] as i128 - borrow;
+        let d = lhs[i] as i128 - rhs[i] as i128 - borrow;
         if d < 0 {
             out[i] = (d + (1i128 << 64)) as u64;
             borrow = 1;
@@ -442,31 +449,32 @@ fn sub_u256(a: [u64; 4], b: [u64; 4]) -> ([u64; 4], bool) {
     (out, borrow != 0)
 }
 
-/// Compare a `u256` (`[u64; 4]`) against a `u128` `q`: `-1`/`0`/`1`. The high
-/// two limbs of the u256 decide first; only when they are zero does the low
-/// 128 bits compare against `q`.
+/// Compare a `u256` (`[u64; 4]`) against a `u128` `rhs`: `-1`/`0`/`1`. The
+/// high two limbs of the u256 decide first; only when they are zero does the
+/// low 128 bits compare against `rhs`.
 #[inline]
-fn cmp_u256_u128(a: [u64; 4], q: u128) -> i32 {
-    if a[3] != 0 || a[2] != 0 {
-        return 1; // a >= 2^128 > q
+fn cmp_u256_u128(lhs: [u64; 4], rhs: u128) -> i32 {
+    if lhs[3] != 0 || lhs[2] != 0 {
+        return 1; // lhs >= 2^128 > rhs
     }
-    let lo = (a[0] as u128) | ((a[1] as u128) << 64);
-    if lo < q {
+    let lo = (lhs[0] as u128) | ((lhs[1] as u128) << 64);
+    if lo < rhs {
         -1
-    } else if lo > q {
+    } else if lo > rhs {
         1
     } else {
         0
     }
 }
 
-/// Apply the rounding bump to the floor root `q` and pack it into an `Int<N>`,
+/// Apply the rounding bump to the floor `root` and pack it into an `Int<N>`,
 /// or [`None`] on true overflow (the rounded root does not fit the signed
 /// range of `Int<N>`). Shared by both scalar fast arms; the predicates
 /// `diff_nonzero` / `halfway_round_up` are the SAME exact-remainder tests
 /// [`hypot_pythagoras`] uses, so the result is bit-identical.
 #[inline]
-fn finish<const N: usize>(q: u128, diff_nonzero: bool, halfway_round_up: bool, mode: RoundingMode) -> Option<Int<N>> {
+fn finish<const N: usize>(root: u128, diff_nonzero: bool, halfway_round_up: bool,
+    mode: RoundingMode) -> Option<Int<N>> {
     let bump = match mode {
         RoundingMode::HalfToEven
         | RoundingMode::HalfAwayFromZero
@@ -474,17 +482,18 @@ fn finish<const N: usize>(q: u128, diff_nonzero: bool, halfway_round_up: bool, m
         RoundingMode::Trunc | RoundingMode::Floor => false,
         RoundingMode::Ceiling => diff_nonzero,
     };
-    // q < 2^128 and the bump is at most +1, so the rounded value is <= 2^128.
-    // When q == u128::MAX (= 2^128-1) and bump, the sum is exactly 2^128, which
-    // does NOT fit a u128 -- use `overflowing_add` so the bit-128 carry lands in
-    // `top_overflow` instead of wrapping `result` to 0 (a silent wrong answer).
-    let (result, carried) = q.overflowing_add(bump as u128);
+    // root < 2^128 and the bump is at most +1, so the rounded value is
+    // <= 2^128. When root == u128::MAX (= 2^128-1) and bump, the sum is
+    // exactly 2^128, which does NOT fit a u128 -- use `overflowing_add` so the
+    // bit-128 carry lands in `top_overflow` instead of wrapping `result` to 0
+    // (a silent wrong answer).
+    let (result, carried) = root.overflowing_add(bump as u128);
     let hi = (result >> 64) as u64;
     let lo = result as u64;
     // Fit check: must be < 2^(64N-1) (signed range). For N == 1 the whole
     // value must be < 2^63; for N == 2 it must be < 2^127; for N >= 3 a
     // 128-bit (here <= 2^128) value always fits, BUT result can reach 2^128
-    // exactly (q = 2^128-1, bump) -- that needs bit 128, i.e. a third limb.
+    // exactly (root = 2^128-1, bump) -- that needs bit 128, i.e. a third limb.
     let top_overflow = carried as u128; // bit 128 (1 iff the sum == 2^128)
     match N {
         1 => {
@@ -535,9 +544,9 @@ mod tests {
         RoundingMode::Ceiling,
     ];
 
-    fn mix(s: &mut u64) -> u64 {
-        *s = s.wrapping_add(0x9E37_79B9_7F4A_7C15);
-        let mut z = *s;
+    fn mix(state: &mut u64) -> u64 {
+        *state = state.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        let mut z = *state;
         z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
         z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
         z ^ (z >> 31)
@@ -549,7 +558,7 @@ mod tests {
     /// production column code.
     #[test]
     fn sq_u256_matches_reference() {
-        let mut s = 0x1234_5678_9ABC_DEF0u64;
+        let mut state = 0x1234_5678_9ABC_DEF0u64;
         // Hand checks against externally (Python) computed limbs.
         assert_eq!(sq_u256(0), [0, 0, 0, 0]);
         assert_eq!(sq_u256(1), [1, 0, 0, 0]);
@@ -560,23 +569,24 @@ mod tests {
         // The low 128 bits of the exact square must equal the wrapping square,
         // and the round-trip isqrt(sq) == x pins the full value for every x.
         for _ in 0..5000 {
-            let x = (mix(&mut s) as u128) | ((mix(&mut s) as u128) << 64);
-            let q = sq_u256(x);
-            let low = (q[0] as u128) | ((q[1] as u128) << 64);
+            let x = (mix(&mut state) as u128) | ((mix(&mut state) as u128) << 64);
+            let square = sq_u256(x);
+            let low = (square[0] as u128) | ((square[1] as u128) << 64);
             assert_eq!(low, x.wrapping_mul(x), "low128 x={x}");
-            assert_eq!(isqrt_u256(q), (x, [0u64; 4]), "roundtrip x={x}");
+            assert_eq!(isqrt_u256(square), (x, [0u64; 4]), "roundtrip x={x}");
         }
     }
 
     /// `isqrt_u256` must equal the exact floor sqrt for u256 radicands.
     #[test]
     fn isqrt_u256_exact_floor() {
-        let mut s = 0xDEAD_F00D_u64;
+        let mut state = 0xDEAD_F00D_u64;
         for _ in 0..3000 {
             // Build a u128 root r, square it, optionally add a small delta, and
             // confirm isqrt recovers floor(sqrt(r² + delta)) = r for delta in
             // [0, 2r].
-            let r = ((mix(&mut s) as u128) | ((mix(&mut s) as u128) << 64)) >> (mix(&mut s) % 64);
+            let r = ((mix(&mut state) as u128) | ((mix(&mut state) as u128) << 64))
+                >> (mix(&mut state) % 64);
             if r == 0 {
                 continue;
             }
@@ -606,14 +616,14 @@ mod tests {
     /// completely independently of the production Newton path: build the root
     /// one bit at a time from the top, accepting a trial bit iff its square
     /// does not exceed `n`. O(256·squaring) but exact -- the test oracle.
-    fn isqrt_u256_ref(n: [u64; 4]) -> u128 {
+    fn isqrt_u256_ref(radicand: [u64; 4]) -> u128 {
         // n < 2^256 so the floor root is < 2^128.
         let mut root: u128 = 0;
         let mut bit = 127i32;
         while bit >= 0 {
             let trial = root | (1u128 << bit);
             // accept iff trial² <= n.
-            if cmp_u256(sq_u256(trial), n) <= 0 {
+            if cmp_u256(sq_u256(trial), radicand) <= 0 {
                 root = trial;
             }
             bit -= 1;
@@ -634,33 +644,33 @@ mod tests {
     fn isqrt_u256_adversarial_perfect_square_tops() {
         // Recompute the production seed exactly as `isqrt_u256` does, so the
         // over-estimate assertion exercises the same library call/buffer.
-        fn seed_of(n: [u64; 4], bits: u32) -> u128 {
+        fn seed_of(radicand: [u64; 4], bits: u32) -> u128 {
             let mut out = [0u64; 3];
-            crate::algo_x_support::seed::sqrt_seed(&n, bits, &mut out);
+            crate::algo_x_support::seed::sqrt_seed(&radicand, bits, &mut out);
             if out[2] != 0 {
                 u128::MAX
             } else {
                 (out[0] as u128) | ((out[1] as u128) << 64)
             }
         }
-        fn bit_len_u256(n: [u64; 4]) -> u32 {
-            if n[3] != 0 {
-                192 + (64 - n[3].leading_zeros())
-            } else if n[2] != 0 {
-                128 + (64 - n[2].leading_zeros())
-            } else if n[1] != 0 {
-                64 + (64 - n[1].leading_zeros())
+        fn bit_len_u256(radicand: [u64; 4]) -> u32 {
+            if radicand[3] != 0 {
+                192 + (64 - radicand[3].leading_zeros())
+            } else if radicand[2] != 0 {
+                128 + (64 - radicand[2].leading_zeros())
+            } else if radicand[1] != 0 {
+                64 + (64 - radicand[1].leading_zeros())
             } else {
-                64 - n[0].leading_zeros()
+                64 - radicand[0].leading_zeros()
             }
         }
 
-        let mut s = 0x5EED_A11A_C0DE_u64;
+        let mut state = 0x5EED_A11A_C0DE_u64;
         // perfect-square roots k (so top = k² is an exact square): the two
         // boundary values + a spread of random k in [2^31, 2^32).
         let mut ks: Vec<u64> = vec![1u64 << 31, (1u64 << 32) - 1];
         for _ in 0..32 {
-            let k = (mix(&mut s) % (1u64 << 31)) + (1u64 << 31); // [2^31, 2^32)
+            let k = (mix(&mut state) % (1u64 << 31)) + (1u64 << 31); // [2^31, 2^32)
             ks.push(k);
         }
         // also a few small perfect-square tops near the top-window minimum.
@@ -673,23 +683,24 @@ mod tests {
                 // top < 2^64, shift <= 191 -> top·2^shift < 2^255, fits u256.
                 let mut n = [0u64; 4];
                 // place top << shift
-                let limb = (shift / 64) as usize;
-                let off = shift % 64;
-                let lo = (top << off) as u128; // low 128 bits at limb..limb+2
-                let hi = if off == 0 { 0u128 } else { top >> (128 - off) };
+                let limb_index = (shift / 64) as usize;
+                let bit_offset = shift % 64;
+                // low 128 bits at limb_index..limb_index+2
+                let lo = (top << bit_offset) as u128;
+                let hi = if bit_offset == 0 { 0u128 } else { top >> (128 - bit_offset) };
                 let pieces = [lo as u64, (lo >> 64) as u64, hi as u64];
-                for (idx, &pc) in pieces.iter().enumerate() {
-                    if limb + idx < 4 {
-                        n[limb + idx] = pc;
+                for (idx, &piece) in pieces.iter().enumerate() {
+                    if limb_index + idx < 4 {
+                        n[limb_index + idx] = piece;
                     }
                 }
                 // OR in (2^shift - 1): all bits below `shift` set.
                 let full_limbs = (shift / 64) as usize;
-                for l in n.iter_mut().take(full_limbs) {
-                    *l = u64::MAX;
+                for limb in n.iter_mut().take(full_limbs) {
+                    *limb = u64::MAX;
                 }
-                if off != 0 && full_limbs < 4 {
-                    n[full_limbs] |= (1u64 << off) - 1;
+                if bit_offset != 0 && full_limbs < 4 {
+                    n[full_limbs] |= (1u64 << bit_offset) - 1;
                 }
 
                 let bits = bit_len_u256(n);
@@ -732,20 +743,21 @@ mod tests {
             assert_eq!(got, want, "isqrt_u256 saturation-zone floor (d={d}) n={n:?}");
         }
         // A few more values near 2^256 generally (top bits set, large floor).
-        let mut s = 0xCAFE_5A7Eu64;
+        let mut state = 0xCAFE_5A7Eu64;
         for _ in 0..500 {
             // n near 2^256: set the top limb high, fill the rest randomly.
-            let n = [mix(&mut s), mix(&mut s), mix(&mut s), mix(&mut s) | (1u64 << 63)];
+            let n = [mix(&mut state), mix(&mut state), mix(&mut state),
+                mix(&mut state) | (1u64 << 63)];
             assert_eq!(isqrt_u256(n).0, isqrt_u256_ref(n), "near-2^256 floor n={n:?}");
         }
 
         // Full-kernel cross-check on the reachable N>=3 saturation input:
         // hypot(2^128-1, 1) -> u256 arm, n = (2^128-1)² + 1, floor = 2^128-1.
         let big = {
-            let mut l = [0u64; 3];
-            l[0] = u64::MAX;
-            l[1] = u64::MAX; // 2^128 - 1
-            Int::<3>::from_limbs(l)
+            let mut limbs = [0u64; 3];
+            limbs[0] = u64::MAX;
+            limbs[1] = u64::MAX; // 2^128 - 1
+            Int::<3>::from_limbs(limbs)
         };
         let one = Int::<3>::from_i64(1);
         for mode in ALL_MODES {
@@ -764,49 +776,49 @@ mod tests {
     where
         crate::int::types::compute_limbs::Limbs<N>: crate::int::types::compute_limbs::ComputeLimbs,
     {
-        let mut s = 0xDEAD_BEEF_CAFE_F00D_u64 ^ (N as u64);
+        let mut state = 0xDEAD_BEEF_CAFE_F00D_u64 ^ (N as u64);
         for _ in 0..400 {
-            let mut la = [0u64; N];
-            let mut lb = [0u64; N];
-            let shape = mix(&mut s) % 5;
+            let mut a_limbs = [0u64; N];
+            let mut b_limbs = [0u64; N];
+            let shape = mix(&mut state) % 5;
             match shape {
                 0 => {
                     // small ~32-bit (u128 fast arm)
-                    la[0] = mix(&mut s) & 0xFFFF_FFFF;
-                    lb[0] = mix(&mut s) & 0xFFFF_FFFF;
+                    a_limbs[0] = mix(&mut state) & 0xFFFF_FFFF;
+                    b_limbs[0] = mix(&mut state) & 0xFFFF_FFFF;
                 }
                 1 => {
                     // full single-limb (u128 fast arm, carry edge)
-                    la[0] = mix(&mut s);
-                    lb[0] = mix(&mut s);
+                    a_limbs[0] = mix(&mut state);
+                    b_limbs[0] = mix(&mut state);
                 }
                 2 if N >= 2 => {
                     // two-limb operands (< 2^128) -- the NEW u256 fast arm.
-                    la[0] = mix(&mut s);
-                    la[1] = mix(&mut s);
-                    lb[0] = mix(&mut s);
-                    lb[1] = mix(&mut s);
+                    a_limbs[0] = mix(&mut state);
+                    a_limbs[1] = mix(&mut state);
+                    b_limbs[0] = mix(&mut state);
+                    b_limbs[1] = mix(&mut state);
                 }
                 3 if N >= 2 => {
                     // two-limb with the TOP bit of limb1 set on one operand
                     // (near 2^128 -- exercises the bit-256-carry fall-through).
-                    la[0] = mix(&mut s);
-                    la[1] = mix(&mut s) | (1u64 << 63);
-                    lb[0] = mix(&mut s);
-                    lb[1] = mix(&mut s) | (1u64 << 63);
+                    a_limbs[0] = mix(&mut state);
+                    a_limbs[1] = mix(&mut state) | (1u64 << 63);
+                    b_limbs[0] = mix(&mut state);
+                    b_limbs[1] = mix(&mut state) | (1u64 << 63);
                 }
                 _ => {
                     // multi-limb -- exercises the fallback (clear top sign bit)
                     for k in 0..N {
-                        la[k] = mix(&mut s);
-                        lb[k] = mix(&mut s);
+                        a_limbs[k] = mix(&mut state);
+                        b_limbs[k] = mix(&mut state);
                     }
-                    la[N - 1] &= i64::MAX as u64;
-                    lb[N - 1] &= i64::MAX as u64;
+                    a_limbs[N - 1] &= i64::MAX as u64;
+                    b_limbs[N - 1] &= i64::MAX as u64;
                 }
             }
-            let a = Int::<N>::from_limbs(la);
-            let b = Int::<N>::from_limbs(lb);
+            let a = Int::<N>::from_limbs(a_limbs);
+            let b = Int::<N>::from_limbs(b_limbs);
             for mode in ALL_MODES {
                 assert_eq!(
                     hypot_u128_fast::<N>(a, b, mode),
@@ -819,14 +831,14 @@ mod tests {
         }
         // Explicit pythagorean triples and edges.
         let checks: [(i64, i64); 6] = [(3, 4), (5, 12), (8, 15), (1, 1), (0, 0), (0, 42)];
-        for (av, bv) in checks {
-            let a = Int::<N>::from_i64(av);
-            let b = Int::<N>::from_i64(bv);
+        for (a_value, b_value) in checks {
+            let a = Int::<N>::from_i64(a_value);
+            let b = Int::<N>::from_i64(b_value);
             for mode in ALL_MODES {
                 assert_eq!(
                     hypot_u128_fast::<N>(a, b, mode),
                     hypot_pythagoras::<N>(a, b, mode),
-                    "explicit N={N} mode={mode:?} a={av} b={bv}"
+                    "explicit N={N} mode={mode:?} a={a_value} b={b_value}"
                 );
             }
         }

--- a/src/int/algos/icbrt/icbrt_newton.rs
+++ b/src/int/algos/icbrt/icbrt_newton.rs
@@ -6,7 +6,7 @@
 //! [`icbrt_newton`] is the width-agnostic Brent–Zimmermann integer Newton
 //! cube root used by the fixed-width fast-arm dispatch in
 //! [`crate::int::policy::icbrt`] (`N >= 3`). Pure kernel — it takes the
-//! operand and writes `floor(cbrt(n))`; no algorithm choice.
+//! operand and writes `floor(cbrt(radicand))`; no algorithm choice.
 
 use crate::algo_x_support::seed::cbrt_seed;
 use crate::int::algos::support::limbs::{add_assign, bit_len, cmp};
@@ -20,7 +20,7 @@ use crate::int::algos::support::limbs::max_n_limbs;
 
 const SCRATCH_LIMBS: usize = max_n_limbs(4);
 
-/// `out = floor(cbrt(n))`. Newton iteration for the integer cube root.
+/// `out = floor(cbrt(radicand))`. Newton iteration for the integer cube root.
 ///
 /// Implements the Brent–Zimmermann integer Newton iteration for cube root
 /// (Modern Computer Arithmetic §1.5.2): starting from a safe over-estimate
@@ -34,26 +34,26 @@ const SCRATCH_LIMBS: usize = max_n_limbs(4);
 ///
 /// The seed is delegated to the cross-algorithm seed leaf
 /// ([`crate::algo_x_support::seed::cbrt_seed`]): under `std` it is derived
-/// from the hardware `f64::cbrt` of the top 64 bits of `n`, scaled back and
-/// rounded up to a safe over-estimate; under `no_std` it is the classical
-/// pure-integer 1-bit seed `2^ceil(bits/3)`. No `libm` / `num_traits::Float`
-/// is reached either way.
+/// from the hardware `f64::cbrt` of the top 64 bits of `radicand`, scaled
+/// back and rounded up to a safe over-estimate; under `no_std` it is the
+/// classical pure-integer 1-bit seed `2^ceil(bits/3)`. No `libm` /
+/// `num_traits::Float` is reached either way.
 ///
 /// All arithmetic uses fixed-size `SCRATCH_LIMBS` scratch buffers —
 /// no heap allocation, `core`/no_std-safe.
 ///
 /// Hasselgren seed strategy: see Crandall & Pomerance 2005, "Prime Numbers:
 /// A Computational Perspective" §9.2.1.
-pub(crate) fn icbrt_newton(n: &[u64], out: &mut [u64]) {
-    for o in out.iter_mut() {
-        *o = 0;
+pub(crate) fn icbrt_newton(radicand: &[u64], out: &mut [u64]) {
+    for limb in out.iter_mut() {
+        *limb = 0;
     }
-    let bits = bit_len(n);
+    let bits = bit_len(radicand);
     if bits == 0 {
         return;
     }
     if bits <= 1 {
-        // n == 0 already handled; n == 1 → root is 1.
+        // radicand == 0 already handled; radicand == 1 → root is 1.
         out[0] = 1;
         return;
     }
@@ -62,23 +62,23 @@ pub(crate) fn icbrt_newton(n: &[u64], out: &mut [u64]) {
     // We need scratch wide enough for s² — the same SCRATCH_LIMBS budget
     // as isqrt covers this (SCRATCH_LIMBS ≥ 288 limbs = 18 432 bits; the
     // widest shipped work-int is Int<256> = 16 384 bits).
-    let work = n.len() + 1;
-    debug_assert!(work <= SCRATCH_LIMBS, "icbrt scratch overflow");
+    let work_len = radicand.len() + 1;
+    debug_assert!(work_len <= SCRATCH_LIMBS, "icbrt scratch overflow");
 
     // ── seed ──────────────────────────────────────────────────────────
     // Delegated to the cross-algorithm seed leaf
     // (`algo_x_support::seed::cbrt_seed`): under `std` it is the hardware
-    // `f64::cbrt` of the top 64 bits of `n` scaled back and rounded up to a
-    // strict over-estimate; under `no_std` it is the classical pure-integer
-    // 1-bit seed `2^ceil(bits/3)`. Both over-estimate, so the
+    // `f64::cbrt` of the top 64 bits of `radicand` scaled back and rounded up
+    // to a strict over-estimate; under `no_std` it is the classical
+    // pure-integer 1-bit seed `2^ceil(bits/3)`. Both over-estimate, so the
     // monotone-downward Newton loop below converges to the same floor root.
     // The leaf calls nothing in-crate — `num_traits::Float`/libm is never
     // reached.
     let mut x = [0u64; SCRATCH_LIMBS];
-    cbrt_seed(n, bits, &mut x[..work]);
+    cbrt_seed(radicand, bits, &mut x[..work_len]);
 
     // ── Newton loop ───────────────────────────────────────────────────
-    // Invariant: x ≥ floor(cbrt(n)) at entry of each iteration.
+    // Invariant: x ≥ floor(cbrt(radicand)) at entry of each iteration.
     // The iteration s_new = (2*s + n/s²) / 3 is monotone-non-increasing
     // and halts when s_new ≥ s (i.e. s is the floor root).
     //
@@ -87,7 +87,7 @@ pub(crate) fn icbrt_newton(n: &[u64], out: &mut [u64]) {
     // wide-tier tax). Per pass only the live slices are touched: `sq` is
     // re-zeroed (mul_schoolbook accumulates); the n/s² divide re-zeros
     // `q`/`r`; the /3 divide's `y`/`rem3` are re-zeroed defensively (the
-    // single-limb divisor path may not). `x = y` is a `[..work]` copy.
+    // single-limb divisor path may not). `x = y` is a `[..work_len]` copy.
     let three = [3u64];
     let mut sq = [0u64; SCRATCH_LIMBS];
     let mut q = [0u64; SCRATCH_LIMBS];
@@ -95,34 +95,34 @@ pub(crate) fn icbrt_newton(n: &[u64], out: &mut [u64]) {
     let mut y = [0u64; SCRATCH_LIMBS];
     let mut rem3_buf = [0u64; SCRATCH_LIMBS];
     loop {
-        // t = s²  (2 * work limbs, but only work+1 matter)
-        let sq_work = (work * 2).min(SCRATCH_LIMBS);
-        for s in sq[..sq_work].iter_mut() {
-            *s = 0;
+        // t = s²  (2 * work_len limbs, but only work_len+1 matter)
+        let sq_len = (work_len * 2).min(SCRATCH_LIMBS);
+        for limb in sq[..sq_len].iter_mut() {
+            *limb = 0;
         }
-        mul_schoolbook(&x[..work], &x[..work], &mut sq[..sq_work]);
+        mul_schoolbook(&x[..work_len], &x[..work_len], &mut sq[..sq_len]);
 
-        // q = n / s²  (the divide engine re-zeros q[..work] / r[..sq_work])
-        div_rem_dispatch(n, &sq[..sq_work], &mut q[..work], &mut r[..sq_work]);
+        // q = n / s²  (the divide engine re-zeros q[..work_len] / r[..sq_len])
+        div_rem_dispatch(radicand, &sq[..sq_len], &mut q[..work_len], &mut r[..sq_len]);
 
         // t = 2*s + q: add 2*x into q.
         // 2*s = s << 1: add s twice (no overflow into extra limbs because
-        // the result fits in work+1 limbs by the cube-root bound).
-        add_assign(&mut q[..work], &x[..work]);
-        add_assign(&mut q[..work], &x[..work]);
+        // the result fits in work_len+1 limbs by the cube-root bound).
+        add_assign(&mut q[..work_len], &x[..work_len]);
+        add_assign(&mut q[..work_len], &x[..work_len]);
 
         // y = t / 3
-        for v in y[..work].iter_mut() {
-            *v = 0;
+        for limb in y[..work_len].iter_mut() {
+            *limb = 0;
         }
         rem3_buf[0] = 0;
-        div_rem_dispatch(&q[..work], &three, &mut y[..work], &mut rem3_buf[..1]);
+        div_rem_dispatch(&q[..work_len], &three, &mut y[..work_len], &mut rem3_buf[..1]);
 
-        if cmp(&y[..work], &x[..work]) >= 0 {
+        if cmp(&y[..work_len], &x[..work_len]) >= 0 {
             break;
         }
-        x[..work].copy_from_slice(&y[..work]);
+        x[..work_len].copy_from_slice(&y[..work_len]);
     }
-    let copy_len = if out.len() < work { out.len() } else { work };
+    let copy_len = if out.len() < work_len { out.len() } else { work_len };
     out[..copy_len].copy_from_slice(&x[..copy_len]);
 }

--- a/src/int/algos/icbrt/icbrt_newton_recip.rs
+++ b/src/int/algos/icbrt/icbrt_newton_recip.rs
@@ -87,28 +87,28 @@ use crate::int::types::compute_limbs::MAX_QUADRUPLE_LIMBS;
 
 /// Scratch capacity for the reciprocal-Newton cube root. The widest
 /// intermediate is `prod = Y·bracket ≈ 2^{4F−bits/3}` (≈`4F` bits); with
-/// `F ≈ 2·bits/3`, that is `≈8·bits/3` bits ≈ `4·n.len()` limbs of headroom
-/// over the operand. `2·MAX_QUADRUPLE_LIMBS + 8` u64 limbs covers it for
-/// every shipped operand width. Local to this candidate; it sizes no other
-/// tier. The wider footprint is the division-free trade's cost,
+/// `F ≈ 2·bits/3`, that is `≈8·bits/3` bits ≈ `4·radicand.len()` limbs of
+/// headroom over the operand. `2·MAX_QUADRUPLE_LIMBS + 8` u64 limbs covers
+/// it for every shipped operand width. Local to this candidate; it sizes no
+/// other tier. The wider footprint is the division-free trade's cost,
 /// weighed at bench time.
 const SCRATCH_LIMBS: usize = 2 * MAX_QUADRUPLE_LIMBS + 8;
 /// Guard fractional bits carried by the reciprocal `Y` beyond the root
 /// precision; ample for the end-correction to finish in O(1) steps.
 const GUARD_BITS: u32 = 32;
 
-/// `out = floor(cbrt(n))`, computed division-free via a reciprocal-root
-/// Newton iteration plus an exact integer end-correction.
+/// `out = floor(cbrt(radicand))`, computed division-free via a
+/// reciprocal-root Newton iteration plus an exact integer end-correction.
 ///
 /// Bit-identical to
 /// [`crate::int::algos::icbrt::icbrt_newton::icbrt_newton`]; see the module
 /// docs for the algorithm and references.
 #[allow(dead_code)]
-pub(crate) fn icbrt_newton_recip(n: &[u64], out: &mut [u64]) {
-    for o in out.iter_mut() {
-        *o = 0;
+pub(crate) fn icbrt_newton_recip(radicand: &[u64], out: &mut [u64]) {
+    for limb in out.iter_mut() {
+        *limb = 0;
     }
-    let bits = bit_len(n);
+    let bits = bit_len(radicand);
     if bits == 0 {
         return;
     }
@@ -117,32 +117,36 @@ pub(crate) fn icbrt_newton_recip(n: &[u64], out: &mut [u64]) {
         return;
     }
 
-    let nsig = sig_len(n);
-    let work = nsig + 1;
+    let radicand_len = sig_len(radicand);
+    let work_len = radicand_len + 1;
 
     // ── fixed-point scale + intermediate widths (see module docs) ─────────
     let f: u32 = (2 * bits).div_ceil(3) + GUARD_BITS;
-    let fz = f as usize;
-    let yl = fz / 64 + 2; // Y < 2^F
-    let f3l = (3 * fz) / 64 + 3; // ~3F-bit values: 2^{3F+2}, n·Y³, bracket
-    let prodl = (4 * fz) / 64 + 4; // ~4F-bit: prod = Y·bracket (the peak)
-    debug_assert!(prodl <= SCRATCH_LIMBS, "icbrt_recip 4F scratch overflow");
-    debug_assert!(nsig + f3l <= SCRATCH_LIMBS, "icbrt_recip n·Y³ scratch overflow");
+    let f_usize = f as usize;
+    let y_len = f_usize / 64 + 2; // Y < 2^F
+    // ~3F-bit values: 2^{3F+2}, n·Y³, bracket
+    let f3_len = (3 * f_usize) / 64 + 3;
+    // ~4F-bit: prod = Y·bracket (the peak)
+    let peak_prod_len = (4 * f_usize) / 64 + 4;
+    debug_assert!(peak_prod_len <= SCRATCH_LIMBS, "icbrt_recip 4F scratch overflow");
+    debug_assert!(radicand_len + f3_len <= SCRATCH_LIMBS,
+        "icbrt_recip n·Y³ scratch overflow");
 
     // ── seed s0 ≥ ⌊∛n⌋ (shared cube-root seed) ────────────────────────────
     let mut s0 = [0u64; SCRATCH_LIMBS];
-    cbrt_seed(n, bits, &mut s0[..work]);
+    cbrt_seed(radicand, bits, &mut s0[..work_len]);
 
     // ── Y0 = 2^F / s0  (the ONE divide, run ONCE) ─────────────────────────
     let mut two_f = [0u64; SCRATCH_LIMBS];
-    two_f[fz / 64] = 1u64 << (f % 64);
-    let fdl = (fz / 64 + 2).max(work); // dividend length
+    two_f[f_usize / 64] = 1u64 << (f % 64);
+    let dividend_len = (f_usize / 64 + 2).max(work_len);
     let mut y = [0u64; SCRATCH_LIMBS];
     {
-        let mut rem = [0u64; SCRATCH_LIMBS];
-        div_rem_dispatch(&two_f[..fdl], &s0[..work], &mut y[..fdl], &mut rem[..fdl]);
+        let mut remainder = [0u64; SCRATCH_LIMBS];
+        div_rem_dispatch(&two_f[..dividend_len], &s0[..work_len],
+            &mut y[..dividend_len], &mut remainder[..dividend_len]);
     }
-    if is_zero(&y[..yl]) {
+    if is_zero(&y[..y_len]) {
         y[0] = 1; // never let the reciprocal collapse to zero
     }
 
@@ -155,131 +159,132 @@ pub(crate) fn icbrt_newton_recip(n: &[u64], out: &mut [u64]) {
     let mut bracket = [0u64; SCRATCH_LIMBS];
     let mut prod = [0u64; SCRATCH_LIMBS];
     let mut tmp = [0u64; SCRATCH_LIMBS];
-    let mut newy = [0u64; SCRATCH_LIMBS];
+    let mut new_y = [0u64; SCRATCH_LIMBS];
     let mut rem3 = [0u64; SCRATCH_LIMBS];
     let mut iter = 0;
     while iter < iters {
-        let ysig = sig_len(&y[..(yl + 2).min(SCRATCH_LIMBS)]);
+        let y_sig_len = sig_len(&y[..(y_len + 2).min(SCRATCH_LIMBS)]);
 
         // y2 = Y²  (full product width).
-        let y2len = 2 * ysig;
-        for v in y2[..y2len].iter_mut() {
-            *v = 0;
+        let y2_len = 2 * y_sig_len;
+        for limb in y2[..y2_len].iter_mut() {
+            *limb = 0;
         }
-        mul_schoolbook(&y[..ysig], &y[..ysig], &mut y2[..y2len]);
-        let y2sig = sig_len(&y2[..y2len]);
+        mul_schoolbook(&y[..y_sig_len], &y[..y_sig_len], &mut y2[..y2_len]);
+        let y2_sig_len = sig_len(&y2[..y2_len]);
 
         // y3 = y2·Y.
-        let y3len = y2sig + ysig;
-        for v in y3[..y3len].iter_mut() {
-            *v = 0;
+        let y3_len = y2_sig_len + y_sig_len;
+        for limb in y3[..y3_len].iter_mut() {
+            *limb = 0;
         }
-        mul_schoolbook(&y2[..y2sig], &y[..ysig], &mut y3[..y3len]);
-        let y3sig = sig_len(&y3[..y3len]);
+        mul_schoolbook(&y2[..y2_sig_len], &y[..y_sig_len], &mut y3[..y3_len]);
+        let y3_sig_len = sig_len(&y3[..y3_len]);
 
         // ny3 = n·Y³ ≈ 2^{3F}.
-        let ny3len = nsig + y3sig;
-        for v in ny3[..ny3len].iter_mut() {
-            *v = 0;
+        let ny3_len = radicand_len + y3_sig_len;
+        for limb in ny3[..ny3_len].iter_mut() {
+            *limb = 0;
         }
-        mul_schoolbook(&n[..nsig], &y3[..y3sig], &mut ny3[..ny3len]);
-        let ny3sig = sig_len(&ny3[..ny3len]);
+        mul_schoolbook(&radicand[..radicand_len], &y3[..y3_sig_len], &mut ny3[..ny3_len]);
+        let ny3_sig_len = sig_len(&ny3[..ny3_len]);
 
         // bracket = 4·2^{3F} − n·Y³  (4·2^{3F} = 2^{3F+2}).
-        for v in bracket[..f3l].iter_mut() {
-            *v = 0;
+        for limb in bracket[..f3_len].iter_mut() {
+            *limb = 0;
         }
         {
-            let pos = 3 * fz + 2;
+            let pos = 3 * f_usize + 2;
             bracket[pos / 64] = 1u64 << (pos % 64);
         }
-        if cmp(&bracket[..f3l], &ny3[..ny3sig]) < 0 {
+        if cmp(&bracket[..f3_len], &ny3[..ny3_sig_len]) < 0 {
             // over-shot: clamp the bracket to 0 (Y shrinks toward the fixed
             // point); keeps the unsigned subtraction well-defined.
-            for v in bracket[..f3l].iter_mut() {
-                *v = 0;
+            for limb in bracket[..f3_len].iter_mut() {
+                *limb = 0;
             }
         } else {
-            sub_assign(&mut bracket[..f3l], &ny3[..ny3sig]);
+            sub_assign(&mut bracket[..f3_len], &ny3[..ny3_sig_len]);
         }
-        let brsig = sig_len(&bracket[..f3l]);
+        let bracket_sig_len = sig_len(&bracket[..f3_len]);
 
         // prod = Y·bracket  (the 4F-bit peak — full product width).
-        let prodlen = ysig + brsig;
-        for v in prod[..prodlen].iter_mut() {
-            *v = 0;
+        let prod_len = y_sig_len + bracket_sig_len;
+        for limb in prod[..prod_len].iter_mut() {
+            *limb = 0;
         }
-        mul_schoolbook(&y[..ysig], &bracket[..brsig], &mut prod[..prodlen]);
+        mul_schoolbook(&y[..y_sig_len], &bracket[..bracket_sig_len], &mut prod[..prod_len]);
 
-        // newy = prod / (3·2^{3F}) = (prod >> 3F) / 3.
-        for v in tmp[..prodlen].iter_mut() {
-            *v = 0;
+        // new_y = prod / (3·2^{3F}) = (prod >> 3F) / 3.
+        for limb in tmp[..prod_len].iter_mut() {
+            *limb = 0;
         }
-        shr(&prod[..prodlen], 3 * f, &mut tmp[..prodlen]);
-        let tmpsig = sig_len(&tmp[..prodlen]).max(1);
-        for v in newy[..tmpsig].iter_mut() {
-            *v = 0;
+        shr(&prod[..prod_len], 3 * f, &mut tmp[..prod_len]);
+        let tmp_sig_len = sig_len(&tmp[..prod_len]).max(1);
+        for limb in new_y[..tmp_sig_len].iter_mut() {
+            *limb = 0;
         }
         rem3[0] = 0;
-        div_rem_dispatch(&tmp[..tmpsig], &three, &mut newy[..tmpsig], &mut rem3[..1]);
+        div_rem_dispatch(&tmp[..tmp_sig_len], &three, &mut new_y[..tmp_sig_len],
+            &mut rem3[..1]);
 
         // Fixed-point reached → stop early (the end-correction does the rest).
-        let cmp_len = tmpsig.max(yl);
-        if cmp(&newy[..cmp_len.min(SCRATCH_LIMBS)], &y[..cmp_len.min(SCRATCH_LIMBS)]) == 0 {
+        let cmp_len = tmp_sig_len.max(y_len);
+        if cmp(&new_y[..cmp_len.min(SCRATCH_LIMBS)], &y[..cmp_len.min(SCRATCH_LIMBS)]) == 0 {
             iter = iters;
         } else {
             iter += 1;
         }
-        let copy_len = tmpsig.min(SCRATCH_LIMBS);
-        for v in y[..(yl + 2).min(SCRATCH_LIMBS)].iter_mut() {
-            *v = 0;
+        let copy_len = tmp_sig_len.min(SCRATCH_LIMBS);
+        for limb in y[..(y_len + 2).min(SCRATCH_LIMBS)].iter_mut() {
+            *limb = 0;
         }
-        y[..copy_len].copy_from_slice(&newy[..copy_len]);
+        y[..copy_len].copy_from_slice(&new_y[..copy_len]);
     }
 
     // ── recover s ≈ (n · Y²) >> 2F ────────────────────────────────────────
-    let ysig = sig_len(&y[..(yl + 2).min(SCRATCH_LIMBS)]);
-    let y2len = 2 * ysig;
-    for v in y2[..y2len].iter_mut() {
-        *v = 0;
+    let y_sig_len = sig_len(&y[..(y_len + 2).min(SCRATCH_LIMBS)]);
+    let y2_len = 2 * y_sig_len;
+    for limb in y2[..y2_len].iter_mut() {
+        *limb = 0;
     }
-    mul_schoolbook(&y[..ysig], &y[..ysig], &mut y2[..y2len]);
-    let y2sig = sig_len(&y2[..y2len]);
-    let nylen = nsig + y2sig;
-    for v in prod[..nylen].iter_mut() {
-        *v = 0;
+    mul_schoolbook(&y[..y_sig_len], &y[..y_sig_len], &mut y2[..y2_len]);
+    let y2_sig_len = sig_len(&y2[..y2_len]);
+    let n_y2_len = radicand_len + y2_sig_len;
+    for limb in prod[..n_y2_len].iter_mut() {
+        *limb = 0;
     }
-    mul_schoolbook(&n[..nsig], &y2[..y2sig], &mut prod[..nylen]);
+    mul_schoolbook(&radicand[..radicand_len], &y2[..y2_sig_len], &mut prod[..n_y2_len]);
     let mut s = [0u64; SCRATCH_LIMBS];
-    shr(&prod[..nylen], 2 * f, &mut s[..work]);
+    shr(&prod[..n_y2_len], 2 * f, &mut s[..work_len]);
 
     // If the reciprocal collapsed (s == 0) fall back to the seed over-estimate.
-    if is_zero(&s[..work]) {
-        s[..work].copy_from_slice(&s0[..work]);
+    if is_zero(&s[..work_len]) {
+        s[..work_len].copy_from_slice(&s0[..work_len]);
     }
 
     // ── exact integer end-correction (multiplies only) ────────────────────
     let one = [1u64];
     let mut sq = [0u64; SCRATCH_LIMBS];
     let mut cube = [0u64; SCRATCH_LIMBS];
-    let mut sp1 = [0u64; SCRATCH_LIMBS];
+    let mut s_plus_one = [0u64; SCRATCH_LIMBS];
 
     // Walk DOWN while s³ > n.
     loop {
-        let slen = sig_len(&s[..work]);
-        let sqlen = (2 * slen).min(SCRATCH_LIMBS);
-        for v in sq[..sqlen].iter_mut() {
-            *v = 0;
+        let s_len = sig_len(&s[..work_len]);
+        let sq_len = (2 * s_len).min(SCRATCH_LIMBS);
+        for limb in sq[..sq_len].iter_mut() {
+            *limb = 0;
         }
-        mul_schoolbook(&s[..slen], &s[..slen], &mut sq[..sqlen]);
-        let sqsig = sig_len(&sq[..sqlen]);
-        let cublen = (sqsig + slen).min(SCRATCH_LIMBS);
-        for v in cube[..cublen].iter_mut() {
-            *v = 0;
+        mul_schoolbook(&s[..s_len], &s[..s_len], &mut sq[..sq_len]);
+        let sq_sig_len = sig_len(&sq[..sq_len]);
+        let cube_len = (sq_sig_len + s_len).min(SCRATCH_LIMBS);
+        for limb in cube[..cube_len].iter_mut() {
+            *limb = 0;
         }
-        mul_schoolbook(&sq[..sqsig], &s[..slen], &mut cube[..cublen]);
-        if cmp(&cube[..cublen], n) > 0 {
-            sub_assign(&mut s[..work], &one);
+        mul_schoolbook(&sq[..sq_sig_len], &s[..s_len], &mut cube[..cube_len]);
+        if cmp(&cube[..cube_len], radicand) > 0 {
+            sub_assign(&mut s[..work_len], &one);
         } else {
             break;
         }
@@ -287,40 +292,40 @@ pub(crate) fn icbrt_newton_recip(n: &[u64], out: &mut [u64]) {
 
     // Walk UP while (s+1)³ ≤ n.
     loop {
-        sp1[..work].copy_from_slice(&s[..work]);
-        add_assign(&mut sp1[..work], &one);
-        let slen = sig_len(&sp1[..work]);
-        let sqlen = (2 * slen).min(SCRATCH_LIMBS);
-        for v in sq[..sqlen].iter_mut() {
-            *v = 0;
+        s_plus_one[..work_len].copy_from_slice(&s[..work_len]);
+        add_assign(&mut s_plus_one[..work_len], &one);
+        let s_len = sig_len(&s_plus_one[..work_len]);
+        let sq_len = (2 * s_len).min(SCRATCH_LIMBS);
+        for limb in sq[..sq_len].iter_mut() {
+            *limb = 0;
         }
-        mul_schoolbook(&sp1[..slen], &sp1[..slen], &mut sq[..sqlen]);
-        let sqsig = sig_len(&sq[..sqlen]);
-        let cublen = (sqsig + slen).min(SCRATCH_LIMBS);
-        for v in cube[..cublen].iter_mut() {
-            *v = 0;
+        mul_schoolbook(&s_plus_one[..s_len], &s_plus_one[..s_len], &mut sq[..sq_len]);
+        let sq_sig_len = sig_len(&sq[..sq_len]);
+        let cube_len = (sq_sig_len + s_len).min(SCRATCH_LIMBS);
+        for limb in cube[..cube_len].iter_mut() {
+            *limb = 0;
         }
-        mul_schoolbook(&sq[..sqsig], &sp1[..slen], &mut cube[..cublen]);
-        if cmp(&cube[..cublen], n) <= 0 {
-            s[..work].copy_from_slice(&sp1[..work]);
+        mul_schoolbook(&sq[..sq_sig_len], &s_plus_one[..s_len], &mut cube[..cube_len]);
+        if cmp(&cube[..cube_len], radicand) <= 0 {
+            s[..work_len].copy_from_slice(&s_plus_one[..work_len]);
         } else {
             break;
         }
     }
 
-    let copy_len = out.len().min(work);
+    let copy_len = out.len().min(work_len);
     out[..copy_len].copy_from_slice(&s[..copy_len]);
 }
 
-/// Significant limb count of `a` (highest non-zero index + 1), minimum 1.
+/// Significant limb count of `limbs` (highest non-zero index + 1), minimum 1.
 #[inline]
-fn sig_len(a: &[u64]) -> usize {
-    let mut i = a.len();
-    while i > 0 {
-        if a[i - 1] != 0 {
-            return i;
+fn sig_len(limbs: &[u64]) -> usize {
+    let mut len = limbs.len();
+    while len > 0 {
+        if limbs[len - 1] != 0 {
+            return len;
         }
-        i -= 1;
+        len -= 1;
     }
     1
 }
@@ -330,29 +335,29 @@ mod tests {
     use super::icbrt_newton_recip;
     use crate::int::algos::icbrt::icbrt_newton::icbrt_newton;
 
-    fn recip(n: &[u64], limbs: usize) -> Vec<u64> {
+    fn recip(radicand: &[u64], limbs: usize) -> Vec<u64> {
         let mut out = vec![0u64; limbs];
-        icbrt_newton_recip(n, &mut out);
+        icbrt_newton_recip(radicand, &mut out);
         out
     }
-    fn newton(n: &[u64], limbs: usize) -> Vec<u64> {
+    fn newton(radicand: &[u64], limbs: usize) -> Vec<u64> {
         let mut out = vec![0u64; limbs];
-        icbrt_newton(n, &mut out);
+        icbrt_newton(radicand, &mut out);
         out
     }
-    fn recip_u64(n: u64) -> u64 {
-        recip(&[n], 1)[0]
+    fn recip_u64(radicand: u64) -> u64 {
+        recip(&[radicand], 1)[0]
     }
-    fn newton_u64(n: u64) -> u64 {
-        newton(&[n], 1)[0]
+    fn newton_u64(radicand: u64) -> u64 {
+        newton(&[radicand], 1)[0]
     }
-    fn recip_u128(n: u128) -> u128 {
-        let v = recip(&[n as u64, (n >> 64) as u64], 2);
-        (v[0] as u128) | ((v[1] as u128) << 64)
+    fn recip_u128(radicand: u128) -> u128 {
+        let root = recip(&[radicand as u64, (radicand >> 64) as u64], 2);
+        (root[0] as u128) | ((root[1] as u128) << 64)
     }
-    fn newton_u128(n: u128) -> u128 {
-        let v = newton(&[n as u64, (n >> 64) as u64], 2);
-        (v[0] as u128) | ((v[1] as u128) << 64)
+    fn newton_u128(radicand: u128) -> u128 {
+        let root = newton(&[radicand as u64, (radicand >> 64) as u64], 2);
+        (root[0] as u128) | ((root[1] as u128) << 64)
     }
 
     #[test]
@@ -453,12 +458,12 @@ mod tests {
         for &limbs in &[3usize, 4, 6, 8, 16] {
             for _ in 0..40 {
                 let mut n = vec![0u64; limbs];
-                let top = 1 + (next() as usize % limbs);
-                for l in n.iter_mut().take(top) {
-                    *l = next();
+                let fill_len = 1 + (next() as usize % limbs);
+                for limb in n.iter_mut().take(fill_len) {
+                    *limb = next();
                 }
-                if n[top - 1] == 0 {
-                    n[top - 1] = 1;
+                if n[fill_len - 1] == 0 {
+                    n[fill_len - 1] = 1;
                 }
                 assert_eq!(
                     recip(&n, limbs),
@@ -467,18 +472,18 @@ mod tests {
                 );
             }
             for _ in 0..10 {
-                let mut b = vec![0u64; limbs];
-                let bt = 1 + (next() as usize % limbs.div_ceil(3).max(1));
-                for l in b.iter_mut().take(bt) {
-                    *l = next();
+                let mut base = vec![0u64; limbs];
+                let base_fill_len = 1 + (next() as usize % limbs.div_ceil(3).max(1));
+                for limb in base.iter_mut().take(base_fill_len) {
+                    *limb = next();
                 }
-                if b[bt - 1] == 0 {
-                    b[bt - 1] = 1;
+                if base[base_fill_len - 1] == 0 {
+                    base[base_fill_len - 1] = 1;
                 }
                 let mut sq = vec![0u64; limbs * 3];
-                crate::int::algos::mul::mul_schoolbook::mul_schoolbook(&b, &b, &mut sq);
+                crate::int::algos::mul::mul_schoolbook::mul_schoolbook(&base, &base, &mut sq);
                 let mut cube = vec![0u64; limbs * 3];
-                crate::int::algos::mul::mul_schoolbook::mul_schoolbook(&sq, &b, &mut cube);
+                crate::int::algos::mul::mul_schoolbook::mul_schoolbook(&sq, &base, &mut cube);
                 let mut n = vec![0u64; limbs];
                 n.copy_from_slice(&cube[..limbs]);
                 assert_eq!(

--- a/src/int/algos/icbrt/icbrt_schoolbook.rs
+++ b/src/int/algos/icbrt/icbrt_schoolbook.rs
@@ -27,9 +27,9 @@
 //!   `p_sq_new = (p + d)² = p² + 2·p·d + d²`
 //!   computed by the same schoolbook kernel.
 //!
-//! The running term `p_cube_rem = n - p³` (the remainder) is maintained to
-//! avoid recomputing `p³` from scratch each step. On acceptance:
-//!   `p_cube_rem -= delta`.
+//! The running term `remainder = n - p³` is maintained to avoid recomputing
+//! `p³` from scratch each step. On acceptance:
+//!   `remainder -= delta`.
 //!
 //! # Properties
 //!
@@ -47,20 +47,21 @@ use crate::int::algos::support::limbs::{
 /// Scratch capacity — 288 u64 limbs, matching the Newton icbrt budget.
 use crate::int::types::compute_limbs::MAX_QUADRUPLE_LIMBS;
 
-/// `out = floor(cbrt(n))`. Bit-by-bit integer cube root.
+/// `out = floor(cbrt(radicand))`. Bit-by-bit integer cube root.
 ///
 /// Determines each bit of the result from MSB to LSB. At each step tests
-/// whether the next candidate bit can be set by checking `(p + bit)³ <= n`
-/// via an incremental delta, using schoolbook multiply kernels directly.
-/// No division, no floating-point seed, no Newton iteration.
+/// whether the next candidate bit can be set by checking
+/// `(p + bit)³ <= radicand` via an incremental delta, using schoolbook
+/// multiply kernels directly. No division, no floating-point seed, no Newton
+/// iteration.
 ///
 /// Result is identical to
 /// [`crate::int::algos::icbrt::icbrt_newton::icbrt_newton`].
-pub(crate) fn icbrt_schoolbook(n: &[u64], out: &mut [u64]) {
-    for o in out.iter_mut() {
-        *o = 0;
+pub(crate) fn icbrt_schoolbook(radicand: &[u64], out: &mut [u64]) {
+    for limb in out.iter_mut() {
+        *limb = 0;
     }
-    let bits = bit_len(n);
+    let bits = bit_len(radicand);
     if bits == 0 {
         return;
     }
@@ -69,21 +70,21 @@ pub(crate) fn icbrt_schoolbook(n: &[u64], out: &mut [u64]) {
         return;
     }
 
-    let work = n.len() + 1;
-    // sq_work: p_sq needs at most 2*(work/3)+2 limbs, but we use work+1 as
-    // an upper bound (the result has at most ceil(bits/3) bits, so p_sq has
-    // at most ceil(2*bits/3) bits, which is < work limbs).
-    let sq_work = (work * 2).min(MAX_QUADRUPLE_LIMBS);
-    debug_assert!(work <= MAX_QUADRUPLE_LIMBS, "icbrt_schoolbook scratch overflow");
+    let work_len = radicand.len() + 1;
+    // sq_len: p_sq needs at most 2*(work_len/3)+2 limbs, but we use
+    // work_len+1 as an upper bound (the result has at most ceil(bits/3) bits,
+    // so p_sq has at most ceil(2*bits/3) bits, which is < work_len limbs).
+    let sq_len = (work_len * 2).min(MAX_QUADRUPLE_LIMBS);
+    debug_assert!(work_len <= MAX_QUADRUPLE_LIMBS, "icbrt_schoolbook scratch overflow");
 
     // `p`: partial root (result bits accumulated so far).
     // `p_sq`: p², maintained incrementally.
-    // `rem`: n - p³, the running remainder.
+    // `remainder`: n - p³, the running remainder.
     let mut p = [0u64; MAX_QUADRUPLE_LIMBS];
     let mut p_sq = [0u64; MAX_QUADRUPLE_LIMBS];
-    let mut rem = [0u64; MAX_QUADRUPLE_LIMBS];
-    // Initialise rem = n.
-    rem[..n.len()].copy_from_slice(n);
+    let mut remainder = [0u64; MAX_QUADRUPLE_LIMBS];
+    // Initialise remainder = n.
+    remainder[..radicand.len()].copy_from_slice(radicand);
 
     // result_bits = ceil(bits / 3): the number of bits in floor(cbrt(n)).
     let result_bits = bits.div_ceil(3);
@@ -93,85 +94,85 @@ pub(crate) fn icbrt_schoolbook(n: &[u64], out: &mut [u64]) {
     while k >= 0 {
         // `d` = 1 << k  (a single-bit value in a limb array).
         let bit_pos = k as u32;
-        let d_limb = (bit_pos / 64) as usize;
-        let d_off = bit_pos % 64;
+        let d_limb_index = (bit_pos / 64) as usize;
+        let d_bit_offset = bit_pos % 64;
         let mut d = [0u64; MAX_QUADRUPLE_LIMBS];
-        if d_limb < MAX_QUADRUPLE_LIMBS {
-            d[d_limb] = 1u64 << d_off;
+        if d_limb_index < MAX_QUADRUPLE_LIMBS {
+            d[d_limb_index] = 1u64 << d_bit_offset;
         }
 
         // Compute delta = d * (3*p_sq + 3*p*d + d*d)
         //               = (p + d)^3 - p^3
         //
-        // Step 1: t1 = 3 * p_sq  (just shift p_sq left by 1 and add once)
+        // Step 1: three_p_sq = 3 * p_sq  (shift p_sq left by 1 and add once)
         // 3*p_sq = p_sq + p_sq + p_sq = p_sq*2 + p_sq = (p_sq << 1) + p_sq
-        let mut t1 = [0u64; MAX_QUADRUPLE_LIMBS];
+        let mut three_p_sq = [0u64; MAX_QUADRUPLE_LIMBS];
         {
             let mut shifted = [0u64; MAX_QUADRUPLE_LIMBS];
-            shl(&p_sq[..sq_work], 1, &mut shifted[..sq_work]);
-            t1[..sq_work].copy_from_slice(&shifted[..sq_work]);
-            add_assign(&mut t1[..sq_work], &p_sq[..sq_work]);
+            shl(&p_sq[..sq_len], 1, &mut shifted[..sq_len]);
+            three_p_sq[..sq_len].copy_from_slice(&shifted[..sq_len]);
+            add_assign(&mut three_p_sq[..sq_len], &p_sq[..sq_len]);
         }
-        // t1 = 3 * p_sq
 
-        // Step 2: p_d = p * d  (using mul_schoolbook, result in 2*work area)
-        let pd_work = (work + d_limb + 1).min(MAX_QUADRUPLE_LIMBS);
+        // Step 2: p_d = p * d  (using mul_schoolbook, result in 2*work_len
+        // area)
+        let p_d_len = (work_len + d_limb_index + 1).min(MAX_QUADRUPLE_LIMBS);
         let mut p_d = [0u64; MAX_QUADRUPLE_LIMBS];
-        mul_schoolbook(&p[..work], &d[..d_limb + 1], &mut p_d[..pd_work]);
+        mul_schoolbook(&p[..work_len], &d[..d_limb_index + 1], &mut p_d[..p_d_len]);
 
-        // Step 3: t2 = 3 * p_d = (p_d << 1) + p_d
-        let mut t2 = [0u64; MAX_QUADRUPLE_LIMBS];
+        // Step 3: three_p_d = 3 * p_d = (p_d << 1) + p_d
+        let mut three_p_d = [0u64; MAX_QUADRUPLE_LIMBS];
         {
             let mut shifted = [0u64; MAX_QUADRUPLE_LIMBS];
-            shl(&p_d[..pd_work], 1, &mut shifted[..pd_work]);
-            t2[..pd_work].copy_from_slice(&shifted[..pd_work]);
-            add_assign(&mut t2[..pd_work], &p_d[..pd_work]);
+            shl(&p_d[..p_d_len], 1, &mut shifted[..p_d_len]);
+            three_p_d[..p_d_len].copy_from_slice(&shifted[..p_d_len]);
+            add_assign(&mut three_p_d[..p_d_len], &p_d[..p_d_len]);
         }
-        // t2 = 3 * p * d
 
         // Step 4: d_sq = d * d = d << k (since d = 2^k, d^2 = 2^(2k))
         // d^2 has bit at position 2k.
         let d_sq_pos = (k as u32) * 2;
-        let d_sq_limb = (d_sq_pos / 64) as usize;
-        let d_sq_off = d_sq_pos % 64;
+        let d_sq_limb_index = (d_sq_pos / 64) as usize;
+        let d_sq_bit_offset = d_sq_pos % 64;
         let mut d_sq = [0u64; MAX_QUADRUPLE_LIMBS];
-        if d_sq_limb < MAX_QUADRUPLE_LIMBS {
-            d_sq[d_sq_limb] = 1u64 << d_sq_off;
+        if d_sq_limb_index < MAX_QUADRUPLE_LIMBS {
+            d_sq[d_sq_limb_index] = 1u64 << d_sq_bit_offset;
         }
-        // Handle overflow into the next limb if d_sq_off == 63 and a carry
-        // would appear — but since d = 2^k and d^2 = 2^(2k), there is
+        // Handle overflow into the next limb if d_sq_bit_offset == 63 and a
+        // carry would appear — but since d = 2^k and d^2 = 2^(2k), there is
         // exactly one bit set at position 2k, no carry needed.
 
-        // Step 5: inner = t1 + t2 + d_sq = 3p^2 + 3pd + d^2
-        let inner_work = sq_work.max(pd_work).max(d_sq_limb + 1) + 1;
-        let inner_work = inner_work.min(MAX_QUADRUPLE_LIMBS);
+        // Step 5: inner = three_p_sq + three_p_d + d_sq = 3p^2 + 3pd + d^2
+        let inner_len = sq_len.max(p_d_len).max(d_sq_limb_index + 1) + 1;
+        let inner_len = inner_len.min(MAX_QUADRUPLE_LIMBS);
         let mut inner = [0u64; MAX_QUADRUPLE_LIMBS];
-        inner[..sq_work].copy_from_slice(&t1[..sq_work]);
-        add_assign(&mut inner[..inner_work], &t2[..pd_work.min(inner_work)]);
-        add_assign(&mut inner[..inner_work], &d_sq[..(d_sq_limb + 1).min(inner_work)]);
+        inner[..sq_len].copy_from_slice(&three_p_sq[..sq_len]);
+        add_assign(&mut inner[..inner_len], &three_p_d[..p_d_len.min(inner_len)]);
+        add_assign(&mut inner[..inner_len], &d_sq[..(d_sq_limb_index + 1).min(inner_len)]);
         // inner = 3*p^2 + 3*p*d + d^2
 
         // Step 6: delta = d * inner
-        let delta_work = (d_limb + 1 + inner_work).min(MAX_QUADRUPLE_LIMBS);
+        let delta_len = (d_limb_index + 1 + inner_len).min(MAX_QUADRUPLE_LIMBS);
         let mut delta = [0u64; MAX_QUADRUPLE_LIMBS];
-        mul_schoolbook(&d[..d_limb + 1], &inner[..inner_work], &mut delta[..delta_work]);
+        mul_schoolbook(&d[..d_limb_index + 1], &inner[..inner_len],
+            &mut delta[..delta_len]);
         // delta = (p + d)^3 - p^3
 
-        // Step 7: If rem >= delta, accept the bit.
-        //   rem -= delta; p += d; p_sq = p^2 (recomputed).
-        if cmp(&rem[..work], &delta[..delta_work.min(work)]) >= 0 {
-            sub_assign(&mut rem[..work], &delta[..delta_work.min(work)]);
-            add_assign(&mut p[..work], &d[..d_limb + 1]);
+        // Step 7: If remainder >= delta, accept the bit.
+        //   remainder -= delta; p += d; p_sq = p^2 (recomputed).
+        if cmp(&remainder[..work_len], &delta[..delta_len.min(work_len)]) >= 0 {
+            sub_assign(&mut remainder[..work_len], &delta[..delta_len.min(work_len)]);
+            add_assign(&mut p[..work_len], &d[..d_limb_index + 1]);
             // Recompute p_sq = p * p
             let mut new_p_sq = [0u64; MAX_QUADRUPLE_LIMBS];
-            mul_schoolbook(&p[..work], &p[..work], &mut new_p_sq[..sq_work]);
-            p_sq[..sq_work].copy_from_slice(&new_p_sq[..sq_work]);
+            mul_schoolbook(&p[..work_len], &p[..work_len], &mut new_p_sq[..sq_len]);
+            p_sq[..sq_len].copy_from_slice(&new_p_sq[..sq_len]);
         }
 
         k -= 1;
     }
 
-    let copy_len = out.len().min(work);
+    let copy_len = out.len().min(work_len);
     out[..copy_len].copy_from_slice(&p[..copy_len]);
 }
 
@@ -182,32 +183,32 @@ mod tests {
     use crate::int::algos::icbrt::icbrt_newton::icbrt_newton;
 
     /// Helper: run icbrt_schoolbook on a u64 value using 1-limb buffers.
-    fn schoolbook_u64(n: u64) -> u64 {
-        let input = [n];
+    fn schoolbook_u64(radicand: u64) -> u64 {
+        let input = [radicand];
         let mut out = [0u64];
         icbrt_schoolbook(&input, &mut out);
         out[0]
     }
 
     /// Helper: run icbrt_schoolbook on a u128 value using 2-limb buffers.
-    fn schoolbook_u128(n: u128) -> u128 {
-        let input = [n as u64, (n >> 64) as u64];
+    fn schoolbook_u128(radicand: u128) -> u128 {
+        let input = [radicand as u64, (radicand >> 64) as u64];
         let mut out = [0u64, 0u64];
         icbrt_schoolbook(&input, &mut out);
         (out[0] as u128) | ((out[1] as u128) << 64)
     }
 
     /// Helper: run icbrt_newton on a u64 value (cross-check oracle).
-    fn newton_u64(n: u64) -> u64 {
-        let input = [n];
+    fn newton_u64(radicand: u64) -> u64 {
+        let input = [radicand];
         let mut out = [0u64];
         icbrt_newton(&input, &mut out);
         out[0]
     }
 
     /// Helper: run icbrt_newton on a u128 value (cross-check oracle).
-    fn newton_u128(n: u128) -> u128 {
-        let input = [n as u64, (n >> 64) as u64];
+    fn newton_u128(radicand: u128) -> u128 {
+        let input = [radicand as u64, (radicand >> 64) as u64];
         let mut out = [0u64, 0u64];
         icbrt_newton(&input, &mut out);
         (out[0] as u128) | ((out[1] as u128) << 64)

--- a/src/int/algos/isqrt/isqrt_karatsuba.rs
+++ b/src/int/algos/isqrt/isqrt_karatsuba.rs
@@ -53,13 +53,14 @@
 //! `~2^{bits/2}`-iteration loop (a hang).
 //!
 //! This implementation instead normalizes into a **power-of-two limb
-//! window** `w = next_pow2(sig_len)`: it left-shifts `n` by an **even** bit
-//! amount so its most-significant bit lands in the top two bits of limb
-//! `w−1` (recovering the root by `>> shift/2`, since `√(n·2^e) = √n·2^{e/2}`
-//! for even `e`). Then `h = w/4` is exact, the high half `a₃·B + a₂` is
-//! exactly `w/2` limbs (also a power of two) and inherits the top limb — so
-//! it stays normalized — and the recursion halves cleanly with NO
-//! re-normalization. `a₃ ≥ B/4` therefore holds at every level, `q ≤ B`, and
+//! window** `window_len = next_pow2(sig_len)`: it left-shifts `n` by an
+//! **even** bit amount so its most-significant bit lands in the top two bits
+//! of limb `window_len−1` (recovering the root by `>> shift/2`, since
+//! `√(n·2^e) = √n·2^{e/2}` for even `e`). Then `h = window_len/4` is exact,
+//! the high half `a₃·B + a₂` is exactly `window_len/2` limbs (also a power of
+//! two) and inherits the top limb — so it stays normalized — and the
+//! recursion halves cleanly with NO re-normalization. `a₃ ≥ B/4` therefore
+//! holds at every level, `q ≤ B`, and
 //! the correction is the paper's single step (a small bounded loop guards
 //! against any residual, per the defense-in-depth recursion rule).
 //!
@@ -83,8 +84,9 @@ use crate::int::policy::div_rem::dispatch as div_rem_dispatch;
 use crate::int::types::compute_limbs::MAX_DOUBLE_LIMBS;
 
 /// Scratch capacity — the double-N budget shared with the shipped Newton
-/// `isqrt` (radicand ≤ 2N). The normalized window `w = next_pow2(sig) ≤
-/// 2·sig` and every intermediate (`num`, `q²`, `s`, `r`) stays within it.
+/// `isqrt` (radicand ≤ 2N). The normalized window
+/// `window_len = next_pow2(radicand_len) ≤ 2·radicand_len` and every
+/// intermediate (`numerator`, `q²`, `s`, `r`) stays within it.
 const SCRATCH_LIMBS: usize = MAX_DOUBLE_LIMBS;
 
 /// Below this many *significant* limbs the kernel hands straight to the
@@ -93,16 +95,17 @@ const SCRATCH_LIMBS: usize = MAX_DOUBLE_LIMBS;
 /// small-width regime where it wins.
 const BASE_LIMBS: usize = 2;
 
-/// `out = floor(sqrt(n))`, computed by the Karatsuba Square Root recursion.
+/// `out = floor(sqrt(radicand))`, computed by the Karatsuba Square Root
+/// recursion.
 ///
 /// Bit-identical to
 /// [`crate::int::algos::isqrt::isqrt_newton::isqrt_newton`]; see the module
 /// docs for the algorithm and the RR-3805 reference.
-pub(crate) fn isqrt_karatsuba(n: &[u64], out: &mut [u64]) {
-    for o in out.iter_mut() {
-        *o = 0;
+pub(crate) fn isqrt_karatsuba(radicand: &[u64], out: &mut [u64]) {
+    for limb in out.iter_mut() {
+        *limb = 0;
     }
-    let bits = bit_len(n);
+    let bits = bit_len(radicand);
     if bits == 0 {
         return;
     }
@@ -111,62 +114,63 @@ pub(crate) fn isqrt_karatsuba(n: &[u64], out: &mut [u64]) {
         return;
     }
 
-    let sig = sig_len(n);
+    let radicand_len = sig_len(radicand);
 
     // ── small widths: the shipped exact Newton kernel owns them ───────────
-    if sig <= BASE_LIMBS {
-        isqrt_newton(&n[..sig], out);
+    if radicand_len <= BASE_LIMBS {
+        isqrt_newton(&radicand[..radicand_len], out);
         return;
     }
 
     // ── normalize into a power-of-two limb window ─────────────────────────
-    // `w` = next power of two ≥ sig. Left-shift n by an EVEN bit amount so
-    // its MSB lands in the top two bits of limb `w−1` (⇒ a₃ ≥ B/4 at every
-    // recursion level). Even shift `e` ⇒ √(n·2^e) = √n·2^{e/2}, so the root
-    // is recovered by `>> e/2`.
-    let w = next_pow2_limbs(sig);
-    debug_assert!(w <= SCRATCH_LIMBS, "isqrt_karatsuba window exceeds scratch");
-    let sh = (w as u32) * 64 - bits; // ≥ 0: w ≥ sig ⇒ w·64 ≥ bits
-    let sh_even = sh & !1u32;
+    // `window_len` = next power of two ≥ radicand_len. Left-shift n by an
+    // EVEN bit amount so its MSB lands in the top two bits of limb
+    // `window_len−1` (⇒ a₃ ≥ B/4 at every recursion level). Even shift `e` ⇒
+    // √(n·2^e) = √n·2^{e/2}, so the root is recovered by `>> e/2`.
+    let window_len = next_pow2_limbs(radicand_len);
+    debug_assert!(window_len <= SCRATCH_LIMBS, "isqrt_karatsuba window exceeds scratch");
+    // ≥ 0: window_len ≥ radicand_len ⇒ window_len·64 ≥ bits
+    let shift = (window_len as u32) * 64 - bits;
+    let even_shift = shift & !1u32;
 
-    let mut nn = [0u64; SCRATCH_LIMBS];
-    shl(&n[..sig], sh_even, &mut nn[..w]);
+    let mut normalized = [0u64; SCRATCH_LIMBS];
+    shl(&radicand[..radicand_len], even_shift, &mut normalized[..window_len]);
 
     // ── recurse on the normalized window ──────────────────────────────────
     let mut s = [0u64; SCRATCH_LIMBS];
     let mut r = [0u64; SCRATCH_LIMBS];
-    sqrtrem(&nn[..w], &mut s, &mut r);
+    sqrtrem(&normalized[..window_len], &mut s, &mut r);
 
-    // ── de-normalize: s_real = s >> (sh_even/2) ───────────────────────────
+    // ── de-normalize: s_real = s >> (even_shift/2) ────────────────────────
     let s_len = sig_len(&s[..SCRATCH_LIMBS]);
     let mut s_out = [0u64; SCRATCH_LIMBS];
-    shr(&s[..s_len], sh_even / 2, &mut s_out[..s_len]);
+    shr(&s[..s_len], even_shift / 2, &mut s_out[..s_len]);
 
     let copy_len = out.len().min(s_len);
     out[..copy_len].copy_from_slice(&s_out[..copy_len]);
 }
 
-/// Smallest power-of-two limb count `≥ x`, at least 4 (the four-block split
-/// needs a window divisible by 4, and the recursion bottoms out at 2).
+/// Smallest power-of-two limb count `≥ min_limbs`, at least 4 (the four-block
+/// split needs a window divisible by 4, and the recursion bottoms out at 2).
 #[inline]
-fn next_pow2_limbs(x: usize) -> usize {
-    let mut w = 4usize;
-    while w < x {
-        w <<= 1;
+fn next_pow2_limbs(min_limbs: usize) -> usize {
+    let mut window_len = 4usize;
+    while window_len < min_limbs {
+        window_len <<= 1;
     }
-    w
+    window_len
 }
 
-/// Significant limb count of `a` (index of the highest non-zero limb + 1),
+/// Significant limb count of `limbs` (index of the highest non-zero limb + 1),
 /// minimum 1.
 #[inline]
-fn sig_len(a: &[u64]) -> usize {
-    let mut i = a.len();
-    while i > 0 {
-        if a[i - 1] != 0 {
-            return i;
+fn sig_len(limbs: &[u64]) -> usize {
+    let mut len = limbs.len();
+    while len > 0 {
+        if limbs[len - 1] != 0 {
+            return len;
         }
-        i -= 1;
+        len -= 1;
     }
     1
 }
@@ -178,35 +182,36 @@ fn sig_len(a: &[u64]) -> usize {
 /// Karatsuba Square Root (RR-3805 Algorithm 1); base case = the shipped
 /// exact Newton kernel with the remainder recovered as `n − s²`.
 fn sqrtrem(n: &[u64], s: &mut [u64], r: &mut [u64]) {
-    for v in s.iter_mut() {
-        *v = 0;
+    for limb in s.iter_mut() {
+        *limb = 0;
     }
-    for v in r.iter_mut() {
-        *v = 0;
+    for limb in r.iter_mut() {
+        *limb = 0;
     }
-    let w = n.len();
+    let window_len = n.len();
 
     // ── base case: exact Newton root + remainder n − s² ───────────────────
-    if w <= BASE_LIMBS {
-        isqrt_newton(n, &mut s[..w]);
-        let s_len = sig_len(&s[..w]);
+    if window_len <= BASE_LIMBS {
+        isqrt_newton(n, &mut s[..window_len]);
+        let s_len = sig_len(&s[..window_len]);
         let mut sq = [0u64; SCRATCH_LIMBS];
         let sq_len = (2 * s_len).min(SCRATCH_LIMBS);
         mul_schoolbook(&s[..s_len], &s[..s_len], &mut sq[..sq_len]);
         // r = n − s²  (n ≥ s² by definition of the floor root).
-        r[..w].copy_from_slice(n);
-        sub_assign(&mut r[..w], &sq[..sq_len.min(w)]);
+        r[..window_len].copy_from_slice(n);
+        sub_assign(&mut r[..window_len], &sq[..sq_len.min(window_len)]);
         return;
     }
 
-    // ── four equal blocks of h = w/4 limbs: n = a3·B³+a2·B²+a1·B+a0 ────────
-    // B = 2^{64·h}. high (= a3·B + a2) is the top w/2 limbs and is itself a
-    // normalized power-of-two-length number → the recursion needs no
+    // ── four equal blocks of h = window_len/4 limbs:
+    //    n = a3·B³+a2·B²+a1·B+a0 ─────────────────────────────────────────────
+    // B = 2^{64·h}. high (= a3·B + a2) is the top window_len/2 limbs and is
+    // itself a normalized power-of-two-length number → the recursion needs no
     // re-normalization.
-    let h = w / 4;
+    let h = window_len / 4;
     let a0 = &n[0..h];
     let a1 = &n[h..2 * h];
-    let high = &n[2 * h..w]; // a3·B + a2, w/2 limbs
+    let high = &n[2 * h..window_len]; // a3·B + a2, window_len/2 limbs
 
     // ── (s', r') = SqrtRem(high) ──────────────────────────────────────────
     let mut sp = [0u64; SCRATCH_LIMBS];
@@ -217,26 +222,26 @@ fn sqrtrem(n: &[u64], s: &mut [u64], r: &mut [u64]) {
 
     // ── (q, u) = DivRem(r'·B + a1, 2·s') ──────────────────────────────────
     // numerator = r'·B + a1  (r' at limb offset h, a1 in the low h).
-    let mut num = [0u64; SCRATCH_LIMBS];
-    for (i, &v) in rp[..rp_len].iter().enumerate() {
+    let mut numerator = [0u64; SCRATCH_LIMBS];
+    for (i, &limb) in rp[..rp_len].iter().enumerate() {
         if h + i < SCRATCH_LIMBS {
-            num[h + i] = v;
+            numerator[h + i] = limb;
         }
     }
-    add_assign(&mut num, a1);
-    let num_len = sig_len(&num[..SCRATCH_LIMBS]);
+    add_assign(&mut numerator, a1);
+    let numerator_len = sig_len(&numerator[..SCRATCH_LIMBS]);
 
     // divisor = 2·s'
-    let mut den = [0u64; SCRATCH_LIMBS];
-    shl(&sp[..sp_len], 1, &mut den[..sp_len + 1]);
-    let den_len = sig_len(&den[..SCRATCH_LIMBS]);
+    let mut divisor = [0u64; SCRATCH_LIMBS];
+    shl(&sp[..sp_len], 1, &mut divisor[..sp_len + 1]);
+    let divisor_len = sig_len(&divisor[..SCRATCH_LIMBS]);
 
     let mut q = [0u64; SCRATCH_LIMBS];
     let mut u = [0u64; SCRATCH_LIMBS];
-    let qrlen = num_len.max(den_len);
+    let qrlen = numerator_len.max(divisor_len);
     div_rem_dispatch(
-        &num[..num_len],
-        &den[..den_len],
+        &numerator[..numerator_len],
+        &divisor[..divisor_len],
         &mut q[..qrlen],
         &mut u[..qrlen],
     );
@@ -244,18 +249,18 @@ fn sqrtrem(n: &[u64], s: &mut [u64], r: &mut [u64]) {
     let u_len = sig_len(&u[..qrlen]);
 
     // ── s = s'·B + q  (s' at offset h, q low; add_assign folds any carry) ──
-    for (i, &v) in sp[..sp_len].iter().enumerate() {
+    for (i, &limb) in sp[..sp_len].iter().enumerate() {
         if h + i < SCRATCH_LIMBS {
-            s[h + i] = v;
+            s[h + i] = limb;
         }
     }
     add_assign(s, &q[..q_len]);
 
     // ── r = u·B + a0 − q² ─────────────────────────────────────────────────
     let mut rr = [0u64; SCRATCH_LIMBS];
-    for (i, &v) in u[..u_len].iter().enumerate() {
+    for (i, &limb) in u[..u_len].iter().enumerate() {
         if h + i < SCRATCH_LIMBS {
-            rr[h + i] = v;
+            rr[h + i] = limb;
         }
     }
     add_assign(&mut rr, a0);
@@ -287,21 +292,22 @@ fn sqrtrem(n: &[u64], s: &mut [u64], r: &mut [u64]) {
                 &deficit[..SCRATCH_LIMBS.min(8)],
                 &s[..SCRATCH_LIMBS.min(8)],
             );
-            // tm = 2·s − 1 (uses the current s).
-            let mut tm = [0u64; SCRATCH_LIMBS];
-            shl(s, 1, &mut tm);
-            sub_assign(&mut tm, &one);
-            if cmp(&deficit[..SCRATCH_LIMBS], &tm[..SCRATCH_LIMBS]) <= 0 {
-                // r += 2s − 1 makes it ≥ 0: r = tm − deficit. Then s −= 1.
+            // correction = 2·s − 1 (uses the current s).
+            let mut correction = [0u64; SCRATCH_LIMBS];
+            shl(s, 1, &mut correction);
+            sub_assign(&mut correction, &one);
+            if cmp(&deficit[..SCRATCH_LIMBS], &correction[..SCRATCH_LIMBS]) <= 0 {
+                // r += 2s − 1 makes it ≥ 0: r = correction − deficit.
+                // Then s −= 1.
                 let mut rfinal = [0u64; SCRATCH_LIMBS];
-                rfinal.copy_from_slice(&tm);
+                rfinal.copy_from_slice(&correction);
                 sub_assign(&mut rfinal, &deficit[..SCRATCH_LIMBS]);
                 sub_assign(s, &one);
                 r[..SCRATCH_LIMBS].copy_from_slice(&rfinal[..SCRATCH_LIMBS]);
                 break;
             }
-            // r += 2s − 1 still < 0: deficit −= tm; s −= 1; repeat.
-            sub_assign(&mut deficit, &tm[..SCRATCH_LIMBS]);
+            // r += 2s − 1 still < 0: deficit −= correction; s −= 1; repeat.
+            sub_assign(&mut deficit, &correction[..SCRATCH_LIMBS]);
             sub_assign(s, &one);
         }
     }
@@ -312,29 +318,29 @@ mod tests {
     use super::isqrt_karatsuba;
     use crate::int::algos::isqrt::isqrt_newton::isqrt_newton;
 
-    fn kara(n: &[u64], limbs: usize) -> Vec<u64> {
+    fn kara(radicand: &[u64], limbs: usize) -> Vec<u64> {
         let mut out = vec![0u64; limbs];
-        isqrt_karatsuba(n, &mut out);
+        isqrt_karatsuba(radicand, &mut out);
         out
     }
-    fn newton(n: &[u64], limbs: usize) -> Vec<u64> {
+    fn newton(radicand: &[u64], limbs: usize) -> Vec<u64> {
         let mut out = vec![0u64; limbs];
-        isqrt_newton(n, &mut out);
+        isqrt_newton(radicand, &mut out);
         out
     }
-    fn kara_u64(n: u64) -> u64 {
-        kara(&[n], 1)[0]
+    fn kara_u64(radicand: u64) -> u64 {
+        kara(&[radicand], 1)[0]
     }
-    fn newton_u64(n: u64) -> u64 {
-        newton(&[n], 1)[0]
+    fn newton_u64(radicand: u64) -> u64 {
+        newton(&[radicand], 1)[0]
     }
-    fn kara_u128(n: u128) -> u128 {
-        let v = kara(&[n as u64, (n >> 64) as u64], 2);
-        (v[0] as u128) | ((v[1] as u128) << 64)
+    fn kara_u128(radicand: u128) -> u128 {
+        let root = kara(&[radicand as u64, (radicand >> 64) as u64], 2);
+        (root[0] as u128) | ((root[1] as u128) << 64)
     }
-    fn newton_u128(n: u128) -> u128 {
-        let v = newton(&[n as u64, (n >> 64) as u64], 2);
-        (v[0] as u128) | ((v[1] as u128) << 64)
+    fn newton_u128(radicand: u128) -> u128 {
+        let root = newton(&[radicand as u64, (radicand >> 64) as u64], 2);
+        (root[0] as u128) | ((root[1] as u128) << 64)
     }
 
     #[test]
@@ -435,12 +441,12 @@ mod tests {
         for &limbs in &[3usize, 4, 5, 6, 8, 16, 24] {
             for _ in 0..40 {
                 let mut n = vec![0u64; limbs];
-                let top = 1 + (next() as usize % limbs);
-                for l in n.iter_mut().take(top) {
-                    *l = next();
+                let fill_len = 1 + (next() as usize % limbs);
+                for limb in n.iter_mut().take(fill_len) {
+                    *limb = next();
                 }
-                if n[top - 1] == 0 {
-                    n[top - 1] = 1;
+                if n[fill_len - 1] == 0 {
+                    n[fill_len - 1] = 1;
                 }
                 assert_eq!(
                     kara(&n, limbs),
@@ -450,16 +456,16 @@ mod tests {
             }
             // Perfect-square ±1 edges at this width.
             for _ in 0..10 {
-                let mut b = vec![0u64; limbs];
-                let bt = 1 + (next() as usize % limbs.div_ceil(2).max(1));
-                for l in b.iter_mut().take(bt) {
-                    *l = next();
+                let mut base = vec![0u64; limbs];
+                let base_fill_len = 1 + (next() as usize % limbs.div_ceil(2).max(1));
+                for limb in base.iter_mut().take(base_fill_len) {
+                    *limb = next();
                 }
-                if b[bt - 1] == 0 {
-                    b[bt - 1] = 1;
+                if base[base_fill_len - 1] == 0 {
+                    base[base_fill_len - 1] = 1;
                 }
                 let mut sq = vec![0u64; limbs * 2 + 1];
-                crate::int::algos::mul::mul_schoolbook::mul_schoolbook(&b, &b, &mut sq);
+                crate::int::algos::mul::mul_schoolbook::mul_schoolbook(&base, &base, &mut sq);
                 let mut n = vec![0u64; limbs];
                 n.copy_from_slice(&sq[..limbs]);
                 assert_eq!(
@@ -488,12 +494,12 @@ mod tests {
         for &limbs in &[32usize, 48, 64] {
             for _ in 0..20 {
                 let mut n = vec![0u64; limbs];
-                let top = 1 + (next() as usize % limbs);
-                for l in n.iter_mut().take(top) {
-                    *l = next();
+                let fill_len = 1 + (next() as usize % limbs);
+                for limb in n.iter_mut().take(fill_len) {
+                    *limb = next();
                 }
-                if n[top - 1] == 0 {
-                    n[top - 1] = 1;
+                if n[fill_len - 1] == 0 {
+                    n[fill_len - 1] = 1;
                 }
                 assert_eq!(
                     kara(&n, limbs),
@@ -503,16 +509,16 @@ mod tests {
             }
             // Perfect-square ±1 edges at this width.
             for _ in 0..6 {
-                let mut b = vec![0u64; limbs];
-                let bt = 1 + (next() as usize % limbs.div_ceil(2).max(1));
-                for l in b.iter_mut().take(bt) {
-                    *l = next();
+                let mut base = vec![0u64; limbs];
+                let base_fill_len = 1 + (next() as usize % limbs.div_ceil(2).max(1));
+                for limb in base.iter_mut().take(base_fill_len) {
+                    *limb = next();
                 }
-                if b[bt - 1] == 0 {
-                    b[bt - 1] = 1;
+                if base[base_fill_len - 1] == 0 {
+                    base[base_fill_len - 1] = 1;
                 }
                 let mut sq = vec![0u64; limbs * 2 + 1];
-                crate::int::algos::mul::mul_schoolbook::mul_schoolbook(&b, &b, &mut sq);
+                crate::int::algos::mul::mul_schoolbook::mul_schoolbook(&base, &base, &mut sq);
                 let mut n = vec![0u64; limbs];
                 n.copy_from_slice(&sq[..limbs]);
                 assert_eq!(

--- a/src/int/algos/isqrt/isqrt_mag_fixed.rs
+++ b/src/int/algos/isqrt/isqrt_mag_fixed.rs
@@ -12,22 +12,22 @@
 use crate::int::algos::isqrt::isqrt_newton::isqrt_newton;
 
 /// Const-`N` fast-arm integer square root over little-endian u64
-/// magnitude limbs. Writes `floor(sqrt(n))` into `out`.
+/// magnitude limbs. Writes `floor(sqrt(radicand))` into `out`.
 ///
 /// Mirrors `div_rem_mag_fixed`: `N == 1` uses the native `u64::isqrt`,
 /// `N == 2` uses `u128::isqrt`, and `N >= 3` falls through to the shared
 /// [`isqrt_newton`] (Newton with a hardware-`f64::sqrt` seed). All arms
 /// return the identical floor square root.
 #[inline]
-pub(crate) fn isqrt_mag_fixed<const N: usize>(n: &[u64; N], out: &mut [u64; N]) {
+pub(crate) fn isqrt_mag_fixed<const N: usize>(radicand: &[u64; N], out: &mut [u64; N]) {
     if N == 1 {
-        out[0] = n[0].isqrt();
+        out[0] = radicand[0].isqrt();
     } else if N == 2 {
-        let v = (n[0] as u128) | ((n[1] as u128) << 64);
-        let r = v.isqrt();
-        out[0] = r as u64;
-        out[1] = (r >> 64) as u64;
+        let radicand_u128 = (radicand[0] as u128) | ((radicand[1] as u128) << 64);
+        let root = radicand_u128.isqrt();
+        out[0] = root as u64;
+        out[1] = (root >> 64) as u64;
     } else {
-        isqrt_newton(n, out);
+        isqrt_newton(radicand, out);
     }
 }

--- a/src/int/algos/isqrt/isqrt_newton.rs
+++ b/src/int/algos/isqrt/isqrt_newton.rs
@@ -7,7 +7,7 @@
 //! by the fixed-width fast-arm dispatch
 //! [`crate::int::algos::isqrt::isqrt_mag_fixed::isqrt_mag_fixed`] (`N >= 3`)
 //! and by the decimal `sqrt` work-width path. Pure kernel — it takes the
-//! operand and writes `floor(sqrt(n))`; no algorithm choice.
+//! operand and writes `floor(sqrt(radicand))`; no algorithm choice.
 
 use crate::algo_x_support::seed::sqrt_seed;
 use crate::int::algos::support::limbs::{add_assign, bit_len, cmp, shr};
@@ -20,8 +20,8 @@ use crate::int::algos::support::limbs::max_n_limbs;
 
 const SCRATCH_LIMBS: usize = max_n_limbs(2);
 
-/// `out = floor(sqrt(n))`. Newton iteration on top of the runtime divide
-/// dispatcher.
+/// `out = floor(sqrt(radicand))`. Newton iteration on top of the runtime
+/// divide dispatcher.
 ///
 /// Uses [`div_rem_dispatch`] (not the *const* `div_rem`) per iteration: the
 /// const path routes multi-limb divisors through the O(bits²)
@@ -30,11 +30,11 @@ const SCRATCH_LIMBS: usize = max_n_limbs(2);
 /// `~65k`-limb-op divmod. The dispatcher gets
 /// Knuth-base-2⁶⁴ per iteration (~`~32²` = 1024 limb-ops), worth ~40× on
 /// D307 sqrt.
-pub(crate) fn isqrt_newton(n: &[u64], out: &mut [u64]) {
-    for o in out.iter_mut() {
-        *o = 0;
+pub(crate) fn isqrt_newton(radicand: &[u64], out: &mut [u64]) {
+    for limb in out.iter_mut() {
+        *limb = 0;
     }
-    let bits = bit_len(n);
+    let bits = bit_len(radicand);
     if bits == 0 {
         return;
     }
@@ -42,37 +42,38 @@ pub(crate) fn isqrt_newton(n: &[u64], out: &mut [u64]) {
         out[0] = 1;
         return;
     }
-    let work = n.len() + 1;
-    debug_assert!(work <= SCRATCH_LIMBS, "isqrt scratch overflow");
+    let work_len = radicand.len() + 1;
+    debug_assert!(work_len <= SCRATCH_LIMBS, "isqrt scratch overflow");
     let mut x = [0u64; SCRATCH_LIMBS];
 
     // Initial guess — delegated to the cross-algorithm seed leaf
     // (`algo_x_support::seed`). Under `std` it bootstraps from the hardware
-    // `f64::sqrt` of the top 64 bits of `n` (~53 correct bits in one shot,
-    // dropping the Newton iteration count by ~half); under `no_std` it uses
-    // the classical pure-integer 1-bit seed `2^ceil(bits/2)`. Both are safe
-    // over-estimates, so this monotone-downward loop converges to the same
-    // floor root either way. The leaf calls nothing in-crate (primitives +
-    // std-gated inherent f64) — `num_traits::Float`/libm is never reached.
-    sqrt_seed(n, bits, &mut x[..work]);
+    // `f64::sqrt` of the top 64 bits of `radicand` (~53 correct bits in one
+    // shot, dropping the Newton iteration count by ~half); under `no_std` it
+    // uses the classical pure-integer 1-bit seed `2^ceil(bits/2)`. Both are
+    // safe over-estimates, so this monotone-downward loop converges to the
+    // same floor root either way. The leaf calls nothing in-crate (primitives
+    // + std-gated inherent f64) — `num_traits::Float`/libm is never reached.
+    sqrt_seed(radicand, bits, &mut x[..work_len]);
 
     // Newton working buffers hoisted OUT of the loop. The divide engine
     // re-zeros `q`/`r` each pass and `shr` re-zeros `y`, so only the live
-    // `[..work]` slice is touched per iteration — no per-iteration build-max
-    // memset (the previous in-loop `[0u64; SCRATCH_LIMBS]` allocs were the
-    // wide-tier tax). `x = y` is likewise a `[..work]` copy, not a full array.
+    // `[..work_len]` slice is touched per iteration — no per-iteration
+    // build-max memset (the previous in-loop `[0u64; SCRATCH_LIMBS]` allocs
+    // were the wide-tier tax). `x = y` is likewise a `[..work_len]` copy, not
+    // a full array.
     let mut q = [0u64; SCRATCH_LIMBS];
     let mut r = [0u64; SCRATCH_LIMBS];
     let mut y = [0u64; SCRATCH_LIMBS];
     loop {
-        div_rem_dispatch(n, &x[..work], &mut q[..work], &mut r[..work]);
-        add_assign(&mut q[..work], &x[..work]);
-        shr(&q[..work], 1, &mut y[..work]);
-        if cmp(&y[..work], &x[..work]) >= 0 {
+        div_rem_dispatch(radicand, &x[..work_len], &mut q[..work_len], &mut r[..work_len]);
+        add_assign(&mut q[..work_len], &x[..work_len]);
+        shr(&q[..work_len], 1, &mut y[..work_len]);
+        if cmp(&y[..work_len], &x[..work_len]) >= 0 {
             break;
         }
-        x[..work].copy_from_slice(&y[..work]);
+        x[..work_len].copy_from_slice(&y[..work_len]);
     }
-    let copy_len = if out.len() < work { out.len() } else { work };
+    let copy_len = if out.len() < work_len { out.len() } else { work_len };
     out[..copy_len].copy_from_slice(&x[..copy_len]);
 }

--- a/src/int/algos/isqrt/isqrt_schoolbook.rs
+++ b/src/int/algos/isqrt/isqrt_schoolbook.rs
@@ -22,14 +22,14 @@ use crate::int::algos::support::limbs::{bit_len, cmp, shl, sub_assign};
 
 use crate::int::types::compute_limbs::MAX_DOUBLE_LIMBS;
 
-/// floor(sqrt(n)) via two-bits-at-a-time bitwise algorithm.
-pub(crate) fn isqrt_schoolbook(n: &[u64], out: &mut [u64]) {
-    for o in out.iter_mut() { *o = 0; }
-    let bits = bit_len(n);
+/// floor(sqrt(radicand)) via two-bits-at-a-time bitwise algorithm.
+pub(crate) fn isqrt_schoolbook(radicand: &[u64], out: &mut [u64]) {
+    for limb in out.iter_mut() { *limb = 0; }
+    let bits = bit_len(radicand);
     if bits == 0 { return; }
     if bits <= 1 { out[0] = 1; return; }
-    let work = n.len() + 1;
-    debug_assert!(work <= MAX_DOUBLE_LIMBS, "isqrt_schoolbook scratch overflow");
+    let work_len = radicand.len() + 1;
+    debug_assert!(work_len <= MAX_DOUBLE_LIMBS, "isqrt_schoolbook scratch overflow");
     let mut p = [0u64; MAX_DOUBLE_LIMBS];
     let mut r = [0u64; MAX_DOUBLE_LIMBS];
     let mut tmp = [0u64; MAX_DOUBLE_LIMBS];
@@ -39,37 +39,37 @@ pub(crate) fn isqrt_schoolbook(n: &[u64], out: &mut [u64]) {
     let mut b = start;
     while b >= 0 {
         // Step 1: r = (r << 2) | 2-bit group at [b+1, b].
-        shl(&r[..work], 2, &mut tmp[..work]);
-        r[..work].copy_from_slice(&tmp[..work]);
+        shl(&r[..work_len], 2, &mut tmp[..work_len]);
+        r[..work_len].copy_from_slice(&tmp[..work_len]);
         let b_u32 = b as u32;
-        let li = (b_u32 / 64) as usize;
-        let bo = b_u32 % 64;
-        let group: u64 = if bo == 63 {
-            let lo = if li < n.len() { (n[li] >> 63) & 1 } else { 0 };
-            let hi = if li + 1 < n.len() { n[li + 1] & 1 } else { 0 };
+        let limb_index = (b_u32 / 64) as usize;
+        let bit_offset = b_u32 % 64;
+        let group: u64 = if bit_offset == 63 {
+            let lo = if limb_index < radicand.len() { (radicand[limb_index] >> 63) & 1 } else { 0 };
+            let hi = if limb_index + 1 < radicand.len() { radicand[limb_index + 1] & 1 } else { 0 };
             (hi << 1) | lo
-        } else if li < n.len() {
-            (n[li] >> bo) & 3
+        } else if limb_index < radicand.len() {
+            (radicand[limb_index] >> bit_offset) & 3
         } else { 0 };
         r[0] |= group;
         // Step 2: t = (p << 2) | 1 = 4p + 1.
-        shl(&p[..work], 2, &mut tmp[..work]);
+        shl(&p[..work_len], 2, &mut tmp[..work_len]);
         let mut t = [0u64; MAX_DOUBLE_LIMBS];
-        t[..work].copy_from_slice(&tmp[..work]);
+        t[..work_len].copy_from_slice(&tmp[..work_len]);
         t[0] |= 1;
         // Step 3: accept or reject next bit.
-        if cmp(&r[..work], &t[..work]) >= 0 {
-            sub_assign(&mut r[..work], &t[..work]);
-            shl(&p[..work], 1, &mut tmp[..work]);
-            p[..work].copy_from_slice(&tmp[..work]);
+        if cmp(&r[..work_len], &t[..work_len]) >= 0 {
+            sub_assign(&mut r[..work_len], &t[..work_len]);
+            shl(&p[..work_len], 1, &mut tmp[..work_len]);
+            p[..work_len].copy_from_slice(&tmp[..work_len]);
             p[0] |= 1;
         } else {
-            shl(&p[..work], 1, &mut tmp[..work]);
-            p[..work].copy_from_slice(&tmp[..work]);
+            shl(&p[..work_len], 1, &mut tmp[..work_len]);
+            p[..work_len].copy_from_slice(&tmp[..work_len]);
         }
         b -= 2;
     }
-    let copy_len = out.len().min(work);
+    let copy_len = out.len().min(work_len);
     out[..copy_len].copy_from_slice(&p[..copy_len]);
 }
 
@@ -77,19 +77,21 @@ pub(crate) fn isqrt_schoolbook(n: &[u64], out: &mut [u64]) {
 mod tests {
     use super::isqrt_schoolbook;
     use crate::int::algos::isqrt::isqrt_newton::isqrt_newton;
-    fn sb64(n: u64) -> u64 {
-        let i = [n]; let mut o = [0u64]; isqrt_schoolbook(&i, &mut o); o[0]
+    fn sb64(radicand: u64) -> u64 {
+        let input = [radicand]; let mut output = [0u64];
+        isqrt_schoolbook(&input, &mut output); output[0]
     }
-    fn sb128(n: u128) -> u128 {
-        let i = [n as u64, (n>>64) as u64]; let mut o = [0u64, 0u64];
-        isqrt_schoolbook(&i, &mut o); (o[0] as u128) | ((o[1] as u128) << 64)
+    fn sb128(radicand: u128) -> u128 {
+        let input = [radicand as u64, (radicand>>64) as u64]; let mut output = [0u64, 0u64];
+        isqrt_schoolbook(&input, &mut output); (output[0] as u128) | ((output[1] as u128) << 64)
     }
-    fn nt64(n: u64) -> u64 {
-        let i = [n]; let mut o = [0u64]; isqrt_newton(&i, &mut o); o[0]
+    fn nt64(radicand: u64) -> u64 {
+        let input = [radicand]; let mut output = [0u64];
+        isqrt_newton(&input, &mut output); output[0]
     }
-    fn nt128(n: u128) -> u128 {
-        let i = [n as u64, (n>>64) as u64]; let mut o = [0u64, 0u64];
-        isqrt_newton(&i, &mut o); (o[0] as u128) | ((o[1] as u128) << 64)
+    fn nt128(radicand: u128) -> u128 {
+        let input = [radicand as u64, (radicand>>64) as u64]; let mut output = [0u64, 0u64];
+        isqrt_newton(&input, &mut output); (output[0] as u128) | ((output[1] as u128) << 64)
     }
     /// Fixed known values -- externally verified via Python math.isqrt.
     #[test]

--- a/src/int/algos/mul/mod.rs
+++ b/src/int/algos/mul/mod.rs
@@ -33,9 +33,9 @@ mod tests {
     /// Pack a `[u128; N]` little-endian limb array into `[u64; 2*N]`.
     fn pack(limbs: &[u128]) -> Vec<u64> {
         let mut out = vec![0u64; 2 * limbs.len()];
-        for (i, &l) in limbs.iter().enumerate() {
-            out[2 * i] = l as u64;
-            out[2 * i + 1] = (l >> 64) as u64;
+        for (i, &limb) in limbs.iter().enumerate() {
+            out[2 * i] = limb as u64;
+            out[2 * i + 1] = (limb >> 64) as u64;
         }
         out
     }
@@ -62,19 +62,19 @@ mod tests {
     /// split/recombine algebra is exercised even at narrow widths).
     #[test]
     fn karatsuba_matches_schoolbook() {
-        for a in corpus() {
-            for b in corpus() {
-                let a64 = pack(&a);
-                let b64 = pack(&b);
-                let n = a64.len().min(b64.len());
-                let mut a_buf = vec![0u64; n];
-                let mut b_buf = vec![0u64; n];
-                a_buf.copy_from_slice(&a64[..n]);
-                b_buf.copy_from_slice(&b64[..n]);
+        for lhs in corpus() {
+            for rhs in corpus() {
+                let lhs_limbs = pack(&lhs);
+                let rhs_limbs = pack(&rhs);
+                let n = lhs_limbs.len().min(rhs_limbs.len());
+                let mut lhs_buf = vec![0u64; n];
+                let mut rhs_buf = vec![0u64; n];
+                lhs_buf.copy_from_slice(&lhs_limbs[..n]);
+                rhs_buf.copy_from_slice(&rhs_limbs[..n]);
                 let mut out_school = vec![0u64; 2 * n];
                 let mut out_kara = vec![0u64; 2 * n];
-                mul_schoolbook(&a_buf, &b_buf, &mut out_school);
-                mul_karatsuba_with_threshold(&a_buf, &b_buf, &mut out_kara, 4);
+                mul_schoolbook(&lhs_buf, &rhs_buf, &mut out_school);
+                mul_karatsuba_with_threshold(&lhs_buf, &rhs_buf, &mut out_kara, 4);
                 assert_eq!(out_kara, out_school, "Karatsuba mismatch at n={n}");
             }
         }
@@ -104,19 +104,19 @@ mod tests {
         const THRESHOLDS: &[usize] = &[4, 8, 16, 24, 256];
 
         let edge_fill = |buf: &mut [u64], kind: usize, next: &mut dyn FnMut() -> u64| match kind {
-            0 => buf.iter_mut().for_each(|x| *x = 0),
-            1 => buf.iter_mut().for_each(|x| *x = u64::MAX),
+            0 => buf.iter_mut().for_each(|slot| *slot = 0),
+            1 => buf.iter_mut().for_each(|slot| *slot = u64::MAX),
             2 => {
-                buf.iter_mut().for_each(|x| *x = 0);
+                buf.iter_mut().for_each(|slot| *slot = 0);
                 if let Some(last) = buf.last_mut() {
                     *last = u64::MAX;
                 }
             }
             3 => {
-                buf.iter_mut().for_each(|x| *x = 0);
+                buf.iter_mut().for_each(|slot| *slot = 0);
                 buf[0] = u64::MAX;
             }
-            _ => buf.iter_mut().for_each(|x| *x = next()),
+            _ => buf.iter_mut().for_each(|slot| *slot = next()),
         };
 
         for &n in WIDTHS {
@@ -130,44 +130,44 @@ mod tests {
 
             let mut pairs: Vec<(Vec<u64>, Vec<u64>)> =
                 Vec::new();
-            for ka in 0..5 {
-                for kb in 0..5 {
-                    let mut a = vec![0u64; n];
-                    let mut b = vec![0u64; n];
-                    edge_fill(&mut a, ka, &mut next);
-                    edge_fill(&mut b, kb, &mut next);
-                    pairs.push((a, b));
+            for lhs_kind in 0..5 {
+                for rhs_kind in 0..5 {
+                    let mut lhs = vec![0u64; n];
+                    let mut rhs = vec![0u64; n];
+                    edge_fill(&mut lhs, lhs_kind, &mut next);
+                    edge_fill(&mut rhs, rhs_kind, &mut next);
+                    pairs.push((lhs, rhs));
                 }
             }
             for _ in 0..random_pairs {
-                let mut a = vec![0u64; n];
-                let mut b = vec![0u64; n];
-                for x in a.iter_mut() {
-                    *x = next();
+                let mut lhs = vec![0u64; n];
+                let mut rhs = vec![0u64; n];
+                for slot in lhs.iter_mut() {
+                    *slot = next();
                 }
-                for x in b.iter_mut() {
-                    *x = next();
+                for slot in rhs.iter_mut() {
+                    *slot = next();
                 }
-                pairs.push((a, b));
+                pairs.push((lhs, rhs));
             }
 
-            for (a, b) in &pairs {
+            for (lhs, rhs) in &pairs {
                 let mut oracle = vec![0u64; 2 * n];
-                mul_schoolbook(a, b, &mut oracle);
+                mul_schoolbook(lhs, rhs, &mut oracle);
 
-                for &th in THRESHOLDS {
-                    let mut got = vec![0u64; 2 * n];
-                    mul_karatsuba_with_threshold(a, b, &mut got, th);
+                for &threshold in THRESHOLDS {
+                    let mut actual = vec![0u64; 2 * n];
+                    mul_karatsuba_with_threshold(lhs, rhs, &mut actual, threshold);
                     assert_eq!(
-                        got, oracle,
-                        "non-alloc Karatsuba mismatch at n={n}, threshold={th}\na={a:?}\nb={b:?}"
+                        actual, oracle,
+                        "non-alloc Karatsuba mismatch at n={n}, threshold={threshold}\na={lhs:?}\nb={rhs:?}"
                     );
 
-                    let mut got_swapped = vec![0u64; 2 * n];
-                    mul_karatsuba_with_threshold(b, a, &mut got_swapped, th);
+                    let mut actual_swapped = vec![0u64; 2 * n];
+                    mul_karatsuba_with_threshold(rhs, lhs, &mut actual_swapped, threshold);
                     assert_eq!(
-                        got_swapped, oracle,
-                        "non-alloc Karatsuba not commutative at n={n}, threshold={th}"
+                        actual_swapped, oracle,
+                        "non-alloc Karatsuba not commutative at n={n}, threshold={threshold}"
                     );
                 }
             }
@@ -209,24 +209,24 @@ mod tests {
         );
 
         let n = 256;
-        let mut a = vec![0u64; n];
-        let mut b = vec![0u64; n];
-        for x in a.iter_mut() {
-            *x = next();
+        let mut lhs = vec![0u64; n];
+        let mut rhs = vec![0u64; n];
+        for slot in lhs.iter_mut() {
+            *slot = next();
         }
-        for x in b.iter_mut() {
-            *x = next();
+        for slot in rhs.iter_mut() {
+            *slot = next();
         }
         let mut oracle = vec![0u64; 2 * n];
-        let mut got = vec![0u64; 2 * n];
-        mul_schoolbook(&a, &b, &mut oracle);
+        let mut actual = vec![0u64; 2 * n];
+        mul_schoolbook(&lhs, &rhs, &mut oracle);
         // Deep threshold (8) drives maximal recursion at n=256 — the worst
         // case for the fixed scratch, and well below the production threshold,
         // so this over-tests the buffer. Where 256 exceeds the derived ceiling
         // the entry fails closed to schoolbook instead; the product is the
         // same, which is what the comparison below actually pins.
-        mul_karatsuba(&a, &b, &mut got, 8);
-        assert_eq!(got, oracle, "max-width Karatsuba mismatch via fixed scratch");
+        mul_karatsuba(&lhs, &rhs, &mut actual, 8);
+        assert_eq!(actual, oracle, "max-width Karatsuba mismatch via fixed scratch");
     }
 
     /// `mul_schoolbook_fixed::<L, D>` matches `mul_schoolbook` at a
@@ -236,21 +236,21 @@ mod tests {
     fn mul_schoolbook_fixed_matches_slice() {
         macro_rules! check {
             ($L:expr, $D:expr) => {{
-                for a in corpus() {
-                    for b in corpus() {
-                        let a64 = pack(&a);
-                        let b64 = pack(&b);
-                        if a64.len() < $L || b64.len() < $L {
+                for lhs in corpus() {
+                    for rhs in corpus() {
+                        let lhs_limbs = pack(&lhs);
+                        let rhs_limbs = pack(&rhs);
+                        if lhs_limbs.len() < $L || rhs_limbs.len() < $L {
                             continue;
                         }
-                        let mut a_arr = [0u64; $L];
-                        let mut b_arr = [0u64; $L];
-                        a_arr.copy_from_slice(&a64[..$L]);
-                        b_arr.copy_from_slice(&b64[..$L]);
+                        let mut lhs_arr = [0u64; $L];
+                        let mut rhs_arr = [0u64; $L];
+                        lhs_arr.copy_from_slice(&lhs_limbs[..$L]);
+                        rhs_arr.copy_from_slice(&rhs_limbs[..$L]);
                         let mut out_slice = vec![0u64; $D];
                         let mut out_fixed = [0u64; $D];
-                        mul_schoolbook(&a_arr, &b_arr, &mut out_slice);
-                        mul_schoolbook_fixed::<$L, $D>(&a_arr, &b_arr, &mut out_fixed);
+                        mul_schoolbook(&lhs_arr, &rhs_arr, &mut out_slice);
+                        mul_schoolbook_fixed::<$L, $D>(&lhs_arr, &rhs_arr, &mut out_fixed);
                         assert_eq!(
                             &out_slice[..],
                             &out_fixed[..],
@@ -273,7 +273,7 @@ mod tests {
     }
 
     /// `mul_schoolbook_into::<L, L+1>` matches `mul_schoolbook_fixed::<L, 2·L>`
-    /// when the wider operand is `[n, 0, ..., 0]`, across L covering every
+    /// when the wider operand is `[multiplier, 0, ..., 0]`, across L covering every
     /// wide tier from D38 (L=2) to D307 (L=16).
     #[test]
     fn mul_schoolbook_into_matches_fixed() {
@@ -290,19 +290,21 @@ mod tests {
         macro_rules! check_into {
             ($L:expr, $LP1:expr, $D:expr) => {{
                 for _ in 0..1000 {
-                    let mut a = [0u64; $L];
-                    for slot in a.iter_mut() {
+                    let mut multiplicand = [0u64; $L];
+                    for slot in multiplicand.iter_mut() {
                         *slot = next();
                     }
-                    let n = next();
+                    let multiplier = next();
 
                     let mut out_into = [0u64; $LP1];
-                    mul_schoolbook_into::<$L, $LP1>(&a, n, &mut out_into);
+                    mul_schoolbook_into::<$L, $LP1>(&multiplicand, multiplier,
+                        &mut out_into);
 
-                    let mut b = [0u64; $L];
-                    b[0] = n;
+                    let mut multiplier_limbs = [0u64; $L];
+                    multiplier_limbs[0] = multiplier;
                     let mut out_fixed = [0u64; $D];
-                    mul_schoolbook_fixed::<$L, $D>(&a, &b, &mut out_fixed);
+                    mul_schoolbook_fixed::<$L, $D>(&multiplicand, &multiplier_limbs,
+                        &mut out_fixed);
 
                     assert_eq!(
                         &out_into[..],
@@ -310,8 +312,8 @@ mod tests {
                         "mul_schoolbook_into::<{}, {}> low limbs mismatch (a={:?}, n={:#x})",
                         $L,
                         $LP1,
-                        a,
-                        n
+                        multiplicand,
+                        multiplier
                     );
                     for (k, &limb) in out_fixed[$LP1..].iter().enumerate() {
                         assert_eq!(
@@ -337,18 +339,18 @@ mod tests {
     fn mul_low_matches_full_product_low_half() {
         const N: usize = 4;
         const D: usize = 8;
-        for a in corpus() {
-            for b in corpus() {
-                let a64 = pack(&a);
-                let b64 = pack(&b);
-                let mut a_arr = [0u64; N];
-                let mut b_arr = [0u64; N];
-                a_arr.copy_from_slice(&a64[..N]);
-                b_arr.copy_from_slice(&b64[..N]);
+        for lhs in corpus() {
+            for rhs in corpus() {
+                let lhs_limbs = pack(&lhs);
+                let rhs_limbs = pack(&rhs);
+                let mut lhs_arr = [0u64; N];
+                let mut rhs_arr = [0u64; N];
+                lhs_arr.copy_from_slice(&lhs_limbs[..N]);
+                rhs_arr.copy_from_slice(&rhs_limbs[..N]);
                 let mut full = [0u64; D];
-                mul_schoolbook_fixed::<N, D>(&a_arr, &b_arr, &mut full);
+                mul_schoolbook_fixed::<N, D>(&lhs_arr, &rhs_arr, &mut full);
                 let mut low = [0u64; N];
-                mul_low_fixed::<N>(&a_arr, &b_arr, &mut low);
+                mul_low_fixed::<N>(&lhs_arr, &rhs_arr, &mut low);
                 assert_eq!(&full[..N], &low[..], "mul_low_fixed mismatch");
             }
         }
@@ -364,18 +366,18 @@ mod tests {
     fn mul_low_limb_u128_matches_u64() {
         // Edge corpus at N = 4 (all-ones / single-limb / mixed).
         const N4: usize = 4;
-        for a in corpus() {
-            for b in corpus() {
-                let a64 = pack(&a);
-                let b64 = pack(&b);
-                let mut a_arr = [0u64; N4];
-                let mut b_arr = [0u64; N4];
-                a_arr.copy_from_slice(&a64[..N4]);
-                b_arr.copy_from_slice(&b64[..N4]);
+        for lhs in corpus() {
+            for rhs in corpus() {
+                let lhs_limbs = pack(&lhs);
+                let rhs_limbs = pack(&rhs);
+                let mut lhs_arr = [0u64; N4];
+                let mut rhs_arr = [0u64; N4];
+                lhs_arr.copy_from_slice(&lhs_limbs[..N4]);
+                rhs_arr.copy_from_slice(&rhs_limbs[..N4]);
                 let mut lo_ref = [0u64; N4];
                 let mut lo_u128 = [0u64; N4];
-                mul_low_fixed::<N4>(&a_arr, &b_arr, &mut lo_ref);
-                mul_low_limb::<N4, u128>(&a_arr, &b_arr, &mut lo_u128);
+                mul_low_fixed::<N4>(&lhs_arr, &rhs_arr, &mut lo_ref);
+                mul_low_limb::<N4, u128>(&lhs_arr, &rhs_arr, &mut lo_u128);
                 assert_eq!(lo_ref, lo_u128, "u128 low-mul mismatch (corpus N=4)");
             }
         }
@@ -393,18 +395,18 @@ mod tests {
             ($n:literal, $rounds:literal) => {{
                 const N: usize = $n;
                 for _ in 0..$rounds {
-                    let mut a = [0u64; N];
-                    let mut b = [0u64; N];
-                    for x in a.iter_mut() {
-                        *x = next();
+                    let mut lhs = [0u64; N];
+                    let mut rhs = [0u64; N];
+                    for slot in lhs.iter_mut() {
+                        *slot = next();
                     }
-                    for x in b.iter_mut() {
-                        *x = next();
+                    for slot in rhs.iter_mut() {
+                        *slot = next();
                     }
                     let mut lo_ref = [0u64; N];
                     let mut lo_u128 = [0u64; N];
-                    mul_low_fixed::<N>(&a, &b, &mut lo_ref);
-                    mul_low_limb::<N, u128>(&a, &b, &mut lo_u128);
+                    mul_low_fixed::<N>(&lhs, &rhs, &mut lo_ref);
+                    mul_low_limb::<N, u128>(&lhs, &rhs, &mut lo_u128);
                     assert_eq!(
                         lo_ref, lo_u128,
                         "u128 low-mul mismatch at N = {}",
@@ -417,12 +419,12 @@ mod tests {
         macro_rules! check_ones {
             ($n:literal) => {{
                 const N: usize = $n;
-                let a = [u64::MAX; N];
-                let b = [u64::MAX; N];
+                let lhs = [u64::MAX; N];
+                let rhs = [u64::MAX; N];
                 let mut lo_ref = [0u64; N];
                 let mut lo_u128 = [0u64; N];
-                mul_low_fixed::<N>(&a, &b, &mut lo_ref);
-                mul_low_limb::<N, u128>(&a, &b, &mut lo_u128);
+                mul_low_fixed::<N>(&lhs, &rhs, &mut lo_ref);
+                mul_low_limb::<N, u128>(&lhs, &rhs, &mut lo_u128);
                 assert_eq!(lo_ref, lo_u128, "u128 low-mul mismatch (all-ones N={})", N);
             }};
         }

--- a/src/int/algos/mul/mul_karatsuba.rs
+++ b/src/int/algos/mul/mul_karatsuba.rs
@@ -80,11 +80,11 @@ pub(crate) const KARATSUBA_SCRATCH_LIMBS: usize =
 // ---- u64 entry points (existing slice-based interface, unchanged) -----------
 
 /// Non-allocating recursive Karatsuba multiplication at u64 base.
-/// out.len() >= 2 * a.len(), out must be zeroed by the caller.
-pub(crate) fn mul_karatsuba(a: &[u64], b: &[u64], out: &mut [u64], threshold: usize) {
-    debug_assert_eq!(a.len(), b.len());
-    debug_assert!(out.len() >= 2 * a.len());
-    // FAIL CLOSED. This entry is width-erased, so `a.len()` is a RUNTIME
+/// out.len() >= 2 * lhs.len(), out must be zeroed by the caller.
+pub(crate) fn mul_karatsuba(lhs: &[u64], rhs: &[u64], out: &mut [u64], threshold: usize) {
+    debug_assert_eq!(lhs.len(), rhs.len());
+    debug_assert!(out.len() >= 2 * lhs.len());
+    // FAIL CLOSED. This entry is width-erased, so `lhs.len()` is a RUNTIME
     // length that no const assertion can bound -- the scratch below is a
     // fixed build-max frame. An operand past the ceiling takes the
     // schoolbook path (slower, same product) instead of overrunning the
@@ -93,47 +93,48 @@ pub(crate) fn mul_karatsuba(a: &[u64], b: &[u64], out: &mut [u64], threshold: us
     //
     // Sizing argument: `KARATSUBA_SCRATCH_LIMBS` covers `KARATSUBA_MAX_WIDTH`
     // at the threshold FLOOR (4), and `karatsuba_scratch_needed_th` is
-    // non-decreasing in `n` and non-increasing in `threshold` -- so it covers
-    // every `(n <= ceiling, threshold >= 4)` caller, and `a.len()` alone is a
-    // sufficient test. ONE compare against a const at the entry; the
-    // recursion is untouched.
-    if a.len() > KARATSUBA_MAX_WIDTH {
-        mul_schoolbook(a, b, out);
+    // non-decreasing in `limb_count` and non-increasing in `threshold` -- so it
+    // covers every `(limb_count <= ceiling, threshold >= 4)` caller, and
+    // `lhs.len()` alone is a sufficient test. ONE compare against a const at
+    // the entry; the recursion is untouched.
+    if lhs.len() > KARATSUBA_MAX_WIDTH {
+        mul_schoolbook(lhs, rhs, out);
         return;
     }
     let mut scratch = [0u64; KARATSUBA_SCRATCH_LIMBS];
-    karatsuba_rec(a, b, out, &mut scratch, threshold);
+    karatsuba_rec(lhs, rhs, out, &mut scratch, threshold);
 }
 
 /// Bench-only u64 Karatsuba at an arbitrary threshold. out zeroed here.
 #[cfg(feature = "bench-alt")]
-pub(crate) fn mul_karatsuba_forced(a: &[u64], b: &[u64], out: &mut [u64], threshold: usize) {
-    debug_assert_eq!(a.len(), b.len());
-    debug_assert!(out.len() >= 2 * a.len());
-    for o in out.iter_mut() { *o = 0; }
+pub(crate) fn mul_karatsuba_forced(lhs: &[u64], rhs: &[u64], out: &mut [u64],
+    threshold: usize) {
+    debug_assert_eq!(lhs.len(), rhs.len());
+    debug_assert!(out.len() >= 2 * lhs.len());
+    for slot in out.iter_mut() { *slot = 0; }
     // Same fail-closed ceiling as `mul_karatsuba` -- see the sizing argument
     // there. `out` is already zeroed above, which is the schoolbook contract.
-    if a.len() > KARATSUBA_MAX_WIDTH {
-        mul_schoolbook(a, b, out);
+    if lhs.len() > KARATSUBA_MAX_WIDTH {
+        mul_schoolbook(lhs, rhs, out);
         return;
     }
     let mut scratch = [0u64; KARATSUBA_SCRATCH_LIMBS];
-    karatsuba_rec(a, b, out, &mut scratch, threshold);
+    karatsuba_rec(lhs, rhs, out, &mut scratch, threshold);
 }
 
 /// Test-only entry at an arbitrary threshold (allocates scratch).
 #[cfg(test)]
 pub(crate) fn mul_karatsuba_with_threshold(
-    a: &[u64],
-    b: &[u64],
+    lhs: &[u64],
+    rhs: &[u64],
     out: &mut [u64],
     threshold: usize,
 ) {
-    debug_assert_eq!(a.len(), b.len());
-    debug_assert!(out.len() >= 2 * a.len());
-    let need = karatsuba_scratch_needed_th(a.len(), threshold);
-    let mut scratch = vec![0u64; need];
-    karatsuba_rec(a, b, out, &mut scratch, threshold);
+    debug_assert_eq!(lhs.len(), rhs.len());
+    debug_assert!(out.len() >= 2 * lhs.len());
+    let scratch_needed = karatsuba_scratch_needed_th(lhs.len(), threshold);
+    let mut scratch = vec![0u64; scratch_needed];
+    karatsuba_rec(lhs, rhs, out, &mut scratch, threshold);
 }
 // ---- Limb-generic entry point (bench-alt only) ------------------------------
 
@@ -154,8 +155,8 @@ pub(crate) fn mul_karatsuba_with_threshold(
 /// `mul_karatsuba_limb::<N, u128>` — the policy-map showed it beats schoolbook-
 /// u128 by ~1.34x (N=128) .. 1.39x (N=256) at recursion threshold 48.
 pub(crate) fn mul_karatsuba_limb<const N: usize, L: Limb>(
-    a: &[u64; N],
-    b: &[u64; N],
+    lhs: &[u64; N],
+    rhs: &[u64; N],
     out: &mut [u64],
     threshold: usize,
 ) where
@@ -164,10 +165,10 @@ pub(crate) fn mul_karatsuba_limb<const N: usize, L: Limb>(
     let h = L::packed_len(N);
     debug_assert!(h > 0 && h <= N);
     // Pack operands into L-space. [L; N] is always >= packed_len(N) <= N.
-    let mut ap = [L::ZERO; N];
-    let mut bp = [L::ZERO; N];
-    L::pack(a, &mut ap[..h]);
-    L::pack(b, &mut bp[..h]);
+    let mut lhs_packed = [L::ZERO; N];
+    let mut rhs_packed = [L::ZERO; N];
+    L::pack(lhs, &mut lhs_packed[..h]);
+    L::pack(rhs, &mut rhs_packed[..h]);
 
     // Convert threshold from u64-limb to packed-limb units.
     // For u128: packed_len = N/2 so ratio=2, threshold_packed = threshold/2.
@@ -198,81 +199,84 @@ pub(crate) fn mul_karatsuba_limb<const N: usize, L: Limb>(
         scratch.len(),
     );
 
-    karatsuba_rec_limb::<L>(&ap[..h], &bp[..h], &mut *prod, scratch, threshold_packed);
+    karatsuba_rec_limb::<L>(&lhs_packed[..h], &rhs_packed[..h], &mut *prod, scratch,
+        threshold_packed);
 
     L::unpack(&prod[..2 * h], &mut out[..2 * N]);
 }
 
 // ---- Scratch sizing ---------------------------------------------------------
 
-/// Upper bound on scratch (in typed limbs) for n-limb Karatsuba at the
-/// given threshold.
-pub(crate) const fn karatsuba_scratch_needed_th(n: usize, threshold: usize) -> usize {
-    if n < threshold {
+/// Upper bound on scratch (in typed limbs) for `limb_count`-limb Karatsuba at
+/// the given threshold.
+pub(crate) const fn karatsuba_scratch_needed_th(limb_count: usize, threshold: usize) -> usize {
+    if limb_count < threshold {
         return 0;
     }
-    let h = n / 2;
-    let hi = n - h;
-    let level = 2 * h + 2 * hi + (hi + 1) + (hi + 1) + 2 * (hi + 1);
-    level + karatsuba_scratch_needed_th(hi + 1, threshold)
+    let low_len = limb_count / 2;
+    let high_len = limb_count - low_len;
+    let level =
+        2 * low_len + 2 * high_len + (high_len + 1) + (high_len + 1) + 2 * (high_len + 1);
+    level + karatsuba_scratch_needed_th(high_len + 1, threshold)
 }
 
 // ---- u64-slice recursion (unchanged) ----------------------------------------
 
-fn karatsuba_rec(a: &[u64], b: &[u64], out: &mut [u64], scratch: &mut [u64], threshold: usize) {
+fn karatsuba_rec(lhs: &[u64], rhs: &[u64], out: &mut [u64], scratch: &mut [u64],
+    threshold: usize) {
     debug_assert!(threshold >= 4, "Karatsuba threshold must be >= 4 to terminate");
-    let n = a.len();
-    if n < threshold {
-        mul_schoolbook(a, b, out);
+    let limb_count = lhs.len();
+    if limb_count < threshold {
+        mul_schoolbook(lhs, rhs, out);
         return;
     }
-    let h = n / 2;
-    let hi = n - h;
-    let (a_lo, a_hi) = a.split_at(h);
-    let (b_lo, b_hi) = b.split_at(h);
+    let low_len = limb_count / 2;
+    let high_len = limb_count - low_len;
+    let (lhs_lo, lhs_hi) = lhs.split_at(low_len);
+    let (rhs_lo, rhs_hi) = rhs.split_at(low_len);
 
-    let (z0, rest) = scratch.split_at_mut(2 * h);
-    let (z2, rest) = rest.split_at_mut(2 * hi);
-    let (sa, rest) = rest.split_at_mut(hi + 1);
-    let (sb, rest) = rest.split_at_mut(hi + 1);
-    let (z1, tail) = rest.split_at_mut(2 * (hi + 1));
+    let (z0, rest) = scratch.split_at_mut(2 * low_len);
+    let (z2, rest) = rest.split_at_mut(2 * high_len);
+    let (lhs_sum, rest) = rest.split_at_mut(high_len + 1);
+    let (rhs_sum, rest) = rest.split_at_mut(high_len + 1);
+    let (z1, tail) = rest.split_at_mut(2 * (high_len + 1));
 
-    for v in z0.iter_mut() { *v = 0; }
-    for v in z2.iter_mut() { *v = 0; }
-    for v in z1.iter_mut() { *v = 0; }
+    for slot in z0.iter_mut() { *slot = 0; }
+    for slot in z2.iter_mut() { *slot = 0; }
+    for slot in z1.iter_mut() { *slot = 0; }
 
-    karatsuba_rec(a_lo, b_lo, z0, tail, threshold);
-    karatsuba_rec_unbalanced(a_hi, b_hi, z2, tail, threshold);
+    karatsuba_rec(lhs_lo, rhs_lo, z0, tail, threshold);
+    karatsuba_rec_unbalanced(lhs_hi, rhs_hi, z2, tail, threshold);
 
-    for v in sa.iter_mut() { *v = 0; }
-    for v in sb.iter_mut() { *v = 0; }
-    sa[..h].copy_from_slice(a_lo);
-    sb[..h].copy_from_slice(b_lo);
-    let _ = add_assign(sa, a_hi);
-    let _ = add_assign(sb, b_hi);
+    for slot in lhs_sum.iter_mut() { *slot = 0; }
+    for slot in rhs_sum.iter_mut() { *slot = 0; }
+    lhs_sum[..low_len].copy_from_slice(lhs_lo);
+    rhs_sum[..low_len].copy_from_slice(rhs_lo);
+    let _ = add_assign(lhs_sum, lhs_hi);
+    let _ = add_assign(rhs_sum, rhs_hi);
 
-    karatsuba_rec_unbalanced(sa, sb, z1, tail, threshold);
+    karatsuba_rec_unbalanced(lhs_sum, rhs_sum, z1, tail, threshold);
     let _ = sub_assign(z1, z0);
     let _ = sub_assign(z1, z2);
 
     out[..z0.len()].copy_from_slice(z0);
-    let _ = add_assign(&mut out[2 * h..], z2);
-    let _ = add_assign(&mut out[h..], z1);
+    let _ = add_assign(&mut out[2 * low_len..], z2);
+    let _ = add_assign(&mut out[low_len..], z1);
 }
 
 fn karatsuba_rec_unbalanced(
-    a: &[u64],
-    b: &[u64],
+    lhs: &[u64],
+    rhs: &[u64],
     out: &mut [u64],
     scratch: &mut [u64],
     threshold: usize,
 ) {
-    debug_assert_eq!(a.len(), b.len());
-    if a.len() >= threshold {
-        karatsuba_rec(a, b, out, scratch, threshold);
+    debug_assert_eq!(lhs.len(), rhs.len());
+    if lhs.len() >= threshold {
+        karatsuba_rec(lhs, rhs, out, scratch, threshold);
     } else {
-        for v in out.iter_mut() { *v = 0; }
-        mul_schoolbook(a, b, out);
+        for slot in out.iter_mut() { *slot = 0; }
+        mul_schoolbook(lhs, rhs, out);
     }
 }
 // ---- Limb-generic recursion: ONE kernel body for both u64 and u128 ----------
@@ -287,29 +291,29 @@ fn karatsuba_rec_unbalanced(
 /// (Constitution rule 2). (A future tidy could relocate this + the two
 /// `limb_{add,sub}_assign` helpers to `mul_schoolbook.rs` beside `mul_low_limb`.)
 #[inline]
-pub(crate) fn schoolbook_rec_limb<L: Limb>(a: &[L], b: &[L], out: &mut [L]) {
-    let na = a.len();
-    let nb = b.len();
+pub(crate) fn schoolbook_rec_limb<L: Limb>(lhs: &[L], rhs: &[L], out: &mut [L]) {
+    let lhs_len = lhs.len();
+    let rhs_len = rhs.len();
     let mut i = 0;
-    while i < na {
-        let ai = a[i];
-        if ai != L::ZERO {
+    while i < lhs_len {
+        let lhs_limb = lhs[i];
+        if lhs_limb != L::ZERO {
             let mut carry = L::ZERO;
             let mut j = 0;
-            while j < nb {
-                let (lo, hi) = ai.widening_mul(b[j]);
+            while j < rhs_len {
+                let (lo, hi) = lhs_limb.widening_mul(rhs[j]);
                 let idx = i + j;
-                let (s1, c1) = out[idx].overflowing_add(lo);
-                let (s2, c2) = s1.overflowing_add(carry);
-                out[idx] = s2;
-                carry = hi.add_carries(c1, c2);
+                let (sum1, carry1) = out[idx].overflowing_add(lo);
+                let (sum2, carry2) = sum1.overflowing_add(carry);
+                out[idx] = sum2;
+                carry = hi.add_carries(carry1, carry2);
                 j += 1;
             }
-            let mut idx = i + nb;
+            let mut idx = i + rhs_len;
             while carry != L::ZERO && idx < out.len() {
-                let (s, c) = out[idx].overflowing_add(carry);
-                out[idx] = s;
-                carry = if c { L::ONE } else { L::ZERO };
+                let (sum, carried) = out[idx].overflowing_add(carry);
+                out[idx] = sum;
+                carry = if carried { L::ONE } else { L::ZERO };
                 idx += 1;
             }
         }
@@ -317,37 +321,38 @@ pub(crate) fn schoolbook_rec_limb<L: Limb>(a: &[L], b: &[L], out: &mut [L]) {
     }
 }
 
-/// Limb-generic add-assign: a += b, returns carry. a.len() >= b.len().
+/// Limb-generic add-assign: lhs += rhs, returns carry. lhs.len() >= rhs.len().
 /// Used for sum-formation and recombine in L space. `pub(crate)`: shared
 /// with the Toom-3 kernel (one L-space add, no duplicate — rule 2).
 #[inline]
-pub(crate) fn limb_add_assign<L: Limb>(a: &mut [L], b: &[L]) -> bool {
+pub(crate) fn limb_add_assign<L: Limb>(lhs: &mut [L], rhs: &[L]) -> bool {
     let mut carry = false;
     let mut i = 0;
-    while i < a.len() {
-        let bv = if i < b.len() { b[i] } else { L::ZERO };
-        let (s1, c1) = a[i].overflowing_add(bv);
-        let (s2, c2) = s1.overflowing_add(if carry { L::ONE } else { L::ZERO });
-        a[i] = s2;
-        carry = c1 | c2;
+    while i < lhs.len() {
+        let rhs_limb = if i < rhs.len() { rhs[i] } else { L::ZERO };
+        let (sum1, carry1) = lhs[i].overflowing_add(rhs_limb);
+        let (sum2, carry2) = sum1.overflowing_add(if carry { L::ONE } else { L::ZERO });
+        lhs[i] = sum2;
+        carry = carry1 | carry2;
         i += 1;
     }
     carry
 }
 
-/// Limb-generic sub-assign: a -= b, returns borrow. a.len() >= b.len().
+/// Limb-generic sub-assign: lhs -= rhs, returns borrow. lhs.len() >= rhs.len().
 /// Used for z1 formation (z1 -= z0; z1 -= z2) in L space. `pub(crate)`:
 /// shared with the Toom-3 kernel (one L-space sub, no duplicate — rule 2).
 #[inline]
-pub(crate) fn limb_sub_assign<L: Limb>(a: &mut [L], b: &[L]) -> bool {
+pub(crate) fn limb_sub_assign<L: Limb>(lhs: &mut [L], rhs: &[L]) -> bool {
     let mut borrow = false;
     let mut i = 0;
-    while i < a.len() {
-        let bv = if i < b.len() { b[i] } else { L::ZERO };
-        let (d1, b1) = a[i].overflowing_sub(bv);
-        let (d2, b2) = d1.overflowing_sub(if borrow { L::ONE } else { L::ZERO });
-        a[i] = d2;
-        borrow = b1 | b2;
+    while i < lhs.len() {
+        let rhs_limb = if i < rhs.len() { rhs[i] } else { L::ZERO };
+        let (diff1, borrow1) = lhs[i].overflowing_sub(rhs_limb);
+        let (diff2, borrow2) =
+            diff1.overflowing_sub(if borrow { L::ONE } else { L::ZERO });
+        lhs[i] = diff2;
+        borrow = borrow1 | borrow2;
         i += 1;
     }
     borrow
@@ -356,18 +361,18 @@ pub(crate) fn limb_sub_assign<L: Limb>(a: &mut [L], b: &[L]) -> bool {
 /// Limb-generic child dispatch: routes to karatsuba_rec_limb above the
 /// threshold or schoolbook_rec_limb below.
 fn karatsuba_rec_limb_unbalanced<L: Limb>(
-    a: &[L],
-    b: &[L],
+    lhs: &[L],
+    rhs: &[L],
     out: &mut [L],
     scratch: &mut [L],
     threshold: usize,
 ) {
-    debug_assert_eq!(a.len(), b.len());
-    if a.len() >= threshold {
-        karatsuba_rec_limb::<L>(a, b, out, scratch, threshold);
+    debug_assert_eq!(lhs.len(), rhs.len());
+    if lhs.len() >= threshold {
+        karatsuba_rec_limb::<L>(lhs, rhs, out, scratch, threshold);
     } else {
-        for v in out.iter_mut() { *v = L::ZERO; }
-        schoolbook_rec_limb::<L>(a, b, out);
+        for slot in out.iter_mut() { *slot = L::ZERO; }
+        schoolbook_rec_limb::<L>(lhs, rhs, out);
     }
 }
 
@@ -378,51 +383,51 @@ fn karatsuba_rec_limb_unbalanced<L: Limb>(
 /// karatsuba_rec; for L = u128 runs in n/2 u128 limbs, halving the
 /// carry-chain depth per inner step. ONE body, no per-limb-type copy.
 ///
-/// out must be pre-zeroed for the 2*n-limb window.
+/// out must be pre-zeroed for the 2*limb_count-limb window.
 fn karatsuba_rec_limb<L: Limb>(
-    a: &[L],
-    b: &[L],
+    lhs: &[L],
+    rhs: &[L],
     out: &mut [L],
     scratch: &mut [L],
     threshold: usize,
 ) {
     debug_assert!(threshold >= 4);
-    let n = a.len();
-    if n < threshold {
-        schoolbook_rec_limb::<L>(a, b, out);
+    let limb_count = lhs.len();
+    if limb_count < threshold {
+        schoolbook_rec_limb::<L>(lhs, rhs, out);
         return;
     }
-    let h = n / 2;
-    let hi = n - h;
+    let low_len = limb_count / 2;
+    let high_len = limb_count - low_len;
 
-    let (a_lo, a_hi) = a.split_at(h);
-    let (b_lo, b_hi) = b.split_at(h);
+    let (lhs_lo, lhs_hi) = lhs.split_at(low_len);
+    let (rhs_lo, rhs_hi) = rhs.split_at(low_len);
 
-    let (z0, rest) = scratch.split_at_mut(2 * h);
-    let (z2, rest) = rest.split_at_mut(2 * hi);
-    let (sa, rest) = rest.split_at_mut(hi + 1);
-    let (sb, rest) = rest.split_at_mut(hi + 1);
-    let (z1, tail) = rest.split_at_mut(2 * (hi + 1));
+    let (z0, rest) = scratch.split_at_mut(2 * low_len);
+    let (z2, rest) = rest.split_at_mut(2 * high_len);
+    let (lhs_sum, rest) = rest.split_at_mut(high_len + 1);
+    let (rhs_sum, rest) = rest.split_at_mut(high_len + 1);
+    let (z1, tail) = rest.split_at_mut(2 * (high_len + 1));
 
-    for v in z0.iter_mut() { *v = L::ZERO; }
-    for v in z2.iter_mut() { *v = L::ZERO; }
-    for v in z1.iter_mut() { *v = L::ZERO; }
+    for slot in z0.iter_mut() { *slot = L::ZERO; }
+    for slot in z2.iter_mut() { *slot = L::ZERO; }
+    for slot in z1.iter_mut() { *slot = L::ZERO; }
 
-    karatsuba_rec_limb::<L>(a_lo, b_lo, z0, tail, threshold);
-    karatsuba_rec_limb_unbalanced::<L>(a_hi, b_hi, z2, tail, threshold);
+    karatsuba_rec_limb::<L>(lhs_lo, rhs_lo, z0, tail, threshold);
+    karatsuba_rec_limb_unbalanced::<L>(lhs_hi, rhs_hi, z2, tail, threshold);
 
-    for v in sa.iter_mut() { *v = L::ZERO; }
-    for v in sb.iter_mut() { *v = L::ZERO; }
-    sa[..h].copy_from_slice(a_lo);
-    sb[..h].copy_from_slice(b_lo);
-    let _ = limb_add_assign::<L>(sa, a_hi);
-    let _ = limb_add_assign::<L>(sb, b_hi);
+    for slot in lhs_sum.iter_mut() { *slot = L::ZERO; }
+    for slot in rhs_sum.iter_mut() { *slot = L::ZERO; }
+    lhs_sum[..low_len].copy_from_slice(lhs_lo);
+    rhs_sum[..low_len].copy_from_slice(rhs_lo);
+    let _ = limb_add_assign::<L>(lhs_sum, lhs_hi);
+    let _ = limb_add_assign::<L>(rhs_sum, rhs_hi);
 
-    karatsuba_rec_limb_unbalanced::<L>(sa, sb, z1, tail, threshold);
+    karatsuba_rec_limb_unbalanced::<L>(lhs_sum, rhs_sum, z1, tail, threshold);
     let _ = limb_sub_assign::<L>(z1, z0);
     let _ = limb_sub_assign::<L>(z1, z2);
 
     out[..z0.len()].copy_from_slice(z0);
-    let _ = limb_add_assign::<L>(&mut out[2 * h..], z2);
-    let _ = limb_add_assign::<L>(&mut out[h..], z1);
+    let _ = limb_add_assign::<L>(&mut out[2 * low_len..], z2);
+    let _ = limb_add_assign::<L>(&mut out[low_len..], z1);
 }

--- a/src/int/algos/mul/mul_schoolbook.rs
+++ b/src/int/algos/mul/mul_schoolbook.rs
@@ -15,35 +15,35 @@
 
 use crate::int::types::compute_limbs::{ComputeLimbs, Limb, Limbs};
 
-/// `out = a · b` schoolbook. `out.len() >= a.len() + b.len()` and `out`
-/// must be zeroed by the caller.
+/// `out = lhs · rhs` schoolbook. `out.len() >= lhs.len() + rhs.len()` and
+/// `out` must be zeroed by the caller.
 ///
 /// Inner step uses the native `u64 × u64 → u128` widening mul
 /// (`MUL` + `UMULH` on x86-64 / aarch64).
-pub(crate) const fn mul_schoolbook(a: &[u64], b: &[u64], out: &mut [u64]) {
+pub(crate) const fn mul_schoolbook(lhs: &[u64], rhs: &[u64], out: &mut [u64]) {
     let mut i = 0;
-    while i < a.len() {
-        if a[i] != 0 {
+    while i < lhs.len() {
+        if lhs[i] != 0 {
             let mut carry: u64 = 0;
             let mut j = 0;
-            while j < b.len() {
-                if b[j] != 0 || carry != 0 {
-                    let prod = (a[i] as u128) * (b[j] as u128);
+            while j < rhs.len() {
+                if rhs[j] != 0 || carry != 0 {
+                    let prod = (lhs[i] as u128) * (rhs[j] as u128);
                     let prod_lo = prod as u64;
                     let prod_hi = (prod >> 64) as u64;
                     let idx = i + j;
-                    let (s1, c1) = out[idx].overflowing_add(prod_lo);
-                    let (s2, c2) = s1.overflowing_add(carry);
-                    out[idx] = s2;
-                    carry = prod_hi + (c1 as u64) + (c2 as u64);
+                    let (sum1, carry1) = out[idx].overflowing_add(prod_lo);
+                    let (sum2, carry2) = sum1.overflowing_add(carry);
+                    out[idx] = sum2;
+                    carry = prod_hi + (carry1 as u64) + (carry2 as u64);
                 }
                 j += 1;
             }
-            let mut idx = i + b.len();
+            let mut idx = i + rhs.len();
             while carry != 0 && idx < out.len() {
-                let (s, c) = out[idx].overflowing_add(carry);
-                out[idx] = s;
-                carry = c as u64;
+                let (sum, carried) = out[idx].overflowing_add(carry);
+                out[idx] = sum;
+                carry = carried as u64;
                 idx += 1;
             }
         }
@@ -63,32 +63,33 @@ pub(crate) const fn mul_schoolbook(a: &[u64], b: &[u64], out: &mut [u64]) {
 /// width).
 #[inline]
 pub(crate) const fn mul_schoolbook_fixed<const L: usize, const D: usize>(
-    a: &[u64; L],
-    b: &[u64; L],
+    lhs: &[u64; L],
+    rhs: &[u64; L],
     out: &mut [u64; D],
 ) {
     debug_assert!(D >= 2 * L, "mul_schoolbook_fixed: D must be ≥ 2·L");
     let mut i = 0;
     while i < L {
-        let ai = a[i];
-        if ai != 0 {
+        let lhs_limb = lhs[i];
+        if lhs_limb != 0 {
             let mut carry: u64 = 0;
             let mut j = 0;
             while j < L {
-                let v = (ai as u128) * (b[j] as u128) + (out[i + j] as u128) + (carry as u128);
-                out[i + j] = v as u64;
-                carry = (v >> 64) as u64;
+                let acc = (lhs_limb as u128) * (rhs[j] as u128)
+                    + (out[i + j] as u128) + (carry as u128);
+                out[i + j] = acc as u64;
+                carry = (acc >> 64) as u64;
                 j += 1;
             }
             // Final row carry, propagated until exhausted or end of
             // `out`. Worst-case unbounded chain when out[i + L ..]
             // is all-ones; ordinarily exits after 1 iteration.
             let mut idx = i + L;
-            let mut c = carry;
-            while c != 0 && idx < D {
-                let v = (out[idx] as u128) + (c as u128);
-                out[idx] = v as u64;
-                c = (v >> 64) as u64;
+            let mut tail_carry = carry;
+            while tail_carry != 0 && idx < D {
+                let acc = (out[idx] as u128) + (tail_carry as u128);
+                out[idx] = acc as u64;
+                tail_carry = (acc >> 64) as u64;
                 idx += 1;
             }
         }
@@ -96,65 +97,68 @@ pub(crate) const fn mul_schoolbook_fixed<const L: usize, const D: usize>(
     }
 }
 
-/// `out = a · n` where `n` is a single u64 multiplier, `a` is a
-/// fixed-width `L`-limb input, and `out` is a fixed-width `LP1 = L + 1`
-/// limb output. `out` must be zeroed by the caller.
+/// `out = multiplicand · multiplier` where `multiplier` is a single u64,
+/// `multiplicand` is a fixed-width `L`-limb input, and `out` is a
+/// fixed-width `LP1 = L + 1` limb output. `out` must be zeroed by the caller.
 ///
 /// Specialisation of the n-by-1-word multi-precision multiply (Knuth,
 /// TAOCP Vol 2 §4.3.1, Algorithm M with `n = 1`): every inner-loop step
 /// is a single `u64 × u64 → u128` widening mul plus an accumulator-and-
 /// carry fold, so the whole operation is `L` widening muls and `L` adds
 /// with no cross-row carry chains. By contrast, [`mul_schoolbook_fixed`]
-/// called with `b = [n, 0, ..., 0]` still runs the `L²` outer-product
-/// loop (most iterations are short-circuited on `b[j] == 0`, but the
-/// monomorphisation still emits the dead branches and the row
-/// carry-propagation tail).
+/// called with `rhs = [multiplier, 0, ..., 0]` still runs the `L²`
+/// outer-product loop (most iterations are short-circuited on
+/// `rhs[j] == 0`, but the monomorphisation still emits the dead branches
+/// and the row carry-propagation tail).
 ///
 /// `LP1` must equal `L + 1`; the caller passes both because Rust stable
 /// cannot express `L + 1` in a const generic position.
 #[inline(always)]
 pub(crate) const fn mul_schoolbook_into<const L: usize, const LP1: usize>(
-    a: &[u64; L],
-    n: u64,
+    multiplicand: &[u64; L],
+    multiplier: u64,
     out: &mut [u64; LP1],
 ) {
     debug_assert!(LP1 == L + 1, "mul_schoolbook_into: LP1 must equal L + 1");
     let mut carry: u64 = 0;
     let mut i = 0;
     while i < L {
-        // p fits u128 with no overflow:
+        // acc fits u128 with no overflow:
         //   (2^64 - 1)·(2^64 - 1) + (2^64 - 1) + (2^64 - 1)
         //   = 2^128 - 1
-        let p = (a[i] as u128) * (n as u128) + (out[i] as u128) + (carry as u128);
-        out[i] = p as u64;
-        carry = (p >> 64) as u64;
+        let acc = (multiplicand[i] as u128) * (multiplier as u128)
+            + (out[i] as u128) + (carry as u128);
+        out[i] = acc as u64;
+        carry = (acc >> 64) as u64;
         i += 1;
     }
     out[L] = carry;
 }
 
-/// `out = (a · b) mod 2^(64·N)` — the low `N` limbs of the schoolbook
+/// `out = (lhs · rhs) mod 2^(64·N)` — the low `N` limbs of the schoolbook
 /// product, with the high half never formed.
 ///
-/// `out` must be zeroed by the caller. For each operand limb `a[i]`, the
+/// `out` must be zeroed by the caller. For each operand limb `lhs[i]`, the
 /// inner loop runs only while `i + j < N`; products that would land in
 /// limb `N` or above are exactly the bits above the width and are
 /// dropped, including the final row carry. Bit-identical to the low `N`
 /// limbs of [`mul_schoolbook_fixed`].
 #[inline]
-pub(crate) const fn mul_low_fixed<const N: usize>(a: &[u64; N], b: &[u64; N], out: &mut [u64; N]) {
+pub(crate) const fn mul_low_fixed<const N: usize>(lhs: &[u64; N], rhs: &[u64; N],
+    out: &mut [u64; N]) {
     let mut i = 0;
     while i < N {
-        let ai = a[i];
-        if ai != 0 {
+        let lhs_limb = lhs[i];
+        if lhs_limb != 0 {
             let mut carry: u64 = 0;
             let mut j = 0;
             // Stop once `i + j` reaches `N`: those partial products lie
             // entirely above `2^(64·N)` and drop out of the result.
             while j < N - i {
-                let v = (ai as u128) * (b[j] as u128) + (out[i + j] as u128) + (carry as u128);
-                out[i + j] = v as u64;
-                carry = (v >> 64) as u64;
+                let acc = (lhs_limb as u128) * (rhs[j] as u128)
+                    + (out[i + j] as u128) + (carry as u128);
+                out[i + j] = acc as u64;
+                carry = (acc >> 64) as u64;
                 j += 1;
             }
             // The final row carry would land in limb `i + (N - i) = N`,
@@ -164,8 +168,8 @@ pub(crate) const fn mul_low_fixed<const N: usize>(a: &[u64; N], b: &[u64; N], ou
     }
 }
 
-/// `out = (a · b) mod 2^(64·N)` — the truncated-low schoolbook, generic over
-/// the limb type `L` (the [`Limb`] axis). For `L = u64` it is base-2^64 over
+/// `out = (lhs · rhs) mod 2^(64·N)` — the truncated-low schoolbook, generic
+/// over the limb type `L` (the [`Limb`] axis). For `L = u64` it is base-2^64 over
 /// `N` limbs; for `L = u128` it packs the operands into `N/2` u128 limbs
 /// (`limb = lo | hi << 64`) and runs base-2^128 — half the limb count, so
 /// ~1/4 the partial products at the cost of a wider 128×128→256 inner step —
@@ -177,66 +181,70 @@ pub(crate) const fn mul_low_fixed<const N: usize>(a: &[u64; N], b: &[u64; N], ou
 /// (`L::packed_len` halves it); callers gate on that. Scratch is `[L; N]`
 /// (the value's own width — `packed_len(N) ≤ N`), not a build-max blanket.
 ///
-/// The carry merge `hi.add_carries(c1, c2)` never overflows: the product
-/// high limb satisfies `hi ≤ L::MAX − 1` (maximal only when the low limb is
-/// 1), and `c1`/`c2` are never both set (`c1` needs `acc + lo` to wrap to 0,
-/// after which `+ carry` cannot wrap), so `hi + c1 + c2 ≤ L::MAX`.
+/// The carry merge `hi.add_carries(carry1, carry2)` never overflows: the
+/// product high limb satisfies `hi ≤ L::MAX − 1` (maximal only when the low
+/// limb is 1), and `carry1`/`carry2` are never both set (`carry1` needs
+/// `acc + lo` to wrap to 0, after which `+ carry` cannot wrap), so
+/// `hi + carry1 + carry2 ≤ L::MAX`.
 ///
 /// [`LimbSize`]: crate::int::types::compute_limbs::LimbSize
 #[inline]
-pub(crate) fn mul_low_limb<const N: usize, L: Limb>(a: &[u64; N], b: &[u64; N], out: &mut [u64; N]) {
+pub(crate) fn mul_low_limb<const N: usize, L: Limb>(lhs: &[u64; N], rhs: &[u64; N],
+    out: &mut [u64; N]) {
     let h = L::packed_len(N);
     // `[L; N]` covers `packed_len(N) ≤ N` for both limb types (stable Rust
     // cannot put `N/2` in an array-length position; only the low `h` are used).
-    let mut ap = [L::ZERO; N];
-    let mut bp = [L::ZERO; N];
-    L::pack(a, &mut ap[..h]);
-    L::pack(b, &mut bp[..h]);
-    // `sb` = `b`'s live packed-limb count. The inner loop need only run over
-    // `b`'s significant limbs; its zero high limbs contribute only a carry,
-    // replicated bit-identically by the carry tail below. Skipping them turns
-    // a full-width multiply of a SMALL operand — the common shape in the wide
-    // transcendental series (terms shrink) and the working-scale lift — into
-    // one scaled by `b`'s magnitude. Gated to wide `N`: for the narrow tiers
-    // the operands are dense, so the scan is pure overhead and the const folds
-    // it away.
-    let sb = if N >= 16 {
-        let mut s = h;
-        while s > 0 && bp[s - 1] == L::ZERO {
-            s -= 1;
+    let mut lhs_packed = [L::ZERO; N];
+    let mut rhs_packed = [L::ZERO; N];
+    L::pack(lhs, &mut lhs_packed[..h]);
+    L::pack(rhs, &mut rhs_packed[..h]);
+    // `rhs_len` = `rhs`'s live packed-limb count. The inner loop need only run
+    // over `rhs`'s significant limbs; its zero high limbs contribute only a
+    // carry, replicated bit-identically by the carry tail below. Skipping them
+    // turns a full-width multiply of a SMALL operand — the common shape in the
+    // wide transcendental series (terms shrink) and the working-scale lift —
+    // into one scaled by `rhs`'s magnitude. Gated to wide `N`: for the narrow
+    // tiers the operands are dense, so the scan is pure overhead and the const
+    // folds it away.
+    let rhs_len = if N >= 16 {
+        let mut len = h;
+        while len > 0 && rhs_packed[len - 1] == L::ZERO {
+            len -= 1;
         }
-        s
+        len
     } else {
         h
     };
     let mut acc = [L::ZERO; N];
     let mut i = 0;
     while i < h {
-        let ai = ap[i];
-        if ai != L::ZERO {
+        let lhs_limb = lhs_packed[i];
+        if lhs_limb != L::ZERO {
             let mut carry = L::ZERO;
             let mut j = 0;
             // Stop once `i + j` reaches `h` (partials above 2^(64·N) drop out
-            // of the truncated-low result) OR once `b`'s significant limbs are
-            // exhausted (`sb`); the residual carry is propagated by the tail.
-            let jmax = (h - i).min(sb);
+            // of the truncated-low result) OR once `rhs`'s significant limbs
+            // are exhausted (`rhs_len`); the residual carry is propagated by
+            // the tail.
+            let jmax = (h - i).min(rhs_len);
             while j < jmax {
-                let (lo, hi) = ai.widening_mul(bp[j]);
+                let (lo, hi) = lhs_limb.widening_mul(rhs_packed[j]);
                 let idx = i + j;
-                let (s1, c1) = acc[idx].overflowing_add(lo);
-                let (s2, c2) = s1.overflowing_add(carry);
-                acc[idx] = s2;
-                carry = hi.add_carries(c1, c2);
+                let (sum1, carry1) = acc[idx].overflowing_add(lo);
+                let (sum2, carry2) = sum1.overflowing_add(carry);
+                acc[idx] = sum2;
+                carry = hi.add_carries(carry1, carry2);
                 j += 1;
             }
-            // Carry tail over the zero-`b` region — bit-identical to running
-            // the inner loop with `bp[j] == 0` (the multiply yields 0, leaving
-            // only `acc[idx] += carry` and its overflow into the next limb).
+            // Carry tail over the zero-`rhs` region — bit-identical to running
+            // the inner loop with `rhs_packed[j] == 0` (the multiply yields 0,
+            // leaving only `acc[idx] += carry` and its overflow into the next
+            // limb).
             let mut idx = i + jmax;
             while idx < h && carry != L::ZERO {
-                let (s, c) = acc[idx].overflowing_add(carry);
-                acc[idx] = s;
-                carry = L::ZERO.add_carries(false, c);
+                let (sum, carried) = acc[idx].overflowing_add(carry);
+                acc[idx] = sum;
+                carry = L::ZERO.add_carries(false, carried);
                 idx += 1;
             }
         }
@@ -245,7 +253,7 @@ pub(crate) fn mul_low_limb<const N: usize, L: Limb>(a: &[u64; N], b: &[u64; N], 
     L::unpack(&acc[..h], out);
 }
 
-/// `out = a · b` — the FULL `2·N`-u64 schoolbook product, generic over the
+/// `out = lhs · rhs` — the FULL `2·N`-u64 schoolbook product, generic over the
 /// limb type `L` (the [`Limb`] axis). The full-product sibling of
 /// [`mul_low_limb`]: for `L = u64` it is base-2^64 over `N` limbs (bit-identical
 /// to [`mul_schoolbook_fixed`]); for `L = u128` it packs each operand into `N/2`
@@ -265,34 +273,35 @@ pub(crate) fn mul_low_limb<const N: usize, L: Limb>(a: &[u64; N], b: &[u64; N], 
 ///
 /// [`LimbSize`]: crate::int::types::compute_limbs::LimbSize
 #[inline]
-pub(crate) fn mul_full_limb<const N: usize, L: Limb>(a: &[u64; N], b: &[u64; N], out: &mut [u64])
+pub(crate) fn mul_full_limb<const N: usize, L: Limb>(lhs: &[u64; N], rhs: &[u64; N],
+    out: &mut [u64])
 where
     Limbs<N>: ComputeLimbs,
 {
     let h = L::packed_len(N); // operand packed length (N for u64, N/2 for u128)
     let d = 2 * h; // full-product length in L-limbs (2N u64 / N u128)
     // `[L; N]` covers `packed_len(N) ≤ N` for both limb types (only low `h` used).
-    let mut ap = [L::ZERO; N];
-    let mut bp = [L::ZERO; N];
-    L::pack(a, &mut ap[..h]);
-    L::pack(b, &mut bp[..h]);
+    let mut lhs_packed = [L::ZERO; N];
+    let mut rhs_packed = [L::ZERO; N];
+    L::pack(lhs, &mut lhs_packed[..h]);
+    L::pack(rhs, &mut rhs_packed[..h]);
     // Accumulator: the value's own 2N-u64-width buffer in limb type `L`
     // (= 2h L-limbs exactly), freshly zeroed.
     let mut acc_buf = L::double::<Limbs<N>>();
     let acc = acc_buf.as_mut();
     let mut i = 0;
     while i < h {
-        let ai = ap[i];
-        if ai != L::ZERO {
+        let lhs_limb = lhs_packed[i];
+        if lhs_limb != L::ZERO {
             let mut carry = L::ZERO;
             let mut j = 0;
             while j < h {
-                let (lo, hi) = ai.widening_mul(bp[j]);
+                let (lo, hi) = lhs_limb.widening_mul(rhs_packed[j]);
                 let idx = i + j;
-                let (s1, c1) = acc[idx].overflowing_add(lo);
-                let (s2, c2) = s1.overflowing_add(carry);
-                acc[idx] = s2;
-                carry = hi.add_carries(c1, c2);
+                let (sum1, carry1) = acc[idx].overflowing_add(lo);
+                let (sum2, carry2) = sum1.overflowing_add(carry);
+                acc[idx] = sum2;
+                carry = hi.add_carries(carry1, carry2);
                 j += 1;
             }
             // Final row carry, propagated into the high half until exhausted.
@@ -300,9 +309,9 @@ where
             // propagated carry is at most one (a single-limb add).
             let mut idx = i + h;
             while carry != L::ZERO && idx < d {
-                let (s, c) = acc[idx].overflowing_add(carry);
-                acc[idx] = s;
-                carry = if c { L::ONE } else { L::ZERO };
+                let (sum, carried) = acc[idx].overflowing_add(carry);
+                acc[idx] = sum;
+                carry = if carried { L::ONE } else { L::ZERO };
                 idx += 1;
             }
         }

--- a/src/int/algos/mul/mul_toom3.rs
+++ b/src/int/algos/mul/mul_toom3.rs
@@ -114,10 +114,10 @@ pub(crate) fn mul_toom3_limb<const N: usize, L: Limb>(a: &[u64; N], b: &[u64; N]
     let h = L::packed_len(N);
     debug_assert!(h > 0 && h <= N);
     // Pack operands into L-space. [L; N] always covers packed_len(N) <= N.
-    let mut ap = [L::ZERO; N];
-    let mut bp = [L::ZERO; N];
-    L::pack(a, &mut ap[..h]);
-    L::pack(b, &mut bp[..h]);
+    let mut a_packed = [L::ZERO; N];
+    let mut b_packed = [L::ZERO; N];
+    L::pack(a, &mut a_packed[..h]);
+    L::pack(b, &mut b_packed[..h]);
 
     // Threshold in packed-limb units: u128 packs 2 u64/limb so halve it.
     let ratio: usize = if h < N { 2 } else { 1 };
@@ -142,12 +142,12 @@ pub(crate) fn mul_toom3_limb<const N: usize, L: Limb>(a: &[u64; N], b: &[u64; N]
         BENCH_SCRATCH,
     );
 
-    for v in prod[..2 * h].iter_mut() {
-        *v = L::ZERO;
+    for slot in prod[..2 * h].iter_mut() {
+        *slot = L::ZERO;
     }
     toom3_rec_limb::<L>(
-        &ap[..h],
-        &bp[..h],
+        &a_packed[..h],
+        &b_packed[..h],
         &mut prod[..2 * h],
         &mut scratch,
         threshold_packed,
@@ -162,8 +162,8 @@ pub(crate) fn mul_toom3_limb<const N: usize, L: Limb>(a: &[u64; N], b: &[u64; N]
 pub(crate) fn mul_toom3_with_threshold(a: &[u64], b: &[u64], out: &mut [u64], threshold: usize) {
     debug_assert_eq!(a.len(), b.len());
     debug_assert!(out.len() >= 2 * a.len());
-    let need = toom3_scratch_needed(a.len(), threshold);
-    let mut scratch = vec![0u64; need.max(1)];
+    let scratch_needed = toom3_scratch_needed(a.len(), threshold);
+    let mut scratch = vec![0u64; scratch_needed.max(1)];
     toom3_rec_limb::<u64>(a, b, out, &mut scratch, threshold, inv3_of::<u64>());
 }
 
@@ -200,36 +200,38 @@ fn toom3_rec_limb<L: Limb>(
     let b1 = &b[k..k2];
     let b2 = &b[k2..];
 
-    let ew = k + 1; // eval-buffer width (k+1 for carry headroom)
-    let pw = 2 * ew; // product-buffer width
+    let eval_width = k + 1; // eval-buffer width (k+1 for carry headroom)
+    let prod_width = 2 * eval_width; // product-buffer width
 
     // Carve level-local scratch (26*(k+1) limbs max):
-    //   pa0..pai: 5*ew (a eval points); pb0..pbi: 5*ew (b eval points)
-    //   w0..wi: 5*pw (sub-products); t1, t2, tmp: 3*pw (interp + shift)
-    let level_need = 10 * ew + 8 * pw;
+    //   pa0..pai: 5*eval_width (a eval points);
+    //   pb0..pbi: 5*eval_width (b eval points)
+    //   w0..wi: 5*prod_width (sub-products);
+    //   t1, t2, tmp: 3*prod_width (interp + shift)
+    let level_need = 10 * eval_width + 8 * prod_width;
     let (level_buf, child_scratch) = scratch.split_at_mut(level_need);
-    for v in level_buf.iter_mut() {
-        *v = L::ZERO;
+    for slot in level_buf.iter_mut() {
+        *slot = L::ZERO;
     } // zero level buf (scratch may be dirty from prior calls)
 
-    let (pa0, r) = level_buf.split_at_mut(ew);
-    let (pa1, r) = r.split_at_mut(ew);
-    let (pam, r) = r.split_at_mut(ew);
-    let (pa2, r) = r.split_at_mut(ew);
-    let (pai, r) = r.split_at_mut(ew);
-    let (pb0, r) = r.split_at_mut(ew);
-    let (pb1, r) = r.split_at_mut(ew);
-    let (pbm, r) = r.split_at_mut(ew);
-    let (pb2, r) = r.split_at_mut(ew);
-    let (pbi, r) = r.split_at_mut(ew);
-    let (w0, r) = r.split_at_mut(pw);
-    let (w1, r) = r.split_at_mut(pw);
-    let (wm, r) = r.split_at_mut(pw);
-    let (w2, r) = r.split_at_mut(pw);
-    let (wi, r) = r.split_at_mut(pw);
-    let (t1, r) = r.split_at_mut(pw);
-    let (t2, r) = r.split_at_mut(pw);
-    let (tmp, _) = r.split_at_mut(pw);
+    let (pa0, rest) = level_buf.split_at_mut(eval_width);
+    let (pa1, rest) = rest.split_at_mut(eval_width);
+    let (pam, rest) = rest.split_at_mut(eval_width);
+    let (pa2, rest) = rest.split_at_mut(eval_width);
+    let (pai, rest) = rest.split_at_mut(eval_width);
+    let (pb0, rest) = rest.split_at_mut(eval_width);
+    let (pb1, rest) = rest.split_at_mut(eval_width);
+    let (pbm, rest) = rest.split_at_mut(eval_width);
+    let (pb2, rest) = rest.split_at_mut(eval_width);
+    let (pbi, rest) = rest.split_at_mut(eval_width);
+    let (w0, rest) = rest.split_at_mut(prod_width);
+    let (w1, rest) = rest.split_at_mut(prod_width);
+    let (wm, rest) = rest.split_at_mut(prod_width);
+    let (w2, rest) = rest.split_at_mut(prod_width);
+    let (wi, rest) = rest.split_at_mut(prod_width);
+    let (t1, rest) = rest.split_at_mut(prod_width);
+    let (t2, rest) = rest.split_at_mut(prod_width);
+    let (tmp, _) = rest.split_at_mut(prod_width);
 
     // ---- evaluate a at {0, 1, -1, 2, inf} ---------------------------------
     pa0[..a0.len()].copy_from_slice(a0);
@@ -250,8 +252,8 @@ fn toom3_rec_limb<L: Limb>(
     let _ = limb_add_assign(pa2, a1);
     let _ = limb_add_assign(pa2, a1); // pa2 = a0 + 2*a1
     tmp[..a2.len()].copy_from_slice(a2);
-    shl_inplace_limb(&mut tmp[..ew], 2); // 4*a2
-    let _ = limb_add_assign(pa2, &tmp[..ew]);
+    shl_inplace_limb(&mut tmp[..eval_width], 2); // 4*a2
+    let _ = limb_add_assign(pa2, &tmp[..eval_width]);
 
     // ---- evaluate b at {0, 1, -1, 2, inf} ---------------------------------
     pb0[..b0.len()].copy_from_slice(b0);
@@ -268,12 +270,12 @@ fn toom3_rec_limb<L: Limb>(
     pb2[..b0.len()].copy_from_slice(b0);
     let _ = limb_add_assign(pb2, b1);
     let _ = limb_add_assign(pb2, b1); // pb2 = b0 + 2*b1
-    for v in tmp.iter_mut() {
-        *v = L::ZERO;
+    for slot in tmp.iter_mut() {
+        *slot = L::ZERO;
     }
     tmp[..b2.len()].copy_from_slice(b2);
-    shl_inplace_limb(&mut tmp[..ew], 2); // 4*b2
-    let _ = limb_add_assign(pb2, &tmp[..ew]);
+    shl_inplace_limb(&mut tmp[..eval_width], 2); // 4*b2
+    let _ = limb_add_assign(pb2, &tmp[..eval_width]);
 
     // ---- 5 pointwise sub-products -----------------------------------------
     // w0..wi were already zeroed by the level_buf zero above and nothing
@@ -308,16 +310,16 @@ fn toom3_rec_limb<L: Limb>(
     let t1_neg;
     let t2_neg = if !wm_neg {
         // rm >= 0: t1_before_halve = w1+wm; t2_before_halve = w1-wm (both >= 0)
-        t1[..pw].copy_from_slice(w1);
+        t1[..prod_width].copy_from_slice(w1);
         let _ = limb_add_assign(t1, wm);
         t1_neg = false;
-        t2[..pw].copy_from_slice(w1);
+        t2[..prod_width].copy_from_slice(w1);
         signed_sub_limb(t2, wm) // w1 >= wm since (w1-rm)/2=c1+c3 >= 0
     } else {
         // rm < 0: t1_before_halve = w1-|wm| >= 0; t2_before_halve = w1+|wm| >= 0
-        t1[..pw].copy_from_slice(w1);
+        t1[..prod_width].copy_from_slice(w1);
         t1_neg = signed_sub_limb(t1, wm); // should be false for unsigned inputs
-        t2[..pw].copy_from_slice(w1);
+        t2[..prod_width].copy_from_slice(w1);
         let _ = limb_add_assign(t2, wm);
         false
     };
@@ -338,11 +340,11 @@ fn toom3_rec_limb<L: Limb>(
     debug_assert!(!went_neg, "Toom-3: r2 < r0 -- invariant violated for unsigned inputs");
     shr1_limb(w2); // w2 = (w2-w0)/2 = c1+2*c2+4*c3+8*c4
     // subtract 2*c2 (= 2*t1):
-    tmp[..pw].copy_from_slice(t1); // t1 = c2
+    tmp[..prod_width].copy_from_slice(t1); // t1 = c2
     shl_inplace_limb(tmp, 1); // tmp = 2*c2
     let s_neg = signed_sub_signed_limb(w2, false, tmp, t1_neg);
     // subtract 8*c4 (= 8*wi):
-    tmp[..pw].copy_from_slice(wi);
+    tmp[..prod_width].copy_from_slice(wi);
     shl_inplace_limb(tmp, 3); // tmp = 8*wi = 8*c4
     let s_neg = signed_sub_signed_limb(w2, s_neg, tmp, false);
     // w2 = s = c1+4*c3 >= 0
@@ -351,14 +353,14 @@ fn toom3_rec_limb<L: Limb>(
     // Step C: c3 = (s - t2) / 3
     // s - t2 = (c1+4*c3) - (c1+c3) = 3*c3 >= 0 (exact division).
     // Re-use tmp for c3 (avoid aliasing: s is in w2, t2 is in t2 buf).
-    tmp[..pw].copy_from_slice(w2); // tmp = s
+    tmp[..prod_width].copy_from_slice(w2); // tmp = s
     let c3_neg = signed_sub_signed_limb(tmp, s_neg, t2, t2_neg); // tmp = s - t2 = 3*c3
     debug_assert!(!c3_neg, "3*c3 negative -- interpolation error (step C)");
     let c3_neg = div3_limb(tmp, c3_neg, inv); // tmp = c3
 
     // Step D: c1 = t2 - c3  [= c1+c3 - c3 = c1 >= 0]
     // Re-use w2 for c1.
-    w2[..pw].copy_from_slice(t2); // w2 = c1+c3
+    w2[..prod_width].copy_from_slice(t2); // w2 = c1+c3
     let c1_neg = signed_sub_signed_limb(w2, t2_neg, tmp, c3_neg); // w2 = c1
     debug_assert!(!c1_neg, "c1 negative -- interpolation error (step D)");
 
@@ -378,21 +380,21 @@ fn toom3_rec_limb<L: Limb>(
 // ---- L-generic helpers ------------------------------------------------------
 
 /// Compare two little-endian L-limb magnitudes (lengths may differ): returns
-/// `1` if `a > b`, `-1` if `a < b`, `0` if equal.
+/// `1` if `lhs > rhs`, `-1` if `lhs < rhs`, `0` if equal.
 #[inline]
-fn cmp_cross_limb<L: Limb>(a: &[L], b: &[L]) -> i32 {
-    let la = a.len();
-    let lb = b.len();
-    let top = la.max(lb);
-    let mut i = top;
+fn cmp_cross_limb<L: Limb>(lhs: &[L], rhs: &[L]) -> i32 {
+    let lhs_len = lhs.len();
+    let rhs_len = rhs.len();
+    let max_len = lhs_len.max(rhs_len);
+    let mut i = max_len;
     while i > 0 {
         i -= 1;
-        let av = if i < la { a[i] } else { L::ZERO };
-        let bv = if i < lb { b[i] } else { L::ZERO };
-        if av > bv {
+        let lhs_limb = if i < lhs_len { lhs[i] } else { L::ZERO };
+        let rhs_limb = if i < rhs_len { rhs[i] } else { L::ZERO };
+        if lhs_limb > rhs_limb {
             return 1;
         }
-        if av < bv {
+        if lhs_limb < rhs_limb {
             return -1;
         }
     }
@@ -406,11 +408,12 @@ fn rsub_assign_limb<L: Limb>(dst: &mut [L], src: &[L]) {
     let mut borrow = false;
     let mut i = 0;
     while i < dst.len() {
-        let sv = if i < src.len() { src[i] } else { L::ZERO };
-        let (d1, b1) = sv.overflowing_sub(dst[i]);
-        let (d2, b2) = d1.overflowing_sub(if borrow { L::ONE } else { L::ZERO });
-        dst[i] = d2;
-        borrow = b1 | b2;
+        let src_limb = if i < src.len() { src[i] } else { L::ZERO };
+        let (diff1, borrow1) = src_limb.overflowing_sub(dst[i]);
+        let (diff2, borrow2) =
+            diff1.overflowing_sub(if borrow { L::ONE } else { L::ZERO });
+        dst[i] = diff2;
+        borrow = borrow1 | borrow2;
         i += 1;
     }
 }
@@ -428,24 +431,28 @@ fn signed_sub_limb<L: Limb>(dst: &mut [L], src: &[L]) -> bool {
     }
 }
 
-/// Signed subtraction: `(a, a_neg) -= (b, b_neg)`. Returns the new sign.
+/// Signed subtraction: `(lhs, lhs_is_negative) -= (rhs, rhs_is_negative)`.
+/// Returns the new sign.
 #[inline]
-fn signed_sub_signed_limb<L: Limb>(a: &mut [L], a_neg: bool, b: &[L], b_neg: bool) -> bool {
-    signed_add_signed_limb(a, a_neg, b, !b_neg)
+fn signed_sub_signed_limb<L: Limb>(lhs: &mut [L], lhs_is_negative: bool, rhs: &[L],
+    rhs_is_negative: bool) -> bool {
+    signed_add_signed_limb(lhs, lhs_is_negative, rhs, !rhs_is_negative)
 }
 
-/// Signed addition: `(a, a_neg) += (b, b_neg)`. Returns the new sign.
+/// Signed addition: `(lhs, lhs_is_negative) += (rhs, rhs_is_negative)`.
+/// Returns the new sign.
 #[inline]
-fn signed_add_signed_limb<L: Limb>(a: &mut [L], a_neg: bool, b: &[L], b_neg: bool) -> bool {
-    if a_neg == b_neg {
-        let _ = limb_add_assign(a, b);
-        a_neg
-    } else if cmp_cross_limb(a, b) >= 0 {
-        let _ = limb_sub_assign(a, b);
-        a_neg
+fn signed_add_signed_limb<L: Limb>(lhs: &mut [L], lhs_is_negative: bool, rhs: &[L],
+    rhs_is_negative: bool) -> bool {
+    if lhs_is_negative == rhs_is_negative {
+        let _ = limb_add_assign(lhs, rhs);
+        lhs_is_negative
+    } else if cmp_cross_limb(lhs, rhs) >= 0 {
+        let _ = limb_sub_assign(lhs, rhs);
+        lhs_is_negative
     } else {
-        rsub_assign_limb(a, b); // a = b - a
-        b_neg
+        rsub_assign_limb(lhs, rhs); // lhs = rhs - lhs
+        rhs_is_negative
     }
 }
 
@@ -453,13 +460,13 @@ fn signed_add_signed_limb<L: Limb>(a: &mut [L], a_neg: bool, b: &[L], b_neg: boo
 /// Carry-merge via disjoint-bit addition (the low `shift` bits of `x << shift`
 /// are zero, so OR-ing the carry == adding it).
 #[inline]
-fn shl_inplace_limb<L: Limb>(a: &mut [L], shift: u32) {
+fn shl_inplace_limb<L: Limb>(limbs: &mut [L], shift: u32) {
     if shift == 0 {
         return;
     }
     let rshift = L::BITS - shift;
     let mut carry = L::ZERO;
-    for limb in a.iter_mut() {
+    for limb in limbs.iter_mut() {
         let out_carry = limb.wrapping_shr(rshift);
         *limb = limb.wrapping_shl(shift).overflowing_add(carry).0;
         carry = out_carry;
@@ -469,9 +476,9 @@ fn shl_inplace_limb<L: Limb>(a: &mut [L], shift: u32) {
 /// In-place right shift by 1 (value must be even for correct interpolation).
 /// The bit leaving limb i+1's LSB enters limb i's MSB; disjoint-bit add merges.
 #[inline]
-fn shr1_limb<L: Limb>(a: &mut [L]) {
+fn shr1_limb<L: Limb>(limbs: &mut [L]) {
     let mut carry = L::ZERO; // pre-positioned at the MSB
-    for limb in a.iter_mut().rev() {
+    for limb in limbs.iter_mut().rev() {
         let new_carry = limb.wrapping_shl(L::BITS - 1); // bit0 -> MSB
         *limb = limb.wrapping_shr(1).overflowing_add(carry).0;
         carry = new_carry;
@@ -493,8 +500,8 @@ fn inv3_of<L: Limb>() -> L {
     let mut inv = three; // x0 = 3 (3*3 = 9 == 1 mod 8)
     let mut step = 0;
     while step < 6 {
-        let t = two.overflowing_sub(three.widening_mul(inv).0).0;
-        inv = inv.widening_mul(t).0;
+        let factor = two.overflowing_sub(three.widening_mul(inv).0).0;
+        inv = inv.widening_mul(factor).0;
         step += 1;
     }
     inv
@@ -504,23 +511,25 @@ fn inv3_of<L: Limb>() -> L {
 /// and passes the precomputed modular inverse `inv = 3^{-1} mod 2^BITS`.
 ///
 /// Jebelean exact division: each quotient limb is `(limb - borrow) * inv`
-/// (mod 2^BITS), with next borrow = `mulhi(q, 3) + underflow`. ONE multiply +
-/// a cheap `mulhi` per limb -- no per-limb 128/64 hardware division (the prior
-/// `/3`+`%3` was the kernel's #1 self-time hot spot per the samply probe).
+/// (mod 2^BITS), with next borrow = `mulhi(quotient_limb, 3) + underflow`. ONE
+/// multiply + a cheap `mulhi` per limb -- no per-limb 128/64 hardware division
+/// (the prior `/3`+`%3` was the kernel's #1 self-time hot spot per the samply
+/// probe).
 #[inline]
-fn div3_limb<L: Limb>(a: &mut [L], neg: bool, inv: L) -> bool {
+fn div3_limb<L: Limb>(limbs: &mut [L], is_negative: bool, inv: L) -> bool {
     let three = L::ONE.overflowing_add(L::ONE).0.overflowing_add(L::ONE).0;
     let mut borrow = L::ZERO;
-    for limb in a.iter_mut() {
-        let (s, under) = limb.overflowing_sub(borrow);
-        let q = s.widening_mul(inv).0; // q = s * 3^{-1} mod 2^BITS
-        *limb = q;
-        // next borrow = mulhi(q, 3) + underflow
-        let hi = q.widening_mul(three).1;
-        borrow = hi.overflowing_add(if under { L::ONE } else { L::ZERO }).0;
+    for limb in limbs.iter_mut() {
+        let (diff, underflowed) = limb.overflowing_sub(borrow);
+        // quotient_limb = diff * 3^{-1} mod 2^BITS
+        let quotient_limb = diff.widening_mul(inv).0;
+        *limb = quotient_limb;
+        // next borrow = mulhi(quotient_limb, 3) + underflow
+        let hi = quotient_limb.widening_mul(three).1;
+        borrow = hi.overflowing_add(if underflowed { L::ONE } else { L::ZERO }).0;
     }
     debug_assert!(borrow == L::ZERO, "div3: not divisible by 3 -- Toom-3 interpolation error");
-    neg
+    is_negative
 }
 
 /// Add `src` into `out[offset..]` with carry propagation (L-generic).
@@ -539,46 +548,46 @@ mod tests {
     use crate::int::algos::mul::mul_schoolbook::mul_schoolbook;
 
     /// SplitMix64 -- Vigna 2014, public-domain reference algorithm.
-    fn fill(n: usize, seed: u64) -> Vec<u64> {
-        let mut out = vec![0u64; n];
+    fn fill(limb_count: usize, seed: u64) -> Vec<u64> {
+        let mut out = vec![0u64; limb_count];
         let mut state = seed;
-        for x in out.iter_mut() {
+        for slot in out.iter_mut() {
             state = state.wrapping_add(0x9E37_79B9_7F4A_7C15);
             let mut z = state;
             z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
             z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
-            *x = z ^ (z >> 31);
+            *slot = z ^ (z >> 31);
         }
         out
     }
 
     fn schoolbook_ref(a: &[u64], b: &[u64]) -> Vec<u64> {
-        let n = a.len().max(b.len());
-        let mut a2 = vec![0u64; n];
-        let mut b2 = vec![0u64; n];
-        a2[..a.len()].copy_from_slice(a);
-        b2[..b.len()].copy_from_slice(b);
-        let mut out = vec![0u64; 2 * n];
-        mul_schoolbook(&a2, &b2, &mut out);
+        let len = a.len().max(b.len());
+        let mut a_padded = vec![0u64; len];
+        let mut b_padded = vec![0u64; len];
+        a_padded[..a.len()].copy_from_slice(a);
+        b_padded[..b.len()].copy_from_slice(b);
+        let mut out = vec![0u64; 2 * len];
+        mul_schoolbook(&a_padded, &b_padded, &mut out);
         out
     }
 
-    fn edge_cases(n: usize) -> Vec<Vec<u64>> {
-        let mut v = vec![vec![0u64; n], vec![u64::MAX; n]];
-        let mut lo = vec![0u64; n];
+    fn edge_cases(limb_count: usize) -> Vec<Vec<u64>> {
+        let mut cases = vec![vec![0u64; limb_count], vec![u64::MAX; limb_count]];
+        let mut lo = vec![0u64; limb_count];
         lo[0] = u64::MAX;
-        v.push(lo);
-        if n > 1 {
-            let mut hi = vec![0u64; n];
-            hi[n - 1] = 1;
-            v.push(hi);
+        cases.push(lo);
+        if limb_count > 1 {
+            let mut hi = vec![0u64; limb_count];
+            hi[limb_count - 1] = 1;
+            cases.push(hi);
         }
-        if n > 2 {
-            let mut mid = vec![0u64; n];
-            mid[n / 2] = u64::MAX;
-            v.push(mid);
+        if limb_count > 2 {
+            let mut mid = vec![0u64; limb_count];
+            mid[limb_count / 2] = u64::MAX;
+            cases.push(mid);
         }
-        v
+        cases
     }
 
     /// Bit-identity against schoolbook (u64 path): N in 3..=64, thresholds
@@ -591,25 +600,27 @@ mod tests {
         const THRESHOLDS: &[usize] = &[3, 6, 9];
 
         for &n in WIDTHS {
-            for &th in THRESHOLDS {
+            for &threshold in THRESHOLDS {
                 for a in edge_cases(n) {
                     for b in edge_cases(n) {
                         let expected = schoolbook_ref(&a, &b);
-                        let mut got = vec![0u64; 2 * n];
-                        mul_toom3_with_threshold(&a, &b, &mut got, th);
-                        assert_eq!(got, expected, "mismatch (edge) n={n} th={th}");
-                        let mut got2 = vec![0u64; 2 * n];
-                        mul_toom3_with_threshold(&b, &a, &mut got2, th);
-                        assert_eq!(got2, expected, "not commutative n={n} th={th}");
+                        let mut actual = vec![0u64; 2 * n];
+                        mul_toom3_with_threshold(&a, &b, &mut actual, threshold);
+                        assert_eq!(actual, expected, "mismatch (edge) n={n} th={threshold}");
+                        let mut actual_swapped = vec![0u64; 2 * n];
+                        mul_toom3_with_threshold(&b, &a, &mut actual_swapped, threshold);
+                        assert_eq!(actual_swapped, expected,
+                            "not commutative n={n} th={threshold}");
                     }
                 }
                 for seed in [1u64, 3, 7, 13, 42, 1337, 0xDEAD_BEEF, 0xCAFE_F00D] {
                     let a = fill(n, seed);
                     let b = fill(n, seed.wrapping_add(0x1234_5678));
                     let expected = schoolbook_ref(&a, &b);
-                    let mut got = vec![0u64; 2 * n];
-                    mul_toom3_with_threshold(&a, &b, &mut got, th);
-                    assert_eq!(got, expected, "mismatch (random) n={n} th={th} seed={seed}");
+                    let mut actual = vec![0u64; 2 * n];
+                    mul_toom3_with_threshold(&a, &b, &mut actual, threshold);
+                    assert_eq!(actual, expected,
+                        "mismatch (random) n={n} th={threshold} seed={seed}");
                 }
             }
         }
@@ -635,20 +646,20 @@ mod tests {
                 for seed in [1u64, 7, 42, 0xDEAD_BEEF, 0xCAFE_F00D, 1009] {
                     let a = fill(N, seed);
                     let b = fill(N, seed.wrapping_add(0x9999));
-                    let mut aa = [0u64; N];
-                    let mut bb = [0u64; N];
-                    aa.copy_from_slice(&a);
-                    bb.copy_from_slice(&b);
-                    ops.push((aa, bb));
+                    let mut a_array = [0u64; N];
+                    let mut b_array = [0u64; N];
+                    a_array.copy_from_slice(&a);
+                    b_array.copy_from_slice(&b);
+                    ops.push((a_array, b_array));
                 }
                 for (a, b) in ops {
                     let expected = schoolbook_ref(&a, &b);
-                    let mut g_u64 = vec![0u64; 2 * N];
-                    super::mul_toom3_limb::<N, u64>(&a, &b, &mut g_u64);
-                    assert_eq!(g_u64, expected, "toom3_limb u64 mismatch N={}", N);
-                    let mut g_u128 = vec![0u64; 2 * N];
-                    super::mul_toom3_limb::<N, u128>(&a, &b, &mut g_u128);
-                    assert_eq!(g_u128, expected, "toom3_limb u128 mismatch N={}", N);
+                    let mut actual_u64 = vec![0u64; 2 * N];
+                    super::mul_toom3_limb::<N, u64>(&a, &b, &mut actual_u64);
+                    assert_eq!(actual_u64, expected, "toom3_limb u64 mismatch N={}", N);
+                    let mut actual_u128 = vec![0u64; 2 * N];
+                    super::mul_toom3_limb::<N, u128>(&a, &b, &mut actual_u128);
+                    assert_eq!(actual_u128, expected, "toom3_limb u128 mismatch N={}", N);
                 }
             }};
         }
@@ -671,8 +682,8 @@ mod tests {
         let a = fill(64, 0xABCD_EF01_2345_6789);
         let b = fill(64, 0xFEDC_BA98_7654_3210);
         let expected = schoolbook_ref(&a, &b);
-        let mut got = vec![0u64; 128];
-        mul_toom3(&a, &b, &mut got);
-        assert_eq!(got, expected, "n=64 fixed-scratch mismatch");
+        let mut actual = vec![0u64; 128];
+        mul_toom3(&a, &b, &mut actual);
+        assert_eq!(actual, expected, "n=64 fixed-scratch mismatch");
     }
 }

--- a/src/int/algos/neg/neg_twos_complement.rs
+++ b/src/int/algos/neg/neg_twos_complement.rs
@@ -18,12 +18,12 @@ use crate::int::types::Int;
 /// Limb-0 split shape — the routed kernel after the wide-tier
 /// `neg_kernel_ab` A/B (see `benches/micro/neg_kernel_ab.rs`):
 ///
-/// 1. Compute `out[0] = !a[0] + 1`, capturing the carry `c0`.
-/// 2. If `c0 == false` (the overwhelmingly common path — `a[0] != MAX`),
-///    limbs `1..N` reduce to plain independent `!a[i]` writes: no
+/// 1. Compute `out[0] = !value[0] + 1`, capturing the carry `c0`.
+/// 2. If `c0 == false` (the overwhelmingly common path — `value[0] != MAX`),
+///    limbs `1..N` reduce to plain independent `!value[i]` writes: no
 ///    cross-limb dependency chain, so the compiler can keep them
 ///    register-resident / vectorise the NOT loop.
-/// 3. If `c0 == true` (`a[0] == MAX`), fall back to a dependent
+/// 3. If `c0 == true` (`value[0] == MAX`), fall back to a dependent
 ///    carry-prop chain through limbs `1..N`.
 ///
 /// The previous two-pass shape (NOT loop into `out[N]`, then a
@@ -36,12 +36,12 @@ use crate::int::types::Int;
 /// const-fn so it stays available in const contexts (`abs`,
 /// `wrapping_div`, `wrapping_rem`, `from_mag_limbs`).
 #[inline]
-pub(crate) const fn neg_twos_complement<const N: usize>(a: Int<N>) -> Int<N> {
+pub(crate) const fn neg_twos_complement<const N: usize>(value: Int<N>) -> Int<N> {
     let mut out = [0u64; N];
     if N == 0 {
         return Int::<N>::from_limbs(out);
     }
-    let limbs = a.as_limbs();
+    let limbs = value.as_limbs();
     let (s0, c0) = (!limbs[0]).overflowing_add(1);
     out[0] = s0;
     if c0 {

--- a/src/int/algos/pow/pow_schoolbook.rs
+++ b/src/int/algos/pow/pow_schoolbook.rs
@@ -46,11 +46,11 @@ pub(crate) const fn pow_schoolbook<const N: usize>(base: Uint<N>, exp: u32) -> U
     // Start accumulator at `base`; multiply by `base` for each
     // remaining factor (exp - 1 total multiplications).
     let mut acc = *base.as_limbs();
-    let b = *base.as_limbs();
+    let base_limbs = *base.as_limbs();
     let mut remaining = exp - 1;
     while remaining > 0 {
         let mut prod = [0u64; N];
-        mul_low_fixed(&acc, &b, &mut prod);
+        mul_low_fixed(&acc, &base_limbs, &mut prod);
         acc = prod;
         remaining -= 1;
     }

--- a/src/int/algos/pow/pow_square_and_multiply.rs
+++ b/src/int/algos/pow/pow_square_and_multiply.rs
@@ -42,18 +42,18 @@ pub(crate) const fn pow_square_and_multiply<const N: usize>(base: Uint<N>, mut e
     if N > 0 {
         acc[0] = 1;
     }
-    let mut b = *base.as_limbs();
+    let mut running_base = *base.as_limbs();
     while exp > 0 {
         if exp & 1 == 1 {
             let mut prod = [0u64; N];
-            mul_low_fixed(&acc, &b, &mut prod);
+            mul_low_fixed(&acc, &running_base, &mut prod);
             acc = prod;
         }
         exp >>= 1;
         if exp > 0 {
             let mut sq = [0u64; N];
-            sqr_low_fixed(&b, &mut sq);
-            b = sq;
+            sqr_low_fixed(&running_base, &mut sq);
+            running_base = sq;
         }
     }
     Uint::<N>::from_limbs(acc)

--- a/src/int/algos/rem/rem_native.rs
+++ b/src/int/algos/rem/rem_native.rs
@@ -23,37 +23,37 @@
 
 use crate::int::types::Int;
 
-/// Load the (<=128-bit) magnitude of `x` into a `u128`. Correct only for
+/// Load the (<=128-bit) magnitude of `value` into a `u128`. Correct only for
 /// `N <= 2`; this fn is only routed to for `N <= 2`.
 #[inline]
-fn mag_u128<const N: usize>(x: &Int<N>) -> u128 {
-    let limbs = x.unsigned_abs();
-    let l = limbs.as_limbs();
-    let lo = l[0] as u128;
-    let hi = if N >= 2 { l[1] as u128 } else { 0 };
+fn mag_u128<const N: usize>(value: &Int<N>) -> u128 {
+    let magnitude = value.unsigned_abs();
+    let limbs = magnitude.as_limbs();
+    let lo = limbs[0] as u128;
+    let hi = if N >= 2 { limbs[1] as u128 } else { 0 };
     lo | (hi << 64)
 }
 
 /// Hardware-`%` signed remainder for `Int<N>`, `N <= 2`.
 ///
-/// Loads both magnitudes into `u128`, computes `a_mag % b_mag` with the
-/// native hardware remainder, and re-applies the dividend sign
+/// Loads both magnitudes into `u128`, computes `|dividend| % |divisor|` with
+/// the native hardware remainder, and re-applies the dividend sign
 /// (truncating-toward-zero). Panics on a zero divisor, matching the `Rem`
 /// operator contract.
 #[inline]
-pub(crate) fn rem_native<const N: usize>(a: Int<N>, b: Int<N>) -> Int<N> {
+pub(crate) fn rem_native<const N: usize>(dividend: Int<N>, divisor: Int<N>) -> Int<N> {
     assert!(
-        !b.is_zero(),
+        !divisor.is_zero(),
         "attempt to calculate the remainder with a divisor of zero"
     );
-    let neg_r = a.is_negative();
-    let r = mag_u128(&a) % mag_u128(&b);
-    let mut rem = [0u64; N];
-    rem[0] = r as u64;
+    let remainder_is_negative = dividend.is_negative();
+    let remainder_u128 = mag_u128(&dividend) % mag_u128(&divisor);
+    let mut remainder = [0u64; N];
+    remainder[0] = remainder_u128 as u64;
     if N >= 2 {
-        rem[1] = (r >> 64) as u64;
+        remainder[1] = (remainder_u128 >> 64) as u64;
     }
-    Int::<N>::from_mag_limbs(&rem, neg_r)
+    Int::<N>::from_mag_limbs(&remainder, remainder_is_negative)
 }
 
 #[cfg(test)]
@@ -75,9 +75,10 @@ mod tests {
             (i64::MAX, 2, 1),
             (i64::MIN + 1, 2, -1),
         ];
-        for &(a, b, want) in cases {
-            let got = rem_native::<1>(Int::<1>::from_i64(a), Int::<1>::from_i64(b));
-            assert_eq!(got.to_i64(), want, "rem_native({a}, {b})");
+        for &(dividend, divisor, expected) in cases {
+            let actual = rem_native::<1>(Int::<1>::from_i64(dividend),
+                Int::<1>::from_i64(divisor));
+            assert_eq!(actual.to_i64(), expected, "rem_native({dividend}, {divisor})");
         }
     }
 
@@ -101,9 +102,11 @@ mod tests {
                 12345678901234567,
             ),
         ];
-        for &(a, b) in cases {
-            let got = rem_native::<2>(Int::<2>::from_i128(a), Int::<2>::from_i128(b));
-            assert_eq!(got.to_i128(), a % b, "rem_native({a}, {b})");
+        for &(dividend, divisor) in cases {
+            let actual = rem_native::<2>(Int::<2>::from_i128(dividend),
+                Int::<2>::from_i128(divisor));
+            assert_eq!(actual.to_i128(), dividend % divisor,
+                "rem_native({dividend}, {divisor})");
         }
     }
 }

--- a/src/int/algos/rem/rem_native_direct.rs
+++ b/src/int/algos/rem/rem_native_direct.rs
@@ -40,19 +40,19 @@ use crate::int::types::Int;
 /// does), so it is bit-identical to the shipped magnitude path.
 #[inline]
 #[allow(dead_code)]
-pub(crate) fn rem_native_direct<const N: usize>(a: Int<N>, b: Int<N>) -> Int<N> {
+pub(crate) fn rem_native_direct<const N: usize>(dividend: Int<N>, divisor: Int<N>) -> Int<N> {
     assert!(
-        !b.is_zero(),
+        !divisor.is_zero(),
         "attempt to calculate the remainder with a divisor of zero"
     );
-    let ai = a.to_i128();
-    let bi = b.to_i128();
+    let dividend_i128 = dividend.to_i128();
+    let divisor_i128 = divisor.to_i128();
     // i128::MIN % -1 is the sole overflow trap of signed `%`; the magnitude
     // path can't hit it because its operands are unsigned. The true
     // remainder there is 0 (MIN is exactly divisible by -1), which is what
     // wrapping_rem yields — match it without invoking the trapping `%`.
-    let r = if bi == -1 { 0 } else { ai % bi };
-    Int::<N>::from_i128(r)
+    let remainder = if divisor_i128 == -1 { 0 } else { dividend_i128 % divisor_i128 };
+    Int::<N>::from_i128(remainder)
 }
 
 #[cfg(test)]
@@ -77,13 +77,13 @@ mod tests {
             (i64::MIN, 7),
             (i64::MIN, -1),
         ];
-        for &(a, b) in cases {
-            let ia = Int::<1>::from_i64(a);
-            let ib = Int::<1>::from_i64(b);
+        for &(dividend, divisor) in cases {
+            let dividend_int = Int::<1>::from_i64(dividend);
+            let divisor_int = Int::<1>::from_i64(divisor);
             assert_eq!(
-                rem_native_direct::<1>(ia, ib),
-                rem_native::<1>(ia, ib),
-                "n1 ({a} % {b})"
+                rem_native_direct::<1>(dividend_int, divisor_int),
+                rem_native::<1>(dividend_int, divisor_int),
+                "n1 ({dividend} % {divisor})"
             );
         }
     }
@@ -100,13 +100,13 @@ mod tests {
             (i128::MIN, 7),
             (i128::MIN, -1),
         ];
-        for &(a, b) in cases {
-            let ia = Int::<2>::from_i128(a);
-            let ib = Int::<2>::from_i128(b);
+        for &(dividend, divisor) in cases {
+            let dividend_int = Int::<2>::from_i128(dividend);
+            let divisor_int = Int::<2>::from_i128(divisor);
             assert_eq!(
-                rem_native_direct::<2>(ia, ib),
-                rem_native::<2>(ia, ib),
-                "n2 ({a} % {b})"
+                rem_native_direct::<2>(dividend_int, divisor_int),
+                rem_native::<2>(dividend_int, divisor_int),
+                "n2 ({dividend} % {divisor})"
             );
         }
     }

--- a/src/int/algos/rem/rem_schoolbook.rs
+++ b/src/int/algos/rem/rem_schoolbook.rs
@@ -29,21 +29,21 @@ use crate::int::types::Int;
 ///
 /// Panics on a zero divisor, matching the `Rem` operator contract.
 #[allow(dead_code)]
-pub(crate) fn rem_schoolbook<const N: usize>(a: Int<N>, b: Int<N>) -> Int<N> {
+pub(crate) fn rem_schoolbook<const N: usize>(dividend: Int<N>, divisor: Int<N>) -> Int<N> {
     assert!(
-        !b.is_zero(),
+        !divisor.is_zero(),
         "attempt to calculate the remainder with a divisor of zero"
     );
-    let neg_r = a.is_negative();
-    let mut quot = [0u64; N];
-    let mut rem = [0u64; N];
+    let remainder_is_negative = dividend.is_negative();
+    let mut quotient = [0u64; N];
+    let mut remainder = [0u64; N];
     div_rem_schoolbook(
-        a.unsigned_abs().as_limbs(),
-        b.unsigned_abs().as_limbs(),
-        &mut quot,
-        &mut rem,
+        dividend.unsigned_abs().as_limbs(),
+        divisor.unsigned_abs().as_limbs(),
+        &mut quotient,
+        &mut remainder,
     );
-    Int::<N>::from_mag_limbs(&rem, neg_r)
+    Int::<N>::from_mag_limbs(&remainder, remainder_is_negative)
 }
 
 #[cfg(test)]
@@ -51,8 +51,8 @@ mod tests {
     use super::rem_schoolbook;
     use crate::int::types::Int;
 
-    /// Known-value table: (a, b, expected_remainder) — all fit in i64
-    /// so we can verify by construction.
+    /// Known-value table: (dividend, divisor, expected_remainder) — all fit in
+    /// i64 so we can verify by construction.
     #[test]
     fn rem_schoolbook_known_values_n1() {
         let cases: &[(i64, i64, i64)] = &[
@@ -67,13 +67,14 @@ mod tests {
             (i64::MAX, 2, 1),
             (i64::MIN + 1, 2, -1),
         ];
-        for &(a, b, want) in cases {
-            let got = rem_schoolbook::<1>(Int::<1>::from_i64(a), Int::<1>::from_i64(b));
+        for &(dividend, divisor, expected) in cases {
+            let actual = rem_schoolbook::<1>(Int::<1>::from_i64(dividend),
+                Int::<1>::from_i64(divisor));
             assert_eq!(
-                got.to_i64(),
-                want,
-                "rem_schoolbook({a}, {b}) = {:?}, want {want}",
-                got.to_i64()
+                actual.to_i64(),
+                expected,
+                "rem_schoolbook({dividend}, {divisor}) = {:?}, want {expected}",
+                actual.to_i64()
             );
         }
     }
@@ -102,16 +103,16 @@ mod tests {
                 12345678901234567,
             ),
         ];
-        for &(a, b) in cases {
-            let ia = Int::<2>::from_i128(a);
-            let ib = Int::<2>::from_i128(b);
-            let got = rem_schoolbook::<2>(ia, ib);
-            let want = a % b;
+        for &(dividend, divisor) in cases {
+            let dividend_int = Int::<2>::from_i128(dividend);
+            let divisor_int = Int::<2>::from_i128(divisor);
+            let actual = rem_schoolbook::<2>(dividend_int, divisor_int);
+            let expected = dividend % divisor;
             assert_eq!(
-                got.to_i128(),
-                want,
-                "rem_schoolbook({a}, {b}) = {:?}, want {want}",
-                got.to_i128()
+                actual.to_i128(),
+                expected,
+                "rem_schoolbook({dividend}, {divisor}) = {:?}, want {expected}",
+                actual.to_i128()
             );
         }
     }

--- a/src/int/algos/rem/rem_small_fast.rs
+++ b/src/int/algos/rem/rem_small_fast.rs
@@ -8,8 +8,9 @@
 //! single hardware divide, no scratch, no shape classification). It runs at
 //! EVERY width `N`, gated on the operand VALUE rather than the const width:
 //!
-//! * when `|a| < |b|` the truncating remainder is the dividend itself
-//!   (`a % b == a`), returned after one top-down `N`-limb magnitude compare —
+//! * when `|dividend| < |divisor|` the truncating remainder is the dividend
+//!   itself (`dividend % divisor == dividend`), returned after one top-down
+//!   `N`-limb magnitude compare —
 //!   no divide at all. This catches the balanced-magnitude shape the
 //!   single-word probe below misses (a divisor that crosses the 128-bit line
 //!   while the dividend stays smaller);
@@ -36,18 +37,18 @@
 use crate::int::policy::div_rem::dispatch as div_rem_dispatch;
 use crate::int::types::{Int, Uint};
 
-/// `true` and the packed `u128` magnitude when every limb of `mag` above
+/// `true` and the packed `u128` magnitude when every limb of `magnitude` above
 /// index 1 is zero (i.e. the magnitude fits a single 128-bit word).
 #[inline]
-fn mag_fits_u128<const N: usize>(mag: &Uint<N>) -> (bool, u128) {
-    let l = mag.as_limbs();
-    let lo = l[0] as u128;
-    let hi = if N >= 2 { l[1] as u128 } else { 0 };
+fn mag_fits_u128<const N: usize>(magnitude: &Uint<N>) -> (bool, u128) {
+    let limbs = magnitude.as_limbs();
+    let lo = limbs[0] as u128;
+    let hi = if N >= 2 { limbs[1] as u128 } else { 0 };
     // Any limb at index >= 2 set means the magnitude exceeds u128.
     let mut fits = true;
     let mut i = 2;
     while i < N {
-        if l[i] != 0 {
+        if limbs[i] != 0 {
             fits = false;
             break;
         }
@@ -64,43 +65,45 @@ fn mag_fits_u128<const N: usize>(mag: &Uint<N>) -> (bool, u128) {
 /// `Rem` operator contract. Bit-identical to [`rem_via_div_rem`] at every
 /// `N` and every operand value.
 #[inline]
-pub(crate) fn rem_small_fast<const N: usize>(a: Int<N>, b: Int<N>) -> Int<N> {
+pub(crate) fn rem_small_fast<const N: usize>(dividend: Int<N>, divisor: Int<N>) -> Int<N> {
     assert!(
-        !b.is_zero(),
+        !divisor.is_zero(),
         "attempt to calculate the remainder with a divisor of zero"
     );
     // Compute both magnitudes ONCE (the sign-magnitude conversion the divmod
     // also needs) and reuse them on whichever branch is taken — neither path
     // re-walks `unsigned_abs`.
-    let a_mag = a.unsigned_abs();
-    let b_mag = b.unsigned_abs();
-    let neg_r = a.is_negative();
-    // Dividend-smaller short-circuit: when `|a| < |b|` the truncating
-    // remainder is the dividend itself (`a % b == a`), so return `a`
+    let dividend_mag = dividend.unsigned_abs();
+    let divisor_mag = divisor.unsigned_abs();
+    let remainder_is_negative = dividend.is_negative();
+    // Dividend-smaller short-circuit: when `|dividend| < |divisor|` the
+    // truncating remainder is the dividend itself
+    // (`dividend % divisor == dividend`), so return `dividend`
     // unchanged — one top-down `N`-limb magnitude compare (`Uint::cmp`), no
     // hardware divide, no `[u64; N]` quotient scratch, no `div_rem` shape
     // classifier. Correct for EVERY `N` and value, and it catches the
     // balanced-magnitude shape the single-word `u128` probe below MISSES (an
     // operand pair where the divisor crosses the 128-bit line but the
     // dividend is still smaller). Bit-identical to the divmod (which also
-    // yields `rem == a` here).
-    if a_mag < b_mag {
-        return a;
+    // yields `remainder == dividend` here).
+    if dividend_mag < divisor_mag {
+        return dividend;
     }
-    let (a_fits, a_u) = mag_fits_u128::<N>(&a_mag);
-    let (b_fits, b_u) = mag_fits_u128::<N>(&b_mag);
-    let mut rem = [0u64; N];
-    if a_fits && b_fits {
-        let r = a_u % b_u;
-        rem[0] = r as u64;
+    let (dividend_fits, dividend_u128) = mag_fits_u128::<N>(&dividend_mag);
+    let (divisor_fits, divisor_u128) = mag_fits_u128::<N>(&divisor_mag);
+    let mut remainder = [0u64; N];
+    if dividend_fits && divisor_fits {
+        let remainder_u128 = dividend_u128 % divisor_u128;
+        remainder[0] = remainder_u128 as u64;
         if N >= 2 {
-            rem[1] = (r >> 64) as u64;
+            remainder[1] = (remainder_u128 >> 64) as u64;
         }
     } else {
-        let mut quot = [0u64; N];
-        div_rem_dispatch(a_mag.as_limbs(), b_mag.as_limbs(), &mut quot, &mut rem);
+        let mut quotient = [0u64; N];
+        div_rem_dispatch(dividend_mag.as_limbs(), divisor_mag.as_limbs(), &mut quotient,
+            &mut remainder);
     }
-    Int::<N>::from_mag_limbs(&rem, neg_r)
+    Int::<N>::from_mag_limbs(&remainder, remainder_is_negative)
 }
 
 #[cfg(test)]
@@ -124,28 +127,28 @@ mod tests {
             (i128::MAX, 3),
             (i128::MIN + 1, 3),
         ];
-        for &(a, b) in small {
-            let ia = Int::<8>::from_i128(a);
-            let ib = Int::<8>::from_i128(b);
+        for &(dividend, divisor) in small {
+            let dividend_int = Int::<8>::from_i128(dividend);
+            let divisor_int = Int::<8>::from_i128(divisor);
             assert_eq!(
-                rem_small_fast::<8>(ia, ib),
-                rem_via_div_rem::<8>(ia, ib),
-                "fast path ({a} % {b})"
+                rem_small_fast::<8>(dividend_int, divisor_int),
+                rem_via_div_rem::<8>(dividend_int, divisor_int),
+                "fast path ({dividend} % {divisor})"
             );
         }
         // full-width operands: fallback path. Build magnitudes that span
         // many limbs.
-        let mut a_lim = [0u64; 8];
-        let mut b_lim = [0u64; 8];
+        let mut dividend_limbs = [0u64; 8];
+        let mut divisor_limbs = [0u64; 8];
         for i in 0..8 {
-            a_lim[i] = 0x9E37_79B9_7F4A_7C15u64.wrapping_mul(i as u64 + 1);
-            b_lim[i] = 0xD1B5_4A32_D192_ED03u64.wrapping_mul(i as u64 + 3);
+            dividend_limbs[i] = 0x9E37_79B9_7F4A_7C15u64.wrapping_mul(i as u64 + 1);
+            divisor_limbs[i] = 0xD1B5_4A32_D192_ED03u64.wrapping_mul(i as u64 + 3);
         }
-        let ia = Int::<8>::from_mag_limbs(&a_lim, false);
-        let ib = Int::<8>::from_mag_limbs(&b_lim, false);
+        let dividend_int = Int::<8>::from_mag_limbs(&dividend_limbs, false);
+        let divisor_int = Int::<8>::from_mag_limbs(&divisor_limbs, false);
         assert_eq!(
-            rem_small_fast::<8>(ia, ib),
-            rem_via_div_rem::<8>(ia, ib),
+            rem_small_fast::<8>(dividend_int, divisor_int),
+            rem_via_div_rem::<8>(dividend_int, divisor_int),
             "fallback path full-width"
         );
     }

--- a/src/int/algos/rem/rem_via_div_rem.rs
+++ b/src/int/algos/rem/rem_via_div_rem.rs
@@ -26,19 +26,19 @@ use crate::int::types::Int;
 ///
 /// Panics on a zero divisor, matching the `Rem` operator contract.
 #[inline]
-pub(crate) fn rem_via_div_rem<const N: usize>(a: Int<N>, b: Int<N>) -> Int<N> {
+pub(crate) fn rem_via_div_rem<const N: usize>(dividend: Int<N>, divisor: Int<N>) -> Int<N> {
     assert!(
-        !b.is_zero(),
+        !divisor.is_zero(),
         "attempt to calculate the remainder with a divisor of zero"
     );
-    let neg_r = a.is_negative();
-    let mut quot = [0u64; N];
-    let mut rem = [0u64; N];
+    let remainder_is_negative = dividend.is_negative();
+    let mut quotient = [0u64; N];
+    let mut remainder = [0u64; N];
     div_rem_dispatch(
-        a.unsigned_abs().as_limbs(),
-        b.unsigned_abs().as_limbs(),
-        &mut quot,
-        &mut rem,
+        dividend.unsigned_abs().as_limbs(),
+        divisor.unsigned_abs().as_limbs(),
+        &mut quotient,
+        &mut remainder,
     );
-    Int::<N>::from_mag_limbs(&rem, neg_r)
+    Int::<N>::from_mag_limbs(&remainder, remainder_is_negative)
 }

--- a/src/int/algos/sqr/mod.rs
+++ b/src/int/algos/sqr/mod.rs
@@ -42,13 +42,13 @@ mod tests {
             Uint::<2>::from_limbs([0xDEAD_BEEF_CAFE_F00D, 0x1234_5678_9ABC_DEF0]),
             Uint::<2>::from_limbs([0xFFFF_FFFF_0000_0000, 0x0000_FFFF_FFFF_0000]),
         ];
-        for &x in cases {
-            let got = sqr_schoolbook(x);
-            let want = sqr_half_product(x);
+        for &value in cases {
+            let actual = sqr_schoolbook(value);
+            let expected = sqr_half_product(value);
             assert_eq!(
-                got, want,
+                actual, expected,
                 "sqr_schoolbook Uint<2> mismatch on {:?}",
-                x.as_limbs()
+                value.as_limbs()
             );
         }
     }
@@ -74,13 +74,13 @@ mod tests {
                 0x3C3C_3C3C_C3C3_C3C3,
             ]),
         ];
-        for &x in cases {
-            let got = sqr_schoolbook(x);
-            let want = sqr_half_product(x);
+        for &value in cases {
+            let actual = sqr_schoolbook(value);
+            let expected = sqr_half_product(value);
             assert_eq!(
-                got, want,
+                actual, expected,
                 "sqr_schoolbook Uint<4> mismatch on {:?}",
-                x.as_limbs()
+                value.as_limbs()
             );
         }
     }
@@ -102,12 +102,12 @@ mod tests {
                 (0xFFFF_FFFFu64).wrapping_mul(0xFFFF_FFFF),
             ),
         ];
-        for &(x, expected) in cases {
-            let got = sqr_schoolbook(x);
+        for &(value, expected) in cases {
+            let actual = sqr_schoolbook(value);
             assert_eq!(
-                got.as_limbs()[0], expected,
+                actual.as_limbs()[0], expected,
                 "sqr_schoolbook Uint<1> mismatch on {:?}",
-                x.as_limbs()
+                value.as_limbs()
             );
         }
     }

--- a/src/int/algos/sqr/sqr_half_product.rs
+++ b/src/int/algos/sqr/sqr_half_product.rs
@@ -28,8 +28,8 @@ use crate::int::types::Uint;
 /// dispatcher and the type methods that delegate to it can be `const fn`
 /// too.
 #[inline]
-pub(crate) const fn sqr_half_product<const N: usize>(x: Uint<N>) -> Uint<N> {
+pub(crate) const fn sqr_half_product<const N: usize>(value: Uint<N>) -> Uint<N> {
     let mut out = [0u64; N];
-    sqr_low_fixed(x.as_limbs(), &mut out);
+    sqr_low_fixed(value.as_limbs(), &mut out);
     Uint::<N>::from_limbs(out)
 }

--- a/src/int/algos/sqr/sqr_low_fixed.rs
+++ b/src/int/algos/sqr/sqr_low_fixed.rs
@@ -31,7 +31,7 @@
 /// column is emitted, the accumulator is shifted down 64 bits — the carry
 /// into the next column — and `hi` folds back into the top.
 #[inline]
-pub(crate) const fn sqr_low_fixed<const N: usize>(x: &[u64; N], out: &mut [u64; N]) {
+pub(crate) const fn sqr_low_fixed<const N: usize>(value: &[u64; N], out: &mut [u64; N]) {
     let mut acc: u128 = 0;
     let mut hi: u64 = 0;
     let mut col = 0;
@@ -41,15 +41,15 @@ pub(crate) const fn sqr_low_fixed<const N: usize>(x: &[u64; N], out: &mut [u64; 
         let mut i = 0;
         while 2 * i <= col {
             let j = col - i;
-            let p = (x[i] as u128) * (x[j] as u128);
+            let prod = (value[i] as u128) * (value[j] as u128);
             // Diagonal once; off-diagonal twice (the symmetry doubling).
             let reps = if i == j { 1 } else { 2 };
-            let mut r = 0;
-            while r < reps {
-                let (s, c) = acc.overflowing_add(p);
-                acc = s;
-                hi += c as u64;
-                r += 1;
+            let mut rep = 0;
+            while rep < reps {
+                let (sum, carried) = acc.overflowing_add(prod);
+                acc = sum;
+                hi += carried as u64;
+                rep += 1;
             }
             i += 1;
         }
@@ -77,33 +77,33 @@ mod tests {
     /// propagation.
     fn diff_at<const N: usize>(seeds: &[u64]) {
         for &seed in seeds {
-            let mut x = [0u64; N];
-            let mut s = seed;
-            for limb in x.iter_mut() {
+            let mut value = [0u64; N];
+            let mut state = seed;
+            for limb in value.iter_mut() {
                 // SplitMix64 step.
-                s = s.wrapping_add(0x9E37_79B9_7F4A_7C15);
-                let mut z = s;
+                state = state.wrapping_add(0x9E37_79B9_7F4A_7C15);
+                let mut z = state;
                 z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
                 z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
                 *limb = z ^ (z >> 31);
             }
-            let mut got = [0u64; N];
-            sqr_low_fixed::<N>(&x, &mut got);
-            let mut want = [0u64; N];
-            mul_low_fixed::<N>(&x, &x, &mut want);
-            assert_eq!(got, want, "N={N} seed={seed:#x} x={x:?}");
+            let mut actual = [0u64; N];
+            sqr_low_fixed::<N>(&value, &mut actual);
+            let mut expected = [0u64; N];
+            mul_low_fixed::<N>(&value, &value, &mut expected);
+            assert_eq!(actual, expected, "N={N} seed={seed:#x} x={value:?}");
         }
     }
 
     /// All-ones operand: every column saturates, the worst case for the
     /// running-accumulator carry.
     fn all_ones_at<const N: usize>() {
-        let x = [u64::MAX; N];
-        let mut got = [0u64; N];
-        sqr_low_fixed::<N>(&x, &mut got);
-        let mut want = [0u64; N];
-        mul_low_fixed::<N>(&x, &x, &mut want);
-        assert_eq!(got, want, "all-ones N={N}");
+        let value = [u64::MAX; N];
+        let mut actual = [0u64; N];
+        sqr_low_fixed::<N>(&value, &mut actual);
+        let mut expected = [0u64; N];
+        mul_low_fixed::<N>(&value, &value, &mut expected);
+        assert_eq!(actual, expected, "all-ones N={N}");
     }
 
     #[test]

--- a/src/int/algos/sqr/sqr_low_limb.rs
+++ b/src/int/algos/sqr/sqr_low_limb.rs
@@ -52,10 +52,10 @@ use crate::int::types::compute_limbs::Limb;
 /// `packed_len(N) ≤ N` for both limb types; stable Rust cannot put `N/2` in an
 /// array length, so the high `N − h` slots stay unused). `out` is fully written.
 #[inline]
-pub(crate) fn sqr_low_limb<const N: usize, L: Limb>(x: &[u64; N], out: &mut [u64; N]) {
+pub(crate) fn sqr_low_limb<const N: usize, L: Limb>(value: &[u64; N], out: &mut [u64; N]) {
     let h = L::packed_len(N);
-    let mut xp = [L::ZERO; N];
-    L::pack(x, &mut xp[..h]);
+    let mut value_packed = [L::ZERO; N];
+    L::pack(value, &mut value_packed[..h]);
 
     let mut acc = [L::ZERO; N];
 
@@ -64,17 +64,17 @@ pub(crate) fn sqr_low_limb<const N: usize, L: Limb>(x: &[u64; N], out: &mut [u64
     // high limb), truncated once the column index reaches `h`.
     let mut i = 0;
     while i < h {
-        let ai = xp[i];
-        if ai != L::ZERO {
+        let value_limb = value_packed[i];
+        if value_limb != L::ZERO {
             let mut carry = L::ZERO;
             let mut j = i + 1;
             while i + j < h {
                 let idx = i + j;
-                let (lo, hi) = ai.widening_mul(xp[j]);
-                let (s1, c1) = acc[idx].overflowing_add(lo);
-                let (s2, c2) = s1.overflowing_add(carry);
-                acc[idx] = s2;
-                carry = hi.add_carries(c1, c2);
+                let (lo, hi) = value_limb.widening_mul(value_packed[j]);
+                let (sum1, carry1) = acc[idx].overflowing_add(lo);
+                let (sum2, carry2) = sum1.overflowing_add(carry);
+                acc[idx] = sum2;
+                carry = hi.add_carries(carry1, carry2);
                 j += 1;
             }
             // The trailing `carry` would land at column `i + j ≥ h` — above the
@@ -85,15 +85,16 @@ pub(crate) fn sqr_low_limb<const N: usize, L: Limb>(x: &[u64; N], out: &mut [u64
 
     // Pass 2: acc[0..h] ·= 2 (the `2 · Σ_{i<j}` factor). `2·acc[k]` carries its
     // top bit out; the incoming carry bit is added as a `Limb::ONE` value.
-    let mut dcarry = L::ZERO;
+    let mut double_carry = L::ZERO;
     let mut k = 0;
     while k < h {
-        let (s1, c1) = acc[k].overflowing_add(acc[k]);
-        let (s2, c2) = s1.overflowing_add(dcarry);
-        acc[k] = s2;
-        // `2·acc[k] == MAX` ⇒ c1=0, and `+1` cannot wrap ⇒ c2=0; `acc[k]==MAX`
-        // ⇒ c1=1, s1=MAX−1, `+dcarry(≤1)` ⇒ c2=0. So c1,c2 are never both set.
-        dcarry = if c1 || c2 { L::ONE } else { L::ZERO };
+        let (sum1, carry1) = acc[k].overflowing_add(acc[k]);
+        let (sum2, carry2) = sum1.overflowing_add(double_carry);
+        acc[k] = sum2;
+        // `2·acc[k] == MAX` ⇒ carry1=0, and `+1` cannot wrap ⇒ carry2=0;
+        // `acc[k]==MAX` ⇒ carry1=1, sum1=MAX−1, `+double_carry(≤1)` ⇒ carry2=0.
+        // So carry1,carry2 are never both set.
+        double_carry = if carry1 || carry2 { L::ONE } else { L::ZERO };
         k += 1;
     }
 
@@ -101,23 +102,24 @@ pub(crate) fn sqr_low_limb<const N: usize, L: Limb>(x: &[u64; N], out: &mut [u64
     let mut i = 0;
     while 2 * i < h {
         let pos = 2 * i;
-        let (lo, hi) = xp[i].widening_mul(xp[i]);
-        let (s, mut prop) = acc[pos].overflowing_add(lo);
-        acc[pos] = s;
-        let mut p = pos + 1;
+        let (lo, hi) = value_packed[i].widening_mul(value_packed[i]);
+        let (sum, mut propagate) = acc[pos].overflowing_add(lo);
+        acc[pos] = sum;
+        let mut carry_pos = pos + 1;
         // Add the high limb `hi` plus the low limb's carry at `pos + 1`, then
         // ripple the carry upward — all truncated at `h`.
-        if p < h {
-            let (s1, c1) = acc[p].overflowing_add(hi);
-            let (s2, c2) = s1.overflowing_add(if prop { L::ONE } else { L::ZERO });
-            acc[p] = s2;
-            prop = c1 || c2;
-            p += 1;
-            while prop && p < h {
-                let (s3, c3) = acc[p].overflowing_add(L::ONE);
-                acc[p] = s3;
-                prop = c3;
-                p += 1;
+        if carry_pos < h {
+            let (sum1, carry1) = acc[carry_pos].overflowing_add(hi);
+            let (sum2, carry2) =
+                sum1.overflowing_add(if propagate { L::ONE } else { L::ZERO });
+            acc[carry_pos] = sum2;
+            propagate = carry1 || carry2;
+            carry_pos += 1;
+            while propagate && carry_pos < h {
+                let (sum3, carry3) = acc[carry_pos].overflowing_add(L::ONE);
+                acc[carry_pos] = sum3;
+                propagate = carry3;
+                carry_pos += 1;
             }
         }
         i += 1;
@@ -138,36 +140,36 @@ mod tests {
     /// widths the u128 arm targets, including the all-ones carry worst case.
     fn diff_at<const N: usize>(seeds: &[u64]) {
         for &seed in seeds {
-            let mut x = [0u64; N];
-            let mut s = seed;
-            for limb in x.iter_mut() {
-                s = s.wrapping_add(0x9E37_79B9_7F4A_7C15);
-                let mut z = s;
+            let mut value = [0u64; N];
+            let mut state = seed;
+            for limb in value.iter_mut() {
+                state = state.wrapping_add(0x9E37_79B9_7F4A_7C15);
+                let mut z = state;
                 z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
                 z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
                 *limb = z ^ (z >> 31);
             }
-            let mut want = [0u64; N];
-            sqr_low_fixed::<N>(&x, &mut want);
-            let mut got_u64 = [0u64; N];
-            sqr_low_limb::<N, u64>(&x, &mut got_u64);
-            assert_eq!(got_u64, want, "u64 N={N} seed={seed:#x}");
-            let mut got_u128 = [0u64; N];
-            sqr_low_limb::<N, u128>(&x, &mut got_u128);
-            assert_eq!(got_u128, want, "u128 N={N} seed={seed:#x}");
+            let mut expected = [0u64; N];
+            sqr_low_fixed::<N>(&value, &mut expected);
+            let mut actual_u64 = [0u64; N];
+            sqr_low_limb::<N, u64>(&value, &mut actual_u64);
+            assert_eq!(actual_u64, expected, "u64 N={N} seed={seed:#x}");
+            let mut actual_u128 = [0u64; N];
+            sqr_low_limb::<N, u128>(&value, &mut actual_u128);
+            assert_eq!(actual_u128, expected, "u128 N={N} seed={seed:#x}");
         }
     }
 
     fn all_ones_at<const N: usize>() {
-        let x = [u64::MAX; N];
-        let mut want = [0u64; N];
-        sqr_low_fixed::<N>(&x, &mut want);
-        let mut got_u128 = [0u64; N];
-        sqr_low_limb::<N, u128>(&x, &mut got_u128);
-        assert_eq!(got_u128, want, "u128 all-ones N={N}");
-        let mut got_u64 = [0u64; N];
-        sqr_low_limb::<N, u64>(&x, &mut got_u64);
-        assert_eq!(got_u64, want, "u64 all-ones N={N}");
+        let value = [u64::MAX; N];
+        let mut expected = [0u64; N];
+        sqr_low_fixed::<N>(&value, &mut expected);
+        let mut actual_u128 = [0u64; N];
+        sqr_low_limb::<N, u128>(&value, &mut actual_u128);
+        assert_eq!(actual_u128, expected, "u128 all-ones N={N}");
+        let mut actual_u64 = [0u64; N];
+        sqr_low_limb::<N, u64>(&value, &mut actual_u64);
+        assert_eq!(actual_u64, expected, "u64 all-ones N={N}");
     }
 
     #[test]

--- a/src/int/algos/sqr/sqr_schoolbook.rs
+++ b/src/int/algos/sqr/sqr_schoolbook.rs
@@ -24,15 +24,15 @@ use crate::int::types::Uint;
 
 /// Naive schoolbook integer square for `Uint<N>`: `x²` modulo `2^BITS`.
 ///
-/// Delegates directly to [`mul_low_fixed`] with both operands set to `x`,
-/// forming the full `N×N` outer product and retaining only the low `N`
-/// limbs. Bit-identical to [`crate::int::algos::sqr::sqr_half_product::sqr_half_product`];
+/// Delegates directly to [`mul_low_fixed`] with both operands set to
+/// `value`, forming the full `N×N` outer product and retaining only the low
+/// `N` limbs. Bit-identical to [`crate::int::algos::sqr::sqr_half_product::sqr_half_product`];
 /// slower by roughly 2× because symmetric cross terms are formed twice.
 /// `const fn`, matching the const-ness of the production algorithm.
 #[inline]
 #[allow(dead_code)]
-pub(crate) const fn sqr_schoolbook<const N: usize>(x: Uint<N>) -> Uint<N> {
+pub(crate) const fn sqr_schoolbook<const N: usize>(value: Uint<N>) -> Uint<N> {
     let mut out = [0u64; N];
-    mul_low_fixed(x.as_limbs(), x.as_limbs(), &mut out);
+    mul_low_fixed(value.as_limbs(), value.as_limbs(), &mut out);
     Uint::<N>::from_limbs(out)
 }

--- a/src/int/algos/sub/sub_ripple_borrow.rs
+++ b/src/int/algos/sub/sub_ripple_borrow.rs
@@ -15,9 +15,9 @@ use crate::int::types::Int;
 /// [`sub_assign_fixed`], discarding the borrow-out so the result wraps
 /// modulo `2^BITS` (two's-complement wrapping semantics).
 #[inline]
-pub(crate) const fn sub_ripple_borrow<const N: usize>(a: Int<N>, b: Int<N>) -> Int<N> {
-    let mut limbs = *a.as_limbs();
-    sub_assign_fixed(&mut limbs, b.as_limbs());
+pub(crate) const fn sub_ripple_borrow<const N: usize>(lhs: Int<N>, rhs: Int<N>) -> Int<N> {
+    let mut limbs = *lhs.as_limbs();
+    sub_assign_fixed(&mut limbs, rhs.as_limbs());
     Int::<N>::from_limbs(limbs)
 }
 
@@ -30,25 +30,25 @@ pub(crate) const fn sub_ripple_borrow<const N: usize>(a: Int<N>, b: Int<N>) -> I
 /// [`add_ripple_carry_checked`](crate::int::algos::add::add_ripple_carry::add_ripple_carry_checked)).
 #[inline]
 pub(crate) const fn sub_ripple_borrow_checked<const N: usize>(
-    a: Int<N>,
-    b: Int<N>,
+    lhs: Int<N>,
+    rhs: Int<N>,
 ) -> Option<Int<N>> {
-    let av = a.as_limbs();
-    let bv = b.as_limbs();
+    let lhs_limbs = lhs.as_limbs();
+    let rhs_limbs = rhs.as_limbs();
     let mut out = [0u64; N];
     let mut borrow = 0u64;
     let mut i = 0;
     while i < N {
-        let (d1, b1) = av[i].overflowing_sub(bv[i]);
+        let (d1, b1) = lhs_limbs[i].overflowing_sub(rhs_limbs[i]);
         let (d2, b2) = d1.overflowing_sub(borrow);
         out[i] = d2;
         borrow = (b1 as u64) + (b2 as u64);
         i += 1;
     }
-    let sa = av[N - 1] >> 63;
-    let sb = bv[N - 1] >> 63;
-    let sr = out[N - 1] >> 63;
-    if sa != sb && sr != sa {
+    let lhs_sign = lhs_limbs[N - 1] >> 63;
+    let rhs_sign = rhs_limbs[N - 1] >> 63;
+    let result_sign = out[N - 1] >> 63;
+    if lhs_sign != rhs_sign && result_sign != lhs_sign {
         None
     } else {
         Some(Int::<N>::from_limbs(out))

--- a/src/int/algos/sum_sq/sum_sq_comba.rs
+++ b/src/int/algos/sum_sq/sum_sq_comba.rs
@@ -28,11 +28,11 @@ use crate::int::types::compute_limbs::{ComputeLimbs, Limbs};
 use crate::int::types::Int;
 
 /// Full-width product-scanning (comba) square: `out = x²` over the
-/// little-endian limb slice `x[..l]`, writing the full `2l` result limbs.
-/// `out.len() >= 2*l` and `out` must be zeroed by the caller for the high
-/// limbs it does not reach (this routine overwrites `out[..2*l]`).
+/// little-endian limb slice `x[..len]`, writing the full `2·len` result limbs.
+/// `out.len() >= 2*len` and `out` must be zeroed by the caller for the high
+/// limbs it does not reach (this routine overwrites `out[..2*len]`).
 ///
-/// For each output column `col` in `0..2*l-1`, sum every partial product
+/// For each output column `col` in `0..2*len-1`, sum every partial product
 /// `x_i·x_j` with `i + j == col` and `i ≤ j`: the off-diagonal `i < j` terms
 /// contribute twice (symmetry), the diagonal `i == j` once. A running
 /// 128-bit-plus-overflow accumulator threads the inter-column carry, so there
@@ -40,55 +40,58 @@ use crate::int::types::Int;
 /// [`sqr_low_fixed`](crate::int::algos::sqr::sqr_low_fixed::sqr_low_fixed),
 /// only carried out to the full width.
 #[inline]
-fn sqr_full(x: &[u64], l: usize, out: &mut [u64]) {
+fn sqr_full(x: &[u64], len: usize, out: &mut [u64]) {
     let mut acc: u128 = 0;
-    let mut hi: u64 = 0;
-    let ncol = 2 * l; // columns 0 ..= 2l-2 are emitted; the final carry lands in 2l-1.
+    let mut acc_hi: u64 = 0;
+    // columns 0 ..= 2·len-2 are emitted; the final carry lands in 2·len-1.
+    let col_count = 2 * len;
     let mut col = 0;
-    while col < ncol {
-        // Pairs (i, j) with i ≤ j, i + j == col, and both in 0..l.
-        // i ranges from max(0, col-(l-1)) to floor(col/2).
-        let lo_i = if col >= l { col - (l - 1) } else { 0 };
-        let mut i = lo_i;
+    while col < col_count {
+        // Pairs (i, j) with i ≤ j, i + j == col, and both in 0..len.
+        // i ranges from max(0, col-(len-1)) to floor(col/2).
+        let min_i = if col >= len { col - (len - 1) } else { 0 };
+        let mut i = min_i;
         while 2 * i <= col {
             let j = col - i;
-            // j ≤ l-1 holds because i ≥ col-(l-1) ⇒ j = col-i ≤ l-1.
+            // j ≤ len-1 holds because i ≥ col-(len-1) ⇒ j = col-i ≤ len-1.
             let p = (x[i] as u128) * (x[j] as u128);
             let reps = if i == j { 1 } else { 2 };
             let mut r = 0;
             while r < reps {
                 let (s, c) = acc.overflowing_add(p);
                 acc = s;
-                hi += c as u64;
+                acc_hi += c as u64;
                 r += 1;
             }
             i += 1;
         }
         out[col] = acc as u64;
-        acc = (acc >> 64) + ((hi as u128) << 64);
-        hi = 0;
+        acc = (acc >> 64) + ((acc_hi as u128) << 64);
+        acc_hi = 0;
         col += 1;
     }
 }
 
-/// Form `a² + b²` (on the magnitude slices `ma` / `mb`) into `out` via the
-/// comba square, returning its significant limb length. Drop-in for
+/// Form `a² + b²` (on the magnitude slices `a_magnitude` / `b_magnitude`)
+/// into `out` via the comba square, returning its significant limb length.
+/// Drop-in for
 /// [`crate::int::algos::sum_sq::sum_sq_schoolbook::sum_sq_radicand`]: same
 /// contract, same result, the squares formed by [`sqr_full`].
 #[inline]
-pub(crate) fn sum_sq_radicand_comba<const N: usize>(ma: &[u64], mb: &[u64], out: &mut [u64]) -> usize
+pub(crate) fn sum_sq_radicand_comba<const N: usize>(a_magnitude: &[u64],
+    b_magnitude: &[u64], out: &mut [u64]) -> usize
 where
     Limbs<N>: ComputeLimbs,
 {
-    let la = sig_len(ma);
-    let lb = sig_len(mb);
+    let a_len = sig_len(a_magnitude);
+    let b_len = sig_len(b_magnitude);
     // a² into `out` (zeroed by the caller); b² into its own scratch.
-    sqr_full(ma, la, &mut out[..2 * la]);
-    let mut bsq_buf = Limbs::<N>::double_buffered_u64();
-    let bsq = bsq_buf.as_mut();
-    sqr_full(mb, lb, &mut bsq[..2 * lb]);
-    let span = (2 * la).max(2 * lb) + 1;
-    add_assign(&mut out[..span], &bsq[..2 * lb]);
+    sqr_full(a_magnitude, a_len, &mut out[..2 * a_len]);
+    let mut b_squared_buf = Limbs::<N>::double_buffered_u64();
+    let b_squared = b_squared_buf.as_mut();
+    sqr_full(b_magnitude, b_len, &mut b_squared[..2 * b_len]);
+    let span = (2 * a_len).max(2 * b_len) + 1;
+    add_assign(&mut out[..span], &b_squared[..2 * b_len]);
     sig_len(&out[..span])
 }
 
@@ -100,16 +103,17 @@ pub(crate) fn sum_sq_comba<const N: usize>(a: Int<N>, b: Int<N>) -> Option<Int<N
 where
     Limbs<N>: ComputeLimbs,
 {
-    let ma = a.unsigned_abs();
-    let mb = b.unsigned_abs();
-    let mut n_buf = Limbs::<N>::double_buffered_u64();
-    let n = n_buf.as_mut();
-    let nl = sum_sq_radicand_comba::<N>(ma.as_limbs(), mb.as_limbs(), n);
-    if nl > N || (nl == N && (n[N - 1] >> 63) != 0) {
+    let a_magnitude = a.unsigned_abs();
+    let b_magnitude = b.unsigned_abs();
+    let mut radicand_buf = Limbs::<N>::double_buffered_u64();
+    let radicand = radicand_buf.as_mut();
+    let radicand_len =
+        sum_sq_radicand_comba::<N>(a_magnitude.as_limbs(), b_magnitude.as_limbs(), radicand);
+    if radicand_len > N || (radicand_len == N && (radicand[N - 1] >> 63) != 0) {
         return None;
     }
     let mut out = [0u64; N];
-    out.copy_from_slice(&n[..N]);
+    out.copy_from_slice(&radicand[..N]);
     Some(Int::<N>::from_limbs(out))
 }
 
@@ -120,18 +124,18 @@ mod tests {
     use crate::int::types::Int;
 
     /// SplitMix64 step — deterministic spread for the differential check.
-    fn mix(s: &mut u64) -> u64 {
-        *s = s.wrapping_add(0x9E37_79B9_7F4A_7C15);
-        let mut z = *s;
+    fn mix(state: &mut u64) -> u64 {
+        *state = state.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        let mut z = *state;
         z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
         z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
         z ^ (z >> 31)
     }
 
-    fn rand_int<const N: usize>(s: &mut u64) -> Int<N> {
+    fn rand_int<const N: usize>(state: &mut u64) -> Int<N> {
         let mut limbs = [0u64; N];
         for limb in limbs.iter_mut() {
-            *limb = mix(s);
+            *limb = mix(state);
         }
         // Clear the top bit so the magnitude stays comfortably positive; the
         // value is then interpreted signed by Int, which is fine — the
@@ -146,20 +150,20 @@ mod tests {
     where
         crate::int::types::compute_limbs::Limbs<N>: crate::int::types::compute_limbs::ComputeLimbs,
     {
-        let mut s = 0x0123_4567_89AB_CDEF_u64 ^ (N as u64);
+        let mut state = 0x0123_4567_89AB_CDEF_u64 ^ (N as u64);
         for _ in 0..400 {
             // Shrink one operand sometimes to exercise unequal lengths.
-            let mut a = rand_int::<N>(&mut s);
-            let mut b = rand_int::<N>(&mut s);
-            if mix(&mut s) & 1 == 0 {
+            let mut a = rand_int::<N>(&mut state);
+            let mut b = rand_int::<N>(&mut state);
+            if mix(&mut state) & 1 == 0 {
                 a = Int::<N>::from_limbs({
-                    let mut l = *a.as_limbs();
-                    l[1..N].fill(0);
-                    l[0] &= 0xFFFF_FFFF; // ~32-bit operand
-                    l
+                    let mut limbs = *a.as_limbs();
+                    limbs[1..N].fill(0);
+                    limbs[0] &= 0xFFFF_FFFF; // ~32-bit operand
+                    limbs
                 });
             }
-            if mix(&mut s) & 1 == 0 {
+            if mix(&mut state) & 1 == 0 {
                 b = Int::<N>::ZERO;
             }
             assert_eq!(

--- a/src/int/algos/sum_sq/sum_sq_schoolbook.rs
+++ b/src/int/algos/sum_sq/sum_sq_schoolbook.rs
@@ -28,39 +28,40 @@ use crate::int::algos::support::limbs::add_assign;
 use crate::int::types::compute_limbs::{ComputeLimbs, Limbs};
 use crate::int::types::Int;
 
-/// Significant limb length of `a` (index of the highest non-zero limb plus
-/// one), never below 1. Shared by the sum-of-squares and hypot kernels.
+/// Significant limb length of `limbs` (index of the highest non-zero limb
+/// plus one), never below 1. Shared by the sum-of-squares and hypot kernels.
 #[inline]
-pub(crate) fn sig_len(a: &[u64]) -> usize {
-    let mut l = a.len();
-    while l > 1 && a[l - 1] == 0 {
-        l -= 1;
+pub(crate) fn sig_len(limbs: &[u64]) -> usize {
+    let mut len = limbs.len();
+    while len > 1 && limbs[len - 1] == 0 {
+        len -= 1;
     }
-    l
+    len
 }
 
-/// Form `a^2 + b^2` (on the magnitude slices `ma` / `mb`) into `out`,
-/// returning its significant limb length. `N` is the storage limb count of
-/// the originating `Int<N>` operands, so each magnitude is `<= N` limbs and
-/// the radicand fits the `Buf2` scratch the caller supplies (`out` must be a
-/// freshly zeroed `Limbs::<N>::double_buffered_u64()`, i.e. `>= 2N + 1` limbs). This is the
-/// single radicand former shared by [`sum_sq_schoolbook`] and the hypot
-/// kernel.
+/// Form `a^2 + b^2` (on the magnitude slices `a_magnitude` / `b_magnitude`)
+/// into `out`, returning its significant limb length. `N` is the storage limb
+/// count of the originating `Int<N>` operands, so each magnitude is `<= N`
+/// limbs and the radicand fits the `Buf2` scratch the caller supplies (`out`
+/// must be a freshly zeroed `Limbs::<N>::double_buffered_u64()`, i.e.
+/// `>= 2N + 1` limbs). This is the single radicand former shared by
+/// [`sum_sq_schoolbook`] and the hypot kernel.
 #[inline]
-pub(crate) fn sum_sq_radicand<const N: usize>(ma: &[u64], mb: &[u64], out: &mut [u64]) -> usize
+pub(crate) fn sum_sq_radicand<const N: usize>(a_magnitude: &[u64], b_magnitude: &[u64],
+    out: &mut [u64]) -> usize
 where
     Limbs<N>: ComputeLimbs,
 {
-    let la = sig_len(ma);
-    let lb = sig_len(mb);
+    let a_len = sig_len(a_magnitude);
+    let b_len = sig_len(b_magnitude);
     // a^2 into `out` (zeroed by the caller); b^2 into its own scratch.
-    mul_schoolbook(&ma[..la], &ma[..la], &mut out[..2 * la]);
-    let mut bsq_buf = Limbs::<N>::double_buffered_u64();
-    let bsq = bsq_buf.as_mut();
-    mul_schoolbook(&mb[..lb], &mb[..lb], &mut bsq[..2 * lb]);
+    mul_schoolbook(&a_magnitude[..a_len], &a_magnitude[..a_len], &mut out[..2 * a_len]);
+    let mut b_squared_buf = Limbs::<N>::double_buffered_u64();
+    let b_squared = b_squared_buf.as_mut();
+    mul_schoolbook(&b_magnitude[..b_len], &b_magnitude[..b_len], &mut b_squared[..2 * b_len]);
     // accumulate into `out`; the +1 limb covers the addition carry.
-    let span = (2 * la).max(2 * lb) + 1;
-    add_assign(&mut out[..span], &bsq[..2 * lb]);
+    let span = (2 * a_len).max(2 * b_len) + 1;
+    add_assign(&mut out[..span], &b_squared[..2 * b_len]);
     sig_len(&out[..span])
 }
 
@@ -74,17 +75,18 @@ pub(crate) fn sum_sq_schoolbook<const N: usize>(a: Int<N>, b: Int<N>) -> Option<
 where
     Limbs<N>: ComputeLimbs,
 {
-    let ma = a.unsigned_abs();
-    let mb = b.unsigned_abs();
-    let mut n_buf = Limbs::<N>::double_buffered_u64();
-    let n = n_buf.as_mut();
-    let nl = sum_sq_radicand::<N>(ma.as_limbs(), mb.as_limbs(), n);
+    let a_magnitude = a.unsigned_abs();
+    let b_magnitude = b.unsigned_abs();
+    let mut radicand_buf = Limbs::<N>::double_buffered_u64();
+    let radicand = radicand_buf.as_mut();
+    let radicand_len =
+        sum_sq_radicand::<N>(a_magnitude.as_limbs(), b_magnitude.as_limbs(), radicand);
     // fit check: positive magnitude must be < 2^(64N-1) (signed range).
-    if nl > N || (nl == N && (n[N - 1] >> 63) != 0) {
+    if radicand_len > N || (radicand_len == N && (radicand[N - 1] >> 63) != 0) {
         return None;
     }
     let mut out = [0u64; N];
-    out.copy_from_slice(&n[..N]);
+    out.copy_from_slice(&radicand[..N]);
     Some(Int::<N>::from_limbs(out))
 }
 

--- a/src/int/algos/support/limbs.rs
+++ b/src/int/algos/support/limbs.rs
@@ -64,24 +64,24 @@ pub(crate) const fn max_n_limbs(mult: usize) -> usize {
     mult * MAX_WORK_N + MAX_WORK_N.div_ceil(2)
 }
 
-/// Exact per-`N` work-scratch budget: `mult·n + ceil(n/2)`, the same
-/// formula as [`max_n_limbs`] but for a *specific* limb count `n` rather
-/// than the build-max. Used by the `exact-scratch-nightly` blanket
+/// Exact per-`N` work-scratch budget: `mult·limb_count + ceil(limb_count/2)`,
+/// the same formula as [`max_n_limbs`] but for a *specific* `limb_count`
+/// rather than the build-max. Used by the `exact-scratch-nightly` blanket
 /// [`ComputeLimbs`] impl, where it appears as a `generic_const_exprs` array
 /// length confined to that impl block.
 ///
 /// [`ComputeLimbs`]: crate::int::types::compute_limbs::ComputeLimbs
 #[cfg(feature = "exact-scratch-nightly")]
-pub(crate) const fn n_limbs(mult: usize, n: usize) -> usize {
-    mult * n + (n + 1) / 2
+pub(crate) const fn n_limbs(mult: usize, limb_count: usize) -> usize {
+    mult * limb_count + (limb_count + 1) / 2
 }
 
-/// `a == 0`.
+/// `limbs == 0`.
 #[inline]
-pub(crate) const fn is_zero(a: &[u64]) -> bool {
+pub(crate) const fn is_zero(limbs: &[u64]) -> bool {
     let mut i = 0;
-    while i < a.len() {
-        if a[i] != 0 {
+    while i < limbs.len() {
+        if limbs[i] != 0 {
             return false;
         }
         i += 1;
@@ -92,10 +92,10 @@ pub(crate) const fn is_zero(a: &[u64]) -> bool {
 /// Fixed-width specialisation of [`is_zero`]. `L` const at callsite, lets
 /// LLVM unroll for small `L`.
 #[inline]
-pub(crate) const fn is_zero_fixed<const L: usize>(a: &[u64; L]) -> bool {
+pub(crate) const fn is_zero_fixed<const L: usize>(limbs: &[u64; L]) -> bool {
     let mut i = 0;
     while i < L {
-        if a[i] != 0 {
+        if limbs[i] != 0 {
             return false;
         }
         i += 1;
@@ -103,15 +103,15 @@ pub(crate) const fn is_zero_fixed<const L: usize>(a: &[u64; L]) -> bool {
     true
 }
 
-/// `a == b` for two limb slices of possibly different lengths.
+/// `lhs == rhs` for two limb slices of possibly different lengths.
 #[inline]
-pub(crate) const fn eq(a: &[u64], b: &[u64]) -> bool {
-    let n = if a.len() > b.len() { a.len() } else { b.len() };
+pub(crate) const fn eq(lhs: &[u64], rhs: &[u64]) -> bool {
+    let max_len = if lhs.len() > rhs.len() { lhs.len() } else { rhs.len() };
     let mut i = 0;
-    while i < n {
-        let av = if i < a.len() { a[i] } else { 0 };
-        let bv = if i < b.len() { b[i] } else { 0 };
-        if av != bv {
+    while i < max_len {
+        let lhs_limb = if i < lhs.len() { lhs[i] } else { 0 };
+        let rhs_limb = if i < rhs.len() { rhs[i] } else { 0 };
+        if lhs_limb != rhs_limb {
             return false;
         }
         i += 1;
@@ -121,17 +121,17 @@ pub(crate) const fn eq(a: &[u64], b: &[u64]) -> bool {
 
 /// Three-way comparison `-1`/`0`/`1`.
 #[inline]
-pub(crate) const fn cmp(a: &[u64], b: &[u64]) -> i32 {
-    let n = if a.len() > b.len() { a.len() } else { b.len() };
-    let mut i = n;
+pub(crate) const fn cmp(lhs: &[u64], rhs: &[u64]) -> i32 {
+    let max_len = if lhs.len() > rhs.len() { lhs.len() } else { rhs.len() };
+    let mut i = max_len;
     while i > 0 {
         i -= 1;
-        let av = if i < a.len() { a[i] } else { 0 };
-        let bv = if i < b.len() { b[i] } else { 0 };
-        if av < bv {
+        let lhs_limb = if i < lhs.len() { lhs[i] } else { 0 };
+        let rhs_limb = if i < rhs.len() { rhs[i] } else { 0 };
+        if lhs_limb < rhs_limb {
             return -1;
         }
-        if av > bv {
+        if lhs_limb > rhs_limb {
             return 1;
         }
     }
@@ -141,14 +141,14 @@ pub(crate) const fn cmp(a: &[u64], b: &[u64]) -> i32 {
 /// Fixed-width specialisation of [`cmp`] — both operands the same `L`; no
 /// length-difference handling needed.
 #[inline]
-pub(crate) const fn cmp_fixed<const L: usize>(a: &[u64; L], b: &[u64; L]) -> i32 {
+pub(crate) const fn cmp_fixed<const L: usize>(lhs: &[u64; L], rhs: &[u64; L]) -> i32 {
     let mut i = L;
     while i > 0 {
         i -= 1;
-        if a[i] < b[i] {
+        if lhs[i] < rhs[i] {
             return -1;
         }
-        if a[i] > b[i] {
+        if lhs[i] > rhs[i] {
             return 1;
         }
     }
@@ -157,24 +157,24 @@ pub(crate) const fn cmp_fixed<const L: usize>(a: &[u64; L], b: &[u64; L]) -> i32
 
 /// Cross-width unsigned magnitude comparison of two little-endian limb
 /// slices of possibly different lengths. Returns `-1` / `0` / `1` for
-/// `a < b` / `a == b` / `a > b`. The surplus high limbs of the longer
-/// slice must all be zero for the magnitudes to be equal there; any
+/// `lhs < rhs` / `lhs == rhs` / `lhs > rhs`. The surplus high limbs of the
+/// longer slice must all be zero for the magnitudes to be equal there; any
 /// non-zero surplus limb makes that side the larger. No widening copy is
 /// made — the slices are compared in place. Const.
 #[inline]
-pub(crate) const fn cmp_cross(a: &[u64], b: &[u64]) -> i32 {
-    let la = a.len();
-    let lb = b.len();
-    let max = if la > lb { la } else { lb };
-    let mut i = max;
+pub(crate) const fn cmp_cross(lhs: &[u64], rhs: &[u64]) -> i32 {
+    let lhs_len = lhs.len();
+    let rhs_len = rhs.len();
+    let max_len = if lhs_len > rhs_len { lhs_len } else { rhs_len };
+    let mut i = max_len;
     while i > 0 {
         i -= 1;
-        let av = if i < la { a[i] } else { 0 };
-        let bv = if i < lb { b[i] } else { 0 };
-        if av < bv {
+        let lhs_limb = if i < lhs_len { lhs[i] } else { 0 };
+        let rhs_limb = if i < rhs_len { rhs[i] } else { 0 };
+        if lhs_limb < rhs_limb {
             return -1;
         }
-        if av > bv {
+        if lhs_limb > rhs_limb {
             return 1;
         }
     }
@@ -187,42 +187,42 @@ pub(crate) const fn cmp_cross(a: &[u64], b: &[u64]) -> i32 {
 /// `|value|` (see `Int::bit_length`), so the result is the count of
 /// significant bits, not a two's-complement bit count.
 #[inline]
-pub(crate) const fn bit_len(a: &[u64]) -> u32 {
-    let mut i = a.len();
+pub(crate) const fn bit_len(limbs: &[u64]) -> u32 {
+    let mut i = limbs.len();
     while i > 0 {
         i -= 1;
-        if a[i] != 0 {
-            return (i as u32) * 64 + (64 - a[i].leading_zeros());
+        if limbs[i] != 0 {
+            return (i as u32) * 64 + (64 - limbs[i].leading_zeros());
         }
     }
     0
 }
 
 /// Fixed-width specialisation of [`bit_len`]: significant bits of the
-/// non-negative magnitude held in `a` (`0` for zero).
+/// non-negative magnitude held in `limbs` (`0` for zero).
 #[inline]
-pub(crate) const fn bit_len_fixed<const L: usize>(a: &[u64; L]) -> u32 {
+pub(crate) const fn bit_len_fixed<const L: usize>(limbs: &[u64; L]) -> u32 {
     let mut i = L;
     while i > 0 {
         i -= 1;
-        if a[i] != 0 {
-            return (i as u32) * 64 + (64 - a[i].leading_zeros());
+        if limbs[i] != 0 {
+            return (i as u32) * 64 + (64 - limbs[i].leading_zeros());
         }
     }
     0
 }
 
-/// `a += b`, returns carry out. `a.len() >= b.len()`.
+/// `lhs += rhs`, returns carry out. `lhs.len() >= rhs.len()`.
 #[inline]
-pub(crate) const fn add_assign(a: &mut [u64], b: &[u64]) -> bool {
+pub(crate) const fn add_assign(lhs: &mut [u64], rhs: &[u64]) -> bool {
     let mut carry: u64 = 0;
     let mut i = 0;
-    while i < a.len() {
-        let bv = if i < b.len() { b[i] } else { 0 };
-        let (s1, c1) = a[i].overflowing_add(bv);
-        let (s2, c2) = s1.overflowing_add(carry);
-        a[i] = s2;
-        carry = (c1 as u64) + (c2 as u64);
+    while i < lhs.len() {
+        let rhs_limb = if i < rhs.len() { rhs[i] } else { 0 };
+        let (sum1, carry1) = lhs[i].overflowing_add(rhs_limb);
+        let (sum2, carry2) = sum1.overflowing_add(carry);
+        lhs[i] = sum2;
+        carry = (carry1 as u64) + (carry2 as u64);
         i += 1;
     }
     carry != 0
@@ -231,30 +231,30 @@ pub(crate) const fn add_assign(a: &mut [u64], b: &[u64]) -> bool {
 /// Fixed-width specialisation of [`add_assign`] — both operands the same
 /// `L`.
 #[inline]
-pub(crate) const fn add_assign_fixed<const L: usize>(a: &mut [u64; L], b: &[u64; L]) -> bool {
+pub(crate) const fn add_assign_fixed<const L: usize>(lhs: &mut [u64; L], rhs: &[u64; L]) -> bool {
     let mut carry: u64 = 0;
     let mut i = 0;
     while i < L {
-        let (s1, c1) = a[i].overflowing_add(b[i]);
-        let (s2, c2) = s1.overflowing_add(carry);
-        a[i] = s2;
-        carry = (c1 as u64) + (c2 as u64);
+        let (sum1, carry1) = lhs[i].overflowing_add(rhs[i]);
+        let (sum2, carry2) = sum1.overflowing_add(carry);
+        lhs[i] = sum2;
+        carry = (carry1 as u64) + (carry2 as u64);
         i += 1;
     }
     carry != 0
 }
 
-/// `a -= b`, returns borrow out. `a.len() >= b.len()`.
+/// `lhs -= rhs`, returns borrow out. `lhs.len() >= rhs.len()`.
 #[inline]
-pub(crate) const fn sub_assign(a: &mut [u64], b: &[u64]) -> bool {
+pub(crate) const fn sub_assign(lhs: &mut [u64], rhs: &[u64]) -> bool {
     let mut borrow: u64 = 0;
     let mut i = 0;
-    while i < a.len() {
-        let bv = if i < b.len() { b[i] } else { 0 };
-        let (d1, b1) = a[i].overflowing_sub(bv);
-        let (d2, b2) = d1.overflowing_sub(borrow);
-        a[i] = d2;
-        borrow = (b1 as u64) + (b2 as u64);
+    while i < lhs.len() {
+        let rhs_limb = if i < rhs.len() { rhs[i] } else { 0 };
+        let (diff1, borrow1) = lhs[i].overflowing_sub(rhs_limb);
+        let (diff2, borrow2) = diff1.overflowing_sub(borrow);
+        lhs[i] = diff2;
+        borrow = (borrow1 as u64) + (borrow2 as u64);
         i += 1;
     }
     borrow != 0
@@ -262,14 +262,14 @@ pub(crate) const fn sub_assign(a: &mut [u64], b: &[u64]) -> bool {
 
 /// Fixed-width specialisation of [`sub_assign`].
 #[inline]
-pub(crate) const fn sub_assign_fixed<const L: usize>(a: &mut [u64; L], b: &[u64; L]) -> bool {
+pub(crate) const fn sub_assign_fixed<const L: usize>(lhs: &mut [u64; L], rhs: &[u64; L]) -> bool {
     let mut borrow: u64 = 0;
     let mut i = 0;
     while i < L {
-        let (d1, b1) = a[i].overflowing_sub(b[i]);
-        let (d2, b2) = d1.overflowing_sub(borrow);
-        a[i] = d2;
-        borrow = (b1 as u64) + (b2 as u64);
+        let (diff1, borrow1) = lhs[i].overflowing_sub(rhs[i]);
+        let (diff2, borrow2) = diff1.overflowing_sub(borrow);
+        lhs[i] = diff2;
+        borrow = (borrow1 as u64) + (borrow2 as u64);
         i += 1;
     }
     borrow != 0
@@ -278,24 +278,24 @@ pub(crate) const fn sub_assign_fixed<const L: usize>(a: &mut [u64; L], b: &[u64;
 /// Fixed-width specialisation of [`shl`]. `L` const, but `shift` is still
 /// runtime — bounds checks vanish, the inner loop trip count is known.
 #[inline]
-pub(crate) const fn shl_fixed<const L: usize>(a: &[u64; L], shift: u32, out: &mut [u64; L]) {
+pub(crate) const fn shl_fixed<const L: usize>(limbs: &[u64; L], shift: u32, out: &mut [u64; L]) {
     let mut z = 0;
     while z < L {
         out[z] = 0;
         z += 1;
     }
     let limb_shift = (shift / 64) as usize;
-    let bit = shift % 64;
+    let bit_shift = shift % 64;
     let mut i = 0;
     while i < L {
         let dst = i + limb_shift;
         if dst < L {
-            if bit == 0 {
-                out[dst] |= a[i];
+            if bit_shift == 0 {
+                out[dst] |= limbs[i];
             } else {
-                out[dst] |= a[i] << bit;
+                out[dst] |= limbs[i] << bit_shift;
                 if dst + 1 < L {
-                    out[dst + 1] |= a[i] >> (64 - bit);
+                    out[dst + 1] |= limbs[i] >> (64 - bit_shift);
                 }
             }
         }
@@ -305,24 +305,24 @@ pub(crate) const fn shl_fixed<const L: usize>(a: &[u64; L], shift: u32, out: &mu
 
 /// Fixed-width specialisation of [`shr`].
 #[inline]
-pub(crate) const fn shr_fixed<const L: usize>(a: &[u64; L], shift: u32, out: &mut [u64; L]) {
+pub(crate) const fn shr_fixed<const L: usize>(limbs: &[u64; L], shift: u32, out: &mut [u64; L]) {
     let mut z = 0;
     while z < L {
         out[z] = 0;
         z += 1;
     }
     let limb_shift = (shift / 64) as usize;
-    let bit = shift % 64;
+    let bit_shift = shift % 64;
     let mut i = limb_shift;
     while i < L {
         let dst = i - limb_shift;
         if dst < L {
-            if bit == 0 {
-                out[dst] |= a[i];
+            if bit_shift == 0 {
+                out[dst] |= limbs[i];
             } else {
-                out[dst] |= a[i] >> bit;
+                out[dst] |= limbs[i] >> bit_shift;
                 if dst >= 1 {
-                    out[dst - 1] |= a[i] << (64 - bit);
+                    out[dst - 1] |= limbs[i] << (64 - bit_shift);
                 }
             }
         }
@@ -330,25 +330,25 @@ pub(crate) const fn shr_fixed<const L: usize>(a: &[u64; L], shift: u32, out: &mu
     }
 }
 
-/// `out = a << shift`. `out` is zeroed then filled.
-pub(crate) const fn shl(a: &[u64], shift: u32, out: &mut [u64]) {
+/// `out = limbs << shift`. `out` is zeroed then filled.
+pub(crate) const fn shl(limbs: &[u64], shift: u32, out: &mut [u64]) {
     let mut z = 0;
     while z < out.len() {
         out[z] = 0;
         z += 1;
     }
     let limb_shift = (shift / 64) as usize;
-    let bit = shift % 64;
+    let bit_shift = shift % 64;
     let mut i = 0;
-    while i < a.len() {
+    while i < limbs.len() {
         let dst = i + limb_shift;
         if dst < out.len() {
-            if bit == 0 {
-                out[dst] |= a[i];
+            if bit_shift == 0 {
+                out[dst] |= limbs[i];
             } else {
-                out[dst] |= a[i] << bit;
+                out[dst] |= limbs[i] << bit_shift;
                 if dst + 1 < out.len() {
-                    out[dst + 1] |= a[i] >> (64 - bit);
+                    out[dst + 1] |= limbs[i] >> (64 - bit_shift);
                 }
             }
         }
@@ -356,25 +356,25 @@ pub(crate) const fn shl(a: &[u64], shift: u32, out: &mut [u64]) {
     }
 }
 
-/// `out = a >> shift`. `out` is zeroed then filled.
-pub(crate) const fn shr(a: &[u64], shift: u32, out: &mut [u64]) {
+/// `out = limbs >> shift`. `out` is zeroed then filled.
+pub(crate) const fn shr(limbs: &[u64], shift: u32, out: &mut [u64]) {
     let mut z = 0;
     while z < out.len() {
         out[z] = 0;
         z += 1;
     }
     let limb_shift = (shift / 64) as usize;
-    let bit = shift % 64;
+    let bit_shift = shift % 64;
     let mut i = limb_shift;
-    while i < a.len() {
+    while i < limbs.len() {
         let dst = i - limb_shift;
         if dst < out.len() {
-            if bit == 0 {
-                out[dst] |= a[i];
+            if bit_shift == 0 {
+                out[dst] |= limbs[i];
             } else {
-                out[dst] |= a[i] >> bit;
+                out[dst] |= limbs[i] >> bit_shift;
                 if dst >= 1 {
-                    out[dst - 1] |= a[i] << (64 - bit);
+                    out[dst - 1] |= limbs[i] << (64 - bit_shift);
                 }
             }
         }
@@ -384,12 +384,12 @@ pub(crate) const fn shr(a: &[u64], shift: u32, out: &mut [u64]) {
 
 /// Single-bit left shift in place; returns the bit shifted out.
 #[inline]
-pub(crate) const fn shl1(a: &mut [u64]) -> u64 {
+pub(crate) const fn shl1(limbs: &mut [u64]) -> u64 {
     let mut carry: u64 = 0;
     let mut i = 0;
-    while i < a.len() {
-        let new_carry = a[i] >> 63;
-        a[i] = (a[i] << 1) | carry;
+    while i < limbs.len() {
+        let new_carry = limbs[i] >> 63;
+        limbs[i] = (limbs[i] << 1) | carry;
         carry = new_carry;
         i += 1;
     }
@@ -398,19 +398,20 @@ pub(crate) const fn shl1(a: &mut [u64]) -> u64 {
 
 /// `true` if every limb above index 0 is zero — fits a single u64.
 #[inline]
-pub(crate) const fn fit_one(a: &[u64]) -> bool {
-    fit_k(a, 1)
+pub(crate) const fn fit_one(limbs: &[u64]) -> bool {
+    fit_k(limbs, 1)
 }
 
-/// `true` if every limb at or above index `k` is zero — i.e. the magnitude
-/// fits `k` u64 limbs (`< 2^(64·k)`). A slice shorter than `k` trivially
-/// fits. Generalises [`fit_one`] (`fit_k(a, 1)`); `fit_k(a, 2)` is the
-/// "`< 2^128`" gate the u128/u256 fast paths key on.
+/// `true` if every limb at or above index `limb_count` is zero — i.e. the
+/// magnitude fits `limb_count` u64 limbs (`< 2^(64·limb_count)`). A slice
+/// shorter than `limb_count` trivially fits. Generalises [`fit_one`]
+/// (`fit_k(limbs, 1)`); `fit_k(limbs, 2)` is the "`< 2^128`" gate the
+/// u128/u256 fast paths key on.
 #[inline]
-pub(crate) const fn fit_k(a: &[u64], k: usize) -> bool {
-    let mut i = k;
-    while i < a.len() {
-        if a[i] != 0 {
+pub(crate) const fn fit_k(limbs: &[u64], limb_count: usize) -> bool {
+    let mut i = limb_count;
+    while i < limbs.len() {
+        if limbs[i] != 0 {
             return false;
         }
         i += 1;
@@ -420,10 +421,11 @@ pub(crate) const fn fit_k(a: &[u64], k: usize) -> bool {
 
 /// Signed three-way compare for u64-limb magnitudes with signs.
 #[inline]
-pub(crate) const fn scmp(a_neg: bool, a: &[u64], b_neg: bool, b: &[u64]) -> i32 {
-    match (a_neg, b_neg) {
+pub(crate) const fn scmp(lhs_is_negative: bool, lhs: &[u64], rhs_is_negative: bool,
+    rhs: &[u64]) -> i32 {
+    match (lhs_is_negative, rhs_is_negative) {
         (true, false) => -1,
         (false, true) => 1,
-        _ => cmp(a, b),
+        _ => cmp(lhs, rhs),
     }
 }

--- a/src/int/convert.rs
+++ b/src/int/convert.rs
@@ -32,29 +32,36 @@ use crate::int::types::BigInt;
 use crate::support::error::ConvertError;
 use crate::support::rounding::{should_bump, RoundingMode};
 
-/// Rescales a [`BigInt`] magnitude from scale `s_from` to scale `s_to`
-/// at its own width, applying `mode` to any scale-down rounding.
+/// Rescales a [`BigInt`] magnitude from scale `source_scale` to scale
+/// `target_scale` at its own width, applying `mode` to any scale-down
+/// rounding.
 ///
-/// - `s_to == s_from`: returns `value` unchanged.
-/// - `s_to > s_from` (scale-up): multiplies by `10^(s_to - s_from)`;
-///   returns `None` if that overflows `T`'s range (the caller maps this
-///   to [`ConvertError::Overflow`]).
-/// - `s_to < s_from` (scale-down): divides by `10^(s_from - s_to)` and
-///   rounds per `mode`; always `Some` (the magnitude only shrinks).
+/// - `target_scale == source_scale`: returns `value` unchanged.
+/// - `target_scale > source_scale` (scale-up): multiplies by
+///   `10^(target_scale - source_scale)`; returns `None` if that overflows
+///   `T`'s range (the caller maps this to [`ConvertError::Overflow`]).
+/// - `target_scale < source_scale` (scale-down): divides by
+///   `10^(source_scale - target_scale)` and rounds per `mode`; always
+///   `Some` (the magnitude only shrinks).
 #[inline]
-pub(crate) fn rescale_bigint<T: BigInt>(value: T, s_from: u32, s_to: u32, mode: RoundingMode) -> Option<T> {
-    if s_to == s_from {
+pub(crate) fn rescale_bigint<T: BigInt>(
+    value: T,
+    source_scale: u32,
+    target_scale: u32,
+    mode: RoundingMode
+) -> Option<T> {
+    if target_scale == source_scale {
         return Some(value);
     }
-    if s_to > s_from {
-        let shift = s_to - s_from;
+    if target_scale > source_scale {
+        let shift = target_scale - source_scale;
         let multiplier = T::TEN.checked_pow(shift)?;
         return value.checked_mul(multiplier);
     }
     // Scale-down: divide by 10^shift with rounding.
-    let shift = s_from - s_to;
+    let shift = source_scale - target_scale;
     let divisor = match T::TEN.checked_pow(shift) {
-        Some(d) => d,
+        Some(power_of_ten) => power_of_ten,
         // 10^shift exceeds T's range: every in-range magnitude is
         // strictly smaller than the divisor, so the truncated quotient
         // is 0 and the remainder is the whole value. Round 0 per mode.
@@ -64,14 +71,14 @@ pub(crate) fn rescale_bigint<T: BigInt>(value: T, s_from: u32, s_to: u32, mode: 
     if remainder == T::ZERO {
         return Some(quotient);
     }
-    let abs_rem = magnitude(remainder);
-    let abs_div = magnitude(divisor);
-    // `cmp_r`: |r| vs |divisor| - |r|, i.e. the round-up boundary
+    let abs_remainder = magnitude(remainder);
+    let abs_divisor = magnitude(divisor);
+    // `remainder_cmp`: |r| vs |divisor| - |r|, i.e. the round-up boundary
     // `2|r| vs |divisor|` without the doubling-overflow risk.
-    let cmp_r = abs_rem.cmp(&(abs_div - abs_rem));
-    let q_is_odd = quotient.bit(0);
+    let remainder_cmp = abs_remainder.cmp(&(abs_divisor - abs_remainder));
+    let quotient_is_odd = quotient.bit(0);
     let result_positive = (value < T::ZERO) == (divisor < T::ZERO);
-    if should_bump(mode, cmp_r, q_is_odd, result_positive) {
+    if should_bump(mode, remainder_cmp, quotient_is_odd, result_positive) {
         if result_positive {
             Some(quotient + T::ONE)
         } else {
@@ -103,11 +110,11 @@ fn round_when_quotient_zero<T: BigInt>(value: T, mode: RoundingMode) -> T {
         return T::ZERO;
     }
     let result_positive = value > T::ZERO;
-    // `cmp_r == Less`: |r| is strictly below the half boundary because
-    // the divisor strictly exceeds |value|.
-    let cmp_r = core::cmp::Ordering::Less;
+    // `remainder_cmp == Less`: |r| is strictly below the half boundary
+    // because the divisor strictly exceeds |value|.
+    let remainder_cmp = core::cmp::Ordering::Less;
     // Truncated quotient is 0 (even).
-    if should_bump(mode, cmp_r, false, result_positive) {
+    if should_bump(mode, remainder_cmp, false, result_positive) {
         if result_positive {
             T::ONE
         } else {
@@ -118,9 +125,9 @@ fn round_when_quotient_zero<T: BigInt>(value: T, mode: RoundingMode) -> T {
     }
 }
 
-/// Converts a source magnitude `src` (scale `s_from`, width `Src`) to
-/// the target magnitude type `Dst` at scale `s_to`, rounding any
-/// scale-down per `mode`.
+/// Converts a source magnitude `source` (scale `source_scale`, width
+/// `Src`) to the target magnitude type `Dst` at scale `target_scale`,
+/// rounding any scale-down per `mode`.
 ///
 /// The width-comparison branch uses only `Src::LIMBS` / `Dst::LIMBS`
 /// (concrete `const usize` on each storage) — no computed-width
@@ -132,9 +139,9 @@ fn round_when_quotient_zero<T: BigInt>(value: T, mode: RoundingMode) -> T {
 /// working storage, or when the rescaled magnitude does not fit `Dst`.
 #[inline]
 pub(crate) fn convert_magnitude<Src, Dst>(
-    src: Src,
-    s_from: u32,
-    s_to: u32,
+    source: Src,
+    source_scale: u32,
+    target_scale: u32,
     mode: RoundingMode,
 ) -> Result<Dst, ConvertError>
 where
@@ -146,20 +153,21 @@ where
         // since `Dst`'s range covers `Src`'s), then rescale at the wider
         // (target) width so a legitimate scale-up cannot spuriously
         // overflow the narrower source storage.
-        let widened: Dst = src.resize_to::<Dst>();
-        rescale_bigint(widened, s_from, s_to, mode).ok_or(ConvertError::Overflow)
+        let widened: Dst = source.resize_to::<Dst>();
+        rescale_bigint(widened, source_scale, target_scale, mode).ok_or(ConvertError::Overflow)
     } else {
         // Narrow: rescale at the source (wider) width first — scale-down
         // only shrinks, and a scale-up that overflows the source is a
         // genuine error — then narrow the magnitude into `Dst`.
-        let rescaled: Src = rescale_bigint(src, s_from, s_to, mode).ok_or(ConvertError::Overflow)?;
+        let rescaled: Src = rescale_bigint(source, source_scale, target_scale, mode)
+            .ok_or(ConvertError::Overflow)?;
         // Fallible signed narrow via round-trip: resize down, then back
         // up, and require bit-equality. `resize_to` is the canonical
         // magnitude/sign-preserving width cast on the `BigInt` surface,
         // so a round-trip mismatch means the value did not fit `Dst`.
         let narrowed: Dst = rescaled.resize_to::<Dst>();
-        let back: Src = narrowed.resize_to::<Src>();
-        if back == rescaled {
+        let round_trip: Src = narrowed.resize_to::<Src>();
+        if round_trip == rescaled {
             Ok(narrowed)
         } else {
             Err(ConvertError::Overflow)

--- a/src/int/policy/add.rs
+++ b/src/int/policy/add.rs
@@ -93,16 +93,16 @@ const fn select<const N: usize>() -> Select<N> {
 /// returns the default algorithm tag without invoking the fn pointer,
 /// satisfying the `const fn` constraint.
 #[inline]
-pub(crate) const fn dispatch<const N: usize>(a: Int<N>, b: Int<N>) -> Int<N> {
+pub(crate) const fn dispatch<const N: usize>(lhs: Int<N>, rhs: Int<N>) -> Int<N> {
     let algo = match const { select::<N>() } {
-        Select::ByAlgorithm(a) => a,
+        Select::ByAlgorithm(algorithm) => algorithm,
         // add is always ByAlgorithm; fall through to the default if
         // the arm is reached (fn pointer calls are not allowed in const fn).
         Select::ByValue(_) => Algorithm::RippleCarry,
     };
     match algo {
-        Algorithm::RippleCarry => add_ripple_carry(a, b),
-        Algorithm::Schoolbook => add_ripple_carry(a, b),
+        Algorithm::RippleCarry => add_ripple_carry(lhs, rhs),
+        Algorithm::Schoolbook => add_ripple_carry(lhs, rhs),
     }
 }
 
@@ -114,14 +114,14 @@ pub(crate) const fn dispatch<const N: usize>(a: Int<N>, b: Int<N>) -> Int<N> {
 /// `wrapping_add`-then-sign-check shape it replaces measured ≈2× the
 /// bare loop at 24 limbs in by-value moves between the layers.
 #[inline]
-pub(crate) const fn dispatch_checked<const N: usize>(a: Int<N>, b: Int<N>) -> Option<Int<N>> {
+pub(crate) const fn dispatch_checked<const N: usize>(lhs: Int<N>, rhs: Int<N>) -> Option<Int<N>> {
     let algo = match const { select::<N>() } {
-        Select::ByAlgorithm(a) => a,
+        Select::ByAlgorithm(algorithm) => algorithm,
         Select::ByValue(_) => Algorithm::RippleCarry,
     };
     match algo {
         Algorithm::RippleCarry | Algorithm::Schoolbook => {
-            crate::int::algos::add::add_ripple_carry::add_ripple_carry_checked(a, b)
+            crate::int::algos::add::add_ripple_carry::add_ripple_carry_checked(lhs, rhs)
         }
     }
 }

--- a/src/int/policy/cmp.rs
+++ b/src/int/policy/cmp.rs
@@ -112,15 +112,15 @@ const fn select<const N: usize>() -> Select<N> {
 /// returns the default algorithm tag without invoking the fn pointer,
 /// satisfying the `const fn` constraint.
 #[inline]
-pub(crate) const fn dispatch<const N: usize>(a: Int<N>, b: Int<N>) -> Ordering {
+pub(crate) const fn dispatch<const N: usize>(lhs: Int<N>, rhs: Int<N>) -> Ordering {
     let algo = match const { select::<N>() } {
-        Select::ByAlgorithm(a) => a,
+        Select::ByAlgorithm(algorithm) => algorithm,
         // cmp is always ByAlgorithm; fall through to the default if
         // the arm is reached (fn pointer calls are not allowed in const fn).
         Select::ByValue(_) => Algorithm::Limbwise,
     };
     match algo {
-        Algorithm::Limbwise => cmp_limbwise(a, b),
-        Algorithm::Schoolbook => cmp_limbwise(a, b),
+        Algorithm::Limbwise => cmp_limbwise(lhs, rhs),
+        Algorithm::Schoolbook => cmp_limbwise(lhs, rhs),
     }
 }

--- a/src/int/policy/cube.rs
+++ b/src/int/policy/cube.rs
@@ -125,15 +125,15 @@ const fn select<const N: usize>() -> Select<N> {
 /// `ByValue` arm returns the default algorithm tag without invoking the fn
 /// pointer, satisfying the `const fn` constraint.
 #[inline]
-pub(crate) const fn dispatch<const N: usize>(x: Uint<N>) -> Uint<N> {
+pub(crate) const fn dispatch<const N: usize>(value: Uint<N>) -> Uint<N> {
     let algo = match const { select::<N>() } {
-        Select::ByAlgorithm(a) => a,
+        Select::ByAlgorithm(algorithm) => algorithm,
         // cube is always ByAlgorithm; fall through to the default if the
         // arm is reached (fn pointer calls are not allowed in const fn).
         Select::ByValue(_) => Algorithm::Schoolbook,
     };
     match algo {
-        Algorithm::Schoolbook => cube_schoolbook(x),
-        Algorithm::Comba => cube_fused_comba(x),
+        Algorithm::Schoolbook => cube_schoolbook(value),
+        Algorithm::Comba => cube_fused_comba(value),
     }
 }

--- a/src/int/policy/div_rem.rs
+++ b/src/int/policy/div_rem.rs
@@ -246,11 +246,11 @@ pub(crate) fn select_for_limbs(num: &[u64], den: &[u64]) -> Algorithm {
 /// slice.
 #[inline]
 fn effective_limbs(limbs: &[u64]) -> usize {
-    let mut n = limbs.len();
-    while n > 0 && limbs[n - 1] == 0 {
-        n -= 1;
+    let mut count = limbs.len();
+    while count > 0 && limbs[count - 1] == 0 {
+        count -= 1;
     }
-    n
+    count
 }
 
 // ── 4. the dispatcher: fold `select<N>`, run the selector, route ──────
@@ -271,7 +271,7 @@ fn effective_limbs(limbs: &[u64]) -> usize {
 /// family and calls the chosen engine's `*_into` variant.
 pub(crate) fn dispatch(num: &[u64], den: &[u64], quot: &mut [u64], rem: &mut [u64]) {
     let algo = match const { select() } {
-        Select::ByAlgorithm(fixed) => fixed,
+        Select::ByAlgorithm(algorithm) => algorithm,
         Select::ByShape(selector) => selector(num, den),
     };
     match algo {

--- a/src/int/policy/eq.rs
+++ b/src/int/policy/eq.rs
@@ -104,15 +104,15 @@ const fn select<const N: usize>() -> Select<N> {
 /// returns the default algorithm tag without invoking the fn pointer,
 /// satisfying the `const fn` constraint.
 #[inline]
-pub(crate) const fn dispatch<const N: usize>(a: Int<N>, b: Int<N>) -> bool {
+pub(crate) const fn dispatch<const N: usize>(lhs: Int<N>, rhs: Int<N>) -> bool {
     let algo = match const { select::<N>() } {
-        Select::ByAlgorithm(a) => a,
+        Select::ByAlgorithm(algorithm) => algorithm,
         // eq is always ByAlgorithm; fall through to the default if
         // the arm is reached (fn pointer calls are not allowed in const fn).
         Select::ByValue(_) => Algorithm::Limbwise,
     };
     match algo {
-        Algorithm::Limbwise => eq_limbwise(a, b),
-        Algorithm::Schoolbook => eq_limbwise(a, b),
+        Algorithm::Limbwise => eq_limbwise(lhs, rhs),
+        Algorithm::Schoolbook => eq_limbwise(lhs, rhs),
     }
 }

--- a/src/int/policy/hypot.rs
+++ b/src/int/policy/hypot.rs
@@ -124,16 +124,20 @@ const fn select<const N: usize>() -> Select<N> {
 /// sign drops out).
 #[inline]
 #[must_use]
-pub(crate) fn dispatch<const N: usize>(a: Int<N>, b: Int<N>, mode: RoundingMode) -> Option<Int<N>>
+pub(crate) fn dispatch<const N: usize>(
+    lhs: Int<N>,
+    rhs: Int<N>,
+    mode: RoundingMode
+) -> Option<Int<N>>
 where
     Limbs<N>: ComputeLimbs,
 {
     let algo = match const { select::<N>() } {
-        Select::ByAlgorithm(a) => a,
-        Select::ByValue(f) => f(&a),
+        Select::ByAlgorithm(algorithm) => algorithm,
+        Select::ByValue(choose) => choose(&lhs),
     };
     match algo {
-        Algorithm::Pythagoras => hypot_pythagoras::<N>(a, b, mode),
-        Algorithm::U128Fast => hypot_u128_fast::<N>(a, b, mode),
+        Algorithm::Pythagoras => hypot_pythagoras::<N>(lhs, rhs, mode),
+        Algorithm::U128Fast => hypot_u128_fast::<N>(lhs, rhs, mode),
     }
 }

--- a/src/int/policy/icbrt.rs
+++ b/src/int/policy/icbrt.rs
@@ -101,9 +101,9 @@ const fn select<const N: usize>() -> Select<N> {
 /// terminates in a handful of iterations; there is no distinct hardware
 /// cube-root path, so this one kernel is the icbrt for all widths.
 #[inline]
-pub(crate) fn icbrt_newton<const N: usize>(x: Uint<N>) -> Uint<N> {
+pub(crate) fn icbrt_newton<const N: usize>(radicand: Uint<N>) -> Uint<N> {
     let mut out = [0u64; N];
-    icbrt_newton_kernel(x.as_limbs(), &mut out);
+    icbrt_newton_kernel(radicand.as_limbs(), &mut out);
     Uint::<N>::from_limbs(out)
 }
 
@@ -115,9 +115,9 @@ pub(crate) fn icbrt_newton<const N: usize>(x: Uint<N>) -> Uint<N> {
 /// Serves any `N` as a generic reference baseline.
 #[allow(dead_code)]
 #[inline]
-pub(crate) fn icbrt_schoolbook_policy<const N: usize>(x: Uint<N>) -> Uint<N> {
+pub(crate) fn icbrt_schoolbook_policy<const N: usize>(radicand: Uint<N>) -> Uint<N> {
     let mut out = [0u64; N];
-    icbrt_schoolbook_kernel(x.as_limbs(), &mut out);
+    icbrt_schoolbook_kernel(radicand.as_limbs(), &mut out);
     Uint::<N>::from_limbs(out)
 }
 
@@ -133,13 +133,13 @@ pub(crate) fn icbrt_schoolbook_policy<const N: usize>(x: Uint<N>) -> Uint<N> {
 /// [`crate::int::algos::icbrt::icbrt_newton::icbrt_newton`] (Newton iteration, not
 /// const-evaluable).
 #[inline]
-pub(crate) fn dispatch<const N: usize>(x: Uint<N>) -> Uint<N> {
+pub(crate) fn dispatch<const N: usize>(radicand: Uint<N>) -> Uint<N> {
     let algo = match const { select::<N>() } {
-        Select::ByAlgorithm(a) => a,
-        Select::ByValue(f) => f(&x),
+        Select::ByAlgorithm(algorithm) => algorithm,
+        Select::ByValue(choose) => choose(&radicand),
     };
     match algo {
-        Algorithm::Newton => icbrt_newton::<N>(x),
-        Algorithm::Schoolbook => icbrt_schoolbook_policy::<N>(x),
+        Algorithm::Newton => icbrt_newton::<N>(radicand),
+        Algorithm::Schoolbook => icbrt_schoolbook_policy::<N>(radicand),
     }
 }

--- a/src/int/policy/isqrt.rs
+++ b/src/int/policy/isqrt.rs
@@ -115,9 +115,9 @@ const fn select<const N: usize>() -> Select<N> {
 /// `N == 1` → `u64::isqrt`, `N == 2` → `u128::isqrt`. Both are single
 /// hardware instructions on modern ISAs.
 #[inline]
-pub(crate) fn isqrt_native<const N: usize>(x: Uint<N>) -> Uint<N> {
+pub(crate) fn isqrt_native<const N: usize>(radicand: Uint<N>) -> Uint<N> {
     let mut out = [0u64; N];
-    isqrt_mag_fixed::<N>(x.as_limbs(), &mut out);
+    isqrt_mag_fixed::<N>(radicand.as_limbs(), &mut out);
     Uint::<N>::from_limbs(out)
 }
 
@@ -127,9 +127,9 @@ pub(crate) fn isqrt_native<const N: usize>(x: Uint<N>) -> Uint<N> {
 /// [`crate::int::algos::isqrt::isqrt_newton::isqrt_newton`] for `N >= 3`: Newton
 /// iteration with a hardware-`f64::sqrt` seed over the u64 limbs.
 #[inline]
-pub(crate) fn isqrt_newton<const N: usize>(x: Uint<N>) -> Uint<N> {
+pub(crate) fn isqrt_newton<const N: usize>(radicand: Uint<N>) -> Uint<N> {
     let mut out = [0u64; N];
-    isqrt_mag_fixed::<N>(x.as_limbs(), &mut out);
+    isqrt_mag_fixed::<N>(radicand.as_limbs(), &mut out);
     Uint::<N>::from_limbs(out)
 }
 
@@ -142,9 +142,9 @@ pub(crate) fn isqrt_newton<const N: usize>(x: Uint<N>) -> Uint<N> {
 /// shows it wins at `N == 64` where Newton's full-width-divide-per-iteration
 /// cost finally dominates.
 #[inline]
-pub(crate) fn isqrt_karatsuba<const N: usize>(x: Uint<N>) -> Uint<N> {
+pub(crate) fn isqrt_karatsuba<const N: usize>(radicand: Uint<N>) -> Uint<N> {
     let mut out = [0u64; N];
-    isqrt_karatsuba_kernel(x.as_limbs(), &mut out);
+    isqrt_karatsuba_kernel(radicand.as_limbs(), &mut out);
     Uint::<N>::from_limbs(out)
 }
 
@@ -156,9 +156,9 @@ pub(crate) fn isqrt_karatsuba<const N: usize>(x: Uint<N>) -> Uint<N> {
 /// Serves any `N` as a generic reference baseline.
 #[allow(dead_code)]
 #[inline]
-pub(crate) fn isqrt_schoolbook_policy<const N: usize>(x: Uint<N>) -> Uint<N> {
+pub(crate) fn isqrt_schoolbook_policy<const N: usize>(radicand: Uint<N>) -> Uint<N> {
     let mut out = [0u64; N];
-    isqrt_schoolbook_kernel(x.as_limbs(), &mut out);
+    isqrt_schoolbook_kernel(radicand.as_limbs(), &mut out);
     Uint::<N>::from_limbs(out)
 }
 // ── 4. the dispatcher: fold the verdict, then dispatch ────────────────
@@ -173,15 +173,15 @@ pub(crate) fn isqrt_schoolbook_policy<const N: usize>(x: Uint<N>) -> Uint<N> {
 /// [`crate::int::algos::isqrt::isqrt_newton::isqrt_newton`] (Newton iteration, not
 /// const-evaluable).
 #[inline]
-pub(crate) fn dispatch<const N: usize>(x: Uint<N>) -> Uint<N> {
+pub(crate) fn dispatch<const N: usize>(radicand: Uint<N>) -> Uint<N> {
     let algo = match const { select::<N>() } {
-        Select::ByAlgorithm(a) => a,
-        Select::ByValue(f) => f(&x),
+        Select::ByAlgorithm(algorithm) => algorithm,
+        Select::ByValue(choose) => choose(&radicand),
     };
     match algo {
-        Algorithm::Native => isqrt_native::<N>(x),
-        Algorithm::Newton => isqrt_newton::<N>(x),
-        Algorithm::Karatsuba => isqrt_karatsuba::<N>(x),
-        Algorithm::Schoolbook => isqrt_schoolbook_policy::<N>(x),
+        Algorithm::Native => isqrt_native::<N>(radicand),
+        Algorithm::Newton => isqrt_newton::<N>(radicand),
+        Algorithm::Karatsuba => isqrt_karatsuba::<N>(radicand),
+        Algorithm::Schoolbook => isqrt_schoolbook_policy::<N>(radicand),
     }
 }

--- a/src/int/policy/mul.rs
+++ b/src/int/policy/mul.rs
@@ -180,36 +180,36 @@ const fn select() -> Select {
 /// zero their own accumulators); the result is bit-identical at either limb
 /// width and against the historic slice schoolbook.
 #[inline]
-pub(crate) fn dispatch<const N: usize>(a: &[u64; N], b: &[u64; N], out: &mut [u64])
+pub(crate) fn dispatch<const N: usize>(lhs: &[u64; N], rhs: &[u64; N], out: &mut [u64])
 where
     Limbs<N>: ComputeLimbs,
 {
     // Lengths are both N (equal), so the run-time classifier folds to a
     // const verdict per monomorphisation; resolve its limb width too.
-    let (algo, limb) = {
+    let (algo, limb_size) = {
         let algo = match const { select() } {
-            Select::ByAlgorithm(a) => a,
-            Select::ByShape(f) => f(N, N),
+            Select::ByAlgorithm(algorithm) => algorithm,
+            Select::ByShape(classify) => classify(N, N),
         };
         (algo, algo.limb_size::<N>())
     };
-    match (algo, limb) {
-        (Algorithm::Schoolbook, LimbSize::U64) => mul_full_limb::<N, u64>(a, b, out),
-        (Algorithm::Schoolbook, LimbSize::U128) => mul_full_limb::<N, u128>(a, b, out),
+    match (algo, limb_size) {
+        (Algorithm::Schoolbook, LimbSize::U64) => mul_full_limb::<N, u64>(lhs, rhs, out),
+        (Algorithm::Schoolbook, LimbSize::U128) => mul_full_limb::<N, u128>(lhs, rhs, out),
         // The engaged Karatsuba arm: u128-packed Limb-generic kernel (the
         // swept winner at even N >= ENGAGE), recursing to the schoolbook base
         // at KARATSUBA_RECURSE. Writes `out` in full (the unpack overwrites it).
         (Algorithm::Karatsuba, LimbSize::U128) => {
-            mul_karatsuba_limb::<N, u128>(a, b, out, KARATSUBA_RECURSE)
+            mul_karatsuba_limb::<N, u128>(lhs, rhs, out, KARATSUBA_RECURSE)
         }
         // Unreached (the matcher only engages Karatsuba at even N, which always
         // packs to u128) but kept exhaustive: the u64 slice Karatsuba, zeroing
         // its accumulator first.
         (Algorithm::Karatsuba, LimbSize::U64) => {
-            for o in out.iter_mut() {
-                *o = 0;
+            for limb in out.iter_mut() {
+                *limb = 0;
             }
-            mul_karatsuba(a, b, out, KARATSUBA_RECURSE);
+            mul_karatsuba(lhs, rhs, out, KARATSUBA_RECURSE);
         }
     }
 }
@@ -248,16 +248,16 @@ where
 /// classifier guarantees before it is reached (it only engages Karatsuba for
 /// equal even lengths `>= KARATSUBA_ENGAGE`).
 #[inline]
-pub(crate) fn dispatch_slice(a: &[u64], b: &[u64], out: &mut [u64]) {
+pub(crate) fn dispatch_slice(lhs: &[u64], rhs: &[u64], out: &mut [u64]) {
     // The SAME classifier as the const door, evaluated on the operands' runtime
     // lengths instead of folded on `N`.
     let algo = match const { select() } {
-        Select::ByAlgorithm(alg) => alg,
-        Select::ByShape(classify) => classify(a.len(), b.len()),
+        Select::ByAlgorithm(algorithm) => algorithm,
+        Select::ByShape(classify) => classify(lhs.len(), rhs.len()),
     };
     match algo {
-        Algorithm::Schoolbook => mul_schoolbook(a, b, out),
-        Algorithm::Karatsuba => mul_karatsuba(a, b, out, KARATSUBA_RECURSE),
+        Algorithm::Schoolbook => mul_schoolbook(lhs, rhs, out),
+        Algorithm::Karatsuba => mul_karatsuba(lhs, rhs, out, KARATSUBA_RECURSE),
     }
 }
 
@@ -312,54 +312,54 @@ mod tests {
         ];
 
         let edge_fill = |buf: &mut [u64], kind: usize, next: &mut dyn FnMut() -> u64| match kind {
-            0 => buf.iter_mut().for_each(|x| *x = 0),
-            1 => buf.iter_mut().for_each(|x| *x = u64::MAX),
+            0 => buf.iter_mut().for_each(|limb| *limb = 0),
+            1 => buf.iter_mut().for_each(|limb| *limb = u64::MAX),
             2 => {
-                buf.iter_mut().for_each(|x| *x = 0);
+                buf.iter_mut().for_each(|limb| *limb = 0);
                 if let Some(last) = buf.last_mut() {
                     *last = u64::MAX;
                 }
             }
             3 => {
-                buf.iter_mut().for_each(|x| *x = 0);
+                buf.iter_mut().for_each(|limb| *limb = 0);
                 buf[0] = u64::MAX;
             }
-            _ => buf.iter_mut().for_each(|x| *x = next()),
+            _ => buf.iter_mut().for_each(|limb| *limb = next()),
         };
 
-        for &(la, lb) in SHAPES {
+        for &(lhs_len, rhs_len) in SHAPES {
             let mut pairs: Vec<(Vec<u64>, Vec<u64>)> = Vec::new();
-            for ka in 0..5 {
-                for kb in 0..5 {
-                    let mut a = vec![0u64; la];
-                    let mut b = vec![0u64; lb];
-                    edge_fill(&mut a, ka, &mut next);
-                    edge_fill(&mut b, kb, &mut next);
-                    pairs.push((a, b));
+            for lhs_kind in 0..5 {
+                for rhs_kind in 0..5 {
+                    let mut lhs = vec![0u64; lhs_len];
+                    let mut rhs = vec![0u64; rhs_len];
+                    edge_fill(&mut lhs, lhs_kind, &mut next);
+                    edge_fill(&mut rhs, rhs_kind, &mut next);
+                    pairs.push((lhs, rhs));
                 }
             }
-            let randoms = if la.max(lb) <= 16 { 40 } else { 8 };
+            let randoms = if lhs_len.max(rhs_len) <= 16 { 40 } else { 8 };
             for _ in 0..randoms {
-                let mut a = vec![0u64; la];
-                let mut b = vec![0u64; lb];
-                for x in a.iter_mut() {
-                    *x = next();
+                let mut lhs = vec![0u64; lhs_len];
+                let mut rhs = vec![0u64; rhs_len];
+                for limb in lhs.iter_mut() {
+                    *limb = next();
                 }
-                for x in b.iter_mut() {
-                    *x = next();
+                for limb in rhs.iter_mut() {
+                    *limb = next();
                 }
-                pairs.push((a, b));
+                pairs.push((lhs, rhs));
             }
 
-            for (a, b) in &pairs {
-                // `out` zeroed + sized `a.len() + b.len()` — the door's contract.
-                let mut oracle = vec![0u64; la + lb];
-                mul_schoolbook(a, b, &mut oracle);
-                let mut got = vec![0u64; la + lb];
-                dispatch_slice(a, b, &mut got);
+            for (lhs, rhs) in &pairs {
+                // `out` zeroed + sized `lhs.len() + rhs.len()` — the door's contract.
+                let mut oracle = vec![0u64; lhs_len + rhs_len];
+                mul_schoolbook(lhs, rhs, &mut oracle);
+                let mut got = vec![0u64; lhs_len + rhs_len];
+                dispatch_slice(lhs, rhs, &mut got);
                 assert_eq!(
                     got, oracle,
-                    "dispatch_slice != mul_schoolbook at shape ({la}, {lb})\na={a:?}\nb={b:?}"
+                    "dispatch_slice != mul_schoolbook at shape ({lhs_len}, {rhs_len})\na={lhs:?}\nb={rhs:?}"
                 );
             }
         }

--- a/src/int/policy/mul_low.rs
+++ b/src/int/policy/mul_low.rs
@@ -137,7 +137,7 @@ const fn resolve<const N: usize>() -> (Algorithm, LimbSize) {
 
 // ── 4. the dispatcher: resolve the algorithm, then its limb width ─────
 
-/// Truncated-low product `out = (a · b) mod 2^(64·N)` — the single site
+/// Truncated-low product `out = (lhs · rhs) mod 2^(64·N)` — the single site
 /// [`BigInt::wrapping_mul_low_u128`] flows through. Two-stage verdict: the
 /// algorithm is resolved first, then asked for its own benched limb width
 /// ([`Algorithm::limb_size`]). Both are const here, so the `const { … }`
@@ -149,11 +149,11 @@ const fn resolve<const N: usize>() -> (Algorithm, LimbSize) {
 /// [`BigInt::wrapping_mul_low_u128`]: crate::int::types::traits::BigInt::wrapping_mul_low_u128
 /// [`BigInt::wrapping_mul`]: crate::int::types::traits::BigInt::wrapping_mul
 #[inline]
-pub(crate) fn dispatch<const N: usize>(a: &[u64; N], b: &[u64; N], out: &mut [u64; N]) {
+pub(crate) fn dispatch<const N: usize>(lhs: &[u64; N], rhs: &[u64; N], out: &mut [u64; N]) {
     // Stage 1: resolve the algorithm. Stage 2: ask it for its limb width.
-    let (algo, limb) = const { resolve::<N>() };
-    match (algo, limb) {
-        (Algorithm::LowLimb, LimbSize::U64) => mul_low_limb::<N, u64>(a, b, out),
-        (Algorithm::LowLimb, LimbSize::U128) => mul_low_limb::<N, u128>(a, b, out),
+    let (algo, limb_size) = const { resolve::<N>() };
+    match (algo, limb_size) {
+        (Algorithm::LowLimb, LimbSize::U64) => mul_low_limb::<N, u64>(lhs, rhs, out),
+        (Algorithm::LowLimb, LimbSize::U128) => mul_low_limb::<N, u128>(lhs, rhs, out),
     }
 }

--- a/src/int/policy/neg.rs
+++ b/src/int/policy/neg.rs
@@ -98,15 +98,15 @@ const fn select<const N: usize>() -> Select<N> {
 /// returns the default algorithm tag without invoking the fn pointer,
 /// satisfying the `const fn` constraint.
 #[inline]
-pub(crate) const fn dispatch<const N: usize>(a: Int<N>) -> Int<N> {
+pub(crate) const fn dispatch<const N: usize>(value: Int<N>) -> Int<N> {
     let algo = match const { select::<N>() } {
-        Select::ByAlgorithm(a) => a,
+        Select::ByAlgorithm(algorithm) => algorithm,
         // neg is always ByAlgorithm; fall through to the default if
         // the arm is reached (fn pointer calls are not allowed in const fn).
         Select::ByValue(_) => Algorithm::TwosComplement,
     };
     match algo {
-        Algorithm::TwosComplement => neg_twos_complement(a),
-        Algorithm::Schoolbook => neg_twos_complement(a),
+        Algorithm::TwosComplement => neg_twos_complement(value),
+        Algorithm::Schoolbook => neg_twos_complement(value),
     }
 }

--- a/src/int/policy/pow.rs
+++ b/src/int/policy/pow.rs
@@ -124,7 +124,7 @@ const fn select<const N: usize>() -> Select<N> {
 #[inline]
 pub(crate) const fn dispatch<const N: usize>(base: Uint<N>, exp: u32) -> Uint<N> {
     let algo = match const { select::<N>() } {
-        Select::ByAlgorithm(a) => a,
+        Select::ByAlgorithm(algorithm) => algorithm,
         // pow is always ByAlgorithm; fall through to the default if the
         // arm is reached (fn pointer calls are not allowed in const fn).
         Select::ByValue(_) => Algorithm::SquareAndMultiply,

--- a/src/int/policy/rem.rs
+++ b/src/int/policy/rem.rs
@@ -185,9 +185,9 @@ const fn select<const N: usize>() -> Select<N> {
 /// tag without invoking the fn pointer — no fn pointer call occurs in the
 /// const-select block.
 #[inline]
-pub(crate) fn dispatch<const N: usize>(a: Int<N>, b: Int<N>) -> Int<N> {
+pub(crate) fn dispatch<const N: usize>(dividend: Int<N>, divisor: Int<N>) -> Int<N> {
     let algo = match const { select::<N>() } {
-        Select::ByAlgorithm(a) => a,
+        Select::ByAlgorithm(algorithm) => algorithm,
         // rem is always ByAlgorithm; fall through to the default if
         // the arm is reached (fn pointer calls are not allowed in const fn,
         // but this outer fn is not const so reaching ByValue would be fine
@@ -195,10 +195,10 @@ pub(crate) fn dispatch<const N: usize>(a: Int<N>, b: Int<N>) -> Int<N> {
         Select::ByValue(_) => Algorithm::SmallFast,
     };
     match algo {
-        Algorithm::Native => rem_native(a, b),
-        Algorithm::SmallFast => rem_small_fast(a, b),
-        Algorithm::ViaDivRem => rem_via_div_rem(a, b),
-        Algorithm::Schoolbook => rem_schoolbook(a, b),
+        Algorithm::Native => rem_native(dividend, divisor),
+        Algorithm::SmallFast => rem_small_fast(dividend, divisor),
+        Algorithm::ViaDivRem => rem_via_div_rem(dividend, divisor),
+        Algorithm::Schoolbook => rem_schoolbook(dividend, divisor),
     }
 }
 
@@ -214,7 +214,7 @@ mod tests {
     /// the remainder carries the dividend's sign.
     #[test]
     fn dispatch_matches_truncating_reference_across_boundary() {
-        // (a, b, expected) — small enough to fit i128, hence representable
+        // (dividend, divisor, expected) — small enough to fit i128, hence representable
         // at N=2 and N=3 alike. Covers all four sign combinations and 0.
         let cases: &[(i128, i128, i128)] = &[
             (100, 7, 2),
@@ -226,14 +226,18 @@ mod tests {
             (i128::MAX, 3, i128::MAX % 3),
             (i128::MIN + 1, 3, (i128::MIN + 1) % 3),
         ];
-        for &(a, b, want) in cases {
+        for &(dividend, divisor, want) in cases {
             // N = 2 (native arm).
-            let got2 = dispatch::<2>(Int::<2>::from_i128(a), Int::<2>::from_i128(b));
-            assert_eq!(got2.to_i128(), want, "N=2 native rem({a}, {b})");
+            let got2 = dispatch::<2>(Int::<2>::from_i128(dividend), Int::<2>::from_i128(divisor));
+            assert_eq!(got2.to_i128(), want, "N=2 native rem({dividend}, {divisor})");
             // N = 3 (via-div-rem arm) — same value, wider storage.
-            let got3 = dispatch::<3>(Int::<3>::from_i128(a), Int::<3>::from_i128(b));
-            assert_eq!(got3.to_i128(), want, "N=3 via-div-rem rem({a}, {b})");
-            assert_eq!(got2.to_i128(), got3.to_i128(), "boundary disagreement ({a}, {b})");
+            let got3 = dispatch::<3>(Int::<3>::from_i128(dividend), Int::<3>::from_i128(divisor));
+            assert_eq!(got3.to_i128(), want, "N=3 via-div-rem rem({dividend}, {divisor})");
+            assert_eq!(
+                got2.to_i128(),
+                got3.to_i128(),
+                "boundary disagreement ({dividend}, {divisor})"
+            );
         }
     }
 }

--- a/src/int/policy/sqr.rs
+++ b/src/int/policy/sqr.rs
@@ -165,15 +165,15 @@ const fn select<const N: usize>() -> Select<N> {
 /// returns the default algorithm tag without invoking the fn pointer,
 /// satisfying the `const fn` constraint.
 #[inline]
-pub(crate) const fn dispatch<const N: usize>(x: Uint<N>) -> Uint<N> {
+pub(crate) const fn dispatch<const N: usize>(value: Uint<N>) -> Uint<N> {
     let algo = match const { select::<N>() } {
-        Select::ByAlgorithm(a) => a,
+        Select::ByAlgorithm(algorithm) => algorithm,
         // sqr is always ByAlgorithm; fall through to the default if the
         // arm is reached (fn pointer calls are not allowed in const fn).
         Select::ByValue(_) => Algorithm::HalfProduct,
     };
     match algo {
-        Algorithm::HalfProduct => sqr_half_product(x),
-        Algorithm::Schoolbook => sqr_schoolbook(x),
+        Algorithm::HalfProduct => sqr_half_product(value),
+        Algorithm::Schoolbook => sqr_schoolbook(value),
     }
 }

--- a/src/int/policy/sqr_low.rs
+++ b/src/int/policy/sqr_low.rs
@@ -129,22 +129,23 @@ const fn resolve<const N: usize>() -> (Algorithm, LimbSize) {
 
 // ── 4. the dispatcher: resolve the algorithm, then its limb width ─────
 
-/// Truncated-low square `out = (x²) mod 2^(64·N)` — the single site
+/// Truncated-low square `out = (value²) mod 2^(64·N)` — the single site
 /// [`BigInt::wrapping_sqr_low_u128`] flows through. Two-stage verdict: the
 /// algorithm is resolved first, then asked for its own benched limb width
 /// ([`Algorithm::limb_size`]). Both are const here, so the `const { … }` block
 /// folds them and this compiles to one direct `sqr_low_limb::<N, _>` call per
 /// monomorphisation with the unchosen arm dead-arm eliminated. `out` is written
-/// in full; bit-identical to [`BigInt::wrapping_mul`]`(x, x)` mod `2^(64·N)` at
+/// in full; bit-identical to [`BigInt::wrapping_mul`]`(value, value)` mod
+/// `2^(64·N)` at
 /// either width.
 ///
 /// [`BigInt::wrapping_sqr_low_u128`]: crate::int::types::traits::BigInt::wrapping_sqr_low_u128
 /// [`BigInt::wrapping_mul`]: crate::int::types::traits::BigInt::wrapping_mul
 #[inline]
-pub(crate) fn dispatch<const N: usize>(x: &[u64; N], out: &mut [u64; N]) {
-    let (algo, limb) = const { resolve::<N>() };
-    match (algo, limb) {
-        (Algorithm::LowLimb, LimbSize::U64) => sqr_low_limb::<N, u64>(x, out),
-        (Algorithm::LowLimb, LimbSize::U128) => sqr_low_limb::<N, u128>(x, out),
+pub(crate) fn dispatch<const N: usize>(value: &[u64; N], out: &mut [u64; N]) {
+    let (algo, limb_size) = const { resolve::<N>() };
+    match (algo, limb_size) {
+        (Algorithm::LowLimb, LimbSize::U64) => sqr_low_limb::<N, u64>(value, out),
+        (Algorithm::LowLimb, LimbSize::U128) => sqr_low_limb::<N, u128>(value, out),
     }
 }

--- a/src/int/policy/sub.rs
+++ b/src/int/policy/sub.rs
@@ -96,16 +96,16 @@ const fn select<const N: usize>() -> Select<N> {
 /// returns the default algorithm tag without invoking the fn pointer,
 /// satisfying the `const fn` constraint.
 #[inline]
-pub(crate) const fn dispatch<const N: usize>(a: Int<N>, b: Int<N>) -> Int<N> {
+pub(crate) const fn dispatch<const N: usize>(lhs: Int<N>, rhs: Int<N>) -> Int<N> {
     let algo = match const { select::<N>() } {
-        Select::ByAlgorithm(a) => a,
+        Select::ByAlgorithm(algorithm) => algorithm,
         // sub is always ByAlgorithm; fall through to the default if
         // the arm is reached (fn pointer calls are not allowed in const fn).
         Select::ByValue(_) => Algorithm::RippleBorrow,
     };
     match algo {
-        Algorithm::RippleBorrow => sub_ripple_borrow(a, b),
-        Algorithm::Schoolbook => sub_ripple_borrow(a, b),
+        Algorithm::RippleBorrow => sub_ripple_borrow(lhs, rhs),
+        Algorithm::Schoolbook => sub_ripple_borrow(lhs, rhs),
     }
 }
 
@@ -116,14 +116,14 @@ pub(crate) const fn dispatch<const N: usize>(a: Int<N>, b: Int<N>) -> Int<N> {
 /// panic-on-overflow contract) enters here — the fused-add rationale, see
 /// `int::policy::add::dispatch_checked`.
 #[inline]
-pub(crate) const fn dispatch_checked<const N: usize>(a: Int<N>, b: Int<N>) -> Option<Int<N>> {
+pub(crate) const fn dispatch_checked<const N: usize>(lhs: Int<N>, rhs: Int<N>) -> Option<Int<N>> {
     let algo = match const { select::<N>() } {
-        Select::ByAlgorithm(a) => a,
+        Select::ByAlgorithm(algorithm) => algorithm,
         Select::ByValue(_) => Algorithm::RippleBorrow,
     };
     match algo {
         Algorithm::RippleBorrow | Algorithm::Schoolbook => {
-            crate::int::algos::sub::sub_ripple_borrow::sub_ripple_borrow_checked(a, b)
+            crate::int::algos::sub::sub_ripple_borrow::sub_ripple_borrow_checked(lhs, rhs)
         }
     }
 }

--- a/src/int/policy/sum_sq.rs
+++ b/src/int/policy/sum_sq.rs
@@ -116,16 +116,16 @@ const fn select<const N: usize>() -> Select<N> {
 /// `Int<N>` (true overflow). The signs of the operands drop out of squaring.
 #[inline]
 #[must_use]
-pub(crate) fn dispatch<const N: usize>(a: Int<N>, b: Int<N>) -> Option<Int<N>>
+pub(crate) fn dispatch<const N: usize>(lhs: Int<N>, rhs: Int<N>) -> Option<Int<N>>
 where
     Limbs<N>: ComputeLimbs,
 {
     let algo = match const { select::<N>() } {
-        Select::ByAlgorithm(a) => a,
-        Select::ByValue(f) => f(&a),
+        Select::ByAlgorithm(algorithm) => algorithm,
+        Select::ByValue(choose) => choose(&lhs),
     };
     match algo {
-        Algorithm::Schoolbook => sum_sq_schoolbook::<N>(a, b),
-        Algorithm::Comba => sum_sq_comba::<N>(a, b),
+        Algorithm::Schoolbook => sum_sq_schoolbook::<N>(lhs, rhs),
+        Algorithm::Comba => sum_sq_comba::<N>(lhs, rhs),
     }
 }

--- a/src/int/types/compute_limbs.rs
+++ b/src/int/types/compute_limbs.rs
@@ -237,20 +237,20 @@ pub(crate) enum LimbSize {
 }
 
 impl LimbSize {
-    /// The limb-width verdict for a kernel over `n` u64 limbs: `U128` when the
-    /// packing is exact (even `n` — two u64 fold into one u128, the wide-tier
-    /// win), else `U64`. A `const fn` so callers fold it in a `const { … }`
-    /// block per monomorphisation (the unchosen `match` arm is then dead-arm
-    /// eliminated, like any policy verdict).
+    /// The limb-width verdict for a kernel over `limb_count` u64 limbs:
+    /// `U128` when the packing is exact (an even count — two u64 fold into
+    /// one u128, the wide-tier win), else `U64`. A `const fn` so callers fold
+    /// it in a `const { … }` block per monomorphisation (the unchosen `match`
+    /// arm is then dead-arm eliminated, like any policy verdict).
     ///
     /// This is the limb-width axis as a verdict; the algorithm axis composes
     /// alongside it where a function also chooses *which* algorithm (a full
-    /// `Select<N>` carrying `(Algorithm, LimbSize)`). The even-`n` rule is the
-    /// correctness gate; a per-`(N, SCALE)` *perf* refinement (which even
+    /// `Select<N>` carrying `(Algorithm, LimbSize)`). The even-count rule is
+    /// the correctness gate; a per-`(N, SCALE)` *perf* refinement (which even
     /// widths actually win the u128 packing) is a microbench tuning follow-up.
     #[inline]
-    pub(crate) const fn for_packing(n: usize) -> Self {
-        if n.is_multiple_of(2) {
+    pub(crate) const fn for_packing(limb_count: usize) -> Self {
+        if limb_count.is_multiple_of(2) {
             LimbSize::U128
         } else {
             LimbSize::U64
@@ -289,14 +289,16 @@ pub(crate) trait Limb: Copy + PartialEq + Ord {
     fn overflowing_add(self, rhs: Self) -> (Self, bool);
     /// `self - rhs → (difference, borrow)`. Wraps on underflow.
     fn overflowing_sub(self, rhs: Self) -> (Self, bool);
-    /// `self + c1 + c2` — the schoolbook carry merge. The column bound
-    /// (`hi ≤ MAX − 1`, and `c1`/`c2` never both set) guarantees no overflow.
-    fn add_carries(self, c1: bool, c2: bool) -> Self;
-    /// `self << n` (`n < BITS`) — bits shifted past the top are dropped. Used
-    /// by the width-generic small-shift helpers (`×2`, `×4`, the `>>1` carry).
-    fn wrapping_shl(self, n: u32) -> Self;
-    /// `self >> n` (`n < BITS`) — logical (zero-fill) right shift.
-    fn wrapping_shr(self, n: u32) -> Self;
+    /// `self + carry1 + carry2` — the schoolbook carry merge. The column
+    /// bound (`hi ≤ MAX − 1`, and `carry1`/`carry2` never both set)
+    /// guarantees no overflow.
+    fn add_carries(self, carry1: bool, carry2: bool) -> Self;
+    /// `self << shift` (`shift < BITS`) — bits shifted past the top are
+    /// dropped. Used by the width-generic small-shift helpers (`×2`, `×4`,
+    /// the `>>1` carry).
+    fn wrapping_shl(self, shift: u32) -> Self;
+    /// `self >> shift` (`shift < BITS`) — logical (zero-fill) right shift.
+    fn wrapping_shr(self, shift: u32) -> Self;
 
     // Width-generic scratch fetch. Each forwards to the matching
     // [`ComputeLimbs`] per-element buffer for this limb type, so a
@@ -344,18 +346,18 @@ impl Limb for u64 {
     }
     #[inline]
     fn pack(src_u64: &[u64], dst: &mut [Self]) {
-        let h = dst.len();
-        dst.copy_from_slice(&src_u64[..h]);
+        let len = dst.len();
+        dst.copy_from_slice(&src_u64[..len]);
     }
     #[inline]
     fn unpack(src: &[Self], dst_u64: &mut [u64]) {
-        let h = src.len();
-        dst_u64[..h].copy_from_slice(src);
+        let len = src.len();
+        dst_u64[..len].copy_from_slice(src);
     }
     #[inline]
     fn widening_mul(self, rhs: Self) -> (Self, Self) {
-        let p = (self as u128) * (rhs as u128);
-        (p as u64, (p >> 64) as u64)
+        let product = (self as u128) * (rhs as u128);
+        (product as u64, (product >> 64) as u64)
     }
     #[inline]
     fn overflowing_add(self, rhs: Self) -> (Self, bool) {
@@ -366,16 +368,16 @@ impl Limb for u64 {
         u64::overflowing_sub(self, rhs)
     }
     #[inline]
-    fn add_carries(self, c1: bool, c2: bool) -> Self {
-        self.wrapping_add(c1 as u64).wrapping_add(c2 as u64)
+    fn add_carries(self, carry1: bool, carry2: bool) -> Self {
+        self.wrapping_add(carry1 as u64).wrapping_add(carry2 as u64)
     }
     #[inline]
-    fn wrapping_shl(self, n: u32) -> Self {
-        u64::wrapping_shl(self, n)
+    fn wrapping_shl(self, shift: u32) -> Self {
+        u64::wrapping_shl(self, shift)
     }
     #[inline]
-    fn wrapping_shr(self, n: u32) -> Self {
-        u64::wrapping_shr(self, n)
+    fn wrapping_shr(self, shift: u32) -> Self {
+        u64::wrapping_shr(self, shift)
     }
 
     type Single<I: ComputeLimbs> = I::SingleU64;
@@ -425,15 +427,15 @@ impl Limb for u128 {
     }
     #[inline]
     fn pack(src_u64: &[u64], dst: &mut [Self]) {
-        for (k, d) in dst.iter_mut().enumerate() {
-            *d = (src_u64[2 * k] as u128) | ((src_u64[2 * k + 1] as u128) << 64);
+        for (k, dst_limb) in dst.iter_mut().enumerate() {
+            *dst_limb = (src_u64[2 * k] as u128) | ((src_u64[2 * k + 1] as u128) << 64);
         }
     }
     #[inline]
     fn unpack(src: &[Self], dst_u64: &mut [u64]) {
-        for (k, &s) in src.iter().enumerate() {
-            dst_u64[2 * k] = s as u64;
-            dst_u64[2 * k + 1] = (s >> 64) as u64;
+        for (k, &src_limb) in src.iter().enumerate() {
+            dst_u64[2 * k] = src_limb as u64;
+            dst_u64[2 * k + 1] = (src_limb >> 64) as u64;
         }
     }
     #[inline]
@@ -449,8 +451,8 @@ impl Limb for u128 {
         let hl = a_hi * b_lo;
         let hh = a_hi * b_hi;
         let (mid, mid_carry) = lh.overflowing_add(hl);
-        let (low, c) = ll.overflowing_add(mid << 64);
-        let high = hh + (mid >> 64) + (c as u128) + ((mid_carry as u128) << 64);
+        let (low, low_carry) = ll.overflowing_add(mid << 64);
+        let high = hh + (mid >> 64) + (low_carry as u128) + ((mid_carry as u128) << 64);
         (low, high)
     }
     #[inline]
@@ -462,16 +464,16 @@ impl Limb for u128 {
         u128::overflowing_sub(self, rhs)
     }
     #[inline]
-    fn add_carries(self, c1: bool, c2: bool) -> Self {
-        self.wrapping_add(c1 as u128).wrapping_add(c2 as u128)
+    fn add_carries(self, carry1: bool, carry2: bool) -> Self {
+        self.wrapping_add(carry1 as u128).wrapping_add(carry2 as u128)
     }
     #[inline]
-    fn wrapping_shl(self, n: u32) -> Self {
-        u128::wrapping_shl(self, n)
+    fn wrapping_shl(self, shift: u32) -> Self {
+        u128::wrapping_shl(self, shift)
     }
     #[inline]
-    fn wrapping_shr(self, n: u32) -> Self {
-        u128::wrapping_shr(self, n)
+    fn wrapping_shr(self, shift: u32) -> Self {
+        u128::wrapping_shr(self, shift)
     }
 
     type Single<I: ComputeLimbs> = I::SingleU128;

--- a/src/int/types/mod.rs
+++ b/src/int/types/mod.rs
@@ -167,21 +167,21 @@ impl<const N: usize> Uint<N> {
     /// `2^BITS`.
     #[inline]
     pub fn checked_mul(self, rhs: Self) -> Option<Self> {
-        let (a, b) = (&self.limbs, &rhs.limbs);
+        let (lhs_limbs, rhs_limbs) = (&self.limbs, &rhs.limbs);
         let mut out = [0u64; N];
         let mut overflow = false;
         let mut i = 0;
         while i < N {
-            let ai = a[i];
-            if ai != 0 {
+            let lhs_limb = lhs_limbs[i];
+            if lhs_limb != 0 {
                 let mut carry: u64 = 0;
                 let mut j = 0;
                 while j < N {
-                    let prod = (ai as u128) * (b[j] as u128);
+                    let prod = (lhs_limb as u128) * (rhs_limbs[j] as u128);
                     if i + j < N {
-                        let v = prod + (out[i + j] as u128) + (carry as u128);
-                        out[i + j] = v as u64;
-                        carry = (v >> 64) as u64;
+                        let column = prod + (out[i + j] as u128) + (carry as u128);
+                        out[i + j] = column as u64;
+                        carry = (column >> 64) as u64;
                     } else if prod != 0 || carry != 0 {
                         // Any product or carry landing at/above limb `N`
                         // means the true product exceeds the width.
@@ -439,8 +439,8 @@ impl<const N: usize> Uint<N> {
             return (Self::ONE, true);
         }
         if k == 2 {
-            let r = self.isqrt();
-            return (r, r.wrapping_sqr() == self);
+            let root = self.isqrt();
+            return (root, root.wrapping_sqr() == self);
         }
 
         // Seed: 2^ceil(bit_length / k) is an upper bound on the root.
@@ -470,7 +470,7 @@ impl<const N: usize> Uint<N> {
             s = u;
         }
 
-        let exact = s.checked_pow(k).is_some_and(|p| p == self);
+        let exact = s.checked_pow(k).is_some_and(|power| power == self);
         (s, exact)
     }
 
@@ -485,27 +485,27 @@ impl<const N: usize> Uint<N> {
     }
 
     /// Builds from an unsigned 128-bit value, zero-extending the upper
-    /// limbs. **Truncating** for `Uint<1>` (the high 64 bits of `v` are
-    /// discarded); use the checked `TryFrom` conversion when `v` may
+    /// limbs. **Truncating** for `Uint<1>` (the high 64 bits of `value` are
+    /// discarded); use the checked `TryFrom` conversion when `value` may
     /// not fit.
     #[inline]
-    pub(crate) const fn from_u128(v: u128) -> Self {
+    pub(crate) const fn from_u128(value: u128) -> Self {
         let mut limbs = [0u64; N];
         if N > 0 {
-            limbs[0] = v as u64;
+            limbs[0] = value as u64;
         }
         if N > 1 {
-            limbs[1] = (v >> 64) as u64;
+            limbs[1] = (value >> 64) as u64;
         }
         Self { limbs }
     }
 
-    /// Exact value conversion from `u128`, or `None` if `v` does not fit
+    /// Exact value conversion from `u128`, or `None` if `value` does not fit
     /// `Uint<N>` (only possible for `N < 2`). For `N >= 2` every `u128` fits.
     #[inline]
-    pub(crate) const fn try_from_u128(v: u128) -> Option<Self> {
-        if N >= 2 || v <= u64::MAX as u128 {
-            Some(Self::from_u128(v))
+    pub(crate) const fn try_from_u128(value: u128) -> Option<Self> {
+        if N >= 2 || value <= u64::MAX as u128 {
+            Some(Self::from_u128(value))
         } else {
             None
         }
@@ -567,11 +567,11 @@ impl<const N: usize> Uint<N> {
     }
 
     /// Parses an unsigned decimal string. Only base 10 is supported.
-    pub const fn from_str_radix(s: &str, radix: u32) -> Result<Self, ()> {
+    pub const fn from_str_radix(text: &str, radix: u32) -> Result<Self, ()> {
         if radix != 10 {
             return Err(());
         }
-        let bytes = s.as_bytes();
+        let bytes = text.as_bytes();
         if bytes.is_empty() {
             return Err(());
         }
@@ -582,13 +582,13 @@ impl<const N: usize> Uint<N> {
             if ch < b'0' || ch > b'9' {
                 return Err(());
             }
-            let d = (ch - b'0') as u64;
-            let mut carry: u64 = d;
+            let digit = (ch - b'0') as u64;
+            let mut carry: u64 = digit;
             let mut j = 0;
             while j < N {
-                let p = (acc[j] as u128) * 10u128 + (carry as u128);
-                acc[j] = p as u64;
-                carry = (p >> 64) as u64;
+                let product = (acc[j] as u128) * 10u128 + (carry as u128);
+                acc[j] = product as u64;
+                carry = (product >> 64) as u64;
                 j += 1;
             }
             k += 1;
@@ -677,10 +677,10 @@ impl<const N: usize> Div for Uint<N> {
     type Output = Self;
     #[inline]
     fn div(self, rhs: Self) -> Self {
-        let mut q = [0u64; N];
-        let mut r = [0u64; N];
-        div_rem_dispatch(&self.limbs, &rhs.limbs, &mut q, &mut r);
-        Self { limbs: q }
+        let mut quotient = [0u64; N];
+        let mut remainder = [0u64; N];
+        div_rem_dispatch(&self.limbs, &rhs.limbs, &mut quotient, &mut remainder);
+        Self { limbs: quotient }
     }
 }
 
@@ -688,10 +688,10 @@ impl<const N: usize> Rem for Uint<N> {
     type Output = Self;
     #[inline]
     fn rem(self, rhs: Self) -> Self {
-        let mut q = [0u64; N];
-        let mut r = [0u64; N];
-        div_rem_dispatch(&self.limbs, &rhs.limbs, &mut q, &mut r);
-        Self { limbs: r }
+        let mut quotient = [0u64; N];
+        let mut remainder = [0u64; N];
+        div_rem_dispatch(&self.limbs, &rhs.limbs, &mut quotient, &mut remainder);
+        Self { limbs: remainder }
     }
 }
 
@@ -904,10 +904,10 @@ impl<const N: usize> Int<N> {
     /// `Int<N>`. Only `N == 1` (64-bit storage) can fail; `N >= 2` holds
     /// every `i128`.
     #[inline]
-    pub(crate) const fn try_from_i128(v: i128) -> Option<Self> {
-        let mag = v.unsigned_abs();
-        let built = Self::from_mag_limbs(&[mag as u64, (mag >> 64) as u64], v < 0);
-        if N >= 2 || built.as_i128() == v {
+    pub(crate) const fn try_from_i128(value: i128) -> Option<Self> {
+        let mag = value.unsigned_abs();
+        let built = Self::from_mag_limbs(&[mag as u64, (mag >> 64) as u64], value < 0);
+        if N >= 2 || built.as_i128() == value {
             Some(built)
         } else {
             None
@@ -918,14 +918,14 @@ impl<const N: usize> Int<N> {
     /// `Int<N>`. `N == 1` fails above `i64::MAX`; `N == 2` fails above
     /// `i128::MAX` (the sign bit); `N >= 3` holds every `u128`.
     #[inline]
-    pub(crate) const fn try_from_u128(v: u128) -> Option<Self> {
-        let built = Self::from_mag_limbs(&[v as u64, (v >> 64) as u64], false);
+    pub(crate) const fn try_from_u128(value: u128) -> Option<Self> {
+        let built = Self::from_mag_limbs(&[value as u64, (value >> 64) as u64], false);
         if N >= 3 {
             Some(built)
         } else if built.is_negative() {
             // Magnitude landed in the sign bit of the N-limb storage.
             None
-        } else if N >= 2 || built.as_i128() as u128 == v {
+        } else if N >= 2 || built.as_i128() as u128 == value {
             Some(built)
         } else {
             None
@@ -951,7 +951,8 @@ impl<const N: usize> Int<N> {
     #[inline]
     pub(crate) fn try_to_i32(self) -> Option<i32> {
         match self.to_i128_checked() {
-            Some(v) if v >= i32::MIN as i128 && v <= i32::MAX as i128 => Some(v as i32),
+            Some(wide) if wide >= i32::MIN as i128 && wide <= i32::MAX as i128 =>
+                Some(wide as i32),
             _ => None,
         }
     }
@@ -960,7 +961,7 @@ impl<const N: usize> Int<N> {
     #[inline]
     pub(crate) fn try_to_u32(self) -> Option<u32> {
         match self.to_u128_checked() {
-            Some(v) if v <= u32::MAX as u128 => Some(v as u32),
+            Some(wide) if wide <= u32::MAX as u128 => Some(wide as u32),
             _ => None,
         }
     }
@@ -969,7 +970,8 @@ impl<const N: usize> Int<N> {
     #[inline]
     pub(crate) fn try_to_i64(self) -> Option<i64> {
         match self.to_i128_checked() {
-            Some(v) if v >= i64::MIN as i128 && v <= i64::MAX as i128 => Some(v as i64),
+            Some(wide) if wide >= i64::MIN as i128 && wide <= i64::MAX as i128 =>
+                Some(wide as i64),
             _ => None,
         }
     }
@@ -978,7 +980,7 @@ impl<const N: usize> Int<N> {
     #[inline]
     pub(crate) fn try_to_u64(self) -> Option<u64> {
         match self.to_u128_checked() {
-            Some(v) if v <= u64::MAX as u128 => Some(v as u64),
+            Some(wide) if wide <= u64::MAX as u128 => Some(wide as u64),
             _ => None,
         }
     }
@@ -1062,17 +1064,17 @@ impl<const N: usize> Int<N> {
         if self.is_zero() || rhs.is_zero() {
             return Some(Self::ZERO);
         }
-        let neg = self.is_negative() ^ rhs.is_negative();
-        let ma = Uint::<N>::from_limbs(*self.abs().as_limbs());
-        let mb = Uint::<N>::from_limbs(*rhs.abs().as_limbs());
-        let prod = ma.checked_mul(mb)?;
+        let negative = self.is_negative() ^ rhs.is_negative();
+        let lhs_mag = Uint::<N>::from_limbs(*self.abs().as_limbs());
+        let rhs_mag = Uint::<N>::from_limbs(*rhs.abs().as_limbs());
+        let prod = lhs_mag.checked_mul(rhs_mag)?;
         let signed = Self::from_limbs(*prod.as_limbs());
-        if neg {
-            let r = signed.wrapping_neg();
+        if negative {
+            let negated = signed.wrapping_neg();
             // Negative magnitude must not exceed |MIN|; the round-trip
             // through wrapping_neg detects the single MIN-magnitude case.
-            if r.is_negative() || r.is_zero() {
-                Some(r)
+            if negated.is_negative() || negated.is_zero() {
+                Some(negated)
             } else {
                 None
             }
@@ -1218,9 +1220,9 @@ impl<const N: usize> Int<N> {
             &mut quot,
             &mut rem,
         );
-        let q = Self::from_mag_limbs(&quot, neg_q);
-        let r = Self::from_mag_limbs(&rem, neg_r);
-        (q, r)
+        let quotient = Self::from_mag_limbs(&quot, neg_q);
+        let remainder = Self::from_mag_limbs(&rem, neg_r);
+        (quotient, remainder)
     }
 
     /// Builds a signed value from a non-negative magnitude limb slice
@@ -1228,19 +1230,19 @@ impl<const N: usize> Int<N> {
     #[inline]
     pub(crate) const fn from_mag_limbs(mag: &[u64], negative: bool) -> Self {
         let mut out = [0u64; N];
-        let n = if mag.len() < N { mag.len() } else { N };
+        let copy_len = if mag.len() < N { mag.len() } else { N };
         let mut i = 0;
-        while i < n {
+        while i < copy_len {
             out[i] = mag[i];
             i += 1;
         }
-        let v = Self { limbs: out };
+        let built = Self { limbs: out };
         // Inherent `const` zero-check (avoids the non-const `BigInt`
         // trait method that name-resolution would otherwise pick here).
-        if negative && !is_zero_fixed(&v.limbs) {
-            v.wrapping_neg()
+        if negative && !is_zero_fixed(&built.limbs) {
+            built.wrapping_neg()
         } else {
-            v
+            built
         }
     }
 
@@ -1255,10 +1257,10 @@ impl<const N: usize> Int<N> {
     }
 
     /// Builds from a signed 128-bit value. **Truncating** for `Int<1>`
-    /// (the high 64 bits of `v` are discarded); use the checked `TryFrom`
-    /// conversion when `v` may not fit.
+    /// (the high 64 bits of `value` are discarded); use the checked `TryFrom`
+    /// conversion when `value` may not fit.
     #[inline]
-    pub(crate) const fn from_i128(v: i128) -> Self {
+    pub(crate) const fn from_i128(value: i128) -> Self {
         // Narrow non-limb fast path (const-folds): for N<=2 write the
         // two's-complement limbs directly (truncating for N==1), skipping the
         // magnitude split + `wrapping_neg` re-sign. Bit-identical to the
@@ -1266,20 +1268,20 @@ impl<const N: usize> Int<N> {
         // truncation).
         if N <= 2 {
             let mut limbs = [0u64; N];
-            limbs[0] = v as u64;
+            limbs[0] = value as u64;
             if N == 2 {
-                limbs[1] = (v >> 64) as u64;
+                limbs[1] = (value >> 64) as u64;
             }
             return Self { limbs };
         }
-        let mag = v.unsigned_abs();
-        Self::from_mag_limbs(&[mag as u64, (mag >> 64) as u64], v < 0)
+        let mag = value.unsigned_abs();
+        Self::from_mag_limbs(&[mag as u64, (mag >> 64) as u64], value < 0)
     }
 
     /// Builds from an unsigned 128-bit value.
     #[inline]
-    pub(crate) const fn from_u128(v: u128) -> Self {
-        Self::from_mag_limbs(&[v as u64, (v >> 64) as u64], false)
+    pub(crate) const fn from_u128(value: u128) -> Self {
+        Self::from_mag_limbs(&[value as u64, (value >> 64) as u64], false)
     }
 
     /// Builds directly from the little-endian u64 limb array. Alias of
@@ -1296,33 +1298,33 @@ impl<const N: usize> Int<N> {
         self.limbs
     }
 
-    /// `self · (n as Self)` with the sign of `self`, panicking on
+    /// `self · (multiplier as Self)` with the sign of `self`, panicking on
     /// overflow (the default-form contract). Computes the n-by-1-word
     /// product (the same limb recurrence as `mul_schoolbook_into`) and
     /// rejects a non-zero top carry.
     #[inline]
-    pub fn mul_u64(self, n: u64) -> Self {
+    pub fn mul_u64(self, multiplier: u64) -> Self {
         let mag = *self.unsigned_abs().as_limbs();
         let mut prod = [0u64; N];
         let mut carry: u64 = 0;
         let mut i = 0;
         while i < N {
-            let p = (mag[i] as u128) * (n as u128) + (carry as u128);
-            prod[i] = p as u64;
-            carry = (p >> 64) as u64;
+            let product = (mag[i] as u128) * (multiplier as u128) + (carry as u128);
+            prod[i] = product as u64;
+            carry = (product >> 64) as u64;
             i += 1;
         }
         if carry != 0 {
             panic!("Int: mul overflow");
         }
         let negative = self.is_negative();
-        let r = Self::from_mag_limbs(&prod, negative);
+        let scaled = Self::from_mag_limbs(&prod, negative);
         // `from_mag_limbs` only mishandles the `mag == 2^(BITS-1)` edge:
         // legal as MIN for `negative`, overflow otherwise.
-        if !r.is_zero() && r.is_negative() != negative {
+        if !scaled.is_zero() && scaled.is_negative() != negative {
             panic!("Int: mul overflow");
         }
-        r
+        scaled
     }
 
     /// Exact `i128` value, or `None` if it does not fit.
@@ -1391,14 +1393,14 @@ impl<const N: usize> Int<N> {
         self.to_f64() as f32
     }
 
-    /// Exact conversion from an `f64`, or `None` when `v` is NaN, ±inf,
+    /// Exact conversion from an `f64`, or `None` when `value` is NaN, ±inf,
     /// has a fractional part, or lies outside the `Int<N>` range.
     ///
     /// `const`: classification and decomposition go through the const
     /// `f64::to_bits` plus integer/bit ops only — never the non-const
     /// `is_finite` / `fract` / float-`as` paths.
-    pub(crate) const fn try_from_f64(v: f64) -> Option<Self> {
-        let bits = v.to_bits();
+    pub(crate) const fn try_from_f64(value: f64) -> Option<Self> {
+        let bits = value.to_bits();
         let negative = (bits >> 63) & 1 == 1;
         let exp = ((bits >> 52) & 0x7ff) as i32;
         let mant = bits & 0x000f_ffff_ffff_ffff;
@@ -1407,7 +1409,7 @@ impl<const N: usize> Int<N> {
             return None;
         }
         if exp == 0 {
-            // ±0 is exact zero; a subnormal is a non-zero |v| < 1, i.e.
+            // ±0 is exact zero; a subnormal is a non-zero |value| < 1, i.e.
             // never an integer.
             return if mant == 0 { Some(Self::ZERO) } else { None };
         }
@@ -1421,8 +1423,8 @@ impl<const N: usize> Int<N> {
     /// `f32::to_bits` (8-bit exponent, 23-bit mantissa, bias 127, 24-bit
     /// significand) with integer/bit ops only — `const` for the same
     /// reason as [`Self::try_from_f64`].
-    pub(crate) const fn try_from_f32(v: f32) -> Option<Self> {
-        let bits = v.to_bits();
+    pub(crate) const fn try_from_f32(value: f32) -> Option<Self> {
+        let bits = value.to_bits();
         let negative = (bits >> 31) & 1 == 1;
         let exp = ((bits >> 23) & 0xff) as i32;
         let mant = (bits & 0x007f_ffff) as u64;
@@ -1445,25 +1447,25 @@ impl<const N: usize> Int<N> {
     /// ops — so both float entry points are `const`.
     const fn from_significand_shift(significand: u64, shift: i32, negative: bool) -> Option<Self> {
         if shift < 0 {
-            let s = (-shift) as u32;
-            if s >= 64 {
-                // Whole value is fractional (|v| < 1, non-zero) — not an
+            let right_shift = (-shift) as u32;
+            if right_shift >= 64 {
+                // Whole value is fractional (|value| < 1, non-zero) — not an
                 // integer.
                 return None;
             }
-            if significand & ((1u64 << s) - 1) != 0 {
+            if significand & ((1u64 << right_shift) - 1) != 0 {
                 // Fractional bits set — not an integer.
                 return None;
             }
-            let mag = significand >> s; // integral, fits a single limb
+            let mag = significand >> right_shift; // integral, fits a single limb
             let built = Self::from_mag_limbs(&[mag], negative);
             Self::accept_signed(built, negative)
         } else {
             // Place `significand` left-shifted by `shift` into an N-limb
             // magnitude, rejecting any bit that lands beyond limb N-1.
-            let s = shift as u32;
-            let limb_off = (s / 64) as usize;
-            let bit_off = s % 64;
+            let left_shift = shift as u32;
+            let limb_off = (left_shift / 64) as usize;
+            let bit_off = left_shift % 64;
             let mut mag = [0u64; N];
             // Low chunk into limb `limb_off`; carry into the next limb.
             let lo = significand << bit_off;
@@ -1510,22 +1512,22 @@ impl<const N: usize> Int<N> {
 
     /// Builds from an `f64`, truncating toward zero. Saturates to
     /// `MIN` / `MAX` on out-of-range; non-finite maps to `ZERO`.
-    pub fn from_f64(v: f64) -> Self {
-        if !v.is_finite() {
+    pub fn from_f64(value: f64) -> Self {
+        if !value.is_finite() {
             return Self::ZERO;
         }
-        let negative = v < 0.0;
-        let mut m = if negative { -v } else { v };
+        let negative = value < 0.0;
+        let mut magnitude = if negative { -value } else { value };
         let radix: f64 = 18_446_744_073_709_551_616.0; // 2^64
         let mut limbs = [0u64; N];
         let mut i = 0;
-        while m >= 1.0 && i < N {
-            let rem = m % radix;
+        while magnitude >= 1.0 && i < N {
+            let rem = magnitude % radix;
             limbs[i] = rem as u64;
-            m = (m - rem) / radix;
+            magnitude = (magnitude - rem) / radix;
             i += 1;
         }
-        if m >= 1.0 {
+        if magnitude >= 1.0 {
             return if negative {
                 Self::min_value()
             } else {
@@ -1535,14 +1537,14 @@ impl<const N: usize> Int<N> {
         Self::from_mag_limbs(&limbs, negative)
     }
 
-    /// Parses a signed decimal magnitude from `s`. Accepts an optional
+    /// Parses a signed decimal magnitude from `text`. Accepts an optional
     /// leading `-`, then ASCII digits. Only `radix == 10` is supported;
     /// any other value returns `Err(())`.
-    pub const fn from_str_radix(s: &str, radix: u32) -> Result<Self, ()> {
+    pub const fn from_str_radix(text: &str, radix: u32) -> Result<Self, ()> {
         if radix != 10 {
             return Err(());
         }
-        let bytes = s.as_bytes();
+        let bytes = text.as_bytes();
         let (negative, start): (bool, usize) = if !bytes.is_empty() && bytes[0] == b'-' {
             (true, 1)
         } else {
@@ -1551,7 +1553,7 @@ impl<const N: usize> Int<N> {
         if start >= bytes.len() {
             return Err(());
         }
-        // acc = acc * 10 + d per digit, truncating into N limbs — the
+        // acc = acc * 10 + digit per digit, truncating into N limbs — the
         // same Horner recurrence the macro runs through `mul_schoolbook`
         // + `add_assign`, but the low-N-limb multiply-by-10 is
         // folded into one n-by-1-word pass (no `2*N` staging buffer).
@@ -1562,13 +1564,13 @@ impl<const N: usize> Int<N> {
             if ch < b'0' || ch > b'9' {
                 return Err(());
             }
-            let d = (ch - b'0') as u64;
-            let mut carry: u64 = d;
+            let digit = (ch - b'0') as u64;
+            let mut carry: u64 = digit;
             let mut j = 0;
             while j < N {
-                let p = (acc[j] as u128) * 10u128 + (carry as u128);
-                acc[j] = p as u64;
-                carry = (p >> 64) as u64;
+                let product = (acc[j] as u128) * 10u128 + (carry as u128);
+                acc[j] = product as u64;
+                carry = (product >> 64) as u64;
                 j += 1;
             }
             k += 1;
@@ -1764,57 +1766,57 @@ impl<const N: usize> Int<N> {
     /// remainder.
     #[inline]
     pub const fn div_euclid(self, rhs: Self) -> Self {
-        let q = self.wrapping_div(rhs);
-        let r = self.wrapping_rem(rhs);
-        if r.is_negative() {
+        let quotient = self.wrapping_div(rhs);
+        let remainder = self.wrapping_rem(rhs);
+        if remainder.is_negative() {
             if rhs.is_negative() {
-                q.wrapping_add(Self::ONE)
+                quotient.wrapping_add(Self::ONE)
             } else {
-                q.wrapping_sub(Self::ONE)
+                quotient.wrapping_sub(Self::ONE)
             }
         } else {
-            q
+            quotient
         }
     }
 
     /// Euclidean remainder — always non-negative.
     #[inline]
     pub const fn rem_euclid(self, rhs: Self) -> Self {
-        let r = self.wrapping_rem(rhs);
-        if r.is_negative() {
-            r.wrapping_add(rhs.abs())
+        let remainder = self.wrapping_rem(rhs);
+        if remainder.is_negative() {
+            remainder.wrapping_add(rhs.abs())
         } else {
-            r
+            remainder
         }
     }
 
     /// Wrapping addition paired with the two's-complement overflow flag.
     #[inline]
     pub const fn overflowing_add(self, rhs: Self) -> (Self, bool) {
-        let r = self.wrapping_add(rhs);
-        let sa = self.is_negative();
-        let sb = rhs.is_negative();
-        let sr = r.is_negative();
-        (r, sa == sb && sr != sa)
+        let sum = self.wrapping_add(rhs);
+        let lhs_negative = self.is_negative();
+        let rhs_negative = rhs.is_negative();
+        let sum_negative = sum.is_negative();
+        (sum, lhs_negative == rhs_negative && sum_negative != lhs_negative)
     }
 
     /// Wrapping subtraction paired with the two's-complement overflow
     /// flag.
     #[inline]
     pub const fn overflowing_sub(self, rhs: Self) -> (Self, bool) {
-        let r = self.wrapping_sub(rhs);
-        let sa = self.is_negative();
-        let sb = rhs.is_negative();
-        let sr = r.is_negative();
-        (r, sa != sb && sr != sa)
+        let difference = self.wrapping_sub(rhs);
+        let lhs_negative = self.is_negative();
+        let rhs_negative = rhs.is_negative();
+        let difference_negative = difference.is_negative();
+        (difference, lhs_negative != rhs_negative && difference_negative != lhs_negative)
     }
 
     /// Wrapping negation paired with the overflow flag (`true` only at
     /// `MIN`).
     #[inline]
     pub const fn overflowing_neg(self) -> (Self, bool) {
-        let ov = cmp_fixed(&self.limbs, &Self::MIN.limbs) == 0;
-        (self.wrapping_neg(), ov)
+        let overflow = cmp_fixed(&self.limbs, &Self::MIN.limbs) == 0;
+        (self.wrapping_neg(), overflow)
     }
 
     /// Wrapping remainder paired with an overflow flag. The flag is `true`
@@ -1833,7 +1835,7 @@ impl<const N: usize> Int<N> {
     #[inline]
     pub const fn saturating_add(self, rhs: Self) -> Self {
         match self.checked_add(rhs) {
-            Some(v) => v,
+            Some(exact) => exact,
             None => {
                 if self.is_negative() {
                     Self::MIN
@@ -1848,7 +1850,7 @@ impl<const N: usize> Int<N> {
     #[inline]
     pub const fn saturating_sub(self, rhs: Self) -> Self {
         match self.checked_sub(rhs) {
-            Some(v) => v,
+            Some(exact) => exact,
             None => {
                 if self.is_negative() {
                     Self::MIN
@@ -1863,27 +1865,27 @@ impl<const N: usize> Int<N> {
     #[inline]
     pub const fn saturating_neg(self) -> Self {
         match self.checked_neg() {
-            Some(v) => v,
+            Some(exact) => exact,
             None => Self::MAX,
         }
     }
 
-    /// Rotates the bits left by `n` (modulo `BITS`).
+    /// Rotates the bits left by `rotation` (modulo `BITS`).
     #[inline]
-    pub fn rotate_left(self, n: u32) -> Self {
+    pub fn rotate_left(self, rotation: u32) -> Self {
         let bits = Self::BITS;
-        let n = n % bits;
-        if n == 0 {
+        let rotation = rotation % bits;
+        if rotation == 0 {
             return self;
         }
-        let u = self.cast_unsigned();
-        Self::from_limbs(((u.shl(n)) | (u.shr(bits - n))).limbs)
+        let unsigned = self.cast_unsigned();
+        Self::from_limbs(((unsigned.shl(rotation)) | (unsigned.shr(bits - rotation))).limbs)
     }
 
-    /// Rotates the bits right by `n` (modulo `BITS`).
+    /// Rotates the bits right by `rotation` (modulo `BITS`).
     #[inline]
-    pub fn rotate_right(self, n: u32) -> Self {
-        self.rotate_left(Self::BITS - (n % Self::BITS))
+    pub fn rotate_right(self, rotation: u32) -> Self {
+        self.rotate_left(Self::BITS - (rotation % Self::BITS))
     }
 
     /// Truncating cast to `u128` (low 128 magnitude bits, sign ignored).
@@ -1947,15 +1949,15 @@ impl<const N: usize> Int<N> {
             panic!("attempt to divide by zero");
         }
         let negative = self.is_negative() ^ rhs.is_negative();
-        let mut q = [0u64; N];
-        let mut r = [0u64; N];
+        let mut quotient = [0u64; N];
+        let mut remainder = [0u64; N];
         div_rem(
             self.unsigned_abs().as_limbs(),
             rhs.unsigned_abs().as_limbs(),
-            &mut q,
-            &mut r,
+            &mut quotient,
+            &mut remainder,
         );
-        Self::from_mag_limbs(&q, negative)
+        Self::from_mag_limbs(&quotient, negative)
     }
 
     /// Truncating remainder; result carries the sign of `self`. Panics
@@ -1965,15 +1967,15 @@ impl<const N: usize> Int<N> {
         if is_zero_fixed(&rhs.limbs) {
             panic!("attempt to calculate the remainder with a divisor of zero");
         }
-        let mut q = [0u64; N];
-        let mut r = [0u64; N];
+        let mut quotient = [0u64; N];
+        let mut remainder = [0u64; N];
         div_rem(
             self.unsigned_abs().as_limbs(),
             rhs.unsigned_abs().as_limbs(),
-            &mut q,
-            &mut r,
+            &mut quotient,
+            &mut remainder,
         );
-        Self::from_mag_limbs(&r, self.is_negative())
+        Self::from_mag_limbs(&remainder, self.is_negative())
     }
 
     /// Full `self · rhs` product widened into a `W: BigInt`, in one
@@ -1989,8 +1991,8 @@ impl<const N: usize> Int<N> {
     {
         use crate::int::types::compute_limbs::{ComputeLimbs, Limbs};
         let negative = self.is_negative() ^ rhs.is_negative();
-        let a = *self.unsigned_abs().as_limbs();
-        let b = *rhs.unsigned_abs().as_limbs();
+        let lhs_mag = *self.unsigned_abs().as_limbs();
+        let rhs_mag = *rhs.unsigned_abs().as_limbs();
         // Full product spans 2·N u64 limbs — sized exactly by the source's
         // `ComputeLimbs::double_buffered_u64()` (no build-max blanket). Route through
         // the equal-length multiply dispatcher: both operands are `[u64; N]`,
@@ -2000,7 +2002,7 @@ impl<const N: usize> Int<N> {
         // non-allocating Karatsuba kernel at or above it.
         let mut prod_buf = <Limbs<N> as ComputeLimbs>::double_buffered_u64();
         let prod = prod_buf.as_mut();
-        mul_fast::<N>(&a, &b, &mut prod[..2 * N]);
+        mul_fast::<N>(&lhs_mag, &rhs_mag, &mut prod[..2 * N]);
         // Pack the `2·N`-u64 product into `N` u128 limbs for the kept
         // `BigInt::from_mag_sign_u128` bridge. The result `W` holds the
         // product, so its scratch carrier's `single_u128()` buffer (`≥ N`)
@@ -2027,23 +2029,23 @@ impl<const N: usize> Int<N> {
     /// magnitude is the smaller value, so the magnitude order is flipped.
     #[inline]
     pub(crate) const fn cmp_cross<const M: usize>(self, other: Int<M>) -> Ordering {
-        let sn = self.is_negative();
-        let so = other.is_negative();
-        if sn && !so {
+        let self_negative = self.is_negative();
+        let other_negative = other.is_negative();
+        if self_negative && !other_negative {
             return Ordering::Less;
         }
-        if !sn && so {
+        if !self_negative && other_negative {
             return Ordering::Greater;
         }
         // Same sign: compare magnitudes length-aware.
-        let a = self.unsigned_abs();
-        let b = other.unsigned_abs();
-        let c = cmp_cross(a.as_limbs(), b.as_limbs());
+        let self_mag = self.unsigned_abs();
+        let other_mag = other.unsigned_abs();
+        let mag_cmp = cmp_cross(self_mag.as_limbs(), other_mag.as_limbs());
         // For two negatives the larger magnitude is the smaller value.
-        let c = if sn { -c } else { c };
-        if c < 0 {
+        let mag_cmp = if self_negative { -mag_cmp } else { mag_cmp };
+        if mag_cmp < 0 {
             Ordering::Less
-        } else if c > 0 {
+        } else if mag_cmp > 0 {
             Ordering::Greater
         } else {
             Ordering::Equal
@@ -2084,22 +2086,22 @@ impl<const N: usize> Int<N> {
         other: Int<M>,
         scale_diff: u32,
     ) -> Ordering {
-        let sn = self.is_negative();
-        let so = other.is_negative();
-        if sn && !so {
+        let self_negative = self.is_negative();
+        let other_negative = other.is_negative();
+        if self_negative && !other_negative {
             return Ordering::Less;
         }
-        if !sn && so {
+        if !self_negative && other_negative {
             return Ordering::Greater;
         }
 
         // Same sign (or one/both zero): compare magnitudes. `mag_cmp` is
         // the i32 sign of `|self|` − `|other| · 10^scale_diff`.
-        let a = self.unsigned_abs();
-        let b = other.unsigned_abs();
+        let self_mag = self.unsigned_abs();
+        let other_mag = other.unsigned_abs();
 
         let mag_cmp = if scale_diff == 0 {
-            cmp_cross(a.as_limbs(), b.as_limbs())
+            cmp_cross(self_mag.as_limbs(), other_mag.as_limbs())
         } else {
             // Build the divisor 10^scale_diff in a fixed staging buffer.
             // `max_n_limbs(4)` (= 288 at xx-wide) is the wide-tier staging
@@ -2107,8 +2109,8 @@ impl<const N: usize> Int<N> {
             // the widest tier's buffer; it covers every shipped width/scale.
             let mut pow = [0u64; max_n_limbs(4)];
             pow[0] = 1;
-            let mut e = 0;
-            while e < scale_diff {
+            let mut step = 0;
+            while step < scale_diff {
                 // pow *= 10, propagating carry across limbs.
                 let mut carry: u128 = 0;
                 let mut i = 0;
@@ -2118,30 +2120,30 @@ impl<const N: usize> Int<N> {
                     carry = prod >> 64;
                     i += 1;
                 }
-                e += 1;
+                step += 1;
             }
 
-            // |self| = q · 10^scale_diff + r.
-            let mut q = [0u64; max_n_limbs(4)];
-            let mut r = [0u64; max_n_limbs(4)];
-            div_rem(a.as_limbs(), &pow, &mut q, &mut r);
+            // |self| = quotient · 10^scale_diff + remainder.
+            let mut quotient = [0u64; max_n_limbs(4)];
+            let mut remainder = [0u64; max_n_limbs(4)];
+            div_rem(self_mag.as_limbs(), &pow, &mut quotient, &mut remainder);
 
             // Compare quotient against |other|; tie-break on remainder.
-            let c = cmp_cross(&q, b.as_limbs());
-            if c != 0 {
-                c
+            let quotient_cmp = cmp_cross(&quotient, other_mag.as_limbs());
+            if quotient_cmp != 0 {
+                quotient_cmp
             } else {
                 // Quotients equal: a nonzero remainder makes |self| larger.
-                let mut rk = 0;
-                let mut nz = false;
-                while rk < r.len() {
-                    if r[rk] != 0 {
-                        nz = true;
+                let mut limb_index = 0;
+                let mut remainder_nonzero = false;
+                while limb_index < remainder.len() {
+                    if remainder[limb_index] != 0 {
+                        remainder_nonzero = true;
                         break;
                     }
-                    rk += 1;
+                    limb_index += 1;
                 }
-                if nz {
+                if remainder_nonzero {
                     1
                 } else {
                     0
@@ -2150,10 +2152,10 @@ impl<const N: usize> Int<N> {
         };
 
         // For two negatives, the larger magnitude is the smaller value.
-        let c = if sn { -mag_cmp } else { mag_cmp };
-        if c < 0 {
+        let signed_cmp = if self_negative { -mag_cmp } else { mag_cmp };
+        if signed_cmp < 0 {
             Ordering::Less
-        } else if c > 0 {
+        } else if signed_cmp > 0 {
             Ordering::Greater
         } else {
             Ordering::Equal
@@ -2188,41 +2190,41 @@ impl<const N: usize> Int<N> {
     /// the magnitude order is flipped). `m == 0` is the float zero.
     pub(crate) const fn cmp_f64_exact(self, scale: u32, value: f64) -> Ordering {
         let bits = value.to_bits();
-        let fsign = (bits >> 63) != 0;
+        let float_negative = (bits >> 63) != 0;
         let exp_field = ((bits >> 52) & 0x7ff) as i32;
         let frac = bits & 0x000f_ffff_ffff_ffff;
-        // Mantissa `m` and unbiased power-of-two exponent `e`.
-        let (m, e): (u64, i32) = if exp_field == 0 {
+        // Mantissa and unbiased power-of-two exponent.
+        let (mantissa, exponent): (u64, i32) = if exp_field == 0 {
             // Subnormal (or zero): no implicit leading bit.
             (frac, -1074)
         } else {
             (frac | 0x0010_0000_0000_0000, exp_field - 1075)
         };
 
-        let sn = self.is_negative();
-        let fzero = m == 0;
+        let self_negative = self.is_negative();
+        let float_is_zero = mantissa == 0;
         // Resolve signs. The float's zero has no sign for ordering.
-        if fzero {
+        if float_is_zero {
             // value == 0: compare against self's sign / zeroness.
             let self_limbs = self.as_limbs();
-            let mut nz = false;
+            let mut self_nonzero = false;
             let mut k = 0;
             while k < self_limbs.len() {
                 if self_limbs[k] != 0 {
-                    nz = true;
+                    self_nonzero = true;
                     break;
                 }
                 k += 1;
             }
-            if !nz {
+            if !self_nonzero {
                 return Ordering::Equal;
             }
-            return if sn { Ordering::Less } else { Ordering::Greater };
+            return if self_negative { Ordering::Less } else { Ordering::Greater };
         }
-        if sn && !fsign {
+        if self_negative && !float_negative {
             return Ordering::Less;
         }
-        if !sn && fsign {
+        if !self_negative && float_negative {
             return Ordering::Greater;
         }
 
@@ -2231,14 +2233,14 @@ impl<const N: usize> Int<N> {
         // buffers (288 u64 limbs covers every shipped width / scale /
         // f64 exponent: D307 magnitude ≤ 16 limbs, 10^scale ≤ 16 limbs,
         // 2^1074 ≤ 17 limbs — products stay well under 288).
-        let a = self.unsigned_abs();
-        let a_limbs = a.as_limbs();
+        let self_mag = self.unsigned_abs();
+        let self_mag_limbs = self_mag.as_limbs();
 
         // 10^scale in a buffer.
         let mut pow10 = [0u64; 288];
         pow10[0] = 1;
-        let mut pe = 0;
-        while pe < scale {
+        let mut step = 0;
+        while step < scale {
             let mut carry: u128 = 0;
             let mut i = 0;
             while i < pow10.len() {
@@ -2247,38 +2249,38 @@ impl<const N: usize> Int<N> {
                 carry = prod >> 64;
                 i += 1;
             }
-            pe += 1;
+            step += 1;
         }
 
-        let m_limbs = [m];
+        let mantissa_limbs = [mantissa];
 
         let mut lhs = [0u64; 288];
         let mut rhs = [0u64; 288];
 
-        if e >= 0 {
-            // lhs = |self|; rhs = m · 2^e · 10^scale.
+        if exponent >= 0 {
+            // lhs = |self|; rhs = mantissa · 2^exponent · 10^scale.
             let mut i = 0;
-            while i < a_limbs.len() {
-                lhs[i] = a_limbs[i];
+            while i < self_mag_limbs.len() {
+                lhs[i] = self_mag_limbs[i];
                 i += 1;
             }
-            // tmp = m · 10^scale
-            let mut tmp = [0u64; 288];
-            mul_schoolbook(&m_limbs, &pow10, &mut tmp);
-            // rhs = tmp << e
-            shl(&tmp, e as u32, &mut rhs);
+            // scaled_mantissa = mantissa · 10^scale
+            let mut scaled_mantissa = [0u64; 288];
+            mul_schoolbook(&mantissa_limbs, &pow10, &mut scaled_mantissa);
+            // rhs = scaled_mantissa << exponent
+            shl(&scaled_mantissa, exponent as u32, &mut rhs);
         } else {
-            // lhs = |self| · 2^(−e); rhs = m · 10^scale.
-            shl(a_limbs, (-e) as u32, &mut lhs);
-            mul_schoolbook(&m_limbs, &pow10, &mut rhs);
+            // lhs = |self| · 2^(−exponent); rhs = mantissa · 10^scale.
+            shl(self_mag_limbs, (-exponent) as u32, &mut lhs);
+            mul_schoolbook(&mantissa_limbs, &pow10, &mut rhs);
         }
 
         let mag_cmp = cmp_cross(&lhs, &rhs);
         // For two negatives the larger magnitude is the smaller value.
-        let c = if sn { -mag_cmp } else { mag_cmp };
-        if c < 0 {
+        let signed_cmp = if self_negative { -mag_cmp } else { mag_cmp };
+        if signed_cmp < 0 {
             Ordering::Less
-        } else if c > 0 {
+        } else if signed_cmp > 0 {
             Ordering::Greater
         } else {
             Ordering::Equal
@@ -2315,8 +2317,8 @@ impl<const N: usize, const M: usize> PartialOrd<Int<M>> for Int<N> {
 // (the trait form of `as_i128`). Enables `i128::from(int2)` / `.into()`.
 impl From<Int<2>> for i128 {
     #[inline]
-    fn from(v: Int<2>) -> i128 {
-        v.as_i128()
+    fn from(value: Int<2>) -> i128 {
+        value.as_i128()
     }
 }
 
@@ -2351,15 +2353,15 @@ impl PartialOrd<Int<2>> for i128 {
 // literals without an explicit conversion. Deliberately `Int<1>`-only.
 impl From<Int<1>> for i64 {
     #[inline]
-    fn from(v: Int<1>) -> i64 {
-        v.as_i128() as i64
+    fn from(value: Int<1>) -> i64 {
+        value.as_i128() as i64
     }
 }
 // `Int<1>` is 64-bit, so widening to `i128` is exact.
 impl From<Int<1>> for i128 {
     #[inline]
-    fn from(v: Int<1>) -> i128 {
-        v.as_i128()
+    fn from(value: Int<1>) -> i128 {
+        value.as_i128()
     }
 }
 impl PartialEq<i64> for Int<1> {
@@ -2543,14 +2545,14 @@ impl<const N: usize> core::fmt::Display for Uint<N>
 where
     crate::int::types::compute_limbs::Limbs<N>: crate::int::types::compute_limbs::ComputeLimbs,
 {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         // Exact per-`N` decimal output buffer (`20N + 2` bytes), drawn from
         // the `Limbs<N>` scratch carrier; the formatter writes the base-10
         // digits from its tail.
         let mut buf =
             <crate::int::types::compute_limbs::Limbs<N> as crate::int::types::compute_limbs::ComputeLimbs>::digit_formatting_limbs_u8();
-        let s = fmt_into::<N>(&self.limbs, 10, true, buf.as_mut());
-        f.pad_integral(true, "", s)
+        let rendered = fmt_into::<N>(&self.limbs, 10, true, buf.as_mut());
+        formatter.pad_integral(true, "", rendered)
     }
 }
 
@@ -2558,7 +2560,7 @@ impl<const N: usize> core::fmt::Display for Int<N>
 where
     crate::int::types::compute_limbs::Limbs<N>: crate::int::types::compute_limbs::ComputeLimbs,
 {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let mag = *self.unsigned_abs().as_limbs();
         // Exact per-`N` decimal output buffer (`20N + 2` bytes): an `Int<N>`
         // is `64N` bits, so its base-10 form is `⌈64·N·log10(2)⌉ ≈ 19.27·N`
@@ -2566,16 +2568,16 @@ where
         // scratch carrier; the formatter writes the digits from its tail.
         let mut buf =
             <crate::int::types::compute_limbs::Limbs<N> as crate::int::types::compute_limbs::ComputeLimbs>::digit_formatting_limbs_u8();
-        let s = fmt_into::<N>(&mag, 10, true, buf.as_mut());
-        f.pad_integral(!self.is_negative() || self.is_zero(), "", s)
+        let rendered = fmt_into::<N>(&mag, 10, true, buf.as_mut());
+        formatter.pad_integral(!self.is_negative() || self.is_zero(), "", rendered)
     }
 }
 
 impl<const N: usize> core::str::FromStr for Int<N> {
     type Err = ();
     #[inline]
-    fn from_str(s: &str) -> Result<Self, ()> {
-        Self::from_str_radix(s, 10)
+    fn from_str(text: &str) -> Result<Self, ()> {
+        Self::from_str_radix(text, 10)
     }
 }
 
@@ -2592,11 +2594,11 @@ impl<const N: usize> core::fmt::LowerHex for Int<N>
 where
     crate::int::types::compute_limbs::Limbs<N>: crate::int::types::compute_limbs::ComputeLimbs,
 {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let mut buf =
             <crate::int::types::compute_limbs::Limbs<N> as crate::int::types::compute_limbs::ComputeLimbs>::digit_formatting_limbs_u8();
-        let s = fmt_into::<N>(&self.limbs, 16, true, buf.as_mut());
-        f.pad_integral(true, "0x", s)
+        let rendered = fmt_into::<N>(&self.limbs, 16, true, buf.as_mut());
+        formatter.pad_integral(true, "0x", rendered)
     }
 }
 
@@ -2604,11 +2606,11 @@ impl<const N: usize> core::fmt::UpperHex for Int<N>
 where
     crate::int::types::compute_limbs::Limbs<N>: crate::int::types::compute_limbs::ComputeLimbs,
 {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let mut buf =
             <crate::int::types::compute_limbs::Limbs<N> as crate::int::types::compute_limbs::ComputeLimbs>::digit_formatting_limbs_u8();
-        let s = fmt_into::<N>(&self.limbs, 16, false, buf.as_mut());
-        f.pad_integral(true, "0x", s)
+        let rendered = fmt_into::<N>(&self.limbs, 16, false, buf.as_mut());
+        formatter.pad_integral(true, "0x", rendered)
     }
 }
 
@@ -2616,11 +2618,11 @@ impl<const N: usize> core::fmt::Octal for Int<N>
 where
     crate::int::types::compute_limbs::Limbs<N>: crate::int::types::compute_limbs::ComputeLimbs,
 {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let mut buf =
             <crate::int::types::compute_limbs::Limbs<N> as crate::int::types::compute_limbs::ComputeLimbs>::bit_formatting_limbs_u8();
-        let s = fmt_into::<N>(&self.limbs, 8, true, buf.as_mut());
-        f.pad_integral(true, "0o", s)
+        let rendered = fmt_into::<N>(&self.limbs, 8, true, buf.as_mut());
+        formatter.pad_integral(true, "0o", rendered)
     }
 }
 
@@ -2628,11 +2630,11 @@ impl<const N: usize> core::fmt::Binary for Int<N>
 where
     crate::int::types::compute_limbs::Limbs<N>: crate::int::types::compute_limbs::ComputeLimbs,
 {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let mut buf =
             <crate::int::types::compute_limbs::Limbs<N> as crate::int::types::compute_limbs::ComputeLimbs>::bit_formatting_limbs_u8();
-        let s = fmt_into::<N>(&self.limbs, 2, true, buf.as_mut());
-        f.pad_integral(true, "0b", s)
+        let rendered = fmt_into::<N>(&self.limbs, 2, true, buf.as_mut());
+        formatter.pad_integral(true, "0b", rendered)
     }
 }
 
@@ -2775,7 +2777,7 @@ macro_rules! int_from_signed {
     ($($prim:ty => $base:ident),+) => {$(
         impl<const N: usize> From<$prim> for Int<N> {
             #[inline]
-            fn from(v: $prim) -> Self { Self::$base(v) }
+            fn from(value: $prim) -> Self { Self::$base(value) }
         }
     )+};
 }
@@ -2785,7 +2787,7 @@ macro_rules! int_from_unsigned {
     ($($prim:ty => $base:ident),+) => {$(
         impl<const N: usize> From<$prim> for Int<N> {
             #[inline]
-            fn from(v: $prim) -> Self { Self::$base(v) }
+            fn from(value: $prim) -> Self { Self::$base(value) }
         }
     )+};
 }
@@ -2795,7 +2797,7 @@ macro_rules! uint_from_unsigned {
     ($($prim:ty),+) => {$(
         impl<const N: usize> From<$prim> for Uint<N> {
             #[inline]
-            fn from(v: $prim) -> Self { Self::from_u64(v as u64) }
+            fn from(value: $prim) -> Self { Self::from_u64(value as u64) }
         }
     )+};
 }
@@ -2806,24 +2808,24 @@ uint_from_unsigned!(u8, u16, u32, u64);
 impl<const N: usize> TryFrom<u64> for Int<N> {
     type Error = crate::support::error::ConvertError;
     #[inline]
-    fn try_from(v: u64) -> Result<Self, Self::Error> {
-        Self::try_from_u64(v).ok_or(crate::support::error::ConvertError::Overflow)
+    fn try_from(value: u64) -> Result<Self, Self::Error> {
+        Self::try_from_u64(value).ok_or(crate::support::error::ConvertError::Overflow)
     }
 }
 
 impl<const N: usize> TryFrom<i128> for Int<N> {
     type Error = crate::support::error::ConvertError;
     #[inline]
-    fn try_from(v: i128) -> Result<Self, Self::Error> {
-        Self::try_from_i128(v).ok_or(crate::support::error::ConvertError::Overflow)
+    fn try_from(value: i128) -> Result<Self, Self::Error> {
+        Self::try_from_i128(value).ok_or(crate::support::error::ConvertError::Overflow)
     }
 }
 
 impl<const N: usize> TryFrom<u128> for Int<N> {
     type Error = crate::support::error::ConvertError;
     #[inline]
-    fn try_from(v: u128) -> Result<Self, Self::Error> {
-        Self::try_from_u128(v).ok_or(crate::support::error::ConvertError::Overflow)
+    fn try_from(value: u128) -> Result<Self, Self::Error> {
+        Self::try_from_u128(value).ok_or(crate::support::error::ConvertError::Overflow)
     }
 }
 
@@ -2838,40 +2840,40 @@ impl<const N: usize> TryFrom<u128> for Int<N> {
 impl<const N: usize> TryFrom<Int<N>> for i32 {
     type Error = crate::support::error::ConvertError;
     #[inline]
-    fn try_from(v: Int<N>) -> Result<Self, Self::Error> {
-        v.try_to_i32().ok_or(crate::support::error::ConvertError::Overflow)
+    fn try_from(value: Int<N>) -> Result<Self, Self::Error> {
+        value.try_to_i32().ok_or(crate::support::error::ConvertError::Overflow)
     }
 }
 
 impl<const N: usize> TryFrom<Int<N>> for u32 {
     type Error = crate::support::error::ConvertError;
     #[inline]
-    fn try_from(v: Int<N>) -> Result<Self, Self::Error> {
-        v.try_to_u32().ok_or(crate::support::error::ConvertError::Overflow)
+    fn try_from(value: Int<N>) -> Result<Self, Self::Error> {
+        value.try_to_u32().ok_or(crate::support::error::ConvertError::Overflow)
     }
 }
 
 impl<const N: usize> TryFrom<Int<N>> for u64 {
     type Error = crate::support::error::ConvertError;
     #[inline]
-    fn try_from(v: Int<N>) -> Result<Self, Self::Error> {
-        v.try_to_u64().ok_or(crate::support::error::ConvertError::Overflow)
+    fn try_from(value: Int<N>) -> Result<Self, Self::Error> {
+        value.try_to_u64().ok_or(crate::support::error::ConvertError::Overflow)
     }
 }
 
 impl<const N: usize> TryFrom<Int<N>> for u128 {
     type Error = crate::support::error::ConvertError;
     #[inline]
-    fn try_from(v: Int<N>) -> Result<Self, Self::Error> {
-        v.try_to_u128().ok_or(crate::support::error::ConvertError::Overflow)
+    fn try_from(value: Int<N>) -> Result<Self, Self::Error> {
+        value.try_to_u128().ok_or(crate::support::error::ConvertError::Overflow)
     }
 }
 
 impl<const N: usize> TryFrom<u128> for Uint<N> {
     type Error = crate::support::error::ConvertError;
     #[inline]
-    fn try_from(v: u128) -> Result<Self, Self::Error> {
-        Self::try_from_u128(v).ok_or(crate::support::error::ConvertError::Overflow)
+    fn try_from(value: u128) -> Result<Self, Self::Error> {
+        Self::try_from_u128(value).ok_or(crate::support::error::ConvertError::Overflow)
     }
 }
 
@@ -2883,16 +2885,16 @@ impl<const N: usize> TryFrom<u128> for Uint<N> {
 impl<const N: usize> TryFrom<f64> for Int<N> {
     type Error = crate::support::error::ConvertError;
     #[inline]
-    fn try_from(v: f64) -> Result<Self, Self::Error> {
-        Self::try_from_f64(v).ok_or(crate::support::error::ConvertError::Overflow)
+    fn try_from(value: f64) -> Result<Self, Self::Error> {
+        Self::try_from_f64(value).ok_or(crate::support::error::ConvertError::Overflow)
     }
 }
 
 impl<const N: usize> TryFrom<f32> for Int<N> {
     type Error = crate::support::error::ConvertError;
     #[inline]
-    fn try_from(v: f32) -> Result<Self, Self::Error> {
-        Self::try_from_f32(v).ok_or(crate::support::error::ConvertError::Overflow)
+    fn try_from(value: f32) -> Result<Self, Self::Error> {
+        Self::try_from_f32(value).ok_or(crate::support::error::ConvertError::Overflow)
     }
 }
 
@@ -3093,15 +3095,15 @@ mod tests {
     /// the full `2N`-limb schoolbook product, across widths and edges.
     #[test]
     fn limbs_mul_low_matches_full_product_low_half() {
-        fn check<const N: usize, const D: usize>(a: [u64; N], b: [u64; N]) {
+        fn check<const N: usize, const D: usize>(lhs: [u64; N], rhs: [u64; N]) {
             debug_assert!(D == 2 * N);
             let mut full = [0u64; D];
-            mul_schoolbook_fixed::<N, D>(&a, &b, &mut full);
+            mul_schoolbook_fixed::<N, D>(&lhs, &rhs, &mut full);
             let mut low = [0u64; N];
-            mul_low_fixed::<N>(&a, &b, &mut low);
+            mul_low_fixed::<N>(&lhs, &rhs, &mut low);
             let mut expected = [0u64; N];
             expected.copy_from_slice(&full[..N]);
-            assert_eq!(low, expected, "low-half mismatch for {a:?} * {b:?}");
+            assert_eq!(low, expected, "low-half mismatch for {lhs:?} * {rhs:?}");
         }
 
         // Width 4 (256-bit): zero, one, MAX, cross-limb spans.
@@ -3122,12 +3124,12 @@ mod tests {
     /// general truncated product `x · x` at every width and edge case.
     #[test]
     fn dedicated_sqr_matches_general_mul() {
-        fn check<const N: usize>(x: [u64; N]) {
-            let a = Uint::<N>::from_limbs(x);
+        fn check<const N: usize>(limbs: [u64; N]) {
+            let value = Uint::<N>::from_limbs(limbs);
             assert_eq!(
-                a.wrapping_sqr(),
-                a.wrapping_mul(a),
-                "sqr != mul(self,self) for {x:?}"
+                value.wrapping_sqr(),
+                value.wrapping_mul(value),
+                "sqr != mul(self,self) for {limbs:?}"
             );
         }
 
@@ -3185,15 +3187,15 @@ mod tests {
             if m == 0 {
                 return (0, true);
             }
-            let mut r: u128 = 0;
-            // Smallest r with (r+1)^k > m, capped to avoid overflow.
+            let mut root: u128 = 0;
+            // Smallest root with (root+1)^k > m, capped to avoid overflow.
             while {
-                let next = r + 1;
-                next.checked_pow(k).is_some_and(|p| p <= m)
+                let next = root + 1;
+                next.checked_pow(k).is_some_and(|power| power <= m)
             } {
-                r += 1;
+                root += 1;
             }
-            (r, r.pow(k) == m)
+            (root, root.pow(k) == m)
         }
 
         fn check<const N: usize>(m: u128, k: u32) {
@@ -3204,20 +3206,20 @@ mod tests {
             if N > 1 {
                 limbs[1] = hi;
             }
-            let n = Uint::<N>::from_limbs(limbs);
-            let (root, exact) = n.root_int(k);
-            let (eroot, eexact) = brute(m, k);
+            let value = Uint::<N>::from_limbs(limbs);
+            let (root, exact) = value.root_int(k);
+            let (expected_root, expected_exact) = brute(m, k);
             let root_lo = root.as_limbs()[0] as u128
                 | ((if N > 1 { root.as_limbs()[1] as u128 } else { 0 }) << 64);
-            assert_eq!(root_lo, eroot, "root mismatch for m={m}, k={k}");
-            assert_eq!(exact, eexact, "exact flag mismatch for m={m}, k={k}");
+            assert_eq!(root_lo, expected_root, "root mismatch for m={m}, k={k}");
+            assert_eq!(exact, expected_exact, "exact flag mismatch for m={m}, k={k}");
 
             // The defining bracket, computed in-width.
-            let rk = root.pow(k);
-            assert!(rk <= n, "root^k > m for m={m}, k={k}");
+            let root_pow = root.pow(k);
+            assert!(root_pow <= value, "root^k > m for m={m}, k={k}");
             let next = root.wrapping_add(Uint::<N>::ONE);
             // (root+1)^k overflowing the width still satisfies > m.
-            if let Some(p) = next.checked_pow(k) { assert!(p > n, "(root+1)^k <= m for m={m}, k={k}") }
+            if let Some(next_pow) = next.checked_pow(k) { assert!(next_pow > value, "(root+1)^k <= m for m={m}, k={k}") }
         }
 
         let samples: [u128; 14] = [
@@ -3857,9 +3859,9 @@ mod tests {
     #[test]
     fn uint_sqr_policy_matches_wrapping_sqr() {
         fn check<const N: usize>(limbs: [u64; N]) {
-            let x = Uint::<N>::from_limbs(limbs);
-            assert_eq!(x.sqr(), x.wrapping_sqr(), "sqr mismatch at {limbs:?}");
-            assert_eq!(x.sqr(), x.wrapping_mul(x), "sqr != x*x at {limbs:?}");
+            let value = Uint::<N>::from_limbs(limbs);
+            assert_eq!(value.sqr(), value.wrapping_sqr(), "sqr mismatch at {limbs:?}");
+            assert_eq!(value.sqr(), value.wrapping_mul(value), "sqr != x*x at {limbs:?}");
         }
         // Width 1
         check::<1>([0]);
@@ -3882,11 +3884,11 @@ mod tests {
     #[test]
     fn uint_cube_policy_matches_wrapping_cube() {
         fn check<const N: usize>(limbs: [u64; N]) {
-            let x = Uint::<N>::from_limbs(limbs);
-            assert_eq!(x.cube(), x.wrapping_cube(), "cube mismatch at {limbs:?}");
+            let value = Uint::<N>::from_limbs(limbs);
+            assert_eq!(value.cube(), value.wrapping_cube(), "cube mismatch at {limbs:?}");
             assert_eq!(
-                x.cube(),
-                x.wrapping_mul(x).wrapping_mul(x),
+                value.cube(),
+                value.wrapping_mul(value).wrapping_mul(value),
                 "cube != x*x*x at {limbs:?}"
             );
         }
@@ -3905,14 +3907,14 @@ mod tests {
     /// `Int<N>::sqr` and `Int<N>::cube` must match their wrapping siblings.
     #[test]
     fn int_sqr_cube_match_wrapping() {
-        fn check<const N: usize>(v: i128) {
-            let x = Int::<N>::from_i128(v);
-            assert_eq!(x.sqr(), x.wrapping_sqr(), "int sqr mismatch v={v}");
-            assert_eq!(x.cube(), x.wrapping_cube(), "int cube mismatch v={v}");
+        fn check<const N: usize>(value: i128) {
+            let int = Int::<N>::from_i128(value);
+            assert_eq!(int.sqr(), int.wrapping_sqr(), "int sqr mismatch v={value}");
+            assert_eq!(int.cube(), int.wrapping_cube(), "int cube mismatch v={value}");
         }
-        for v in [0i128, 1, -1, 12, -12, 100, -100, 1_000_000, -1_000_000] {
-            check::<4>(v);
-            check::<8>(v);
+        for value in [0i128, 1, -1, 12, -12, 100, -100, 1_000_000, -1_000_000] {
+            check::<4>(value);
+            check::<8>(value);
         }
     }
 
@@ -3921,46 +3923,46 @@ mod tests {
     #[test]
     fn uint_icbrt_floor_correctness() {
         // Brute-force floor cube-root of a u64, used as oracle for small inputs.
-        fn brute_cbrt(n: u64) -> u64 {
-            if n == 0 {
+        fn brute_cbrt(value: u64) -> u64 {
+            if value == 0 {
                 return 0;
             }
-            let mut r: u64 = 0;
-            while (r + 1).checked_mul((r + 1) * (r + 1) + r + 1)
-                .is_some_and(|p| p <= n)
-                || (r + 1).checked_pow(3).is_some_and(|p| p <= n)
+            let mut root: u64 = 0;
+            while (root + 1).checked_mul((root + 1) * (root + 1) + root + 1)
+                .is_some_and(|power| power <= value)
+                || (root + 1).checked_pow(3).is_some_and(|power| power <= value)
             {
-                r += 1;
+                root += 1;
             }
-            r
+            root
         }
 
-        fn check<const N: usize>(n: u64) {
-            let x = Uint::<N>::from_u64(n);
-            let root = x.icbrt();
+        fn check<const N: usize>(value: u64) {
+            let uint = Uint::<N>::from_u64(value);
+            let root = uint.icbrt();
             let root_u64 = root.as_limbs()[0];
-            let expected = brute_cbrt(n);
-            assert_eq!(root_u64, expected, "icbrt({n}) = {root_u64}, expected {expected}");
+            let expected = brute_cbrt(value);
+            assert_eq!(root_u64, expected, "icbrt({value}) = {root_u64}, expected {expected}");
             // Higher limbs of root must be zero for a u64 input.
             for i in 1..N {
-                assert_eq!(root.as_limbs()[i], 0, "icbrt({n}) high limb {i} nonzero");
+                assert_eq!(root.as_limbs()[i], 0, "icbrt({value}) high limb {i} nonzero");
             }
         }
 
         // Perfect cubes.
-        for n in [0u64, 1, 8, 27, 64, 125, 216, 343, 512, 729, 1000,
-                  1_000_000_000u64, 8_000_000_000u64] {
-            check::<1>(n);
-            check::<2>(n);
-            check::<4>(n);
+        for value in [0u64, 1, 8, 27, 64, 125, 216, 343, 512, 729, 1000,
+                      1_000_000_000u64, 8_000_000_000u64] {
+            check::<1>(value);
+            check::<2>(value);
+            check::<4>(value);
         }
 
         // Non-cubes (floor must be correct).
-        for n in [2u64, 3, 4, 5, 6, 7, 9, 10, 26, 28, 63, 65, 999,
-                  1_000_000_001u64] {
-            check::<1>(n);
-            check::<2>(n);
-            check::<4>(n);
+        for value in [2u64, 3, 4, 5, 6, 7, 9, 10, 26, 28, 63, 65, 999,
+                      1_000_000_001u64] {
+            check::<1>(value);
+            check::<2>(value);
+            check::<4>(value);
         }
 
         // Boundary cases: 0 and 1.
@@ -3970,9 +3972,9 @@ mod tests {
         check::<4>(1);
 
         // Large 64-bit values.
-        for n in [u64::MAX, u64::MAX - 1, u64::MAX - 100, 1 << 60, 1 << 48] {
-            check::<2>(n);
-            check::<4>(n);
+        for value in [u64::MAX, u64::MAX - 1, u64::MAX - 100, 1 << 60, 1 << 48] {
+            check::<2>(value);
+            check::<4>(value);
         }
     }
 
@@ -3982,21 +3984,21 @@ mod tests {
     #[test]
     fn uint_icbrt_wide_floor_identity() {
         fn check_wide<const N: usize>(limbs: [u64; N]) {
-            let x = Uint::<N>::from_limbs(limbs);
-            let r = x.icbrt();
+            let value = Uint::<N>::from_limbs(limbs);
+            let root = value.icbrt();
             // Verify r³ <= x.
-            let r3 = r.wrapping_pow(3);
+            let root_cubed = root.wrapping_pow(3);
             assert!(
-                r3 <= x,
+                root_cubed <= value,
                 "icbrt violated: r³ > x for {limbs:?}"
             );
             // Verify (r+1)³ > x (i.e. r is the floor).
-            let r1 = r.wrapping_add(Uint::<N>::ONE);
-            let r1_3 = r1.wrapping_pow(3);
+            let next_root = root.wrapping_add(Uint::<N>::ONE);
+            let next_root_cubed = next_root.wrapping_pow(3);
             // (r+1)³ wraps to 0 only if r+1 itself wraps (i.e. r == MAX),
             // which for a cube root of a representable value cannot happen.
             assert!(
-                r1_3 > x || r1 == Uint::<N>::ZERO,
+                next_root_cubed > value || next_root == Uint::<N>::ZERO,
                 "icbrt not floor: (r+1)³ <= x for {limbs:?}"
             );
         }
@@ -4004,11 +4006,11 @@ mod tests {
         // Perfect cubes in 2 limbs (root fits one limb).
         // 10^18 cubed = 10^54 — too large; use modest values.
         // 1_000_000^3 = 10^18, which fits 2 limbs (u64 goes to ~1.8 * 10^19).
-        let m = 1_000_000u64;
-        let m3 = m * m * m; // 10^18, fits u64
-        check_wide::<4>([m3, 0, 0, 0]);
-        check_wide::<4>([m3 + 1, 0, 0, 0]);
-        check_wide::<4>([m3 - 1, 0, 0, 0]);
+        let base = 1_000_000u64;
+        let base_cubed = base * base * base; // 10^18, fits u64
+        check_wide::<4>([base_cubed, 0, 0, 0]);
+        check_wide::<4>([base_cubed + 1, 0, 0, 0]);
+        check_wide::<4>([base_cubed - 1, 0, 0, 0]);
 
         // A 2-limb value: combine two u64 halves.
         let hi = 1u64;
@@ -4018,7 +4020,7 @@ mod tests {
         check_wide::<4>([u64::MAX, u64::MAX, 0, 0]); // near 2^128
 
         // Width 6 (N >= 3, Newton path for sure).
-        check_wide::<6>([m3, 0, 0, 0, 0, 0]);
+        check_wide::<6>([base_cubed, 0, 0, 0, 0, 0]);
         check_wide::<6>([u64::MAX, u64::MAX, u64::MAX, 0, 0, 0]); // near 2^192
     }
 
@@ -4113,21 +4115,21 @@ mod unified_mg_feasibility {
     use crate::int::types::traits::BigInt;
     use crate::support::rounding::RoundingMode;
 
-    /// `(a · b) / 10^scale` through the unified pipeline, computed as
+    /// `(lhs · rhs) / 10^scale` through the unified pipeline, computed as
     /// `Int<N>::widen_mul::<Int<M>>` (full product into the wider type)
     /// then `div_wide_pow10::<Int<M>>`. The wider type's u128 magnitude
     /// width is read from its scratch carrier's [`ComputeLimbs`] buffer
     /// (`single_u128`) inside the divide — the `Limbs<N>` carrier IS the
     /// mechanism for the wider work intermediate, so no work-width const
     /// parameter is named. Returns the scaled wider-width quotient.
-    fn scaled<const N: usize, const M: usize>(a: Int<N>, b: Int<N>, scale: u32) -> Int<M>
+    fn scaled<const N: usize, const M: usize>(lhs: Int<N>, rhs: Int<N>, scale: u32) -> Int<M>
     where
         Limbs<N>: ComputeLimbs,
         Int<M>: BigInt,
         Limbs<M>: ComputeLimbs,
         <Int<M> as BigInt>::Scratch: ComputeLimbs,
     {
-        let prod: Int<M> = a.widen_mul::<Int<M>>(b);
+        let prod: Int<M> = lhs.widen_mul::<Int<M>>(rhs);
         div_wide_pow10::<Int<M>>(prod, scale, RoundingMode::HalfToEven)
     }
 

--- a/src/int/types/traits.rs
+++ b/src/int/types/traits.rs
@@ -161,17 +161,18 @@ pub trait BigInt:
     /// `true` if bit `idx` of the two's-complement representation is set.
     fn bit(self, idx: u32) -> bool;
     /// Builds the value from a signed 128-bit integer.
-    fn from_i128(v: i128) -> Self;
+    fn from_i128(value: i128) -> Self;
     /// The value as a signed 128-bit integer (truncating to the low 128
     /// bits; the inverse of [`BigInt::from_i128`]).
     fn to_i128(self) -> i128;
-    /// `self * n` for an unsigned 64-bit multiplier (panics on overflow —
-    /// the default-form contract, matching `Mul`-operator semantics).
-    fn mul_u64(self, n: u64) -> Self;
+    /// `self * multiplier` for an unsigned 64-bit multiplier (panics on
+    /// overflow — the default-form contract, matching `Mul`-operator
+    /// semantics).
+    fn mul_u64(self, multiplier: u64) -> Self;
     /// Nearest-`f64` value of `self` (lossy above 53 significant bits).
     fn to_f64(self) -> f64;
     /// Truncating conversion from `f64` (saturating on out-of-range).
-    fn from_f64_val(v: f64) -> Self;
+    fn from_f64_val(value: f64) -> Self;
 
     // ── Limb round-trip bridge ───────────────────────────────────────
 
@@ -208,7 +209,7 @@ pub trait BigInt:
     where
         I: IntoIterator<Item = Self>,
     {
-        iter.into_iter().fold(Self::ZERO, |acc, x| acc + x)
+        iter.into_iter().fold(Self::ZERO, |acc, value| acc + value)
     }
 
     #[inline]
@@ -216,7 +217,7 @@ pub trait BigInt:
     where
         I: IntoIterator<Item = Self>,
     {
-        iter.into_iter().fold(Self::ONE, |acc, x| acc * x)
+        iter.into_iter().fold(Self::ONE, |acc, value| acc * value)
     }
 }
 
@@ -267,10 +268,10 @@ impl<const N: usize> BigInt for Int<N> {
         // verdict (the architecture's second axis) and const-folds it to a
         // single direct `mul_low_limb::<N, _>` call per monomorphisation.
         // Bit-identical to `wrapping_mul` (mod 2^64N) at either limb width.
-        let a = *self.as_limbs();
-        let b = *rhs.as_limbs();
+        let lhs_limbs = *self.as_limbs();
+        let rhs_limbs = *rhs.as_limbs();
         let mut out = [0u64; N];
-        crate::int::policy::mul_low::dispatch::<N>(&a, &b, &mut out);
+        crate::int::policy::mul_low::dispatch::<N>(&lhs_limbs, &rhs_limbs, &mut out);
         Int::from_limbs(out)
     }
 
@@ -280,9 +281,9 @@ impl<const N: usize> BigInt for Int<N> {
         // `int::policy::sqr_low`: same `(Algorithm, LimbSize)` second-axis
         // shape as `mul_low`, const-folded to one direct `sqr_low_limb::<N, _>`
         // call. Bit-identical to `sqr` (mod 2^64N) at either limb width.
-        let a = *self.as_limbs();
+        let value_limbs = *self.as_limbs();
         let mut out = [0u64; N];
-        crate::int::policy::sqr_low::dispatch::<N>(&a, &mut out);
+        crate::int::policy::sqr_low::dispatch::<N>(&value_limbs, &mut out);
         Int::from_limbs(out)
     }
 
@@ -378,8 +379,8 @@ impl<const N: usize> BigInt for Int<N> {
     }
 
     #[inline]
-    fn from_i128(v: i128) -> Self {
-        Int::from_i128(v)
+    fn from_i128(value: i128) -> Self {
+        Int::from_i128(value)
     }
 
     #[inline]
@@ -388,8 +389,8 @@ impl<const N: usize> BigInt for Int<N> {
     }
 
     #[inline]
-    fn mul_u64(self, n: u64) -> Self {
-        Int::mul_u64(self, n)
+    fn mul_u64(self, multiplier: u64) -> Self {
+        Int::mul_u64(self, multiplier)
     }
 
     #[inline]
@@ -398,8 +399,8 @@ impl<const N: usize> BigInt for Int<N> {
     }
 
     #[inline]
-    fn from_f64_val(v: f64) -> Self {
-        Int::from_f64(v)
+    fn from_f64_val(value: f64) -> Self {
+        Int::from_f64(value)
     }
 
     #[inline]
@@ -420,8 +421,8 @@ impl<const N: usize> BigInt for Int<N> {
         let n_full_pairs = N / 2;
         let dst_len = dst.len();
         let mut i = 0;
-        let m = n_full_pairs.min(dst_len);
-        while i < m {
+        let pairs_to_write = n_full_pairs.min(dst_len);
+        while i < pairs_to_write {
             dst[i] = (mag[2 * i] as u128) | ((mag[2 * i + 1] as u128) << 64);
             i += 1;
         }
@@ -450,18 +451,18 @@ impl<const N: usize> BigInt for Int<N> {
     fn from_mag_sign_u128(mag: &[u128], negative: bool) -> Self {
         let u128_limbs = N.div_ceil(2);
         let mut out = [0u64; N];
-        let m = u128_limbs.min(mag.len());
+        let readable_limbs = u128_limbs.min(mag.len());
         let n_full_pairs = N / 2;
-        let copy_pairs = n_full_pairs.min(m);
+        let copy_pairs = n_full_pairs.min(readable_limbs);
         let mut i = 0;
         while i < copy_pairs {
-            let v = mag[i];
-            out[2 * i] = v as u64;
-            out[2 * i + 1] = (v >> 64) as u64;
+            let pair = mag[i];
+            out[2 * i] = pair as u64;
+            out[2 * i + 1] = (pair >> 64) as u64;
             i += 1;
         }
         // Odd-N tail: only the low u64 of mag[i] survives.
-        if (N & 1) == 1 && i < m {
+        if (N & 1) == 1 && i < readable_limbs {
             out[2 * i] = mag[i] as u64;
         }
         Self::from_mag_limbs(&out, negative)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -217,16 +217,16 @@ mod types;
 #[doc(hidden)]
 pub mod __bench_internals {
     #[inline(never)]
-    pub fn mul_slice(a: &[u64], b: &[u64], out: &mut [u64]) {
-        crate::int::algos::mul::mul_schoolbook::mul_schoolbook(a, b, out)
+    pub fn mul_slice(lhs: &[u64], rhs: &[u64], out: &mut [u64]) {
+        crate::int::algos::mul::mul_schoolbook::mul_schoolbook(lhs, rhs, out)
     }
     /// Truncated-low fixed-width schoolbook multiply (base-2^64),
     /// `out = (a * b) mod 2^(64*N)`. The kernel the wide-tier exp/powf
     /// Taylor work-multiply (`Int<N>::wrapping_mul`) routes through.
     /// Exposed for the `mul_low_u128_ab` pilot microbench.
     #[inline(never)]
-    pub fn mul_low_u64<const N: usize>(a: &[u64; N], b: &[u64; N], out: &mut [u64; N]) {
-        crate::int::algos::mul::mul_schoolbook::mul_low_limb::<N, u64>(a, b, out)
+    pub fn mul_low_u64<const N: usize>(lhs: &[u64; N], rhs: &[u64; N], out: &mut [u64; N]) {
+        crate::int::algos::mul::mul_schoolbook::mul_low_limb::<N, u64>(lhs, rhs, out)
     }
     /// u128-limb-packed truncated-low schoolbook multiply (even `N` only):
     /// bit-identical low `N` limbs to [`mul_low_u64`], computed in `N/2`
@@ -234,8 +234,8 @@ pub mod __bench_internals {
     /// `mul_low_limb` kernel. Exposed for the `mul_low_u128_ab` `LimbSize`
     /// microbench (u64 vs u128 of the same generic kernel).
     #[inline(never)]
-    pub fn mul_low_u128<const N: usize>(a: &[u64; N], b: &[u64; N], out: &mut [u64; N]) {
-        crate::int::algos::mul::mul_schoolbook::mul_low_limb::<N, u128>(a, b, out)
+    pub fn mul_low_u128<const N: usize>(lhs: &[u64; N], rhs: &[u64; N], out: &mut [u64; N]) {
+        crate::int::algos::mul::mul_schoolbook::mul_low_limb::<N, u128>(lhs, rhs, out)
     }
     /// Per-`N` monomorphic wrappers over the ONE generic full-product
     /// schoolbook kernel `mul_full_limb::<N, L>` (the production
@@ -251,19 +251,19 @@ pub mod __bench_internals {
         // u64-only (odd N — u128 packing requires even N)
         ($u64name:ident, $n:literal) => {
             #[inline(never)]
-            pub fn $u64name(a: &[u64; $n], b: &[u64; $n], out: &mut [u64]) {
-                crate::int::algos::mul::mul_schoolbook::mul_full_limb::<$n, u64>(a, b, out)
+            pub fn $u64name(lhs: &[u64; $n], rhs: &[u64; $n], out: &mut [u64]) {
+                crate::int::algos::mul::mul_schoolbook::mul_full_limb::<$n, u64>(lhs, rhs, out)
             }
         };
         // both u64 + u128 (even N)
         ($u64name:ident, $u128name:ident, $n:literal) => {
             #[inline(never)]
-            pub fn $u64name(a: &[u64; $n], b: &[u64; $n], out: &mut [u64]) {
-                crate::int::algos::mul::mul_schoolbook::mul_full_limb::<$n, u64>(a, b, out)
+            pub fn $u64name(lhs: &[u64; $n], rhs: &[u64; $n], out: &mut [u64]) {
+                crate::int::algos::mul::mul_schoolbook::mul_full_limb::<$n, u64>(lhs, rhs, out)
             }
             #[inline(never)]
-            pub fn $u128name(a: &[u64; $n], b: &[u64; $n], out: &mut [u64]) {
-                crate::int::algos::mul::mul_schoolbook::mul_full_limb::<$n, u128>(a, b, out)
+            pub fn $u128name(lhs: &[u64; $n], rhs: &[u64; $n], out: &mut [u64]) {
+                crate::int::algos::mul::mul_schoolbook::mul_full_limb::<$n, u128>(lhs, rhs, out)
             }
         };
     }
@@ -287,8 +287,8 @@ pub mod __bench_internals {
     /// (`BigInt::wrapping_sqr_low_u128`) routes through at `L = u64`. Exposed
     /// for the `sqr_low_u128_ab` pilot microbench.
     #[inline(never)]
-    pub fn sqr_low_u64<const N: usize>(x: &[u64; N], out: &mut [u64; N]) {
-        crate::int::algos::sqr::sqr_low_limb::sqr_low_limb::<N, u64>(x, out)
+    pub fn sqr_low_u64<const N: usize>(value: &[u64; N], out: &mut [u64; N]) {
+        crate::int::algos::sqr::sqr_low_limb::sqr_low_limb::<N, u64>(value, out)
     }
     /// u128-limb-packed truncated-low symmetric square (even `N` only):
     /// bit-identical low `N` limbs to [`sqr_low_u64`], computed in `N/2`
@@ -296,16 +296,16 @@ pub mod __bench_internals {
     /// `sqr_low_limb` kernel. Exposed for the `sqr_low_u128_ab` `LimbSize`
     /// microbench (u64 vs u128 of the same generic kernel).
     #[inline(never)]
-    pub fn sqr_low_u128<const N: usize>(x: &[u64; N], out: &mut [u64; N]) {
-        crate::int::algos::sqr::sqr_low_limb::sqr_low_limb::<N, u128>(x, out)
+    pub fn sqr_low_u128<const N: usize>(value: &[u64; N], out: &mut [u64; N]) {
+        crate::int::algos::sqr::sqr_low_limb::sqr_low_limb::<N, u128>(value, out)
     }
     #[inline(never)]
     pub fn mul_fixed<const L: usize, const D: usize>(
-        a: &[u64; L],
-        b: &[u64; L],
+        lhs: &[u64; L],
+        rhs: &[u64; L],
         out: &mut [u64; D],
     ) {
-        crate::int::algos::mul::mul_schoolbook::mul_schoolbook_fixed::<L, D>(a, b, out)
+        crate::int::algos::mul::mul_schoolbook::mul_schoolbook_fixed::<L, D>(lhs, rhs, out)
     }
     /// Non-allocating Karatsuba multiply forced to recurse at the given
     /// `threshold` (rather than the parked production
@@ -313,8 +313,8 @@ pub mod __bench_internals {
     /// kernel at sub-threshold widths. `threshold >= 4` (the recursion's
     /// termination floor). `out` is zeroed by the callee.
     #[inline(never)]
-    pub fn mul_karatsuba_forced(a: &[u64], b: &[u64], out: &mut [u64], threshold: usize) {
-        crate::int::algos::mul::mul_karatsuba::mul_karatsuba_forced(a, b, out, threshold)
+    pub fn mul_karatsuba_forced(lhs: &[u64], rhs: &[u64], out: &mut [u64], threshold: usize) {
+        crate::int::algos::mul::mul_karatsuba::mul_karatsuba_forced(lhs, rhs, out, threshold)
     }
     /// Per-N monomorphic wrappers over the Limb-generic Karatsuba kernel
     /// mul_karatsuba_limb::<N, L>. The u64 arm runs the same recursion as
@@ -324,18 +324,18 @@ pub mod __bench_internals {
     macro_rules! mul_kara_limb_wrappers {
         ($u64name:ident, $n:literal) => {
             #[inline(never)]
-            pub fn $u64name(a: &[u64; $n], b: &[u64; $n], out: &mut [u64]) {
-                crate::int::algos::mul::mul_karatsuba::mul_karatsuba_limb::<$n, u64>(a, b, out, $n)
+            pub fn $u64name(lhs: &[u64; $n], rhs: &[u64; $n], out: &mut [u64]) {
+                crate::int::algos::mul::mul_karatsuba::mul_karatsuba_limb::<$n, u64>(lhs, rhs, out, $n)
             }
         };
         ($u64name:ident, $u128name:ident, $n:literal) => {
             #[inline(never)]
-            pub fn $u64name(a: &[u64; $n], b: &[u64; $n], out: &mut [u64]) {
-                crate::int::algos::mul::mul_karatsuba::mul_karatsuba_limb::<$n, u64>(a, b, out, $n)
+            pub fn $u64name(lhs: &[u64; $n], rhs: &[u64; $n], out: &mut [u64]) {
+                crate::int::algos::mul::mul_karatsuba::mul_karatsuba_limb::<$n, u64>(lhs, rhs, out, $n)
             }
             #[inline(never)]
-            pub fn $u128name(a: &[u64; $n], b: &[u64; $n], out: &mut [u64]) {
-                crate::int::algos::mul::mul_karatsuba::mul_karatsuba_limb::<$n, u128>(a, b, out, $n)
+            pub fn $u128name(lhs: &[u64; $n], rhs: &[u64; $n], out: &mut [u64]) {
+                crate::int::algos::mul::mul_karatsuba::mul_karatsuba_limb::<$n, u128>(lhs, rhs, out, $n)
             }
         };
     }
@@ -358,8 +358,8 @@ pub mod __bench_internals {
     macro_rules! mul_kara_u128_thresh {
         ($name:ident, $n:literal) => {
             #[inline(never)]
-            pub fn $name(a: &[u64; $n], b: &[u64; $n], out: &mut [u64], threshold: usize) {
-                crate::int::algos::mul::mul_karatsuba::mul_karatsuba_limb::<$n, u128>(a, b, out, threshold)
+            pub fn $name(lhs: &[u64; $n], rhs: &[u64; $n], out: &mut [u64], threshold: usize) {
+                crate::int::algos::mul::mul_karatsuba::mul_karatsuba_limb::<$n, u128>(lhs, rhs, out, threshold)
             }
         };
     }
@@ -370,8 +370,8 @@ pub mod __bench_internals {
     /// Toom-Cook 3-way multiply exposed for the mul_toom3_ab microbench.
     /// out must be zeroed by the caller; out.len() >= 2 * a.len().
     #[inline(never)]
-    pub fn mul_toom3_slice(a: &[u64], b: &[u64], out: &mut [u64]) {
-        crate::int::algos::mul::mul_toom3::mul_toom3(a, b, out)
+    pub fn mul_toom3_slice(lhs: &[u64], rhs: &[u64], out: &mut [u64]) {
+        crate::int::algos::mul::mul_toom3::mul_toom3(lhs, rhs, out)
     }
     /// Per-N monomorphic wrappers over the Limb-generic Toom-3 kernel
     /// mul_toom3_limb::<N, L>. The u64 arm runs the value-slice recursion; the
@@ -381,12 +381,12 @@ pub mod __bench_internals {
     macro_rules! mul_toom3_limb_wrappers {
         ($u64name:ident, $u128name:ident, $n:literal) => {
             #[inline(never)]
-            pub fn $u64name(a: &[u64; $n], b: &[u64; $n], out: &mut [u64]) {
-                crate::int::algos::mul::mul_toom3::mul_toom3_limb::<$n, u64>(a, b, out)
+            pub fn $u64name(lhs: &[u64; $n], rhs: &[u64; $n], out: &mut [u64]) {
+                crate::int::algos::mul::mul_toom3::mul_toom3_limb::<$n, u64>(lhs, rhs, out)
             }
             #[inline(never)]
-            pub fn $u128name(a: &[u64; $n], b: &[u64; $n], out: &mut [u64]) {
-                crate::int::algos::mul::mul_toom3::mul_toom3_limb::<$n, u128>(a, b, out)
+            pub fn $u128name(lhs: &[u64; $n], rhs: &[u64; $n], out: &mut [u64]) {
+                crate::int::algos::mul::mul_toom3::mul_toom3_limb::<$n, u128>(lhs, rhs, out)
             }
         };
     }
@@ -403,12 +403,12 @@ pub mod __bench_internals {
     /// path). Both take little-endian u64 magnitude limb
     /// slices; `quot` / `rem` are written by the engine.
     #[inline(never)]
-    pub fn div_knuth_slice(num: &[u64], den: &[u64], quot: &mut [u64], rem: &mut [u64]) {
-        crate::int::algos::div::div_knuth::div_knuth(num, den, quot, rem)
+    pub fn div_knuth_slice(numerator: &[u64], divisor: &[u64], quotient: &mut [u64], remainder: &mut [u64]) {
+        crate::int::algos::div::div_knuth::div_knuth(numerator, divisor, quotient, remainder)
     }
     #[inline(never)]
-    pub fn div_dispatch_slice(num: &[u64], den: &[u64], quot: &mut [u64], rem: &mut [u64]) {
-        crate::int::policy::div_rem::dispatch(num, den, quot, rem)
+    pub fn div_dispatch_slice(numerator: &[u64], divisor: &[u64], quotient: &mut [u64], remainder: &mut [u64]) {
+        crate::int::policy::div_rem::dispatch(numerator, divisor, quotient, remainder)
     }
     /// Base-2¹²⁸ (u128-limb) Knuth candidate for `div_kernel_ab` — the
     /// divide side of the `LimbSize` axis, PARKED (not wired into any
@@ -416,16 +416,16 @@ pub mod __bench_internals {
     /// the aligned u128 carry-chain beats base-2⁶⁴ despite the 4-mult q̂·v
     /// product.
     #[inline(never)]
-    pub fn div_knuth_u128_limb_slice(num: &[u64], den: &[u64], quot: &mut [u64], rem: &mut [u64]) {
-        crate::int::algos::div::div_knuth_u128_limb::div_knuth_u128_limb(num, den, quot, rem)
+    pub fn div_knuth_u128_limb_slice(numerator: &[u64], divisor: &[u64], quotient: &mut [u64], remainder: &mut [u64]) {
+        crate::int::algos::div::div_knuth_u128_limb::div_knuth_u128_limb(numerator, divisor, quotient, remainder)
     }
     /// Burnikel-Ziegler chunking engine FORCED on (production engagement
     /// guard bypassed) so the Knuth-vs-BZ crossover can be timed at
     /// sub-threshold widths in `div_kernel_ab`.
     #[inline(never)]
-    pub fn div_bz_forced_slice(num: &[u64], den: &[u64], quot: &mut [u64], rem: &mut [u64]) {
+    pub fn div_bz_forced_slice(numerator: &[u64], divisor: &[u64], quotient: &mut [u64], remainder: &mut [u64]) {
         crate::int::algos::div::div_burnikel_ziegler_with_knuth::bz_chunk_core_forced(
-            num, den, quot, rem,
+            numerator, divisor, quotient, remainder,
         )
     }
     /// `div_rem` single-/double-limb hardware fast-path candidate for
@@ -433,16 +433,16 @@ pub mod __bench_internals {
     /// engines; A/B measures the small-divisor regime where the const
     /// `u128 / u64` path is the production routing.
     #[inline(never)]
-    pub fn div_rem_fast_slice(num: &[u64], den: &[u64], quot: &mut [u64], rem: &mut [u64]) {
-        crate::int::algos::div::div_rem::div_rem(num, den, quot, rem)
+    pub fn div_rem_fast_slice(numerator: &[u64], divisor: &[u64], quotient: &mut [u64], remainder: &mut [u64]) {
+        crate::int::algos::div::div_rem::div_rem(numerator, divisor, quotient, remainder)
     }
     /// `div_rem_schoolbook` binary shift-subtract reference baseline for
     /// `div_kernel_ab` — the `Algorithm::Schoolbook` arm. Bit-identical to the
     /// other engines; A/B confirms it is the slowest (the never-routed
     /// baseline) at every shape.
     #[inline(never)]
-    pub fn div_schoolbook_slice(num: &[u64], den: &[u64], quot: &mut [u64], rem: &mut [u64]) {
-        crate::int::algos::div::div_rem_schoolbook::div_rem_schoolbook(num, den, quot, rem)
+    pub fn div_schoolbook_slice(numerator: &[u64], divisor: &[u64], quotient: &mut [u64], remainder: &mut [u64]) {
+        crate::int::algos::div::div_rem_schoolbook::div_rem_schoolbook(numerator, divisor, quotient, remainder)
     }
     /// Integer hypot kernel candidates for the `hypot_ab` microbench:
     /// the production Pythagoras path (radicand `a²+b²` + Newton slice
@@ -451,26 +451,26 @@ pub mod __bench_internals {
     #[inline(never)]
     #[allow(private_bounds)]
     pub fn hypot_pythagoras<const N: usize>(
-        a: crate::int::types::Int<N>,
-        b: crate::int::types::Int<N>,
+        lhs: crate::int::types::Int<N>,
+        rhs: crate::int::types::Int<N>,
         mode: crate::RoundingMode,
     ) -> Option<crate::int::types::Int<N>>
     where
         crate::int::types::compute_limbs::Limbs<N>: crate::int::types::compute_limbs::ComputeLimbs,
     {
-        crate::int::algos::hypot::hypot_pythagoras::hypot_pythagoras::<N>(a, b, mode)
+        crate::int::algos::hypot::hypot_pythagoras::hypot_pythagoras::<N>(lhs, rhs, mode)
     }
     #[inline(never)]
     #[allow(private_bounds)]
     pub fn hypot_u128_fast<const N: usize>(
-        a: crate::int::types::Int<N>,
-        b: crate::int::types::Int<N>,
+        lhs: crate::int::types::Int<N>,
+        rhs: crate::int::types::Int<N>,
         mode: crate::RoundingMode,
     ) -> Option<crate::int::types::Int<N>>
     where
         crate::int::types::compute_limbs::Limbs<N>: crate::int::types::compute_limbs::ComputeLimbs,
     {
-        crate::int::algos::hypot::hypot_u128_fast::hypot_u128_fast::<N>(a, b, mode)
+        crate::int::algos::hypot::hypot_u128_fast::hypot_u128_fast::<N>(lhs, rhs, mode)
     }
 
     /// Remainder algorithm candidates exposed for the `rem_kernel_ab`
@@ -478,43 +478,43 @@ pub mod __bench_internals {
     /// `select` arm per width).
     #[inline(never)]
     pub fn rem_native<const N: usize>(
-        a: crate::int::types::Int<N>,
-        b: crate::int::types::Int<N>,
+        lhs: crate::int::types::Int<N>,
+        rhs: crate::int::types::Int<N>,
     ) -> crate::int::types::Int<N> {
-        crate::int::algos::rem::rem_native::rem_native::<N>(a, b)
+        crate::int::algos::rem::rem_native::rem_native::<N>(lhs, rhs)
     }
     #[inline(never)]
     pub fn rem_via_div_rem<const N: usize>(
-        a: crate::int::types::Int<N>,
-        b: crate::int::types::Int<N>,
+        lhs: crate::int::types::Int<N>,
+        rhs: crate::int::types::Int<N>,
     ) -> crate::int::types::Int<N> {
-        crate::int::algos::rem::rem_via_div_rem::rem_via_div_rem::<N>(a, b)
+        crate::int::algos::rem::rem_via_div_rem::rem_via_div_rem::<N>(lhs, rhs)
     }
     #[inline(never)]
     pub fn rem_schoolbook<const N: usize>(
-        a: crate::int::types::Int<N>,
-        b: crate::int::types::Int<N>,
+        lhs: crate::int::types::Int<N>,
+        rhs: crate::int::types::Int<N>,
     ) -> crate::int::types::Int<N> {
-        crate::int::algos::rem::rem_schoolbook::rem_schoolbook::<N>(a, b)
+        crate::int::algos::rem::rem_schoolbook::rem_schoolbook::<N>(lhs, rhs)
     }
     /// Width-agnostic small-magnitude hardware-`%` fast path candidate (the
     /// value-gated single-word fast path; falls
     /// back to `via_div_rem` for genuinely-wide operands).
     #[inline(never)]
     pub fn rem_small_fast<const N: usize>(
-        a: crate::int::types::Int<N>,
-        b: crate::int::types::Int<N>,
+        lhs: crate::int::types::Int<N>,
+        rhs: crate::int::types::Int<N>,
     ) -> crate::int::types::Int<N> {
-        crate::int::algos::rem::rem_small_fast::rem_small_fast::<N>(a, b)
+        crate::int::algos::rem::rem_small_fast::rem_small_fast::<N>(lhs, rhs)
     }
     /// Direct two's-complement `i128 %` remainder candidate for `N <= 2`
     /// (skips the sign-magnitude round trip `rem_native` pays).
     #[inline(never)]
     pub fn rem_native_direct<const N: usize>(
-        a: crate::int::types::Int<N>,
-        b: crate::int::types::Int<N>,
+        lhs: crate::int::types::Int<N>,
+        rhs: crate::int::types::Int<N>,
     ) -> crate::int::types::Int<N> {
-        crate::int::algos::rem::rem_native_direct::rem_native_direct::<N>(a, b)
+        crate::int::algos::rem::rem_native_direct::rem_native_direct::<N>(lhs, rhs)
     }
 
     /// Integer `sqr` kernel candidates exposed for the `int_unary_kernel_ab`
@@ -522,15 +522,15 @@ pub mod __bench_internals {
     /// routes to `HalfProduct` at every width vs the `Schoolbook` reference).
     #[inline(never)]
     pub fn sqr_half_product<const N: usize>(
-        x: crate::int::types::Uint<N>,
+        value: crate::int::types::Uint<N>,
     ) -> crate::int::types::Uint<N> {
-        crate::int::algos::sqr::sqr_half_product::sqr_half_product::<N>(x)
+        crate::int::algos::sqr::sqr_half_product::sqr_half_product::<N>(value)
     }
     #[inline(never)]
     pub fn sqr_schoolbook<const N: usize>(
-        x: crate::int::types::Uint<N>,
+        value: crate::int::types::Uint<N>,
     ) -> crate::int::types::Uint<N> {
-        crate::int::algos::sqr::sqr_schoolbook::sqr_schoolbook::<N>(x)
+        crate::int::algos::sqr::sqr_schoolbook::sqr_schoolbook::<N>(value)
     }
 
     /// Integer `pow` kernel candidates exposed for the `int_unary_kernel_ab`
@@ -555,12 +555,12 @@ pub mod __bench_internals {
     /// `Schoolbook` reference) over little-endian magnitude limb slices,
     /// exposed for the `int_unary_kernel_ab` microbench.
     #[inline(never)]
-    pub fn isqrt_newton_slice(n: &[u64], out: &mut [u64]) {
-        crate::int::algos::isqrt::isqrt_newton::isqrt_newton(n, out)
+    pub fn isqrt_newton_slice(magnitude: &[u64], out: &mut [u64]) {
+        crate::int::algos::isqrt::isqrt_newton::isqrt_newton(magnitude, out)
     }
     #[inline(never)]
-    pub fn isqrt_schoolbook_slice(n: &[u64], out: &mut [u64]) {
-        crate::int::algos::isqrt::isqrt_schoolbook::isqrt_schoolbook(n, out)
+    pub fn isqrt_schoolbook_slice(magnitude: &[u64], out: &mut [u64]) {
+        crate::int::algos::isqrt::isqrt_schoolbook::isqrt_schoolbook(magnitude, out)
     }
     /// Native hardware integer square root candidate (`u64::isqrt` for
     /// `N == 1`, `u128::isqrt` for `N == 2`) exposed for the dedicated
@@ -571,20 +571,20 @@ pub mod __bench_internals {
     ///
     /// [m]: crate::int::algos::isqrt::isqrt_mag_fixed::isqrt_mag_fixed
     #[inline(never)]
-    pub fn isqrt_native_fixed<const N: usize>(n: &[u64; N], out: &mut [u64; N]) {
-        crate::int::algos::isqrt::isqrt_mag_fixed::isqrt_mag_fixed::<N>(n, out)
+    pub fn isqrt_native_fixed<const N: usize>(magnitude: &[u64; N], out: &mut [u64; N]) {
+        crate::int::algos::isqrt::isqrt_mag_fixed::isqrt_mag_fixed::<N>(magnitude, out)
     }
 
     /// Integer `icbrt` kernel candidates (Newton f64-seeded vs the bitwise
     /// `Schoolbook` reference) over little-endian magnitude limb slices,
     /// exposed for the `int_unary_kernel_ab` microbench.
     #[inline(never)]
-    pub fn icbrt_newton_slice(n: &[u64], out: &mut [u64]) {
-        crate::int::algos::icbrt::icbrt_newton::icbrt_newton(n, out)
+    pub fn icbrt_newton_slice(magnitude: &[u64], out: &mut [u64]) {
+        crate::int::algos::icbrt::icbrt_newton::icbrt_newton(magnitude, out)
     }
     #[inline(never)]
-    pub fn icbrt_schoolbook_slice(n: &[u64], out: &mut [u64]) {
-        crate::int::algos::icbrt::icbrt_schoolbook::icbrt_schoolbook(n, out)
+    pub fn icbrt_schoolbook_slice(magnitude: &[u64], out: &mut [u64]) {
+        crate::int::algos::icbrt::icbrt_schoolbook::icbrt_schoolbook(magnitude, out)
     }
 
     /// Karatsuba Square Root candidate (`isqrt_karatsuba`) over little-endian
@@ -593,8 +593,8 @@ pub mod __bench_internals {
     /// `O(log n)` half-width divides beat Newton's full-width-divide-per-iter
     /// at each width.
     #[inline(never)]
-    pub fn isqrt_karatsuba_slice(n: &[u64], out: &mut [u64]) {
-        crate::int::algos::isqrt::isqrt_karatsuba::isqrt_karatsuba(n, out)
+    pub fn isqrt_karatsuba_slice(magnitude: &[u64], out: &mut [u64]) {
+        crate::int::algos::isqrt::isqrt_karatsuba::isqrt_karatsuba(magnitude, out)
     }
 
     /// Division-free reciprocal-Newton cube-root candidate
@@ -603,8 +603,8 @@ pub mod __bench_internals {
     /// [`icbrt_newton_slice`]; A/B measures whether the multiply-only
     /// reciprocal iteration beats the shipped divide-per-iteration Newton.
     #[inline(never)]
-    pub fn icbrt_newton_recip_slice(n: &[u64], out: &mut [u64]) {
-        crate::int::algos::icbrt::icbrt_newton_recip::icbrt_newton_recip(n, out)
+    pub fn icbrt_newton_recip_slice(magnitude: &[u64], out: &mut [u64]) {
+        crate::int::algos::icbrt::icbrt_newton_recip::icbrt_newton_recip(magnitude, out)
     }
 
     /// Integer `cube` candidates exposed for the `int_cube_eq_ab`
@@ -613,15 +613,15 @@ pub mod __bench_internals {
     /// over `N`, both `const fn`, bit-identical low `N` limbs.
     #[inline(never)]
     pub fn cube_schoolbook<const N: usize>(
-        x: crate::int::types::Uint<N>,
+        value: crate::int::types::Uint<N>,
     ) -> crate::int::types::Uint<N> {
-        crate::int::algos::cube::cube_schoolbook::cube_schoolbook::<N>(x)
+        crate::int::algos::cube::cube_schoolbook::cube_schoolbook::<N>(value)
     }
     #[inline(never)]
     pub fn cube_fused_comba<const N: usize>(
-        x: crate::int::types::Uint<N>,
+        value: crate::int::types::Uint<N>,
     ) -> crate::int::types::Uint<N> {
-        crate::int::algos::cube::cube_fused_comba::cube_fused_comba::<N>(x)
+        crate::int::algos::cube::cube_fused_comba::cube_fused_comba::<N>(value)
     }
 
     /// Integer `eq` candidates exposed for the `int_cube_eq_ab`
@@ -630,17 +630,17 @@ pub mod __bench_internals {
     /// generic over `N`, both `const fn`, bit-identical.
     #[inline(never)]
     pub fn eq_limbwise<const N: usize>(
-        a: crate::int::types::Int<N>,
-        b: crate::int::types::Int<N>,
+        lhs: crate::int::types::Int<N>,
+        rhs: crate::int::types::Int<N>,
     ) -> bool {
-        crate::int::algos::eq::eq_limbwise::eq_limbwise::<N>(a, b)
+        crate::int::algos::eq::eq_limbwise::eq_limbwise::<N>(lhs, rhs)
     }
     #[inline(never)]
     pub fn eq_xor_fold<const N: usize>(
-        a: crate::int::types::Int<N>,
-        b: crate::int::types::Int<N>,
+        lhs: crate::int::types::Int<N>,
+        rhs: crate::int::types::Int<N>,
     ) -> bool {
-        crate::int::algos::eq::eq_xor_fold::eq_xor_fold::<N>(a, b)
+        crate::int::algos::eq::eq_xor_fold::eq_xor_fold::<N>(lhs, rhs)
     }
 
     /// Per-`N` monomorphic wrappers over the two generic `sum_sq` kernels,
@@ -655,17 +655,17 @@ pub mod __bench_internals {
         ($sb:ident, $cb:ident, $n:literal) => {
             #[inline(never)]
             pub fn $sb(
-                a: crate::int::types::Int<$n>,
-                b: crate::int::types::Int<$n>,
+                lhs: crate::int::types::Int<$n>,
+                rhs: crate::int::types::Int<$n>,
             ) -> Option<crate::int::types::Int<$n>> {
-                crate::int::algos::sum_sq::sum_sq_schoolbook::sum_sq_schoolbook::<$n>(a, b)
+                crate::int::algos::sum_sq::sum_sq_schoolbook::sum_sq_schoolbook::<$n>(lhs, rhs)
             }
             #[inline(never)]
             pub fn $cb(
-                a: crate::int::types::Int<$n>,
-                b: crate::int::types::Int<$n>,
+                lhs: crate::int::types::Int<$n>,
+                rhs: crate::int::types::Int<$n>,
             ) -> Option<crate::int::types::Int<$n>> {
-                crate::int::algos::sum_sq::sum_sq_comba::sum_sq_comba::<$n>(a, b)
+                crate::int::algos::sum_sq::sum_sq_comba::sum_sq_comba::<$n>(lhs, rhs)
             }
         };
     }
@@ -687,55 +687,55 @@ pub mod __bench_internals {
     /// the generic `mul_widen_divide` arm at every band).
     #[inline(never)]
     pub fn dec_div_native<const N: usize, const SCALE: u32>(
-        a: crate::int::types::Int<N>,
-        b: crate::int::types::Int<N>,
+        lhs: crate::int::types::Int<N>,
+        rhs: crate::int::types::Int<N>,
         mode: crate::RoundingMode,
     ) -> crate::int::types::Int<N> {
-        crate::algos::div::div_native::div_native::<N, SCALE>(a, b, mode)
+        crate::algos::div::div_native::div_native::<N, SCALE>(lhs, rhs, mode)
     }
     #[inline(never)]
     pub fn dec_div_widen_scale_n1(
-        a: crate::int::types::Int<1>,
-        b: crate::int::types::Int<1>,
-        mult: crate::int::types::Int<1>,
+        lhs: crate::int::types::Int<1>,
+        rhs: crate::int::types::Int<1>,
+        multiplier: crate::int::types::Int<1>,
         mode: crate::RoundingMode,
     ) -> crate::int::types::Int<1> {
-        crate::algos::div::div_widen_scale::div_widen_scale::<1>(a, b, mult, mode)
+        crate::algos::div::div_widen_scale::div_widen_scale::<1>(lhs, rhs, multiplier, mode)
     }
     #[inline(never)]
     pub fn dec_div_widen_scale_n2(
-        a: crate::int::types::Int<2>,
-        b: crate::int::types::Int<2>,
-        mult: crate::int::types::Int<2>,
+        lhs: crate::int::types::Int<2>,
+        rhs: crate::int::types::Int<2>,
+        multiplier: crate::int::types::Int<2>,
         mode: crate::RoundingMode,
     ) -> crate::int::types::Int<2> {
-        crate::algos::div::div_widen_scale::div_widen_scale::<2>(a, b, mult, mode)
+        crate::algos::div::div_widen_scale::div_widen_scale::<2>(lhs, rhs, multiplier, mode)
     }
     /// Decimal multiply kernels exposed for the `mul_div_native_ab`
     /// microbench (the narrow native-vs-widen mul A/B at the dispatch seam).
     #[inline(never)]
     pub fn dec_mul_native<const N: usize, const SCALE: u32>(
-        a: crate::int::types::Int<N>,
-        b: crate::int::types::Int<N>,
+        lhs: crate::int::types::Int<N>,
+        rhs: crate::int::types::Int<N>,
         mode: crate::RoundingMode,
     ) -> crate::int::types::Int<N> {
-        crate::algos::mul::mul_native::mul_native::<N, SCALE>(a, b, mode)
+        crate::algos::mul::mul_native::mul_native::<N, SCALE>(lhs, rhs, mode)
     }
     #[inline(never)]
     pub fn dec_mul_widen_divide_n1<const SCALE: u32>(
-        a: crate::int::types::Int<1>,
-        b: crate::int::types::Int<1>,
+        lhs: crate::int::types::Int<1>,
+        rhs: crate::int::types::Int<1>,
         mode: crate::RoundingMode,
     ) -> crate::int::types::Int<1> {
-        crate::algos::mul::mul_widen_divide::mul_widen_divide::<1, SCALE>(a, b, mode)
+        crate::algos::mul::mul_widen_divide::mul_widen_divide::<1, SCALE>(lhs, rhs, mode)
     }
     #[inline(never)]
     pub fn dec_mul_widen_divide_n2<const SCALE: u32>(
-        a: crate::int::types::Int<2>,
-        b: crate::int::types::Int<2>,
+        lhs: crate::int::types::Int<2>,
+        rhs: crate::int::types::Int<2>,
         mode: crate::RoundingMode,
     ) -> crate::int::types::Int<2> {
-        crate::algos::mul::mul_widen_divide::mul_widen_divide::<2, SCALE>(a, b, mode)
+        crate::algos::mul::mul_widen_divide::mul_widen_divide::<2, SCALE>(lhs, rhs, mode)
     }
     /// Generic-`N` decimal widen-then-divide multiply, exposed so the
     /// wide-tier `÷10^w` rescale (the D76/D115/D153 high-scale `mul`
@@ -744,27 +744,27 @@ pub mod __bench_internals {
     #[inline(never)]
     #[allow(private_bounds)]
     pub fn dec_mul_widen_divide<const N: usize, const SCALE: u32>(
-        a: crate::int::types::Int<N>,
-        b: crate::int::types::Int<N>,
+        lhs: crate::int::types::Int<N>,
+        rhs: crate::int::types::Int<N>,
         mode: crate::RoundingMode,
     ) -> crate::int::types::Int<N>
     where
         crate::int::types::compute_limbs::Limbs<N>: crate::int::types::compute_limbs::ComputeLimbs,
     {
-        crate::algos::mul::mul_widen_divide::mul_widen_divide::<N, SCALE>(a, b, mode)
+        crate::algos::mul::mul_widen_divide::mul_widen_divide::<N, SCALE>(lhs, rhs, mode)
     }
     /// Decimal remainder kernels exposed for the `rem_kernel_ab` microbench
     /// (the narrow native-vs-int-layer decimal rem A/B at the dispatch seam).
     #[inline(never)]
     #[allow(private_bounds)]
     pub fn dec_rem_int_layer<const N: usize>(
-        a: crate::int::types::Int<N>,
-        b: crate::int::types::Int<N>,
+        lhs: crate::int::types::Int<N>,
+        rhs: crate::int::types::Int<N>,
     ) -> crate::int::types::Int<N>
     where
         crate::int::types::compute_limbs::Limbs<N>: crate::int::types::compute_limbs::ComputeLimbs,
     {
-        crate::algos::rem::rem_int_layer::rem_int_layer::<N>(a, b)
+        crate::algos::rem::rem_int_layer::rem_int_layer::<N>(lhs, rhs)
     }
     /// The pre-fast-path `rem_int_layer`: always the exact-scratch Knuth
     /// divmod (no single-word `u128 % u128` short-circuit). Exposed so
@@ -773,13 +773,13 @@ pub mod __bench_internals {
     #[inline(never)]
     #[allow(private_bounds)]
     pub fn dec_rem_int_layer_divmod<const N: usize>(
-        a: crate::int::types::Int<N>,
-        b: crate::int::types::Int<N>,
+        lhs: crate::int::types::Int<N>,
+        rhs: crate::int::types::Int<N>,
     ) -> crate::int::types::Int<N>
     where
         crate::int::types::compute_limbs::Limbs<N>: crate::int::types::compute_limbs::ComputeLimbs,
     {
-        crate::algos::rem::rem_int_layer::rem_int_layer_divmod::<N>(a, b)
+        crate::algos::rem::rem_int_layer::rem_int_layer_divmod::<N>(lhs, rhs)
     }
     /// The `Int::wrapping_rem` wide decimal-remainder path (the const
     /// single-algorithm `div_rem`, whose multi-limb fallback is an
@@ -788,17 +788,17 @@ pub mod __bench_internals {
     /// on the live-bench `k * 10^SCALE` shape.
     #[inline(never)]
     pub fn int_wrapping_rem_slice<const N: usize>(
-        a: crate::int::types::Int<N>,
-        b: crate::int::types::Int<N>,
+        lhs: crate::int::types::Int<N>,
+        rhs: crate::int::types::Int<N>,
     ) -> crate::int::types::Int<N> {
-        a.wrapping_rem(b)
+        lhs.wrapping_rem(rhs)
     }
     #[inline(never)]
     pub fn dec_rem_native<const N: usize>(
-        a: crate::int::types::Int<N>,
-        b: crate::int::types::Int<N>,
+        lhs: crate::int::types::Int<N>,
+        rhs: crate::int::types::Int<N>,
     ) -> crate::int::types::Int<N> {
-        crate::algos::rem::rem_native::rem_native::<N>(a, b)
+        crate::algos::rem::rem_native::rem_native::<N>(lhs, rhs)
     }
     /// Root kernels exposed for the `root_kernel_ab` microbench (the
     /// dispatch-seam A/B for the D57<20> cbrt candidates).
@@ -1815,17 +1815,17 @@ pub mod __bench_internals {
     /// false). Lets the bench construct wide operands without exposing the
     /// internal constructors.
     #[inline(never)]
-    pub fn int_from_mag_limbs<const N: usize>(mag: &[u64; N]) -> crate::int::types::Int<N> {
-        crate::int::types::Int::<N>::from_mag_limbs(mag, false)
+    pub fn int_from_mag_limbs<const N: usize>(magnitude: &[u64; N]) -> crate::int::types::Int<N> {
+        crate::int::types::Int::<N>::from_mag_limbs(magnitude, false)
     }
 
     #[inline(never)]
     pub fn mul_u64_into<const L: usize, const LP1: usize>(
-        a: &[u64; L],
-        n: u64,
+        value: &[u64; L],
+        multiplier: u64,
         out: &mut [u64; LP1],
     ) {
-        crate::int::algos::mul::mul_schoolbook::mul_schoolbook_into::<L, LP1>(a, n, out)
+        crate::int::algos::mul::mul_schoolbook::mul_schoolbook_into::<L, LP1>(value, multiplier, out)
     }
 
     // ── wide-transcendental `÷10^w` round-divide A/B seam ────────────────
@@ -1839,60 +1839,66 @@ pub mod __bench_internals {
     // Exposed generic over the work-integer `W` so ONE pair covers every
     // wide work width the `div_recover_ab` sweep walks.
 
-    /// SLOW path: half-to-even `round(n / 10^w)` via the generic Knuth
+    /// SLOW path: half-to-even `round(numerator / 10^exponent)` via the
+    /// generic Knuth
     /// `div_rem` reference (mirrors the macro-local `round_div` with a
-    /// `10^w` divisor).
+    /// `10^exponent` divisor).
     #[inline(never)]
     #[allow(private_bounds)]
-    pub fn round_div_pow10_slow<W: crate::int::types::traits::BigInt>(n: W, w: u32) -> W {
-        let d: W = W::TEN.pow(w);
+    pub fn round_div_pow10_slow<W: crate::int::types::traits::BigInt>(
+        numerator: W,
+        exponent: u32
+    ) -> W {
+        let divisor: W = W::TEN.pow(exponent);
         let zero = W::ZERO;
         let one = W::ONE;
-        let (q, r) = n.div_rem(d);
-        if r == zero {
-            return q;
+        let (quotient, remainder) = numerator.div_rem(divisor);
+        if remainder == zero {
+            return quotient;
         }
-        let ar = if r < zero { zero - r } else { r };
-        let ad = if d < zero { zero - d } else { d };
-        let comp = ad - ar;
-        let cmp_r = ar.cmp(&comp);
-        let q_is_odd = q.bit(0);
-        let result_positive = (n < zero) == (d < zero);
+        let abs_remainder = if remainder < zero { zero - remainder } else { remainder };
+        let abs_divisor = if divisor < zero { zero - divisor } else { divisor };
+        let complement = abs_divisor - abs_remainder;
+        let remainder_cmp = abs_remainder.cmp(&complement);
+        let quotient_is_odd = quotient.bit(0);
+        let result_positive = (numerator < zero) == (divisor < zero);
         if crate::support::rounding::should_bump(
             crate::support::rounding::RoundingMode::HalfToEven,
-            cmp_r,
-            q_is_odd,
+            remainder_cmp,
+            quotient_is_odd,
             result_positive,
         ) {
-            if result_positive { q + one } else { q - one }
+            if result_positive { quotient + one } else { quotient - one }
         } else {
-            q
+            quotient
         }
     }
 
-    /// FAST path: half-to-even `round(n / 10^w)` via the production
+    /// FAST path: half-to-even `round(numerator / 10^exponent)` via the
+    /// production
     /// power-of-10 divide kernel (the macro-local `round_div_pow10`):
-    /// single-chunk MG for `w <= 38`, MG / Newton chain dispatch above.
+    /// single-chunk MG for `exponent <= 38`, MG / Newton chain dispatch
+    /// above.
     #[inline(never)]
     #[allow(private_bounds)]
-    pub fn round_div_pow10_fast<W>(n: W, w: u32) -> W
+    pub fn round_div_pow10_fast<W>(numerator: W, exponent: u32) -> W
     where
         W: crate::int::types::traits::BigInt,
         W::Scratch: crate::int::types::compute_limbs::ComputeLimbs,
     {
-        if w == 0 {
-            return n;
+        if exponent == 0 {
+            return numerator;
         }
-        if w <= 38 {
+        if exponent <= 38 {
             return crate::algos::support::mg_divide::div_wide_pow10::<W>(
-                n,
-                w,
+                numerator,
+                exponent,
                 crate::support::rounding::RoundingMode::HalfToEven,
             );
         }
         crate::algos::support::rescale::dispatch_wide_pow10::<W>(
-            n,
-            w,
+            numerator,
+            exponent,
             crate::support::rounding::RoundingMode::HalfToEven,
         )
     }
@@ -1930,35 +1936,39 @@ pub mod __bench_internals {
                     #[inline(never)]
                     pub fn build_numerator(top_limb_idx: usize) -> Storage {
                         use crate::int::types::traits::BigInt;
-                        let mut mag = [0u128; 256];
-                        mag[top_limb_idx] = 1u128 << 32;
-                        mag[1] = 0xdeadbeef_cafef00d_u128;
-                        Storage(W::from_mag_sign_u128(&mag, false))
+                        let mut magnitude = [0u128; 256];
+                        magnitude[top_limb_idx] = 1u128 << 32;
+                        magnitude[1] = 0xdeadbeef_cafef00d_u128;
+                        Storage(W::from_mag_sign_u128(&magnitude, false))
                     }
 
                     #[inline(never)]
-                    pub fn mg_chain(n: Storage, scale: u32) -> Storage {
+                    pub fn mg_chain(numerator: Storage, scale: u32) -> Storage {
                         Storage(crate::algos::support::mg_divide::div_wide_pow10_chain::<W>(
-                            n.0,
+                            numerator.0,
                             scale,
                             RoundingMode::HalfToEven,
                         ))
                     }
 
                     #[inline(never)]
-                    pub fn mg_single(n: Storage, scale: u32) -> Storage {
+                    pub fn mg_single(numerator: Storage, scale: u32) -> Storage {
                         Storage(crate::algos::support::mg_divide::div_wide_pow10::<W>(
-                            n.0,
+                            numerator.0,
                             scale,
                             RoundingMode::HalfToEven,
                         ))
                     }
 
                     #[inline(never)]
-                    pub fn newton(n: Storage, scale: u32, table: &NewtonReciprocal) -> Storage {
+                    pub fn newton(
+                        numerator: Storage,
+                        scale: u32,
+                        table: &NewtonReciprocal
+                    ) -> Storage {
                         Storage(
                             crate::algos::support::newton_reciprocal::div_wide_pow10_newton_with::<W>(
-                                n.0,
+                                numerator.0,
                                 scale,
                                 RoundingMode::HalfToEven,
                                 &table.0,
@@ -1974,7 +1984,11 @@ pub mod __bench_internals {
                     /// scale) cell -- verified by the `newton_u64_eq_u128_*` unit
                     /// tests in `newton_reciprocal.rs`.
                     #[inline(never)]
-                    pub fn newton_u128(n: Storage, scale: u32, table: &NewtonReciprocal) -> Storage {
+                    pub fn newton_u128(
+                        numerator: Storage,
+                        scale: u32,
+                        table: &NewtonReciprocal
+                    ) -> Storage {
                         use crate::int::types::traits::BigInt;
                         // Match production slicing: the Newton kernel operates
                         // on EXACTLY `W::U128_LIMBS` u128 limbs (the storage
@@ -1982,15 +1996,15 @@ pub mod __bench_internals {
                         // would inflate the schoolbook product cost on smaller
                         // widths — production never does that.
                         let mut mag_u128 = [0u128; 256];
-                        let mag = &mut mag_u128[..W::U128_LIMBS];
-                        let neg = n.0.mag_into_u128(mag);
+                        let magnitude = &mut mag_u128[..W::U128_LIMBS];
+                        let is_negative = numerator.0.mag_into_u128(magnitude);
                         crate::algos::support::newton_reciprocal::newton_pow10_mag_u128_packed(
-                            mag,
-                            neg,
+                            magnitude,
+                            is_negative,
                             RoundingMode::HalfToEven,
                             &table.0,
                         );
-                        Storage(W::from_mag_sign_u128(mag, neg))
+                        Storage(W::from_mag_sign_u128(magnitude, is_negative))
                     }
                 }
             };
@@ -2039,15 +2053,17 @@ pub mod __bench_internals {
     ///   on the common path.
     #[inline(never)]
     pub fn neg_fused_split<const N: usize>(
-        a: crate::int::types::Int<N>,
+        value: crate::int::types::Int<N>,
     ) -> crate::int::types::Int<N> {
-        crate::int::algos::neg::neg_twos_complement::neg_twos_complement::<N>(a)
+        crate::int::algos::neg::neg_twos_complement::neg_twos_complement::<N>(value)
     }
     /// Previous routed shape, retained as the `neg_kernel_ab` reference
     /// baseline. Bit-identical to `neg_fused_split`.
     #[inline(never)]
-    pub fn neg_two_pass<const N: usize>(a: crate::int::types::Int<N>) -> crate::int::types::Int<N> {
-        let limbs_in = a.as_limbs();
+    pub fn neg_two_pass<const N: usize>(
+        value: crate::int::types::Int<N>
+    ) -> crate::int::types::Int<N> {
+        let limbs_in = value.as_limbs();
         let mut out = [0u64; N];
         let mut i = 0;
         while i < N {
@@ -2078,10 +2094,10 @@ pub mod __bench_internals {
     /// `neg_kernel_ab` candidate; bit-identical to `neg_fused_split`.
     #[inline(never)]
     pub fn neg_fused_open<const N: usize>(
-        a: crate::int::types::Int<N>,
+        value: crate::int::types::Int<N>,
     ) -> crate::int::types::Int<N> {
         let mut out = [0u64; N];
-        let limbs = a.as_limbs();
+        let limbs = value.as_limbs();
         let mut carry: u64 = 1;
         let mut i = 0;
         while i < N {

--- a/src/macros/arithmetic.rs
+++ b/src/macros/arithmetic.rs
@@ -76,57 +76,63 @@
 /// result_positive)` triple to `should_bump`.
 #[inline(always)]
 pub(crate) fn i128_divrem_by_u64_with_mode(
-    n: i128,
+    numerator: i128,
     m_mag: u64,
     mode: crate::support::rounding::RoundingMode,
 ) -> i128 {
     debug_assert!(m_mag != 0, "i128_divrem_by_u64_with_mode: m_mag = 0");
-    let n_neg = n < 0;
-    let un = n.unsigned_abs();
-    let (q_mag, r_mag) = {
-        let hi = (un >> 64) as u64;
-        let lo = un as u64;
+    let numerator_is_negative = numerator < 0;
+    let abs_numerator = numerator.unsigned_abs();
+    let (quotient_mag, remainder_mag) = {
+        let hi = (abs_numerator >> 64) as u64;
+        let lo = abs_numerator as u64;
         if hi == 0 {
             // Single-limb dividend — one hardware `divq`.
-            let q = lo / m_mag;
-            let r = lo % m_mag;
-            (q as u128, r)
+            let quotient = lo / m_mag;
+            let remainder = lo % m_mag;
+            (quotient as u128, remainder)
         } else {
             // Two-limb schoolbook divide in base 2^64. Two hardware
             // divides.
-            let q_hi = hi / m_mag;
-            let r_hi = hi % m_mag;
-            let cur = ((r_hi as u128) << 64) | (lo as u128);
-            // The divisor fits u64, so the quotient of (cur / m_mag)
-            // also fits u64 (cur < m_mag * 2^64).
-            let q_lo_u128 = cur / (m_mag as u128);
-            let r = cur - q_lo_u128 * (m_mag as u128);
-            let q = ((q_hi as u128) << 64) | (q_lo_u128 & u128::from(u64::MAX));
-            (q, r as u64)
+            let quotient_hi = hi / m_mag;
+            let remainder_hi = hi % m_mag;
+            let partial = ((remainder_hi as u128) << 64) | (lo as u128);
+            // The divisor fits u64, so the quotient of (partial / m_mag)
+            // also fits u64 (partial < m_mag * 2^64).
+            let quotient_lo_u128 = partial / (m_mag as u128);
+            let remainder = partial - quotient_lo_u128 * (m_mag as u128);
+            let quotient =
+                ((quotient_hi as u128) << 64) | (quotient_lo_u128 & u128::from(u64::MAX));
+            (quotient, remainder as u64)
         }
     };
 
-    if r_mag == 0 {
+    if remainder_mag == 0 {
         // No remainder — exact. Restore sign.
-        return if n_neg {
-            -(q_mag as i128)
+        return if numerator_is_negative {
+            -(quotient_mag as i128)
         } else {
-            q_mag as i128
+            quotient_mag as i128
         };
     }
 
     // `should_bump` needs the same three pre-computed inputs the macro
     // builds. `m_mag` is the divisor magnitude, never zero, never
     // negative.
-    let abs_r = r_mag as u128;
-    let abs_m = m_mag as u128;
-    let comp = abs_m - abs_r;
-    let cmp_r = abs_r.cmp(&comp);
-    let q_is_odd = (q_mag & 1) != 0;
-    let result_positive = !n_neg;
-    let bump = crate::support::rounding::should_bump(mode, cmp_r, q_is_odd, result_positive);
-    let bumped_mag = if bump { q_mag + 1 } else { q_mag };
-    if n_neg {
+    let abs_remainder = remainder_mag as u128;
+    let abs_divisor = m_mag as u128;
+    let complement = abs_divisor - abs_remainder;
+    let remainder_cmp = abs_remainder.cmp(&complement);
+    let quotient_is_odd = (quotient_mag & 1) != 0;
+    let result_positive = !numerator_is_negative;
+    let bump = crate::support::rounding::should_bump(
+        mode,
+        remainder_cmp,
+        quotient_is_odd,
+        result_positive
+    );
+    let bumped_mag = if bump { quotient_mag + 1 } else { quotient_mag };
+    if numerator_is_negative {
         -(bumped_mag as i128)
     } else {
         bumped_mag as i128
@@ -140,31 +146,31 @@ pub(crate) fn i128_divrem_by_u64_with_mode(
 // Always available: D18 / D38 (default features) route their Div /
 // checked_div / wrapping_div through this rounding step too.
 macro_rules! round_with_mode_wide {
-    ($n:expr, $m:expr, $W:ty, $mode:expr) => {{
-        let n = $n;
-        let m = $m;
+    ($numerator:expr, $divisor:expr, $W:ty, $mode:expr) => {{
+        let numerator = $numerator;
+        let divisor = $divisor;
         let mode = $mode;
         // Single divmod call instead of `n / m` + `n % m` (which
         // would do the full multi-limb divide twice).
-        let (q, r) = n.div_rem(m);
+        let (quotient, remainder) = numerator.div_rem(divisor);
         let zero = <$W>::from_i128(0);
-        if r == zero {
-            q
+        if remainder == zero {
+            quotient
         } else {
             let one = <$W>::from_i128(1);
-            let abs_r = if r < zero { -r } else { r };
-            let abs_m = if m < zero { -m } else { m };
-            let comp = abs_m - abs_r;
-            let cmp_r = abs_r.cmp(&comp);
-            let q_is_odd = {
+            let abs_remainder = if remainder < zero { -remainder } else { remainder };
+            let abs_divisor = if divisor < zero { -divisor } else { divisor };
+            let complement = abs_divisor - abs_remainder;
+            let remainder_cmp = abs_remainder.cmp(&complement);
+            let quotient_is_odd = {
                 let two = <$W>::from_i128(2);
-                (q % two) != zero
+                (quotient % two) != zero
             };
-            let result_positive = (n < zero) == (m < zero);
-            if $crate::support::rounding::should_bump(mode, cmp_r, q_is_odd, result_positive) {
-                if result_positive { q + one } else { q - one }
+            let result_positive = (numerator < zero) == (divisor < zero);
+            if $crate::support::rounding::should_bump(mode, remainder_cmp, quotient_is_odd, result_positive) {
+                if result_positive { quotient + one } else { quotient - one }
             } else {
-                q
+                quotient
             }
         }
     }};

--- a/src/macros/basics.rs
+++ b/src/macros/basics.rs
@@ -32,7 +32,7 @@ macro_rules! decl_decimal_basics {
             @impl $Type, $Storage, $max_scale,
             multiplier = {
                 match <$Storage>::from_str_radix("10", 10) {
-                    ::core::result::Result::Ok(v) => v,
+                    ::core::result::Result::Ok(ten) => ten,
                     ::core::result::Result::Err(_) => {
                         panic!("wide decimal: invalid base-10 multiplier literal")
                     }
@@ -41,7 +41,7 @@ macro_rules! decl_decimal_basics {
             },
             zero = {
                 match <$Storage>::from_str_radix("0", 10) {
-                    ::core::result::Result::Ok(v) => v,
+                    ::core::result::Result::Ok(zero) => zero,
                     ::core::result::Result::Err(_) => {
                         panic!("wide decimal: invalid zero literal")
                     }
@@ -247,8 +247,8 @@ macro_rules! decl_decimal_basics {
                 $Type::<SCALE>::midpoint(self, rhs)
             }
             #[inline]
-            fn mul_add(self, a: Self, b: Self) -> Self {
-                $Type::<SCALE>::mul_add(self, a, b)
+            fn mul_add(self, multiplier: Self, addend: Self) -> Self {
+                $Type::<SCALE>::mul_add(self, multiplier, addend)
             }
 
             // Pow.

--- a/src/macros/bitwise.rs
+++ b/src/macros/bitwise.rs
@@ -22,27 +22,27 @@ macro_rules! decl_decimal_bitwise {
         $crate::macros::bitwise::decl_decimal_bitwise!(@common $Type, $Storage);
 
         impl<const SCALE: u32> $Type<SCALE> {
-            /// Logical (zero-fill) right shift of the raw storage by `n`
-            /// bits. Unlike the arithmetic `Shr` operator, the vacated
-            /// high bits are always zero regardless of sign.
+            /// Logical (zero-fill) right shift of the raw storage by
+            /// `shift` bits. Unlike the arithmetic `Shr` operator, the
+            /// vacated high bits are always zero regardless of sign.
             #[inline]
             #[must_use]
-            pub fn unsigned_shr(self, n: u32) -> Self {
-                Self((self.0.cast_unsigned() >> n).cast_signed())
+            pub fn unsigned_shr(self, shift: u32) -> Self {
+                Self((self.0.cast_unsigned() >> shift).cast_signed())
             }
 
-            /// Rotate the raw storage left by `n` bits.
+            /// Rotate the raw storage left by `shift` bits.
             #[inline]
             #[must_use]
-            pub fn rotate_left(self, n: u32) -> Self {
-                Self(self.0.rotate_left(n))
+            pub fn rotate_left(self, shift: u32) -> Self {
+                Self(self.0.rotate_left(shift))
             }
 
-            /// Rotate the raw storage right by `n` bits.
+            /// Rotate the raw storage right by `shift` bits.
             #[inline]
             #[must_use]
-            pub fn rotate_right(self, n: u32) -> Self {
-                Self(self.0.rotate_right(n))
+            pub fn rotate_right(self, shift: u32) -> Self {
+                Self(self.0.rotate_right(shift))
             }
 
             /// Number of leading zero bits in the raw storage.
@@ -138,33 +138,33 @@ macro_rules! decl_decimal_bitwise {
         }
         impl<const SCALE: u32> ::core::ops::Shl<u32> for $Type<SCALE> {
             type Output = Self;
-            /// Left-shift the raw storage by `n` bits. Debug-panics when
-            /// `n` exceeds the storage width; wraps in release.
+            /// Left-shift the raw storage by `shift` bits. Debug-panics
+            /// when `shift` exceeds the storage width; wraps in release.
             #[inline]
-            fn shl(self, n: u32) -> Self {
-                Self(self.0 << n)
+            fn shl(self, shift: u32) -> Self {
+                Self(self.0 << shift)
             }
         }
         impl<const SCALE: u32> ::core::ops::ShlAssign<u32> for $Type<SCALE> {
             #[inline]
-            fn shl_assign(&mut self, n: u32) {
-                self.0 = self.0 << n;
+            fn shl_assign(&mut self, shift: u32) {
+                self.0 = self.0 << shift;
             }
         }
         impl<const SCALE: u32> ::core::ops::Shr<u32> for $Type<SCALE> {
             type Output = Self;
             /// Arithmetic (sign-extending) right-shift of the raw
-            /// storage by `n` bits. Use [`Self::unsigned_shr`] for the
-            /// logical (zero-fill) shift.
+            /// storage by `shift` bits. Use [`Self::unsigned_shr`] for
+            /// the logical (zero-fill) shift.
             #[inline]
-            fn shr(self, n: u32) -> Self {
-                Self(self.0 >> n)
+            fn shr(self, shift: u32) -> Self {
+                Self(self.0 >> shift)
             }
         }
         impl<const SCALE: u32> ::core::ops::ShrAssign<u32> for $Type<SCALE> {
             #[inline]
-            fn shr_assign(&mut self, n: u32) {
-                self.0 = self.0 >> n;
+            fn shr_assign(&mut self, shift: u32) {
+                self.0 = self.0 >> shift;
             }
         }
         impl<const SCALE: u32> ::core::ops::Not for $Type<SCALE> {

--- a/src/macros/conversions.rs
+++ b/src/macros/conversions.rs
@@ -286,8 +286,8 @@ macro_rules! decl_try_from_f64 {
                         $crate::support::error::ConvertError::NotFinite,
                     );
                 }
-                let mult_f64: f64 = Self::multiplier().as_f64();
-                let scaled = value * mult_f64;
+                let multiplier_f64: f64 = Self::multiplier().as_f64();
+                let scaled = value * multiplier_f64;
                 let storage_max_f64: f64 = <$Storage>::MAX.as_f64();
                 let storage_min_f64: f64 = <$Storage>::MIN.as_f64();
                 if !(storage_min_f64..storage_max_f64).contains(&scaled) {
@@ -383,42 +383,42 @@ macro_rules! decl_decimal_int_conversion_methods {
                 let int_rounded: $Storage = if remainder == zero {
                     quotient
                 } else {
-                    let abs_rem = remainder.unsigned_abs();
+                    let abs_remainder = remainder.unsigned_abs();
                     // `divisor` is `10^SCALE` and always positive, so
                     // `unsigned_abs()` is the value itself; `>> 1` is
                     // the half-LSB threshold.
                     let half = divisor.unsigned_abs() >> 1;
-                    let non_negative = !raw.is_negative();
+                    let is_non_negative = !raw.is_negative();
                     match mode {
                         $crate::support::rounding::RoundingMode::HalfToEven => {
-                            if abs_rem < half {
+                            if abs_remainder < half {
                                 quotient
-                            } else if abs_rem > half {
-                                if non_negative {
+                            } else if abs_remainder > half {
+                                if is_non_negative {
                                     quotient + one
                                 } else {
                                     quotient - one
                                 }
                             } else if !quotient.bit(0) {
                                 quotient
-                            } else if non_negative {
+                            } else if is_non_negative {
                                 quotient + one
                             } else {
                                 quotient - one
                             }
                         }
                         $crate::support::rounding::RoundingMode::HalfAwayFromZero => {
-                            if abs_rem < half {
+                            if abs_remainder < half {
                                 quotient
-                            } else if non_negative {
+                            } else if is_non_negative {
                                 quotient + one
                             } else {
                                 quotient - one
                             }
                         }
                         $crate::support::rounding::RoundingMode::HalfTowardZero => {
-                            if abs_rem > half {
-                                if non_negative {
+                            if abs_remainder > half {
+                                if is_non_negative {
                                     quotient + one
                                 } else {
                                     quotient - one
@@ -429,14 +429,14 @@ macro_rules! decl_decimal_int_conversion_methods {
                         }
                         $crate::support::rounding::RoundingMode::Trunc => quotient,
                         $crate::support::rounding::RoundingMode::Floor => {
-                            if non_negative {
+                            if is_non_negative {
                                 quotient
                             } else {
                                 quotient - one
                             }
                         }
                         $crate::support::rounding::RoundingMode::Ceiling => {
-                            if non_negative {
+                            if is_non_negative {
                                 quotient + one
                             } else {
                                 quotient

--- a/src/macros/cross_scale_ops.rs
+++ b/src/macros/cross_scale_ops.rs
@@ -29,8 +29,8 @@ macro_rules! decl_decimal_cross_scale_ops {
         impl<const SCALE: u32> $Type<SCALE> {
             // ── Multiply ─────────────────────────────────────────────
 
-            /// Constructs `Self` as `a × b`, where `a` and `b` may have
-            /// any width ≤ `Self`'s and any SCALE. Both operands are
+            /// Constructs `Self` as `lhs × rhs`, where `lhs` and `rhs` may
+            /// have any width ≤ `Self`'s and any SCALE. Both operands are
             /// widened to `Self`'s storage, rescaled to `Self`'s
             /// `SCALE` (UP-rescale is exact; DOWN uses the crate's
             /// default rounding mode), then multiplied. Panics on overflow
@@ -41,53 +41,53 @@ macro_rules! decl_decimal_cross_scale_ops {
             #[inline]
             #[must_use]
             pub fn mul_of<W1, W2, const S1: u32, const S2: u32>(
-                a: $crate::D<W1, S1>,
-                b: $crate::D<W2, S2>,
+                lhs: $crate::D<W1, S1>,
+                rhs: $crate::D<W2, S2>,
             ) -> Self
             where
                 W1: $crate::WidthLE<$Storage>,
                 W2: $crate::WidthLE<$Storage>,
             {
-                Self::mul_of_with(a, b, $crate::support::rounding::DEFAULT_ROUNDING_MODE)
+                Self::mul_of_with(lhs, rhs, $crate::support::rounding::DEFAULT_ROUNDING_MODE)
             }
 
             /// Like [`Self::mul_of`] but with an explicit rounding mode
-            /// for any DOWN-rescale of `a` / `b` to `Self`'s `SCALE`.
+            /// for any DOWN-rescale of `lhs` / `rhs` to `Self`'s `SCALE`.
             #[inline]
             #[must_use]
             pub fn mul_of_with<W1, W2, const S1: u32, const S2: u32>(
-                a: $crate::D<W1, S1>,
-                b: $crate::D<W2, S2>,
+                lhs: $crate::D<W1, S1>,
+                rhs: $crate::D<W2, S2>,
                 mode: $crate::support::rounding::RoundingMode,
             ) -> Self
             where
                 W1: $crate::WidthLE<$Storage>,
                 W2: $crate::WidthLE<$Storage>,
             {
-                let a_w: $crate::D<$Storage, S1> =
-                    $crate::D::<$Storage, S1>(<W1 as $crate::WidthLE<$Storage>>::widen_into(a.0));
-                let b_w: $crate::D<$Storage, S2> =
-                    $crate::D::<$Storage, S2>(<W2 as $crate::WidthLE<$Storage>>::widen_into(b.0));
-                let a_t: Self = a_w.quantize_with::<SCALE>(mode);
-                let b_t: Self = b_w.quantize_with::<SCALE>(mode);
-                a_t * b_t
+                let lhs_at_width: $crate::D<$Storage, S1> =
+                    $crate::D::<$Storage, S1>(<W1 as $crate::WidthLE<$Storage>>::widen_into(lhs.0));
+                let rhs_at_width: $crate::D<$Storage, S2> =
+                    $crate::D::<$Storage, S2>(<W2 as $crate::WidthLE<$Storage>>::widen_into(rhs.0));
+                let lhs_at_scale: Self = lhs_at_width.quantize_with::<SCALE>(mode);
+                let rhs_at_scale: Self = rhs_at_width.quantize_with::<SCALE>(mode);
+                lhs_at_scale * rhs_at_scale
             }
 
             // ── Add / Sub / Rem ──────────────────────────────────────
 
-            /// Constructs `Self` as `a + b` (cross-width / cross-SCALE).
+            /// Constructs `Self` as `lhs + rhs` (cross-width / cross-SCALE).
             /// See [`Self::mul_of`] for semantics.
             #[inline]
             #[must_use]
             pub fn add_of<W1, W2, const S1: u32, const S2: u32>(
-                a: $crate::D<W1, S1>,
-                b: $crate::D<W2, S2>,
+                lhs: $crate::D<W1, S1>,
+                rhs: $crate::D<W2, S2>,
             ) -> Self
             where
                 W1: $crate::WidthLE<$Storage>,
                 W2: $crate::WidthLE<$Storage>,
             {
-                Self::add_of_with(a, b, $crate::support::rounding::DEFAULT_ROUNDING_MODE)
+                Self::add_of_with(lhs, rhs, $crate::support::rounding::DEFAULT_ROUNDING_MODE)
             }
 
             /// Like [`Self::add_of`] but with explicit rounding for the
@@ -95,35 +95,35 @@ macro_rules! decl_decimal_cross_scale_ops {
             #[inline]
             #[must_use]
             pub fn add_of_with<W1, W2, const S1: u32, const S2: u32>(
-                a: $crate::D<W1, S1>,
-                b: $crate::D<W2, S2>,
+                lhs: $crate::D<W1, S1>,
+                rhs: $crate::D<W2, S2>,
                 mode: $crate::support::rounding::RoundingMode,
             ) -> Self
             where
                 W1: $crate::WidthLE<$Storage>,
                 W2: $crate::WidthLE<$Storage>,
             {
-                let a_w: $crate::D<$Storage, S1> =
-                    $crate::D::<$Storage, S1>(<W1 as $crate::WidthLE<$Storage>>::widen_into(a.0));
-                let b_w: $crate::D<$Storage, S2> =
-                    $crate::D::<$Storage, S2>(<W2 as $crate::WidthLE<$Storage>>::widen_into(b.0));
-                let a_t: Self = a_w.quantize_with::<SCALE>(mode);
-                let b_t: Self = b_w.quantize_with::<SCALE>(mode);
-                a_t + b_t
+                let lhs_at_width: $crate::D<$Storage, S1> =
+                    $crate::D::<$Storage, S1>(<W1 as $crate::WidthLE<$Storage>>::widen_into(lhs.0));
+                let rhs_at_width: $crate::D<$Storage, S2> =
+                    $crate::D::<$Storage, S2>(<W2 as $crate::WidthLE<$Storage>>::widen_into(rhs.0));
+                let lhs_at_scale: Self = lhs_at_width.quantize_with::<SCALE>(mode);
+                let rhs_at_scale: Self = rhs_at_width.quantize_with::<SCALE>(mode);
+                lhs_at_scale + rhs_at_scale
             }
 
-            /// Constructs `Self` as `a - b` (cross-width / cross-SCALE).
+            /// Constructs `Self` as `lhs - rhs` (cross-width / cross-SCALE).
             #[inline]
             #[must_use]
             pub fn sub_of<W1, W2, const S1: u32, const S2: u32>(
-                a: $crate::D<W1, S1>,
-                b: $crate::D<W2, S2>,
+                lhs: $crate::D<W1, S1>,
+                rhs: $crate::D<W2, S2>,
             ) -> Self
             where
                 W1: $crate::WidthLE<$Storage>,
                 W2: $crate::WidthLE<$Storage>,
             {
-                Self::sub_of_with(a, b, $crate::support::rounding::DEFAULT_ROUNDING_MODE)
+                Self::sub_of_with(lhs, rhs, $crate::support::rounding::DEFAULT_ROUNDING_MODE)
             }
 
             /// Like [`Self::sub_of`] but with explicit rounding for the
@@ -131,35 +131,35 @@ macro_rules! decl_decimal_cross_scale_ops {
             #[inline]
             #[must_use]
             pub fn sub_of_with<W1, W2, const S1: u32, const S2: u32>(
-                a: $crate::D<W1, S1>,
-                b: $crate::D<W2, S2>,
+                lhs: $crate::D<W1, S1>,
+                rhs: $crate::D<W2, S2>,
                 mode: $crate::support::rounding::RoundingMode,
             ) -> Self
             where
                 W1: $crate::WidthLE<$Storage>,
                 W2: $crate::WidthLE<$Storage>,
             {
-                let a_w: $crate::D<$Storage, S1> =
-                    $crate::D::<$Storage, S1>(<W1 as $crate::WidthLE<$Storage>>::widen_into(a.0));
-                let b_w: $crate::D<$Storage, S2> =
-                    $crate::D::<$Storage, S2>(<W2 as $crate::WidthLE<$Storage>>::widen_into(b.0));
-                let a_t: Self = a_w.quantize_with::<SCALE>(mode);
-                let b_t: Self = b_w.quantize_with::<SCALE>(mode);
-                a_t - b_t
+                let lhs_at_width: $crate::D<$Storage, S1> =
+                    $crate::D::<$Storage, S1>(<W1 as $crate::WidthLE<$Storage>>::widen_into(lhs.0));
+                let rhs_at_width: $crate::D<$Storage, S2> =
+                    $crate::D::<$Storage, S2>(<W2 as $crate::WidthLE<$Storage>>::widen_into(rhs.0));
+                let lhs_at_scale: Self = lhs_at_width.quantize_with::<SCALE>(mode);
+                let rhs_at_scale: Self = rhs_at_width.quantize_with::<SCALE>(mode);
+                lhs_at_scale - rhs_at_scale
             }
 
-            /// Constructs `Self` as `a / b` (cross-width / cross-SCALE).
+            /// Constructs `Self` as `lhs / rhs` (cross-width / cross-SCALE).
             #[inline]
             #[must_use]
             pub fn div_of<W1, W2, const S1: u32, const S2: u32>(
-                a: $crate::D<W1, S1>,
-                b: $crate::D<W2, S2>,
+                lhs: $crate::D<W1, S1>,
+                rhs: $crate::D<W2, S2>,
             ) -> Self
             where
                 W1: $crate::WidthLE<$Storage>,
                 W2: $crate::WidthLE<$Storage>,
             {
-                Self::div_of_with(a, b, $crate::support::rounding::DEFAULT_ROUNDING_MODE)
+                Self::div_of_with(lhs, rhs, $crate::support::rounding::DEFAULT_ROUNDING_MODE)
             }
 
             /// Like [`Self::div_of`] but with explicit rounding for both
@@ -167,35 +167,35 @@ macro_rules! decl_decimal_cross_scale_ops {
             #[inline]
             #[must_use]
             pub fn div_of_with<W1, W2, const S1: u32, const S2: u32>(
-                a: $crate::D<W1, S1>,
-                b: $crate::D<W2, S2>,
+                lhs: $crate::D<W1, S1>,
+                rhs: $crate::D<W2, S2>,
                 mode: $crate::support::rounding::RoundingMode,
             ) -> Self
             where
                 W1: $crate::WidthLE<$Storage>,
                 W2: $crate::WidthLE<$Storage>,
             {
-                let a_w: $crate::D<$Storage, S1> =
-                    $crate::D::<$Storage, S1>(<W1 as $crate::WidthLE<$Storage>>::widen_into(a.0));
-                let b_w: $crate::D<$Storage, S2> =
-                    $crate::D::<$Storage, S2>(<W2 as $crate::WidthLE<$Storage>>::widen_into(b.0));
-                let a_t: Self = a_w.quantize_with::<SCALE>(mode);
-                let b_t: Self = b_w.quantize_with::<SCALE>(mode);
-                a_t / b_t
+                let lhs_at_width: $crate::D<$Storage, S1> =
+                    $crate::D::<$Storage, S1>(<W1 as $crate::WidthLE<$Storage>>::widen_into(lhs.0));
+                let rhs_at_width: $crate::D<$Storage, S2> =
+                    $crate::D::<$Storage, S2>(<W2 as $crate::WidthLE<$Storage>>::widen_into(rhs.0));
+                let lhs_at_scale: Self = lhs_at_width.quantize_with::<SCALE>(mode);
+                let rhs_at_scale: Self = rhs_at_width.quantize_with::<SCALE>(mode);
+                lhs_at_scale / rhs_at_scale
             }
 
-            /// Constructs `Self` as `a % b` (cross-width / cross-SCALE).
+            /// Constructs `Self` as `lhs % rhs` (cross-width / cross-SCALE).
             #[inline]
             #[must_use]
             pub fn rem_of<W1, W2, const S1: u32, const S2: u32>(
-                a: $crate::D<W1, S1>,
-                b: $crate::D<W2, S2>,
+                lhs: $crate::D<W1, S1>,
+                rhs: $crate::D<W2, S2>,
             ) -> Self
             where
                 W1: $crate::WidthLE<$Storage>,
                 W2: $crate::WidthLE<$Storage>,
             {
-                Self::rem_of_with(a, b, $crate::support::rounding::DEFAULT_ROUNDING_MODE)
+                Self::rem_of_with(lhs, rhs, $crate::support::rounding::DEFAULT_ROUNDING_MODE)
             }
 
             /// Like [`Self::rem_of`] but with explicit rounding for the
@@ -203,26 +203,26 @@ macro_rules! decl_decimal_cross_scale_ops {
             #[inline]
             #[must_use]
             pub fn rem_of_with<W1, W2, const S1: u32, const S2: u32>(
-                a: $crate::D<W1, S1>,
-                b: $crate::D<W2, S2>,
+                lhs: $crate::D<W1, S1>,
+                rhs: $crate::D<W2, S2>,
                 mode: $crate::support::rounding::RoundingMode,
             ) -> Self
             where
                 W1: $crate::WidthLE<$Storage>,
                 W2: $crate::WidthLE<$Storage>,
             {
-                let a_w: $crate::D<$Storage, S1> =
-                    $crate::D::<$Storage, S1>(<W1 as $crate::WidthLE<$Storage>>::widen_into(a.0));
-                let b_w: $crate::D<$Storage, S2> =
-                    $crate::D::<$Storage, S2>(<W2 as $crate::WidthLE<$Storage>>::widen_into(b.0));
-                let a_t: Self = a_w.quantize_with::<SCALE>(mode);
-                let b_t: Self = b_w.quantize_with::<SCALE>(mode);
-                a_t % b_t
+                let lhs_at_width: $crate::D<$Storage, S1> =
+                    $crate::D::<$Storage, S1>(<W1 as $crate::WidthLE<$Storage>>::widen_into(lhs.0));
+                let rhs_at_width: $crate::D<$Storage, S2> =
+                    $crate::D::<$Storage, S2>(<W2 as $crate::WidthLE<$Storage>>::widen_into(rhs.0));
+                let lhs_at_scale: Self = lhs_at_width.quantize_with::<SCALE>(mode);
+                let rhs_at_scale: Self = rhs_at_width.quantize_with::<SCALE>(mode);
+                lhs_at_scale % rhs_at_scale
             }
 
             // ── max / min / clamp ────────────────────────────────────
 
-            /// Returns the larger of `a` and `b` as `Self`. Comparison
+            /// Returns the larger of `lhs` and `rhs` as `Self`. Comparison
             /// is done at the wider operand's `SCALE` (lossless via
             /// UP-rescale on both sides); the winner is then rescaled
             /// to `Self`'s `SCALE` using the crate's default rounding
@@ -230,14 +230,14 @@ macro_rules! decl_decimal_cross_scale_ops {
             #[inline]
             #[must_use]
             pub fn max_of<W1, W2, const S1: u32, const S2: u32>(
-                a: $crate::D<W1, S1>,
-                b: $crate::D<W2, S2>,
+                lhs: $crate::D<W1, S1>,
+                rhs: $crate::D<W2, S2>,
             ) -> Self
             where
                 W1: $crate::WidthLE<$Storage>,
                 W2: $crate::WidthLE<$Storage>,
             {
-                Self::max_of_with(a, b, $crate::support::rounding::DEFAULT_ROUNDING_MODE)
+                Self::max_of_with(lhs, rhs, $crate::support::rounding::DEFAULT_ROUNDING_MODE)
             }
 
             /// Like [`Self::max_of`] but with an explicit rounding mode
@@ -245,8 +245,8 @@ macro_rules! decl_decimal_cross_scale_ops {
             #[inline]
             #[must_use]
             pub fn max_of_with<W1, W2, const S1: u32, const S2: u32>(
-                a: $crate::D<W1, S1>,
-                b: $crate::D<W2, S2>,
+                lhs: $crate::D<W1, S1>,
+                rhs: $crate::D<W2, S2>,
                 mode: $crate::support::rounding::RoundingMode,
             ) -> Self
             where
@@ -254,38 +254,38 @@ macro_rules! decl_decimal_cross_scale_ops {
                 W2: $crate::WidthLE<$Storage>,
             {
                 // Lossless widen each into Self's storage.
-                let a_w: $crate::D<$Storage, S1> =
-                    $crate::D::<$Storage, S1>(<W1 as $crate::WidthLE<$Storage>>::widen_into(a.0));
-                let b_w: $crate::D<$Storage, S2> =
-                    $crate::D::<$Storage, S2>(<W2 as $crate::WidthLE<$Storage>>::widen_into(b.0));
+                let lhs_at_width: $crate::D<$Storage, S1> =
+                    $crate::D::<$Storage, S1>(<W1 as $crate::WidthLE<$Storage>>::widen_into(lhs.0));
+                let rhs_at_width: $crate::D<$Storage, S2> =
+                    $crate::D::<$Storage, S2>(<W2 as $crate::WidthLE<$Storage>>::widen_into(rhs.0));
                 // Compare at the larger of S1 / S2 — that scale-up is
                 // exact on both sides, so the comparison is exact.
                 if S1 >= S2 {
-                    let b_at_s1: $crate::D<$Storage, S1> = b_w.quantize_with::<S1>(mode);
+                    let rhs_at_s1: $crate::D<$Storage, S1> = rhs_at_width.quantize_with::<S1>(mode);
                     let winner: $crate::D<$Storage, S1> =
-                        if a_w >= b_at_s1 { a_w } else { b_at_s1 };
+                        if lhs_at_width >= rhs_at_s1 { lhs_at_width } else { rhs_at_s1 };
                     winner.quantize_with::<SCALE>(mode)
                 } else {
-                    let a_at_s2: $crate::D<$Storage, S2> = a_w.quantize_with::<S2>(mode);
+                    let lhs_at_s2: $crate::D<$Storage, S2> = lhs_at_width.quantize_with::<S2>(mode);
                     let winner: $crate::D<$Storage, S2> =
-                        if a_at_s2 >= b_w { a_at_s2 } else { b_w };
+                        if lhs_at_s2 >= rhs_at_width { lhs_at_s2 } else { rhs_at_width };
                     winner.quantize_with::<SCALE>(mode)
                 }
             }
 
-            /// Returns the smaller of `a` and `b` as `Self`. See
+            /// Returns the smaller of `lhs` and `rhs` as `Self`. See
             /// [`Self::max_of`] for the comparison + rescale semantics.
             #[inline]
             #[must_use]
             pub fn min_of<W1, W2, const S1: u32, const S2: u32>(
-                a: $crate::D<W1, S1>,
-                b: $crate::D<W2, S2>,
+                lhs: $crate::D<W1, S1>,
+                rhs: $crate::D<W2, S2>,
             ) -> Self
             where
                 W1: $crate::WidthLE<$Storage>,
                 W2: $crate::WidthLE<$Storage>,
             {
-                Self::min_of_with(a, b, $crate::support::rounding::DEFAULT_ROUNDING_MODE)
+                Self::min_of_with(lhs, rhs, $crate::support::rounding::DEFAULT_ROUNDING_MODE)
             }
 
             /// Like [`Self::min_of`] but with an explicit rounding mode
@@ -293,27 +293,27 @@ macro_rules! decl_decimal_cross_scale_ops {
             #[inline]
             #[must_use]
             pub fn min_of_with<W1, W2, const S1: u32, const S2: u32>(
-                a: $crate::D<W1, S1>,
-                b: $crate::D<W2, S2>,
+                lhs: $crate::D<W1, S1>,
+                rhs: $crate::D<W2, S2>,
                 mode: $crate::support::rounding::RoundingMode,
             ) -> Self
             where
                 W1: $crate::WidthLE<$Storage>,
                 W2: $crate::WidthLE<$Storage>,
             {
-                let a_w: $crate::D<$Storage, S1> =
-                    $crate::D::<$Storage, S1>(<W1 as $crate::WidthLE<$Storage>>::widen_into(a.0));
-                let b_w: $crate::D<$Storage, S2> =
-                    $crate::D::<$Storage, S2>(<W2 as $crate::WidthLE<$Storage>>::widen_into(b.0));
+                let lhs_at_width: $crate::D<$Storage, S1> =
+                    $crate::D::<$Storage, S1>(<W1 as $crate::WidthLE<$Storage>>::widen_into(lhs.0));
+                let rhs_at_width: $crate::D<$Storage, S2> =
+                    $crate::D::<$Storage, S2>(<W2 as $crate::WidthLE<$Storage>>::widen_into(rhs.0));
                 if S1 >= S2 {
-                    let b_at_s1: $crate::D<$Storage, S1> = b_w.quantize_with::<S1>(mode);
+                    let rhs_at_s1: $crate::D<$Storage, S1> = rhs_at_width.quantize_with::<S1>(mode);
                     let winner: $crate::D<$Storage, S1> =
-                        if a_w <= b_at_s1 { a_w } else { b_at_s1 };
+                        if lhs_at_width <= rhs_at_s1 { lhs_at_width } else { rhs_at_s1 };
                     winner.quantize_with::<SCALE>(mode)
                 } else {
-                    let a_at_s2: $crate::D<$Storage, S2> = a_w.quantize_with::<S2>(mode);
+                    let lhs_at_s2: $crate::D<$Storage, S2> = lhs_at_width.quantize_with::<S2>(mode);
                     let winner: $crate::D<$Storage, S2> =
-                        if a_at_s2 <= b_w { a_at_s2 } else { b_w };
+                        if lhs_at_s2 <= rhs_at_width { lhs_at_s2 } else { rhs_at_width };
                     winner.quantize_with::<SCALE>(mode)
                 }
             }
@@ -365,8 +365,8 @@ macro_rules! decl_decimal_cross_scale_ops {
                 // Pairwise: max(value, lo) then min(.., hi). Each step
                 // delegates to max_of_with / min_of_with which already
                 // pick the higher-scale common space for comparison.
-                let v_after_lo: Self = Self::max_of_with(value, lo, mode);
-                Self::min_of_with(v_after_lo, hi, mode)
+                let clamped_low: Self = Self::max_of_with(value, lo, mode);
+                Self::min_of_with(clamped_low, hi, mode)
             }
 
             // ── convert (cross-width + cross-scale, fallible) ────────
@@ -435,10 +435,10 @@ macro_rules! decl_decimal_cross_scale_ops {
             where
                 W1: $crate::int::types::BigInt,
             {
-                let mag: $Storage = $crate::int::convert::convert_magnitude::<W1, $Storage>(
+                let magnitude: $Storage = $crate::int::convert::convert_magnitude::<W1, $Storage>(
                     src.0, S1, SCALE, mode,
                 )?;
-                ::core::result::Result::Ok(Self::from_bits(mag))
+                ::core::result::Result::Ok(Self::from_bits(magnitude))
             }
 
             // ── Comparators (cmp_of / eq_of / ne_of / lt_of / le_of / gt_of / ge_of) ─

--- a/src/macros/cross_width_ops.rs
+++ b/src/macros/cross_width_ops.rs
@@ -90,8 +90,8 @@ macro_rules! decl_cross_width_assign_op {
         impl<const S1: u32, const S2: u32> ::core::ops::$Trait<$crate::$Wide<S2>> for $crate::$Narrow<S1> {
             #[inline]
             fn $method(&mut self, rhs: $crate::$Wide<S2>) {
-                let wide = $crate::$Wide::<S1>::$of(*self, rhs);
-                let narrowed = wide.0.try_narrow::<$NarrowLimbs>().expect($overflow);
+                let wide_value = $crate::$Wide::<S1>::$of(*self, rhs);
+                let narrowed = wide_value.0.try_narrow::<$NarrowLimbs>().expect($overflow);
                 *self = $crate::$Narrow::<S1>::from_bits(narrowed);
             }
         }

--- a/src/macros/display.rs
+++ b/src/macros/display.rs
@@ -24,30 +24,30 @@ macro_rules! decl_decimal_display {
     // unsigned counterpart (e.g. `Uint<4>` for `Int<4>`).
     (wide $Type:ident, $Unsigned:ty) => {
         impl<const SCALE: u32> ::core::fmt::Display for $Type<SCALE> {
-            fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+            fn fmt(&self, formatter: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
                 let raw = self.to_bits();
                 let negative = raw.is_negative();
-                let mag: $Unsigned = raw.unsigned_abs();
+                let magnitude: $Unsigned = raw.unsigned_abs();
                 let multiplier: $Unsigned = <$Unsigned>::from_str_radix("10", 10)
                     .expect("wide decimal: invalid base-10 literal")
                     .pow(SCALE);
-                let int_part = mag / multiplier;
-                let frac_part = mag % multiplier;
+                let int_part = magnitude / multiplier;
+                let frac_part = magnitude % multiplier;
 
                 if negative {
-                    f.write_str("-")?;
+                    formatter.write_str("-")?;
                 }
                 if SCALE == 0 {
-                    return write!(f, "{int_part}");
+                    return write!(formatter, "{int_part}");
                 }
                 let width = SCALE as usize;
-                write!(f, "{int_part}.{frac_part:0>width$}", width = width)
+                write!(formatter, "{int_part}.{frac_part:0>width$}", width = width)
             }
         }
 
         impl<const SCALE: u32> ::core::fmt::Debug for $Type<SCALE> {
-            fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-                write!(f, concat!(stringify!($Type), "<{}>({})"), SCALE, self)
+            fn fmt(&self, formatter: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+                write!(formatter, concat!(stringify!($Type), "<{}>({})"), SCALE, self)
             }
         }
     };

--- a/src/macros/dyn_bridge.rs
+++ b/src/macros/dyn_bridge.rs
@@ -99,12 +99,12 @@ macro_rules! decl_decimal_dyn_impl {
                 match target_scale {
                     $(
                         $scale => {
-                            let l = *lhs_box.as_any()
+                            let lhs_typed = *lhs_box.as_any()
                                 .downcast_ref::<$crate::$Type<$scale>>()?;
-                            let r = *rhs_box.as_any()
+                            let rhs_typed = *rhs_box.as_any()
                                 .downcast_ref::<$crate::$Type<$scale>>()?;
-                            <$crate::$Type<$scale> as $crate::DecimalArithmetic>::checked_add(l, r)
-                                .map(|res| ::alloc::boxed::Box::new(res)
+                            <$crate::$Type<$scale> as $crate::DecimalArithmetic>::checked_add(lhs_typed, rhs_typed)
+                                .map(|value| ::alloc::boxed::Box::new(value)
                                     as ::alloc::boxed::Box<dyn $crate::types::traits::dyn_decimal::DynDecimal>)
                         }
                     )+
@@ -125,12 +125,12 @@ macro_rules! decl_decimal_dyn_impl {
                 match target_scale {
                     $(
                         $scale => {
-                            let l = *lhs_box.as_any()
+                            let lhs_typed = *lhs_box.as_any()
                                 .downcast_ref::<$crate::$Type<$scale>>()?;
-                            let r = *rhs_box.as_any()
+                            let rhs_typed = *rhs_box.as_any()
                                 .downcast_ref::<$crate::$Type<$scale>>()?;
-                            <$crate::$Type<$scale> as $crate::DecimalArithmetic>::checked_sub(l, r)
-                                .map(|res| ::alloc::boxed::Box::new(res)
+                            <$crate::$Type<$scale> as $crate::DecimalArithmetic>::checked_sub(lhs_typed, rhs_typed)
+                                .map(|value| ::alloc::boxed::Box::new(value)
                                     as ::alloc::boxed::Box<dyn $crate::types::traits::dyn_decimal::DynDecimal>)
                         }
                     )+
@@ -151,12 +151,12 @@ macro_rules! decl_decimal_dyn_impl {
                 match target_scale {
                     $(
                         $scale => {
-                            let l = *lhs_box.as_any()
+                            let lhs_typed = *lhs_box.as_any()
                                 .downcast_ref::<$crate::$Type<$scale>>()?;
-                            let r = *rhs_box.as_any()
+                            let rhs_typed = *rhs_box.as_any()
                                 .downcast_ref::<$crate::$Type<$scale>>()?;
-                            <$crate::$Type<$scale> as $crate::DecimalArithmetic>::checked_mul(l, r)
-                                .map(|res| ::alloc::boxed::Box::new(res)
+                            <$crate::$Type<$scale> as $crate::DecimalArithmetic>::checked_mul(lhs_typed, rhs_typed)
+                                .map(|value| ::alloc::boxed::Box::new(value)
                                     as ::alloc::boxed::Box<dyn $crate::types::traits::dyn_decimal::DynDecimal>)
                         }
                     )+
@@ -177,12 +177,12 @@ macro_rules! decl_decimal_dyn_impl {
                 match target_scale {
                     $(
                         $scale => {
-                            let l = *lhs_box.as_any()
+                            let lhs_typed = *lhs_box.as_any()
                                 .downcast_ref::<$crate::$Type<$scale>>()?;
-                            let r = *rhs_box.as_any()
+                            let rhs_typed = *rhs_box.as_any()
                                 .downcast_ref::<$crate::$Type<$scale>>()?;
-                            <$crate::$Type<$scale> as $crate::DecimalArithmetic>::checked_div(l, r)
-                                .map(|res| ::alloc::boxed::Box::new(res)
+                            <$crate::$Type<$scale> as $crate::DecimalArithmetic>::checked_div(lhs_typed, rhs_typed)
+                                .map(|value| ::alloc::boxed::Box::new(value)
                                     as ::alloc::boxed::Box<dyn $crate::types::traits::dyn_decimal::DynDecimal>)
                         }
                     )+
@@ -203,12 +203,12 @@ macro_rules! decl_decimal_dyn_impl {
                 match target_scale {
                     $(
                         $scale => {
-                            let l = *lhs_box.as_any()
+                            let lhs_typed = *lhs_box.as_any()
                                 .downcast_ref::<$crate::$Type<$scale>>()?;
-                            let r = *rhs_box.as_any()
+                            let rhs_typed = *rhs_box.as_any()
                                 .downcast_ref::<$crate::$Type<$scale>>()?;
-                            <$crate::$Type<$scale> as $crate::DecimalArithmetic>::checked_rem(l, r)
-                                .map(|res| ::alloc::boxed::Box::new(res)
+                            <$crate::$Type<$scale> as $crate::DecimalArithmetic>::checked_rem(lhs_typed, rhs_typed)
+                                .map(|value| ::alloc::boxed::Box::new(value)
                                     as ::alloc::boxed::Box<dyn $crate::types::traits::dyn_decimal::DynDecimal>)
                         }
                     )+
@@ -257,27 +257,27 @@ macro_rules! decl_decimal_dyn_impl {
                 }
                 let target_scale = SCALE.max(rhs.scale_dyn());
                 let lhs_box = match $crate::types::traits::dyn_decimal::DynDecimal::quantize_to(self, target_scale) {
-                    Some(b) => b,
+                    Some(boxed) => boxed,
                     None => return false,
                 };
                 let rhs_box = match rhs.quantize_to(target_scale) {
-                    Some(b) => b,
+                    Some(boxed) => boxed,
                     None => return false,
                 };
                 match target_scale {
                     $(
                         $scale => {
-                            let l = match lhs_box.as_any()
+                            let lhs_typed = match lhs_box.as_any()
                                 .downcast_ref::<$crate::$Type<$scale>>() {
-                                Some(v) => *v,
+                                Some(typed) => *typed,
                                 None => return false,
                             };
-                            let r = match rhs_box.as_any()
+                            let rhs_typed = match rhs_box.as_any()
                                 .downcast_ref::<$crate::$Type<$scale>>() {
-                                Some(v) => *v,
+                                Some(typed) => *typed,
                                 None => return false,
                             };
-                            l == r
+                            lhs_typed == rhs_typed
                         }
                     )+
                     _ => false,
@@ -297,11 +297,11 @@ macro_rules! decl_decimal_dyn_impl {
                 match target_scale {
                     $(
                         $scale => {
-                            let l = *lhs_box.as_any()
+                            let lhs_typed = *lhs_box.as_any()
                                 .downcast_ref::<$crate::$Type<$scale>>()?;
-                            let r = *rhs_box.as_any()
+                            let rhs_typed = *rhs_box.as_any()
                                 .downcast_ref::<$crate::$Type<$scale>>()?;
-                            Some(l.cmp(&r))
+                            Some(lhs_typed.cmp(&rhs_typed))
                         }
                     )+
                     _ => None,

--- a/src/macros/equalities.rs
+++ b/src/macros/equalities.rs
@@ -122,8 +122,8 @@ macro_rules! decl_eq_float {
                 if !other.is_finite() {
                     return false;
                 }
-                let f = *other as f64;
-                self.to_bits().cmp_f64_exact(SCALE, f) == ::core::cmp::Ordering::Equal
+                let float_value = *other as f64;
+                self.to_bits().cmp_f64_exact(SCALE, float_value) == ::core::cmp::Ordering::Equal
             }
         }
         impl<const SCALE: u32> ::core::cmp::PartialEq<$Type<SCALE>> for $Src {

--- a/src/macros/float_bridge.rs
+++ b/src/macros/float_bridge.rs
@@ -54,8 +54,8 @@ macro_rules! decl_decimal_float_bridge {
                 if value.is_infinite() {
                     return if value > 0.0 { Self::MAX } else { Self::MIN };
                 }
-                let mult_f64: f64 = Self::multiplier().as_f64();
-                let scaled = value * mult_f64;
+                let multiplier_f64: f64 = Self::multiplier().as_f64();
+                let scaled = value * multiplier_f64;
                 let storage_max_f64: f64 = <$Storage>::MAX.as_f64();
                 let storage_min_f64: f64 = <$Storage>::MIN.as_f64();
                 if scaled >= storage_max_f64 {
@@ -94,8 +94,8 @@ macro_rules! decl_decimal_float_bridge {
             #[must_use]
             pub fn to_f64(self) -> f64 {
                 let raw_f64: f64 = self.0.as_f64();
-                let mult_f64: f64 = Self::multiplier().as_f64();
-                raw_f64 / mult_f64
+                let multiplier_f64: f64 = Self::multiplier().as_f64();
+                raw_f64 / multiplier_f64
             }
 
             /// Converts to `f32` via `f64`, then narrows.

--- a/src/macros/from_str.rs
+++ b/src/macros/from_str.rs
@@ -35,11 +35,11 @@ macro_rules! decl_decimal_from_str {
     (wide $Type:ident, $Storage:ty) => {
         impl<const SCALE: u32> ::core::str::FromStr for $Type<SCALE> {
             type Err = $crate::types::widths::ParseError;
-            fn from_str(s: &str) -> ::core::result::Result<Self, Self::Err> {
-                let comps = $crate::support::display::parse_components::<SCALE>(s)?;
-                let negative = comps.negative;
-                let int_str = comps.int_str;
-                let frac_str = comps.frac_str;
+            fn from_str(input: &str) -> ::core::result::Result<Self, Self::Err> {
+                let components = $crate::support::display::parse_components::<SCALE>(input)?;
+                let negative = components.negative;
+                let int_str = components.int_str;
+                let frac_str = components.frac_str;
 
                 // Storage-width constants. `from_i128(10).pow(SCALE)`
                 // is wrapping in the inherent impl, but SCALE is
@@ -56,10 +56,10 @@ macro_rules! decl_decimal_from_str {
                 // digit so we approach `MIN` from above without ever
                 // forming the positive intermediate `MAX + 1`.
                 let mut int_value = zero;
-                for &b in int_str {
-                    let digit = <$Storage>::from_i128((b - b'0') as i128);
+                for &byte in int_str {
+                    let digit = <$Storage>::from_i128((byte - b'0') as i128);
                     let scaled = match <$Storage>::checked_mul(int_value, ten) {
-                        ::core::option::Option::Some(v) => v,
+                        ::core::option::Option::Some(value) => value,
                         ::core::option::Option::None => {
                             return ::core::result::Result::Err(
                                 $crate::types::widths::ParseError::OutOfRange,
@@ -68,7 +68,7 @@ macro_rules! decl_decimal_from_str {
                     };
                     int_value = if negative {
                         match <$Storage>::checked_sub(scaled, digit) {
-                            ::core::option::Option::Some(v) => v,
+                            ::core::option::Option::Some(value) => value,
                             ::core::option::Option::None => {
                                 return ::core::result::Result::Err(
                                     $crate::types::widths::ParseError::OutOfRange,
@@ -77,7 +77,7 @@ macro_rules! decl_decimal_from_str {
                         }
                     } else {
                         match <$Storage>::checked_add(scaled, digit) {
-                            ::core::option::Option::Some(v) => v,
+                            ::core::option::Option::Some(value) => value,
                             ::core::option::Option::None => {
                                 return ::core::result::Result::Err(
                                     $crate::types::widths::ParseError::OutOfRange,
@@ -87,7 +87,7 @@ macro_rules! decl_decimal_from_str {
                     };
                 }
                 let int_scaled = match <$Storage>::checked_mul(int_value, multiplier) {
-                    ::core::option::Option::Some(v) => v,
+                    ::core::option::Option::Some(value) => value,
                     ::core::option::Option::None => {
                         return ::core::result::Result::Err(
                             $crate::types::widths::ParseError::OutOfRange,
@@ -98,10 +98,10 @@ macro_rules! decl_decimal_from_str {
                 // Accumulate the fractional part the same way.
                 let mut frac_value = zero;
                 let frac_len = frac_str.len();
-                for &b in frac_str {
-                    let digit = <$Storage>::from_i128((b - b'0') as i128);
+                for &byte in frac_str {
+                    let digit = <$Storage>::from_i128((byte - b'0') as i128);
                     let scaled = match <$Storage>::checked_mul(frac_value, ten) {
-                        ::core::option::Option::Some(v) => v,
+                        ::core::option::Option::Some(value) => value,
                         ::core::option::Option::None => {
                             return ::core::result::Result::Err(
                                 $crate::types::widths::ParseError::OutOfRange,
@@ -110,7 +110,7 @@ macro_rules! decl_decimal_from_str {
                     };
                     frac_value = if negative {
                         match <$Storage>::checked_sub(scaled, digit) {
-                            ::core::option::Option::Some(v) => v,
+                            ::core::option::Option::Some(value) => value,
                             ::core::option::Option::None => {
                                 return ::core::result::Result::Err(
                                     $crate::types::widths::ParseError::OutOfRange,
@@ -119,7 +119,7 @@ macro_rules! decl_decimal_from_str {
                         }
                     } else {
                         match <$Storage>::checked_add(scaled, digit) {
-                            ::core::option::Option::Some(v) => v,
+                            ::core::option::Option::Some(value) => value,
                             ::core::option::Option::None => {
                                 return ::core::result::Result::Err(
                                     $crate::types::widths::ParseError::OutOfRange,
@@ -128,11 +128,11 @@ macro_rules! decl_decimal_from_str {
                         }
                     };
                 }
-                let pad = (SCALE as usize) - frac_len;
-                if pad > 0 {
-                    let pad_factor = <$Storage>::pow(ten, pad as u32);
+                let pad_digits = (SCALE as usize) - frac_len;
+                if pad_digits > 0 {
+                    let pad_factor = <$Storage>::pow(ten, pad_digits as u32);
                     frac_value = match <$Storage>::checked_mul(frac_value, pad_factor) {
-                        ::core::option::Option::Some(v) => v,
+                        ::core::option::Option::Some(value) => value,
                         ::core::option::Option::None => {
                             return ::core::result::Result::Err(
                                 $crate::types::widths::ParseError::OutOfRange,
@@ -144,7 +144,7 @@ macro_rules! decl_decimal_from_str {
                 // `int_scaled` and `frac_value` already share the
                 // value's sign, so a plain add combines them.
                 let combined = match <$Storage>::checked_add(int_scaled, frac_value) {
-                    ::core::option::Option::Some(v) => v,
+                    ::core::option::Option::Some(value) => value,
                     ::core::option::Option::None => {
                         return ::core::result::Result::Err(
                             $crate::types::widths::ParseError::OutOfRange,

--- a/src/macros/helpers.rs
+++ b/src/macros/helpers.rs
@@ -21,8 +21,8 @@ macro_rules! decl_decimal_helpers {
             #[inline]
             #[must_use]
             pub fn copysign(self, sign: Self) -> Self {
-                let mag = self.0.abs();
-                if sign.0.is_negative() { Self(-mag) } else { Self(mag) }
+                let magnitude = self.0.abs();
+                if sign.0.is_negative() { Self(-magnitude) } else { Self(magnitude) }
             }
         }
     };
@@ -37,8 +37,8 @@ macro_rules! decl_decimal_helpers {
             #[inline]
             #[must_use]
             pub fn copysign(self, sign: Self) -> Self {
-                let mag = self.0.abs();
-                if sign.0 < 0 { Self(-mag) } else { Self(mag) }
+                let magnitude = self.0.abs();
+                if sign.0 < 0 { Self(-magnitude) } else { Self(magnitude) }
             }
         }
     };

--- a/src/macros/int_methods.rs
+++ b/src/macros/int_methods.rs
@@ -26,16 +26,16 @@ macro_rules! decl_decimal_int_methods {
             #[inline]
             #[must_use]
             pub fn div_floor(self, rhs: Self) -> Self {
-                let q = self.0 / rhs.0;
-                let r = self.0 % rhs.0;
+                let quotient = self.0 / rhs.0;
+                let remainder = self.0 % rhs.0;
                 let zero = <$Storage>::from_str_radix("0", 10)
                     .expect("wide decimal: invalid base-10 literal");
                 let one = <$Storage>::from_str_radix("1", 10)
                     .expect("wide decimal: invalid base-10 literal");
-                let raw = if r != zero && (r ^ rhs.0).is_negative() {
-                    q - one
+                let raw = if remainder != zero && (remainder ^ rhs.0).is_negative() {
+                    quotient - one
                 } else {
-                    q
+                    quotient
                 };
                 Self(raw * Self::multiplier())
             }
@@ -45,16 +45,16 @@ macro_rules! decl_decimal_int_methods {
             #[inline]
             #[must_use]
             pub fn div_ceil(self, rhs: Self) -> Self {
-                let q = self.0 / rhs.0;
-                let r = self.0 % rhs.0;
+                let quotient = self.0 / rhs.0;
+                let remainder = self.0 % rhs.0;
                 let zero = <$Storage>::from_str_radix("0", 10)
                     .expect("wide decimal: invalid base-10 literal");
                 let one = <$Storage>::from_str_radix("1", 10)
                     .expect("wide decimal: invalid base-10 literal");
-                let raw = if r != zero && !(r ^ rhs.0).is_negative() {
-                    q + one
+                let raw = if remainder != zero && !(remainder ^ rhs.0).is_negative() {
+                    quotient + one
                 } else {
-                    q
+                    quotient
                 };
                 Self(raw * Self::multiplier())
             }
@@ -140,14 +140,15 @@ macro_rules! decl_decimal_int_methods {
                 true
             }
 
-            /// `self * a + b`. Mirrors the `f64::mul_add` call shape so
+            /// `self * multiplier + addend`. Mirrors the `f64::mul_add`
+            /// call shape so
             /// f64-generic numeric code can monomorphise to a decimal
             /// type; there is no hardware FMA — the multiply uses the
             /// type's `Mul` and the add uses its `Add`.
             #[inline]
             #[must_use]
-            pub fn mul_add(self, a: Self, b: Self) -> Self {
-                self * a + b
+            pub fn mul_add(self, multiplier: Self, addend: Self) -> Self {
+                self * multiplier + addend
             }
         }
     };

--- a/src/macros/num_traits.rs
+++ b/src/macros/num_traits.rs
@@ -49,7 +49,7 @@ macro_rules! decl_decimal_num_traits_basics {
         impl<const SCALE: u32> ::num_traits::Num for $Type<SCALE> {
             type FromStrRadixErr = $crate::types::widths::ParseError;
             fn from_str_radix(
-                s: &str,
+                text: &str,
                 radix: u32,
             ) -> ::core::result::Result<Self, Self::FromStrRadixErr> {
                 if radix != 10 {
@@ -57,7 +57,7 @@ macro_rules! decl_decimal_num_traits_basics {
                         $crate::types::widths::ParseError::InvalidChar,
                     );
                 }
-                <Self as ::core::str::FromStr>::from_str(s)
+                <Self as ::core::str::FromStr>::from_str(text)
             }
         }
 
@@ -154,22 +154,22 @@ macro_rules! decl_decimal_num_traits_basics {
                 } else {
                     None
                 };
-                if let Some(f) = float_signal
-                    && f.is_nan()
+                if let Some(float_value) = float_signal
+                    && float_value.is_nan()
                 {
                     return Self::ZERO;
                 }
-                if let Some(d) = <Self as ::num_traits::NumCast>::from(value) {
-                    return d;
+                if let Some(converted) = <Self as ::num_traits::NumCast>::from(value) {
+                    return converted;
                 }
-                if let Some(i) = int_signal {
-                    return if i < 0 { Self::MIN } else { Self::MAX };
+                if let Some(int_value) = int_signal {
+                    return if int_value < 0 { Self::MIN } else { Self::MAX };
                 }
                 if uint_signal.is_some() {
                     return Self::MAX;
                 }
                 match float_signal {
-                    Some(f) if f.is_sign_negative() => Self::MIN,
+                    Some(float_value) if float_value.is_sign_negative() => Self::MIN,
                     Some(_) => Self::MAX,
                     None => Self::ZERO,
                 }
@@ -181,7 +181,7 @@ macro_rules! decl_decimal_num_traits_basics {
             #[must_use]
             pub fn to_num<T: ::num_traits::NumCast + ::num_traits::Bounded>(self) -> T {
                 match T::from(self) {
-                    ::core::option::Option::Some(t) => t,
+                    ::core::option::Option::Some(converted) => converted,
                     ::core::option::Option::None => {
                         if self >= Self::ZERO {
                             T::max_value()
@@ -213,32 +213,32 @@ macro_rules! decl_decimal_num_traits_conversions {
     (wide $Type:ident, $Storage:ty) => {
         impl<const SCALE: u32> ::num_traits::FromPrimitive for $Type<SCALE> {
             #[inline]
-            fn from_i64(n: i64) -> ::core::option::Option<Self> {
-                let widened: $Storage = <$Storage>::from_i128(n as i128);
+            fn from_i64(value: i64) -> ::core::option::Option<Self> {
+                let widened: $Storage = <$Storage>::from_i128(value as i128);
                 widened.checked_mul(Self::multiplier()).map(Self)
             }
             #[inline]
-            fn from_u64(n: u64) -> ::core::option::Option<Self> {
+            fn from_u64(value: u64) -> ::core::option::Option<Self> {
                 // `u64` can exceed a narrow wide-storage's positive range
                 // (e.g. `Int<1>` / D18), so route through the range-checking
                 // `TryFrom<u128>` rather than an unchecked widen.
-                <Self as ::core::convert::TryFrom<u128>>::try_from(n as u128).ok()
+                <Self as ::core::convert::TryFrom<u128>>::try_from(value as u128).ok()
             }
             #[inline]
-            fn from_i128(n: i128) -> ::core::option::Option<Self> {
-                <Self as ::core::convert::TryFrom<i128>>::try_from(n).ok()
+            fn from_i128(value: i128) -> ::core::option::Option<Self> {
+                <Self as ::core::convert::TryFrom<i128>>::try_from(value).ok()
             }
             #[inline]
-            fn from_u128(n: u128) -> ::core::option::Option<Self> {
-                <Self as ::core::convert::TryFrom<u128>>::try_from(n).ok()
+            fn from_u128(value: u128) -> ::core::option::Option<Self> {
+                <Self as ::core::convert::TryFrom<u128>>::try_from(value).ok()
             }
             #[inline]
-            fn from_f32(n: f32) -> ::core::option::Option<Self> {
-                <Self as ::core::convert::TryFrom<f32>>::try_from(n).ok()
+            fn from_f32(value: f32) -> ::core::option::Option<Self> {
+                <Self as ::core::convert::TryFrom<f32>>::try_from(value).ok()
             }
             #[inline]
-            fn from_f64(n: f64) -> ::core::option::Option<Self> {
-                <Self as ::core::convert::TryFrom<f64>>::try_from(n).ok()
+            fn from_f64(value: f64) -> ::core::option::Option<Self> {
+                <Self as ::core::convert::TryFrom<f64>>::try_from(value).ok()
             }
         }
 
@@ -247,7 +247,7 @@ macro_rules! decl_decimal_num_traits_conversions {
             fn to_i64(&self) -> ::core::option::Option<i64> {
                 (self.0 / Self::multiplier())
                     .to_i128_checked()
-                    .and_then(|v| i64::try_from(v).ok())
+                    .and_then(|int_part| i64::try_from(int_part).ok())
             }
             #[inline]
             fn to_u64(&self) -> ::core::option::Option<u64> {
@@ -259,7 +259,7 @@ macro_rules! decl_decimal_num_traits_conversions {
                 }
                 (self.0 / Self::multiplier())
                     .to_u128_checked()
-                    .and_then(|v| u64::try_from(v).ok())
+                    .and_then(|int_part| u64::try_from(int_part).ok())
             }
             #[inline]
             fn to_i128(&self) -> ::core::option::Option<i128> {
@@ -294,19 +294,20 @@ macro_rules! decl_decimal_num_traits_conversions {
     (@numcast $Type:ident) => {
         impl<const SCALE: u32> ::num_traits::NumCast for $Type<SCALE> {
             #[inline]
-            fn from<T: ::num_traits::ToPrimitive>(n: T) -> ::core::option::Option<Self> {
+            fn from<T: ::num_traits::ToPrimitive>(value: T) -> ::core::option::Option<Self> {
                 use ::num_traits::FromPrimitive;
                 // Read f64 early to distinguish integer vs fractional inputs.
-                let f = n.to_f64();
-                // Integer fast path: if `n` round-trips through i128 and
+                let as_float = value.to_f64();
+                // Integer fast path: if the input round-trips through i128
+                // and
                 // the f64 value matches, the input is integer-shaped —
                 // take the lossless integer path (preserves precision for
                 // i64/u64 values beyond f64's 2^53 exact-integer range).
-                if let ::core::option::Option::Some(int) = n.to_i128() {
-                    let take_int_path = match f {
+                if let ::core::option::Option::Some(int) = value.to_i128() {
+                    let take_int_path = match as_float {
                         ::core::option::Option::None => true,
-                        ::core::option::Option::Some(fv) => {
-                            fv.is_finite() && ((int as f64) == fv)
+                        ::core::option::Option::Some(float_value) => {
+                            float_value.is_finite() && ((int as f64) == float_value)
                         }
                     };
                     if take_int_path {
@@ -315,8 +316,8 @@ macro_rules! decl_decimal_num_traits_conversions {
                 }
                 // Float path — preserves fractional information; `None`
                 // for NaN / infinity / out-of-range.
-                if let ::core::option::Option::Some(fv) = f {
-                    return <Self as FromPrimitive>::from_f64(fv);
+                if let ::core::option::Option::Some(float_value) = as_float {
+                    return <Self as FromPrimitive>::from_f64(float_value);
                 }
                 ::core::option::Option::None
             }

--- a/src/macros/overflow.rs
+++ b/src/macros/overflow.rs
@@ -48,11 +48,11 @@ macro_rules! decl_decimal_overflow_variants {
             #[inline]
             #[must_use]
             pub fn checked_mul(self, rhs: Self) -> Option<Self> {
-                let a: $Wider = self.0.resize::<$Wider>();
-                let b: $Wider = rhs.0.resize::<$Wider>();
-                let m: $Wider = $Type::<SCALE>::multiplier().resize::<$Wider>();
-                let prod = a.checked_mul(b)?;
-                let scaled = prod / m;
+                let lhs_wide: $Wider = self.0.resize::<$Wider>();
+                let rhs_wide: $Wider = rhs.0.resize::<$Wider>();
+                let multiplier: $Wider = $Type::<SCALE>::multiplier().resize::<$Wider>();
+                let product = lhs_wide.checked_mul(rhs_wide)?;
+                let scaled = product / multiplier;
                 let storage_max: $Wider = <$Storage>::MAX.resize::<$Wider>();
                 let storage_min: $Wider = <$Storage>::MIN.resize::<$Wider>();
                 if scaled > storage_max || scaled < storage_min {
@@ -69,11 +69,11 @@ macro_rules! decl_decimal_overflow_variants {
             #[inline]
             #[must_use]
             pub fn wrapping_mul(self, rhs: Self) -> Self {
-                let a: $Wider = self.0.resize::<$Wider>();
-                let b: $Wider = rhs.0.resize::<$Wider>();
-                let m: $Wider = $Type::<SCALE>::multiplier().resize::<$Wider>();
-                let prod = a.wrapping_mul(b);
-                let scaled = prod / m;
+                let lhs_wide: $Wider = self.0.resize::<$Wider>();
+                let rhs_wide: $Wider = rhs.0.resize::<$Wider>();
+                let multiplier: $Wider = $Type::<SCALE>::multiplier().resize::<$Wider>();
+                let product = lhs_wide.wrapping_mul(rhs_wide);
+                let scaled = product / multiplier;
                 Self(scaled.resize::<$Storage>())
             }
 
@@ -85,11 +85,11 @@ macro_rules! decl_decimal_overflow_variants {
             #[must_use]
             pub fn saturating_mul(self, rhs: Self) -> Self {
                 match self.checked_mul(rhs) {
-                    Some(v) => v,
+                    Some(product) => product,
                     None => {
-                        let neg_result =
+                        let is_negative_result =
                             self.0.is_negative() ^ rhs.0.is_negative();
-                        if neg_result { Self::MIN } else { Self::MAX }
+                        if is_negative_result { Self::MIN } else { Self::MAX }
                     }
                 }
             }
@@ -101,7 +101,7 @@ macro_rules! decl_decimal_overflow_variants {
             #[must_use]
             pub fn overflowing_mul(self, rhs: Self) -> (Self, bool) {
                 match self.checked_mul(rhs) {
-                    Some(v) => (v, false),
+                    Some(product) => (product, false),
                     None => (self.wrapping_mul(rhs), true),
                 }
             }
@@ -120,16 +120,18 @@ macro_rules! decl_decimal_overflow_variants {
                 if rhs == Self::ZERO {
                     return None;
                 }
-                let b: $Wider = rhs.0.resize::<$Wider>();
-                let n: $Wider = self.0.widen_mul::<$Wider>($Type::<SCALE>::multiplier());
-                let result = $crate::macros::arithmetic::round_with_mode_wide!(
-                    n, b, $Wider, $crate::support::rounding::DEFAULT_ROUNDING_MODE);
+                let divisor_wide: $Wider = rhs.0.resize::<$Wider>();
+                let scaled_numerator: $Wider =
+                    self.0.widen_mul::<$Wider>($Type::<SCALE>::multiplier());
+                let quotient = $crate::macros::arithmetic::round_with_mode_wide!(
+                    scaled_numerator, divisor_wide, $Wider,
+                    $crate::support::rounding::DEFAULT_ROUNDING_MODE);
                 let storage_max: $Wider = <$Storage>::MAX.resize::<$Wider>();
                 let storage_min: $Wider = <$Storage>::MIN.resize::<$Wider>();
-                if result > storage_max || result < storage_min {
+                if quotient > storage_max || quotient < storage_min {
                     None
                 } else {
-                    Some(Self(result.resize::<$Storage>()))
+                    Some(Self(quotient.resize::<$Storage>()))
                 }
             }
 
@@ -141,13 +143,14 @@ macro_rules! decl_decimal_overflow_variants {
             #[inline]
             #[must_use]
             pub fn wrapping_div(self, rhs: Self) -> Self {
-                let a: $Wider = self.0.resize::<$Wider>();
-                let b: $Wider = rhs.0.resize::<$Wider>();
-                let m: $Wider = $Type::<SCALE>::multiplier().resize::<$Wider>();
-                let scaled_numer = a.wrapping_mul(m);
-                let result = $crate::macros::arithmetic::round_with_mode_wide!(
-                    scaled_numer, b, $Wider, $crate::support::rounding::DEFAULT_ROUNDING_MODE);
-                Self(result.resize::<$Storage>())
+                let lhs_wide: $Wider = self.0.resize::<$Wider>();
+                let divisor_wide: $Wider = rhs.0.resize::<$Wider>();
+                let multiplier: $Wider = $Type::<SCALE>::multiplier().resize::<$Wider>();
+                let scaled_numerator = lhs_wide.wrapping_mul(multiplier);
+                let quotient = $crate::macros::arithmetic::round_with_mode_wide!(
+                    scaled_numerator, divisor_wide, $Wider,
+                    $crate::support::rounding::DEFAULT_ROUNDING_MODE);
+                Self(quotient.resize::<$Storage>())
             }
 
             /// Saturating division. Computes `self / rhs`, clamping to
@@ -160,11 +163,11 @@ macro_rules! decl_decimal_overflow_variants {
                     panic!("attempt to divide by zero");
                 }
                 match self.checked_div(rhs) {
-                    Some(v) => v,
+                    Some(quotient) => quotient,
                     None => {
-                        let neg_result =
+                        let is_negative_result =
                             self.0.is_negative() ^ rhs.0.is_negative();
-                        if neg_result { Self::MIN } else { Self::MAX }
+                        if is_negative_result { Self::MIN } else { Self::MAX }
                     }
                 }
             }
@@ -176,7 +179,7 @@ macro_rules! decl_decimal_overflow_variants {
             #[must_use]
             pub fn overflowing_div(self, rhs: Self) -> (Self, bool) {
                 match self.checked_div(rhs) {
-                    Some(v) => (v, false),
+                    Some(quotient) => (quotient, false),
                     None => (self.wrapping_div(rhs), true),
                 }
             }
@@ -197,7 +200,7 @@ macro_rules! decl_decimal_overflow_variants {
             #[must_use]
             pub const fn checked_add(self, rhs: Self) -> Option<Self> {
                 match self.0.checked_add(rhs.0) {
-                    Some(v) => Some(Self(v)),
+                    Some(sum) => Some(Self(sum)),
                     None => None,
                 }
             }
@@ -223,8 +226,8 @@ macro_rules! decl_decimal_overflow_variants {
             #[inline]
             #[must_use]
             pub const fn overflowing_add(self, rhs: Self) -> (Self, bool) {
-                let (v, of) = self.0.overflowing_add(rhs.0);
-                (Self(v), of)
+                let (sum, overflowed) = self.0.overflowing_add(rhs.0);
+                (Self(sum), overflowed)
             }
 
             // ----- sub ----------------------------------------------
@@ -235,7 +238,7 @@ macro_rules! decl_decimal_overflow_variants {
             #[must_use]
             pub const fn checked_sub(self, rhs: Self) -> Option<Self> {
                 match self.0.checked_sub(rhs.0) {
-                    Some(v) => Some(Self(v)),
+                    Some(difference) => Some(Self(difference)),
                     None => None,
                 }
             }
@@ -260,8 +263,8 @@ macro_rules! decl_decimal_overflow_variants {
             #[inline]
             #[must_use]
             pub const fn overflowing_sub(self, rhs: Self) -> (Self, bool) {
-                let (v, of) = self.0.overflowing_sub(rhs.0);
-                (Self(v), of)
+                let (difference, overflowed) = self.0.overflowing_sub(rhs.0);
+                (Self(difference), overflowed)
             }
 
             // ----- neg ----------------------------------------------
@@ -273,7 +276,7 @@ macro_rules! decl_decimal_overflow_variants {
             #[must_use]
             pub const fn checked_neg(self) -> Option<Self> {
                 match self.0.checked_neg() {
-                    Some(v) => Some(Self(v)),
+                    Some(negated) => Some(Self(negated)),
                     None => None,
                 }
             }
@@ -300,8 +303,8 @@ macro_rules! decl_decimal_overflow_variants {
             #[inline]
             #[must_use]
             pub const fn overflowing_neg(self) -> (Self, bool) {
-                let (v, of) = self.0.overflowing_neg();
-                (Self(v), of)
+                let (negated, overflowed) = self.0.overflowing_neg();
+                (Self(negated), overflowed)
             }
 
             // ----- rem ----------------------------------------------
@@ -313,7 +316,7 @@ macro_rules! decl_decimal_overflow_variants {
             #[must_use]
             pub const fn checked_rem(self, rhs: Self) -> Option<Self> {
                 match self.0.checked_rem(rhs.0) {
-                    Some(v) => Some(Self(v)),
+                    Some(remainder) => Some(Self(remainder)),
                     None => None,
                 }
             }
@@ -332,8 +335,8 @@ macro_rules! decl_decimal_overflow_variants {
             #[inline]
             #[must_use]
             pub const fn overflowing_rem(self, rhs: Self) -> (Self, bool) {
-                let (v, of) = self.0.overflowing_rem(rhs.0);
-                (Self(v), of)
+                let (remainder, overflowed) = self.0.overflowing_rem(rhs.0);
+                (Self(remainder), overflowed)
             }
         }
     };

--- a/src/macros/pow.rs
+++ b/src/macros/pow.rs
@@ -23,19 +23,19 @@ macro_rules! decl_decimal_pow {
             #[inline]
             #[must_use]
             pub fn pow(self, exp: u32) -> Self {
-                let mut acc = Self::ONE;
+                let mut accumulator = Self::ONE;
                 let mut base = self;
-                let mut e = exp;
-                while e > 0 {
-                    if e & 1 == 1 {
-                        acc *= base;
+                let mut remaining_exponent = exp;
+                while remaining_exponent > 0 {
+                    if remaining_exponent & 1 == 1 {
+                        accumulator *= base;
                     }
-                    e >>= 1;
-                    if e > 0 {
+                    remaining_exponent >>= 1;
+                    if remaining_exponent > 0 {
                         base = base * base;
                     }
                 }
-                acc
+                accumulator
             }
 
             /// Signed integer exponent. For non-negative `exp` this is
@@ -60,38 +60,38 @@ macro_rules! decl_decimal_pow {
             #[inline]
             #[must_use]
             pub fn checked_pow(self, exp: u32) -> ::core::option::Option<Self> {
-                let mut acc = Self::ONE;
+                let mut accumulator = Self::ONE;
                 let mut base = self;
-                let mut e = exp;
-                while e > 0 {
-                    if e & 1 == 1 {
-                        acc = acc.checked_mul(base)?;
+                let mut remaining_exponent = exp;
+                while remaining_exponent > 0 {
+                    if remaining_exponent & 1 == 1 {
+                        accumulator = accumulator.checked_mul(base)?;
                     }
-                    e >>= 1;
-                    if e > 0 {
+                    remaining_exponent >>= 1;
+                    if remaining_exponent > 0 {
                         base = base.checked_mul(base)?;
                     }
                 }
-                ::core::option::Option::Some(acc)
+                ::core::option::Option::Some(accumulator)
             }
 
             /// Two's-complement wrap at every multiplication step.
             #[inline]
             #[must_use]
             pub fn wrapping_pow(self, exp: u32) -> Self {
-                let mut acc = Self::ONE;
+                let mut accumulator = Self::ONE;
                 let mut base = self;
-                let mut e = exp;
-                while e > 0 {
-                    if e & 1 == 1 {
-                        acc = acc.wrapping_mul(base);
+                let mut remaining_exponent = exp;
+                while remaining_exponent > 0 {
+                    if remaining_exponent & 1 == 1 {
+                        accumulator = accumulator.wrapping_mul(base);
                     }
-                    e >>= 1;
-                    if e > 0 {
+                    remaining_exponent >>= 1;
+                    if remaining_exponent > 0 {
                         base = base.wrapping_mul(base);
                     }
                 }
-                acc
+                accumulator
             }
 
             /// Saturates to `Self::MAX` or `Self::MIN` on overflow,
@@ -104,11 +104,11 @@ macro_rules! decl_decimal_pow {
                 }
                 // The result is negative iff the base is negative and
                 // the exponent is odd.
-                let neg = self < Self::ZERO && (exp & 1) == 1;
+                let is_negative = self < Self::ZERO && (exp & 1) == 1;
                 match self.checked_pow(exp) {
-                    ::core::option::Option::Some(v) => v,
+                    ::core::option::Option::Some(value) => value,
                     ::core::option::Option::None => {
-                        if neg {
+                        if is_negative {
                             Self::MIN
                         } else {
                             Self::MAX
@@ -123,24 +123,24 @@ macro_rules! decl_decimal_pow {
             #[inline]
             #[must_use]
             pub fn overflowing_pow(self, exp: u32) -> (Self, bool) {
-                let mut acc = Self::ONE;
+                let mut accumulator = Self::ONE;
                 let mut base = self;
-                let mut e = exp;
+                let mut remaining_exponent = exp;
                 let mut overflowed = false;
-                while e > 0 {
-                    if e & 1 == 1 {
-                        let (v, ov) = acc.overflowing_mul(base);
-                        acc = v;
-                        overflowed |= ov;
+                while remaining_exponent > 0 {
+                    if remaining_exponent & 1 == 1 {
+                        let (product, step_overflowed) = accumulator.overflowing_mul(base);
+                        accumulator = product;
+                        overflowed |= step_overflowed;
                     }
-                    e >>= 1;
-                    if e > 0 {
-                        let (v, ov) = base.overflowing_mul(base);
-                        base = v;
-                        overflowed |= ov;
+                    remaining_exponent >>= 1;
+                    if remaining_exponent > 0 {
+                        let (squared, step_overflowed) = base.overflowing_mul(base);
+                        base = squared;
+                        overflowed |= step_overflowed;
                     }
                 }
-                (acc, overflowed)
+                (accumulator, overflowed)
             }
         }
     };

--- a/src/macros/quantize.rs
+++ b/src/macros/quantize.rs
@@ -77,11 +77,11 @@ macro_rules! decl_decimal_quantize {
                 if TARGET_SCALE > SCALE {
                     let shift = TARGET_SCALE - SCALE;
                     let multiplier = ten.pow(shift);
-                    let result = match self.0.checked_mul(multiplier) {
-                        Some(v) => v,
+                    let scaled_up = match self.0.checked_mul(multiplier) {
+                        Some(scaled) => scaled,
                         None => panic!(concat!(stringify!($Type), "::quantize: scale-up overflow")),
                     };
-                    return $Type::<TARGET_SCALE>::from_bits(result);
+                    return $Type::<TARGET_SCALE>::from_bits(scaled_up);
                 }
                 let shift = SCALE - TARGET_SCALE;
                 let divisor = ten.pow(shift);
@@ -91,39 +91,39 @@ macro_rules! decl_decimal_quantize {
                 if remainder == zero {
                     return $Type::<TARGET_SCALE>::from_bits(quotient);
                 }
-                let abs_rem = remainder.unsigned_abs();
+                let abs_remainder = remainder.unsigned_abs();
                 let half = divisor.unsigned_abs() >> 1;
-                let non_negative = !raw.is_negative();
+                let is_non_negative = !raw.is_negative();
                 let bits = match mode {
                     $crate::support::rounding::RoundingMode::HalfToEven => {
-                        if abs_rem < half {
+                        if abs_remainder < half {
                             quotient
-                        } else if abs_rem > half {
-                            if non_negative {
+                        } else if abs_remainder > half {
+                            if is_non_negative {
                                 quotient + one
                             } else {
                                 quotient - one
                             }
                         } else if !quotient.bit(0) {
                             quotient
-                        } else if non_negative {
+                        } else if is_non_negative {
                             quotient + one
                         } else {
                             quotient - one
                         }
                     }
                     $crate::support::rounding::RoundingMode::HalfAwayFromZero => {
-                        if abs_rem < half {
+                        if abs_remainder < half {
                             quotient
-                        } else if non_negative {
+                        } else if is_non_negative {
                             quotient + one
                         } else {
                             quotient - one
                         }
                     }
                     $crate::support::rounding::RoundingMode::HalfTowardZero => {
-                        if abs_rem > half {
-                            if non_negative {
+                        if abs_remainder > half {
+                            if is_non_negative {
                                 quotient + one
                             } else {
                                 quotient - one
@@ -134,14 +134,14 @@ macro_rules! decl_decimal_quantize {
                     }
                     $crate::support::rounding::RoundingMode::Trunc => quotient,
                     $crate::support::rounding::RoundingMode::Floor => {
-                        if non_negative {
+                        if is_non_negative {
                             quotient
                         } else {
                             quotient - one
                         }
                     }
                     $crate::support::rounding::RoundingMode::Ceiling => {
-                        if non_negative {
+                        if is_non_negative {
                             quotient + one
                         } else {
                             quotient

--- a/src/macros/requantize.rs
+++ b/src/macros/requantize.rs
@@ -57,11 +57,11 @@ macro_rules! decl_decimal_requantize {
                     // Growing: widen first so the scale-up cannot overflow a
                     // width the target could have held.
                     let widened = self.0.resize_n::<N>();
-                    let out = $crate::int::convert::rescale_bigint(
+                    let rescaled = $crate::int::convert::rescale_bigint(
                         widened, SCALE, TARGET_SCALE, mode,
                     )
                     .expect("attempt to requantize with overflow");
-                    $crate::D(out)
+                    $crate::D(rescaled)
                 } else {
                     // Shrinking: rescale at the source width, then narrow.
                     let scaled = $crate::int::convert::rescale_bigint(

--- a/src/macros/rounding_methods.rs
+++ b/src/macros/rounding_methods.rs
@@ -24,11 +24,11 @@ macro_rules! decl_decimal_rounding_methods {
             #[inline]
             #[must_use]
             pub fn round(self) -> Self {
-                let m = Self::multiplier();
-                // `m` (= 10^SCALE) is positive, so `>> 1` is `m / 2`.
-                let half = m >> 1u32;
+                let multiplier = Self::multiplier();
+                // `multiplier` (= 10^SCALE) is positive, so `>> 1` halves it.
+                let half = multiplier >> 1u32;
                 let bias = if self.0.is_negative() { -half } else { half };
-                Self((self.0 + bias) / m * m)
+                Self((self.0 + bias) / multiplier * multiplier)
             }
         }
     };
@@ -42,10 +42,10 @@ macro_rules! decl_decimal_rounding_methods {
             #[inline]
             #[must_use]
             pub fn round(self) -> Self {
-                let m = Self::multiplier();
-                let half = m / 2;
+                let multiplier = Self::multiplier();
+                let half = multiplier / 2;
                 let bias = if self.0 >= 0 { half } else { -half };
-                Self((self.0 + bias) / m * m)
+                Self((self.0 + bias) / multiplier * multiplier)
             }
         }
     };
@@ -58,8 +58,8 @@ macro_rules! decl_decimal_rounding_methods {
             #[inline]
             #[must_use]
             pub fn floor(self) -> Self {
-                let m = Self::multiplier();
-                Self(self.0.div_euclid(m) * m)
+                let multiplier = Self::multiplier();
+                Self(self.0.div_euclid(multiplier) * multiplier)
             }
 
             /// Smallest integer multiple of `ONE` greater than or equal
@@ -67,24 +67,24 @@ macro_rules! decl_decimal_rounding_methods {
             #[inline]
             #[must_use]
             pub fn ceil(self) -> Self {
-                let m = Self::multiplier();
-                Self(-((-self.0).div_euclid(m)) * m)
+                let multiplier = Self::multiplier();
+                Self(-((-self.0).div_euclid(multiplier)) * multiplier)
             }
 
             /// Drop the fractional part (toward zero).
             #[inline]
             #[must_use]
             pub fn trunc(self) -> Self {
-                let m = Self::multiplier();
-                Self(self.0 / m * m)
+                let multiplier = Self::multiplier();
+                Self(self.0 / multiplier * multiplier)
             }
 
             /// Return only the fractional part: `self - self.trunc()`.
             #[inline]
             #[must_use]
             pub fn fract(self) -> Self {
-                let m = Self::multiplier();
-                Self(self.0 - (self.0 / m * m))
+                let multiplier = Self::multiplier();
+                Self(self.0 - (self.0 / multiplier * multiplier))
             }
         }
     };

--- a/src/macros/sign.rs
+++ b/src/macros/sign.rs
@@ -35,7 +35,7 @@ macro_rules! decl_decimal_sign_methods {
                 // the always-error form.
                 if self.0.is_negative() {
                     match self.0.checked_neg() {
-                        Some(v) => Self(v),
+                        Some(negated) => Self(negated),
                         None => panic!("attempt to compute the absolute value with overflow"),
                     }
                 } else {

--- a/src/macros/storage_formatters.rs
+++ b/src/macros/storage_formatters.rs
@@ -14,23 +14,23 @@
 macro_rules! decl_decimal_storage_formatters {
     ($Type:ident) => {
         impl<const SCALE: u32> ::core::fmt::LowerHex for $Type<SCALE> {
-            fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-                ::core::fmt::LowerHex::fmt(&self.0, f)
+            fn fmt(&self, formatter: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+                ::core::fmt::LowerHex::fmt(&self.0, formatter)
             }
         }
         impl<const SCALE: u32> ::core::fmt::UpperHex for $Type<SCALE> {
-            fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-                ::core::fmt::UpperHex::fmt(&self.0, f)
+            fn fmt(&self, formatter: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+                ::core::fmt::UpperHex::fmt(&self.0, formatter)
             }
         }
         impl<const SCALE: u32> ::core::fmt::Octal for $Type<SCALE> {
-            fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-                ::core::fmt::Octal::fmt(&self.0, f)
+            fn fmt(&self, formatter: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+                ::core::fmt::Octal::fmt(&self.0, formatter)
             }
         }
         impl<const SCALE: u32> ::core::fmt::Binary for $Type<SCALE> {
-            fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-                ::core::fmt::Binary::fmt(&self.0, f)
+            fn fmt(&self, formatter: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+                ::core::fmt::Binary::fmt(&self.0, formatter)
             }
         }
     };

--- a/src/macros/wide_roots.rs
+++ b/src/macros/wide_roots.rs
@@ -38,11 +38,11 @@
 /// integers have no `From<u8>`, so the const-fn `from_str_radix` is the
 /// portable way to materialise a literal.
 macro_rules! wide_lit {
-    ($T:ty, $s:literal) => {
-        match <$T>::from_str_radix($s, 10) {
-            ::core::result::Result::Ok(v) => v,
+    ($T:ty, $digits:literal) => {
+        match <$T>::from_str_radix($digits, 10) {
+            ::core::result::Result::Ok(value) => value,
             ::core::result::Result::Err(_) => {
-                panic!(concat!("wide_roots: invalid base-10 literal ", $s))
+                panic!(concat!("wide_roots: invalid base-10 literal ", $digits))
             }
         }
     };

--- a/src/macros/wide_transcendental.rs
+++ b/src/macros/wide_transcendental.rs
@@ -84,13 +84,15 @@
 //!
 //! [`RoundingMode`]: crate::support::rounding::RoundingMode
 
-/// Emits the per-tier `pow10_table(w)` door onto the `pow10` int policy.
+/// Emits the per-tier `pow10_table(exponent)` door onto the `pow10` int
+/// policy.
 ///
-/// `10^w` keyed on the working width `w`, routed through
+/// `10^exponent` keyed on the working width `exponent`, routed through
 /// [`crate::consts::pow10::dispatch`] — the single int policy for `10^exp`
 /// (the generated `POW10` limb table, with a `TEN.pow` fallback past the
-/// band). For a const `w` (the tier `SCALE`, `GUARD`, etc.) `dispatch`
-/// const-folds to the literal `W`; for a runtime `w` it is the policy's
+/// band). For a const `exponent` (the tier `SCALE`, `GUARD`, etc.)
+/// `dispatch` const-folds to the literal `W`; for a runtime `exponent` it is
+/// the policy's
 /// table lookup. No per-tier `static POW10_TABLE` is baked: that duplicated
 /// the policy's table once per tier in `.rodata`. The `$table_mode` /
 /// `$max_scale` arguments are vestigial (every tier now routes identically)
@@ -100,8 +102,8 @@
 macro_rules! decl_pow10_table {
     ($table_mode:tt, $max_scale:literal) => {
         #[inline]
-        pub(crate) fn pow10_table(w: u32) -> W {
-            $crate::consts::pow10::dispatch::<W>(w)
+        pub(crate) fn pow10_table(exponent: u32) -> W {
+            $crate::consts::pow10::dispatch::<W>(exponent)
         }
     };
 }
@@ -270,15 +272,15 @@ macro_rules! decl_wide_transcendental {
                 // `bit_length(|v_w|) - bit_length(10^SCALE)` clamped
                 // to zero — that's a rough log₂(int_part) bound;
                 // exponentiate to a u32 upper bound on int_part.
-                let av = v_w_at_scale.abs();
-                let bl_v = bit_length(av);
-                let bl_one_s = bit_length(pow10_table(scale));
-                if bl_v <= bl_one_s {
+                let abs_value = v_w_at_scale.abs();
+                let value_bits = bit_length(abs_value);
+                let one_at_scale_bits = bit_length(pow10_table(scale));
+                if value_bits <= one_at_scale_bits {
                     // |v| < 1, no integer part — minimal lift.
                     return 5;
                 }
-                // log₂(int_part) ≤ bl_v - bl_one_s + 1
-                let log2_int_part = bl_v - bl_one_s + 1;
+                // log₂(int_part) ≤ value_bits - one_at_scale_bits + 1
+                let log2_int_part = value_bits - one_at_scale_bits + 1;
                 // int_part ≤ 2^log2_int_part. k ≤ int_part / ln 2 + 1
                 // ≤ 2^log2_int_part · 1.443 + 1.
                 // k_lift = ⌈k · log₁₀(2)⌉ + 4 ≤ ⌈2^log2_int_part · 0.4343⌉ + 4
@@ -302,21 +304,21 @@ macro_rules! decl_wide_transcendental {
             const SERIES_CAP: u128 = 20_000;
 
             #[inline]
-            pub(crate) fn lit(n: u128) -> W {
-                <W as $crate::int::types::traits::BigInt>::from_mag_sign_u128(&[n], false)
+            pub(crate) fn lit(value: u128) -> W {
+                <W as $crate::int::types::traits::BigInt>::from_mag_sign_u128(&[value], false)
             }
             #[inline]
             pub(crate) fn zero() -> W {
                 lit(0)
             }
             #[inline]
-            pub(crate) fn pow10(n: u32) -> W {
-                lit(10).pow(n)
+            pub(crate) fn pow10(exponent: u32) -> W {
+                lit(10).pow(exponent)
             }
             $crate::macros::wide_transcendental::decl_pow10_table!($table_mode, $max_scale);
             #[inline]
-            pub(crate) fn one(w: u32) -> W {
-                pow10_table(w)
+            pub(crate) fn one(working_scale: u32) -> W {
+                pow10_table(working_scale)
             }
             /// Half-to-even round of `(numerator / divisor)` for
             /// the signed wide integer `W`. Pulled out so the
@@ -324,21 +326,22 @@ macro_rules! decl_wide_transcendental {
             /// instead of truncating per op (which leaks ~1 LSB
             /// each into the strict-transcendental series).
             ///
-            /// Uses `div_rem` for the q + r pair (single dispatcher
-            /// call) instead of the previous `n/d` + `n%d` pattern
+            /// Uses `div_rem` for the quotient + remainder pair (single
+            /// dispatcher call) instead of the previous
+            /// `numerator/divisor` + `numerator%divisor` pattern
             /// (two dispatcher calls = two full Knuth runs).
             #[inline]
-            fn round_div(n: W, d: W) -> W {
+            fn round_div(numerator: W, divisor: W) -> W {
                 // Forwards to the single generic source
                 // (`exp_generic::round_div`) — no per-tier copy of the
                 // half-to-even divide logic. `W` is concrete here so the
                 // monomorphisation is the same one direct call.
-                $crate::algos::exp::exp_generic::round_div::<W>(n, d)
+                $crate::algos::exp::exp_generic::round_div::<W>(numerator, divisor)
             }
-            /// Half-to-even quotient `n / 10^w`, selecting the
-            /// fastest available divide kernel.
+            /// Half-to-even quotient `numerator / 10^exponent`, selecting
+            /// the fastest available divide kernel.
             ///
-            /// For `1 ≤ w ≤ 38` the MG (magic-multiply) base-2^128
+            /// For `1 ≤ exponent ≤ 38` the MG (magic-multiply) base-2^128
             /// long-divide kernel ships a constant-time, branchless
             /// inner loop — ~5 ops per u128 numerator limb — which
             /// dominates the generic Knuth Algorithm D path on
@@ -347,84 +350,89 @@ macro_rules! decl_wide_transcendental {
             /// with the generic `div_rem` reference across
             /// 380 000 + 190 000 random inputs.
             ///
-            /// For `w == 0` the divisor is 1 so the result is `n`
-            /// unchanged. For `1 ≤ w ≤ 38` the single-chunk MG
-            /// kernel handles the divide in one pass; for `w > 38`
+            /// For `exponent == 0` the divisor is 1 so the result is
+            /// `numerator` unchanged. For `1 ≤ exponent ≤ 38` the
+            /// single-chunk MG kernel handles the divide in one pass; for
+            /// `exponent > 38`
             /// the chain-MG kernel breaks the divide into a sequence
-            /// of `÷ 10^38` stages plus a final `÷ 10^(w − 38·k)`,
+            /// of `÷ 10^38` stages plus a final `÷ 10^(exponent − 38·k)`,
             /// each one a base-`2^128` MG long-divide, with
             /// combined-remainder bookkeeping that yields bit-exact
             /// half-to-even. The chain audit
             /// (`round_div_chain_audit_*` in `algos::support::mg_divide::tests`)
             /// confirms agreement with the schoolbook `div_rem`
             /// reference on 380K + 190K random inputs across every
-            /// `RoundingMode` and `w ∈ 39..=100`.
+            /// `RoundingMode` and `exponent ∈ 39..=100`.
             #[inline]
-            fn round_div_pow10(n: W, w: u32) -> W {
+            fn round_div_pow10(numerator: W, exponent: u32) -> W {
                 // Forwards to the single generic source
-                // (`exp_generic::round_div_pow10`), which routes the `w > 38`
+                // (`exp_generic::round_div_pow10`), which routes the
+                // `exponent > 38`
                 // rescale through the rescale matcher (baked-Newton / MgChain
                 // per `(scale, width)`, + the 9.24 magnitude-trim). `W`
                 // concrete here ⇒ one direct call.
-                $crate::algos::exp::exp_generic::round_div_pow10::<W>(n, w)
+                $crate::algos::exp::exp_generic::round_div_pow10::<W>(numerator, exponent)
             }
-            /// `(a · b) / 10^w`, rounded half-to-even. The
+            /// `(lhs · rhs) / 10^working_scale`, rounded half-to-even. The
             /// rounded variant replaces the previous truncating
             /// `mul`: each call drops the per-op ≤ 1 LSB
             /// truncation bias to a symmetric ≤ 0.5 LSB error,
             /// which is what 0.5 ULP at storage requires across
             /// the series-evaluation core.
             #[inline]
-            pub(crate) fn mul(a: W, b: W, w: u32) -> W {
+            pub(crate) fn mul(lhs: W, rhs: W, working_scale: u32) -> W {
                 // Forwards to the single generic source (`exp_generic::mul`):
                 // the u128-packed truncated-low product `(a·b) mod 2^(64·N)`
                 // then `÷10^w` — the per-term Series multiply. No per-tier
                 // copy of the multiply logic. `W` concrete ⇒ one direct call.
-                $crate::algos::exp::exp_generic::mul::<W>(a, b, w)
+                $crate::algos::exp::exp_generic::mul::<W>(lhs, rhs, working_scale)
             }
-            /// `(a · 10^w) / b`, rounded half-to-even.
+            /// `(numerator · 10^working_scale) / divisor`, rounded
+            /// half-to-even.
             #[inline]
-            pub(crate) fn div(a: W, b: W, w: u32) -> W {
+            pub(crate) fn div(numerator: W, divisor: W, working_scale: u32) -> W {
                 // Forwards to the single generic source (`exp_generic::div`),
                 // which sources `10^w` from the `pow10` POLICY
                 // (`pow10::dispatch`) — NOT the per-tier `pow10_table` static.
                 // `W` concrete ⇒ one direct call.
-                $crate::algos::exp::exp_generic::div::<W>(a, b, w)
+                $crate::algos::exp::exp_generic::div::<W>(numerator, divisor, working_scale)
             }
             /// Loop-friendly variant of [`div`] taking a precomputed
-            /// `10^w` numerator factor.
+            /// `10^working_scale` numerator factor.
             #[inline]
-            pub(crate) fn div_cached(a: W, b: W, pow10_w: W) -> W {
+            pub(crate) fn div_cached(numerator: W, divisor: W, cached_pow10: W) -> W {
                 // Forwards to the single generic source
                 // (`exp_generic::div_cached`): `(a·10^w)/b` with the `10^w`
                 // numerator factor precomputed by the caller (no `pow10`
                 // accessor here). `W` concrete ⇒ one direct call.
-                $crate::algos::exp::exp_generic::div_cached::<W>(a, b, pow10_w)
+                $crate::algos::exp::exp_generic::div_cached::<W>(numerator, divisor, cached_pow10)
             }
-            /// `a · n` for a small unsigned multiplier.
+            /// `value · multiplier` for a small unsigned multiplier.
             ///
-            /// When `n` fits a single u64 limb, routes through the
+            /// When `multiplier` fits a single u64 limb, routes through the
             /// n-by-1-word `mul_u64` specialisation
             /// (`L` widening muls instead of the generic `L²`
-            /// outer-product loop). For `n > u64::MAX` falls back
-            /// to the generic `a * lit(n)` `Mul` operator path.
+            /// outer-product loop). For `multiplier > u64::MAX` falls back
+            /// to the generic `value * lit(multiplier)` `Mul` operator path.
             #[inline]
-            fn mul_u(a: W, n: u128) -> W {
-                if n <= u64::MAX as u128 {
-                    a.mul_u64(n as u64)
+            fn mul_u(value: W, multiplier: u128) -> W {
+                if multiplier <= u64::MAX as u128 {
+                    value.mul_u64(multiplier as u64)
                 } else {
-                    a * lit(n)
+                    value * lit(multiplier)
                 }
             }
 
-            /// Bit length of `|v|` (0 for zero).
-            pub(crate) fn bit_length(v: W) -> u32 {
-                W::BITS - v.abs().leading_zeros()
+            /// Bit length of `|value|` (0 for zero).
+            pub(crate) fn bit_length(value: W) -> u32 {
+                W::BITS - value.abs().leading_zeros()
             }
 
-            /// `√v` at working scale `w`: `√(|v| · 10^w)`, truncating.
+            /// `√value` at `working_scale`: `√(|value| · 10^working_scale)`,
+            /// truncating.
             ///
-            /// `|v| * 10^w` must fit in `W`. Bit-length headroom is
+            /// `|value| * 10^working_scale` must fit in `W`. Bit-length
+            /// headroom is
             /// asserted in debug builds; in release the multiply
             /// wraps silently if violated. Every caller in this crate
             /// passes a value with sufficient headroom: the working
@@ -447,12 +455,12 @@ macro_rules! decl_wide_transcendental {
             /// monotone-decrease precondition the loop relies on by
             /// AM-GM (`(x + n/x)/2 ≥ √n`), so the seed direction is
             /// irrelevant to correctness.
-            pub(crate) fn sqrt_fixed(v: W, w: u32) -> W {
+            pub(crate) fn sqrt_fixed(value: W, working_scale: u32) -> W {
                 // Delegates to the width-generic kernel
                 // (`exp_generic::sqrt_fixed`) — single source for the narrow
                 // primitive `W` and the wide composition `Wagm` (rule 2). Same
                 // seed-library bootstrap + monotone-downward Newton.
-                crate::algos::exp::exp_generic::sqrt_fixed::<W>(v, w)
+                crate::algos::exp::exp_generic::sqrt_fixed::<W>(value, working_scale)
             }
 
             /// Builds a working-scale value from the type's raw storage:
@@ -509,10 +517,14 @@ macro_rules! decl_wide_transcendental {
             /// (the same strategy the operator path uses), so a
             /// wide-tier `*_strict` honours the active `rounding-*`
             /// feature flag instead of always rounding half-to-even.
-            pub(crate) fn round_to_storage(v: W, w: u32, target: u32) -> $Storage {
+            pub(crate) fn round_to_storage(
+                working_value: W,
+                working_scale: u32,
+                target: u32
+            ) -> $Storage {
                 round_to_storage_with(
-                    v,
-                    w,
+                    working_value,
+                    working_scale,
                     target,
                     $crate::support::rounding::DEFAULT_ROUNDING_MODE,
                 )
@@ -520,7 +532,7 @@ macro_rules! decl_wide_transcendental {
 
             /// Mode-aware variant of [`round_to_storage`].
             ///
-            /// When the narrowing distance `w - target` is in `1..=38`
+            /// When the narrowing distance `working_scale - target` is in `1..=38`
             /// the single-chunk MG kernel `div_wide_pow10` serves
             /// every mode directly. For `shift > 38` the chain-MG
             /// kernel `div_wide_pow10_chain` does the same via
@@ -528,26 +540,27 @@ macro_rules! decl_wide_transcendental {
             /// (bit-exact for every `RoundingMode`; see
             /// `round_div_chain_audit_*` in `algos::support::mg_divide::tests`).
             pub(crate) fn round_to_storage_with(
-                v: W,
-                w: u32,
+                working_value: W,
+                working_scale: u32,
                 target: u32,
                 mode: $crate::support::rounding::RoundingMode,
             ) -> $Storage {
                 // The narrow primitive `W` path; delegates to the work-int-
                 // generic narrowing so the wide compositions can narrow a
                 // `Wagm`-computed value to storage through the same code.
-                round_to_storage_with_g::<W>(v, w, target, mode)
+                round_to_storage_with_g::<W>(working_value, working_scale, target, mode)
             }
 
-            /// Work-int-generic narrowing of a working-scale value `v` (at
-            /// scale `w`) down to storage scale `target`, rounded under `mode`.
+            /// Work-int-generic narrowing of a `working_value` (at
+            /// `working_scale`) down to storage scale `target`, rounded under
+            /// `mode`.
             /// Input width `S` is the primitive narrow `W` OR the wide
             /// composition `Wagm` (two-core split); output is always the tier's
             /// `$Storage`. The `÷10^shift` divides are already width-generic
             /// (`div_wide_pow10::<S>` / `dispatch_wide_pow10::<S>`).
             pub(crate) fn round_to_storage_with_g<S: $crate::int::types::traits::BigInt>(
-                v: S,
-                w: u32,
+                working_value: S,
+                working_scale: u32,
                 target: u32,
                 mode: $crate::support::rounding::RoundingMode,
             ) -> $Storage
@@ -555,7 +568,7 @@ macro_rules! decl_wide_transcendental {
                 S::Scratch: $crate::int::types::compute_limbs::ComputeLimbs,
             {
                 $crate::algos::support::wide_trig_core::round_to_storage_with_g::<$Storage, S>(
-                    v, w, target, mode, <$Storage>::MAX, <$Storage>::MIN,
+                    working_value, working_scale, target, mode, <$Storage>::MAX, <$Storage>::MIN,
                 )
             }
 
@@ -571,9 +584,9 @@ macro_rules! decl_wide_transcendental {
             /// kernel error envelope of that grid line, the approximation
             /// can be on the wrong side, flipping the answer by one LSB.
             ///
-            /// `recompute(guard)` returns the kernel's working-scale value
-            /// computed with `guard` guard digits (working scale
-            /// `target + guard`). When the residual lands inside the
+            /// `recompute(guard_digits)` returns the kernel's working-scale
+            /// value computed with `guard_digits` guard digits (working scale
+            /// `target + guard_digits`). When the residual lands inside the
             /// uncertain band (`ZIV_ERR_LSB` working-scale LSB of either
             /// grid line) we cannot trust the directed decision, so we
             /// recompute with a wider guard and retry — Ziv's strategy.
@@ -588,7 +601,7 @@ macro_rules! decl_wide_transcendental {
             /// is trusted unless its residual sits within the kernel
             /// error band of a grid line, in which case it Ziv-escalates.
             pub(crate) fn round_to_storage_directed<S: $crate::int::types::traits::BigInt>(
-                base_guard: u32,
+                base_guard_digits: u32,
                 target: u32,
                 mode: $crate::support::rounding::RoundingMode,
                 recompute: impl FnMut(u32) -> S,
@@ -597,7 +610,7 @@ macro_rules! decl_wide_transcendental {
                 S::Scratch: $crate::int::types::compute_limbs::ComputeLimbs,
             {
                 $crate::algos::support::wide_trig_core::round_to_storage_directed_g::<$Storage, S>(
-                    base_guard, target, mode, <$Storage>::MAX, <$Storage>::MIN, recompute,
+                    base_guard_digits, target, mode, <$Storage>::MAX, <$Storage>::MIN, recompute,
                 )
             }
 
@@ -615,7 +628,7 @@ macro_rules! decl_wide_transcendental {
             /// `1.0`, whose residual is at scale ~`2S`). The caller MUST pin its
             /// algebraic-exact inputs (`exp 0` etc.) before reaching here.
             pub(crate) fn round_to_storage_directed_never_exact<S: $crate::int::types::traits::BigInt>(
-                base_guard: u32,
+                base_guard_digits: u32,
                 target: u32,
                 mode: $crate::support::rounding::RoundingMode,
                 recompute: impl FnMut(u32) -> S,
@@ -624,7 +637,7 @@ macro_rules! decl_wide_transcendental {
                 S::Scratch: $crate::int::types::compute_limbs::ComputeLimbs,
             {
                 $crate::algos::support::wide_trig_core::round_to_storage_directed_never_exact_g::<$Storage, S>(
-                    base_guard, target, mode, <$Storage>::MAX, <$Storage>::MIN, recompute,
+                    base_guard_digits, target, mode, <$Storage>::MAX, <$Storage>::MIN, recompute,
                 )
             }
 
@@ -640,7 +653,7 @@ macro_rules! decl_wide_transcendental {
             /// kernel error could itself have placed on the wrong side),
             /// so the answer is correctly rounded under every mode.
             pub(crate) fn round_to_storage_directed_near_special<S: $crate::int::types::traits::BigInt>(
-                base_guard: u32,
+                base_guard_digits: u32,
                 target: u32,
                 mode: $crate::support::rounding::RoundingMode,
                 recompute: impl FnMut(u32) -> S,
@@ -649,57 +662,65 @@ macro_rules! decl_wide_transcendental {
                 S::Scratch: $crate::int::types::compute_limbs::ComputeLimbs,
             {
                 $crate::algos::support::wide_trig_core::round_to_storage_directed_near_special_g::<$Storage, S>(
-                    base_guard, target, mode, <$Storage>::MAX, <$Storage>::MIN, recompute,
+                    base_guard_digits, target, mode, <$Storage>::MAX, <$Storage>::MIN, recompute,
                 )
             }
 
             /// Rounds a working-scale value to the nearest integer (ties
             /// away from zero). Used for the range-reduction quotient.
-            pub(crate) fn round_to_nearest_int(v: W, w: u32) -> i128 {
-                let divisor = pow10_table(w);
-                let (q, r) = v.div_rem(divisor);
+            pub(crate) fn round_to_nearest_int(working_value: W, working_scale: u32) -> i128 {
+                let divisor = pow10_table(working_scale);
+                let (quotient, remainder) = working_value.div_rem(divisor);
                 let half = divisor >> 1;
-                let qi = if r.abs() >= half {
-                    if v < lit(0) { q - lit(1) } else { q + lit(1) }
+                let rounded_quotient = if remainder.abs() >= half {
+                    if working_value < lit(0) { quotient - lit(1) } else { quotient + lit(1) }
                 } else {
-                    q
+                    quotient
                 };
-                $crate::int::types::traits::BigInt::to_i128(qi)
+                $crate::int::types::traits::BigInt::to_i128(rounded_quotient)
             }
 
             /// Exact-integer logarithm witness for `log_base(value)`.
             ///
             /// Given the storage-scale raw integers `value_raw` and
             /// `base_raw` (each `x · 10^scale`) and a candidate integer
-            /// result `k`, returns `true` iff `value == base^k` *exactly*
+            /// result `exponent`, returns `true` iff
+            /// `value == base^exponent` *exactly*
             /// at the storage scale — i.e. the true `log_base(value)` is
-            /// the exact integer `k`. This is the directed-rounding
+            /// the exact integer `exponent`. This is the directed-rounding
             /// exact-zero residual flag (Lindemann–Weierstrass guarantees
             /// the logarithm is otherwise irrational, so a non-exact
             /// witness means a genuine non-zero residual): when it fires
-            /// the kernel pins the result to exactly `k` under every mode,
+            /// the kernel pins the result to exactly `exponent` under every
+            /// mode,
             /// rather than letting the `ln(value)/ln(base)` round-off land
             /// a hair above/below the grid line and bump under a directed
             /// mode.
             ///
-            /// The check is exact integer arithmetic in `W`. For `k >= 1`
-            /// it tests `base_raw^k == value_raw · 10^(scale·(k − 1))`;
-            /// for `k == 0` it tests `value_raw == 10^scale` (`value == 1`);
-            /// negative `k` (`value < 1` with an integer base) tests the
-            /// mirror `base_raw^(−k) == 10^scale · 10^(scale·(−k − 1)) ·
+            /// The check is exact integer arithmetic in `W`. For
+            /// `exponent >= 1`
+            /// it tests
+            /// `base_raw^exponent == value_raw · 10^(scale·(exponent − 1))`;
+            /// for `exponent == 0` it tests `value_raw == 10^scale`
+            /// (`value == 1`);
+            /// negative `exponent` (`value < 1` with an integer base) tests
+            /// the
+            /// mirror `base_raw^(−exponent) == 10^scale ·
+            /// 10^(scale·(−exponent − 1)) ·
             /// 10^scale / value`… which reduces to `value_raw ·
-            /// base_raw^(−k) == 10^(scale·(−k + 1))`. Overflow of the
+            /// base_raw^(−exponent) == 10^(scale·(−exponent + 1))`. Overflow
+            /// of the
             /// power short-circuits to `false` (a value that large is not
             /// a representable exact power at this width).
             pub(crate) fn log_is_exact_int<S: $crate::int::types::traits::BigInt>(
                 value_raw: S,
                 base_raw: S,
                 scale: u32,
-                k: i128,
+                exponent: i128,
             ) -> bool {
-                let one_s = $crate::algos::exp::exp_generic::pow10::<S>(scale);
-                if k == 0 {
-                    return value_raw == one_s;
+                let one_at_scale = $crate::algos::exp::exp_generic::pow10::<S>(scale);
+                if exponent == 0 {
+                    return value_raw == one_at_scale;
                 }
                 // Reduce to the integer domain so the running power never
                 // carries the `· 10^scale` factor (which tips into a wider
@@ -708,74 +729,76 @@ macro_rules! decl_wide_transcendental {
                 // when `base` is itself an exact integer multiple of
                 // `10^scale` (only the near-1 ill-conditioning probes are not,
                 // and those are never exact powers).
-                let (bq, br) = base_raw.div_rem(one_s);
-                if br != S::ZERO {
+                let (base_quotient, base_remainder) = base_raw.div_rem(one_at_scale);
+                if base_remainder != S::ZERO {
                     return false;
                 }
-                let base_int = bq;
-                let kk = k.unsigned_abs();
+                let base_int = base_quotient;
+                let abs_exponent = exponent.unsigned_abs();
                 let limit_bits = <S as $crate::int::types::traits::BigInt>::BITS - 4;
-                if k > 0 {
+                if exponent > 0 {
                     // value == base^|k|: require `value` itself integral.
-                    let (vq, vr) = value_raw.div_rem(one_s);
-                    if vr != S::ZERO {
+                    let (value_quotient, value_remainder) = value_raw.div_rem(one_at_scale);
+                    if value_remainder != S::ZERO {
                         return false;
                     }
-                    let value_int = vq;
-                    let mut pow = S::ONE;
+                    let value_int = value_quotient;
+                    let mut running_power = S::ONE;
                     let mut i: u128 = 0;
-                    while i < kk {
-                        if $crate::algos::exp::exp_generic::bit_length::<S>(pow)
+                    while i < abs_exponent {
+                        if $crate::algos::exp::exp_generic::bit_length::<S>(running_power)
                             + $crate::algos::exp::exp_generic::bit_length::<S>(base_int)
                             >= limit_bits
                         {
                             return false;
                         }
-                        pow = pow * base_int;
+                        running_power = running_power * base_int;
                         i += 1;
                     }
-                    pow == value_int
+                    running_power == value_int
                 } else {
                     // value == 1 / base^|k|: `value_raw · base_int^|k|`
                     // must equal the storage `1` exactly.
-                    let mut cur = value_raw;
+                    let mut running_product = value_raw;
                     let mut i: u128 = 0;
-                    while i < kk {
-                        if $crate::algos::exp::exp_generic::bit_length::<S>(cur)
+                    while i < abs_exponent {
+                        if $crate::algos::exp::exp_generic::bit_length::<S>(running_product)
                             + $crate::algos::exp::exp_generic::bit_length::<S>(base_int)
                             >= limit_bits
                         {
                             return false;
                         }
-                        cur = cur * base_int;
+                        running_product = running_product * base_int;
                         i += 1;
                     }
-                    cur == one_s
+                    running_product == one_at_scale
                 }
             }
 
-            /// Storage representation of the exact integer `k` at scale
-            /// `scale`: the `$Storage` value `k · 10^scale`. Panics if it
+            /// Storage representation of the exact `integer_value` at scale
+            /// `scale`: the `$Storage` value `integer_value · 10^scale`.
+            /// Panics if it
             /// does not fit (a result that out-of-range would also panic
             /// in `round_to_storage_with`).
-            pub(crate) fn exact_int_at_scale(k: i128, scale: u32) -> $Storage {
-                narrow_to_storage(scale_by_k(one(scale), k))
+            pub(crate) fn exact_int_at_scale(integer_value: i128, scale: u32) -> $Storage {
+                narrow_to_storage(scale_by_k(one(scale), integer_value))
             }
 
-            /// Range-checked narrowing of a storage-scale working value
-            /// `v` (already at scale `SCALE`, no rounding needed) to the
+            /// Range-checked narrowing of a storage-scale
+            /// `working_value` (already at scale `SCALE`, no rounding
+            /// needed) to the
             /// type's `$Storage`. Panics if out of range, matching
             /// `round_to_storage_with`.
-            pub(crate) fn narrow_to_storage(v: W) -> $Storage {
-                let max_w = $crate::int::types::traits::BigInt::resize_to::<W>(<$Storage>::MAX);
-                let min_w = $crate::int::types::traits::BigInt::resize_to::<W>(<$Storage>::MIN);
-                if v > max_w || v < min_w {
+            pub(crate) fn narrow_to_storage(working_value: W) -> $Storage {
+                let storage_max = $crate::int::types::traits::BigInt::resize_to::<W>(<$Storage>::MAX);
+                let storage_min = $crate::int::types::traits::BigInt::resize_to::<W>(<$Storage>::MIN);
+                if working_value > storage_max || working_value < storage_min {
                     panic!(concat!(
                         stringify!($Type),
                         " strict transcendental: result out of range"
                     ));
                 }
-                $crate::int::types::traits::BigInt::resize_to::<$Storage>(v)
+                $crate::int::types::traits::BigInt::resize_to::<$Storage>(working_value)
             }
 
             /// Exact-power pin for `exp2`: when the storage raw `raw`
@@ -793,16 +816,16 @@ macro_rules! decl_wide_transcendental {
                 mode: $crate::support::rounding::RoundingMode,
             ) -> ::core::option::Option<$Storage> {
                 let raw_w = widen_storage(raw);
-                let one_s = pow10_table(scale);
-                let (kq, kr) = raw_w.div_rem(one_s);
-                if kr != lit(0) {
+                let one_at_scale = pow10_table(scale);
+                let (exponent_quotient, exponent_remainder) = raw_w.div_rem(one_at_scale);
+                if exponent_remainder != lit(0) {
                     return ::core::option::Option::None;
                 }
-                let k = $crate::int::types::traits::BigInt::to_i128(kq);
+                let exponent = $crate::int::types::traits::BigInt::to_i128(exponent_quotient);
                 // The exactly-representable powers (`k ≥ 0`, or `k < 0` with
                 // `|k| ≤ scale`) land on the storage grid with no rounding.
-                if let ::core::option::Option::Some(v) = exp2_exact_pow(k, scale) {
-                    return ::core::option::Option::Some(narrow_to_storage(v));
+                if let ::core::option::Option::Some(exact) = exp2_exact_pow(exponent, scale) {
+                    return ::core::option::Option::Some(narrow_to_storage(exact));
                 }
                 // `k < 0`, `|k| > scale`: `2^k · 10^scale = 5^scale / 2^p`
                 // (`p = |k| − scale ≥ 1`) is a proper dyadic fraction. Round
@@ -814,43 +837,51 @@ macro_rules! decl_wide_transcendental {
                 // than deferring to the `exp(k·ln 2)` composition, whose
                 // to-nearest approximation can directed-round (Floor / Trunc)
                 // back INSIDE the range at an out-by-one boundary.
-                if k >= 0 {
+                if exponent >= 0 {
                     $crate::support::diagnostics::overflow_panic_with_scale(
                         concat!(stringify!($Type), "::exp2"),
                         scale,
                     );
                 }
-                let p = (k.unsigned_abs() as u32) - scale;
-                ::core::option::Option::Some(round_pow2_fraction(scale, p, mode))
+                let pow2_exponent = (exponent.unsigned_abs() as u32) - scale;
+                ::core::option::Option::Some(round_pow2_fraction(scale, pow2_exponent, mode))
             }
 
             /// Correctly-rounded `$Storage` value of the dyadic fraction
-            /// `5^scale / 2^p` (`p ≥ 1`) — the `exp2(k)` storage value when
-            /// `k = −(p + scale)`. The result is strictly positive and at
+            /// `5^scale / 2^pow2_exponent` (`pow2_exponent ≥ 1`) — the
+            /// `exp2(k)` storage value when
+            /// `k = −(pow2_exponent + scale)`. The result is strictly
+            /// positive and at
             /// most `5^scale / 2`, so it always fits storage.
             ///
-            /// `q = num >> p`, residual `r = num mod 2^p`; the half-way
-            /// divisor is `2^p` so the tie compares `2·r` with `2^p`. When
-            /// `2^p` exceeds the working width the quotient is `0` and the
-            /// whole `num` is a sub-half positive residual (only `Ceiling`
-            /// rounds up).
+            /// `quotient = numerator >> pow2_exponent`, residual
+            /// `remainder = numerator mod 2^pow2_exponent`; the half-way
+            /// divisor is `2^pow2_exponent` so the tie compares
+            /// `2·remainder` with `2^pow2_exponent`. When
+            /// `2^pow2_exponent` exceeds the working width the quotient is
+            /// `0` and the
+            /// whole `numerator` is a sub-half positive residual (only
+            /// `Ceiling` rounds up).
             fn round_pow2_fraction(
                 scale: u32,
-                p: u32,
+                pow2_exponent: u32,
                 mode: $crate::support::rounding::RoundingMode,
             ) -> $Storage {
-                let num = lit(5).pow(scale);
-                // When `2^p` does not fit the SIGNED working width it strictly
-                // exceeds `2·num` (since `num < 2^(BITS-1)` and `p ≥ BITS-1`),
-                // so `q = 0` and the residual `num` sits strictly below half —
+                let numerator = lit(5).pow(scale);
+                // When `2^pow2_exponent` does not fit the SIGNED working width
+                // it strictly exceeds `2·numerator` (since
+                // `numerator < 2^(BITS-1)` and `pow2_exponent ≥ BITS-1`), so
+                // `quotient = 0` and the residual `numerator` sits strictly
+                // below half —
                 // a sub-resolution positive value (only `Ceiling` rounds up).
                 // The bound is `BITS-1`, not `BITS`: `lit(1) << (BITS-1)` sets
-                // the SIGN bit, so `denom` would be NEGATIVE and the `2·r` vs
-                // `denom` tie comparison would read `Greater` (positive > neg)
+                // the SIGN bit, so `divisor` would be NEGATIVE and the
+                // `2·remainder` vs
+                // `divisor` tie comparison would read `Greater` (positive > neg)
                 // — misrounding the sub-half residual UP under nearest. (The
                 // golden `exp2(-1053)@D57<30>` / `exp2(-2097)@D115<50>` land
                 // exactly on `p = BITS-1` for their work integer.)
-                if p >= <W as $crate::int::types::traits::BigInt>::BITS - 1 {
+                if pow2_exponent >= <W as $crate::int::types::traits::BigInt>::BITS - 1 {
                     let bump = $crate::support::rounding::should_bump(
                         mode,
                         ::core::cmp::Ordering::Less,
@@ -859,17 +890,17 @@ macro_rules! decl_wide_transcendental {
                     );
                     return narrow_to_storage(if bump { lit(1) } else { lit(0) });
                 }
-                let denom = lit(1) << p;
-                let (q, r) = num.div_rem(denom);
-                if r.is_zero() {
-                    return narrow_to_storage(q);
+                let divisor = lit(1) << pow2_exponent;
+                let (quotient, remainder) = numerator.div_rem(divisor);
+                if remainder.is_zero() {
+                    return narrow_to_storage(quotient);
                 }
-                let twice_r = r << 1;
-                let cmp_r = twice_r.cmp(&denom);
-                let q_is_odd = q.bit(0);
+                let twice_remainder = remainder << 1;
+                let remainder_cmp = twice_remainder.cmp(&divisor);
+                let quotient_is_odd = quotient.bit(0);
                 let bump =
-                    $crate::support::rounding::should_bump(mode, cmp_r, q_is_odd, true);
-                narrow_to_storage(if bump { q + lit(1) } else { q })
+                    $crate::support::rounding::should_bump(mode, remainder_cmp, quotient_is_odd, true);
+                narrow_to_storage(if bump { quotient + lit(1) } else { quotient })
             }
 
             #[inline]
@@ -895,10 +926,12 @@ macro_rules! decl_wide_transcendental {
             /// `Wexp`'s decimal capacity, not `W`'s.
             ///
             /// `exp_fixed` (at `Wexp`) runs at
-            /// `w_ext = scale + GUARD + lift + extra` where its internal
+            /// `extended_working_scale = scale + GUARD + lift + extra_digits`
+            /// where its internal
             /// `2^k` reassembly extra is `≈ 1.25·needed`, then *squares*
-            /// a value at scale `w_ext` — the squaring transiently needs
-            /// `2·w_ext` digits. With `lift = needed` the squaring peak
+            /// a value at the extended working scale — the squaring
+            /// transiently needs
+            /// twice that many digits. With `lift = needed` the squaring peak
             /// is `≈ 2·(scale + GUARD) + 4.5·needed`, which must stay
             /// inside `Wexp`'s `~BITS·log10(2)` decimal capacity. We size
             /// the cap from that bound (with a safety margin). Because
@@ -911,9 +944,9 @@ macro_rules! decl_wide_transcendental {
                 let wexp_digits = <Wexp>::BITS as u128 * 30103 / 100_000;
                 // Solve `2·(scale+GUARD) + 4.5·lift + margin ≤ wexp_digits`
                 // for `lift`. Use 45/10 for the 4.5 factor; margin 64.
-                let base = 2 * (scale as u128 + GUARD as u128) + 64;
-                let head = wexp_digits.saturating_sub(base) * 10 / 45;
-                let lift = needed.min(head);
+                let fixed_overhead = 2 * (scale as u128 + GUARD as u128) + 64;
+                let headroom = wexp_digits.saturating_sub(fixed_overhead) * 10 / 45;
+                let lift = needed.min(headroom);
                 if lift > u32::MAX as u128 {
                     u32::MAX
                 } else {
@@ -945,27 +978,29 @@ macro_rules! decl_wide_transcendental {
                 mag_at_scale: S,
                 scale: u32,
             ) -> u32 {
-                let m = if mag_at_scale < S::ZERO { -mag_at_scale } else { mag_at_scale };
-                exp_lift_cap(pow_result_digits::<S>(m, scale, 43429), scale)
+                let magnitude = if mag_at_scale < S::ZERO { -mag_at_scale } else { mag_at_scale };
+                exp_lift_cap(pow_result_digits::<S>(magnitude, scale, 43429), scale)
             }
 
             /// Shared estimator: `⌈|x| · factor / 100000⌉` decimal digits,
-            /// where `x = av / 10^scale` and `factor` is `log10(base)·1e5`
+            /// where `x = abs_value_at_scale / 10^scale` and `factor` is
+            /// `log10(base)·1e5`
             /// (`30103` for `2^x`, `43429` for `e^x`). Returns `0` when
             /// `|x| < 1` (the result has no integer-digit growth).
             fn pow_result_digits<S: $crate::int::types::traits::BigInt>(
-                av: S,
+                abs_value_at_scale: S,
                 scale: u32,
                 factor: u128,
             ) -> u128 {
-                let bl_v = $crate::algos::exp::exp_generic::bit_length::<S>(av);
-                let bl_one = $crate::algos::exp::exp_generic::bit_length::<S>(
+                let value_bits =
+                    $crate::algos::exp::exp_generic::bit_length::<S>(abs_value_at_scale);
+                let one_bits = $crate::algos::exp::exp_generic::bit_length::<S>(
                     $crate::algos::exp::exp_generic::pow10::<S>(scale),
                 );
-                if bl_v <= bl_one {
+                if value_bits <= one_bits {
                     return 0;
                 }
-                let log2_int = bl_v - bl_one + 1;
+                let log2_int = value_bits - one_bits + 1;
                 let int_upper = if log2_int >= 127 {
                     u128::MAX
                 } else {
@@ -974,154 +1009,165 @@ macro_rules! decl_wide_transcendental {
                 (int_upper.saturating_mul(factor) / 100_000) as u128
             }
 
-            /// Exact `2^k` at scale `scale`, as a `W` working value, when
-            /// `x = k` is an exact integer and `2^k` is representable at
+            /// Exact `2^exponent` at scale `scale`, as a `W` working value,
+            /// when `x = exponent` is an exact integer and `2^exponent` is
+            /// representable at
             /// the storage scale. `exp2(integer k) = 2^k` is an exact
-            /// algebraic point: for `k ≥ 0` it is the integer `2^k`; for
-            /// `k < 0` it is `5^|k| / 10^|k|`, finite with `|k|` decimal
+            /// algebraic point: for `exponent ≥ 0` it is the integer
+            /// `2^exponent`; for
+            /// `exponent < 0` it is `5^|k| / 10^|k|`, finite with `|k|`
+            /// decimal
             /// places (representable iff `|k| ≤ scale`). Returns `None`
             /// when not exactly representable, so the caller falls through
             /// to the working-scale kernel.
-            pub(crate) fn exp2_exact_pow(k: i128, scale: u32) -> ::core::option::Option<W> {
-                let one_s = pow10_table(scale);
-                if k == 0 {
-                    return ::core::option::Option::Some(one_s);
+            pub(crate) fn exp2_exact_pow(
+                exponent: i128,
+                scale: u32
+            ) -> ::core::option::Option<W> {
+                let one_at_scale = pow10_table(scale);
+                if exponent == 0 {
+                    return ::core::option::Option::Some(one_at_scale);
                 }
-                let kk = k.unsigned_abs();
-                if k > 0 {
+                let abs_exponent = exponent.unsigned_abs();
+                if exponent > 0 {
                     // 2^k · 10^scale, guarding the working width.
-                    let mut v = one_s;
+                    let mut power = one_at_scale;
                     let two = lit(2);
                     let mut i: u128 = 0;
-                    while i < kk {
-                        if bit_length(v) + 2 >= W::BITS - 4 {
+                    while i < abs_exponent {
+                        if bit_length(power) + 2 >= W::BITS - 4 {
                             return ::core::option::Option::None;
                         }
-                        v = v * two;
+                        power = power * two;
                         i += 1;
                     }
-                    ::core::option::Option::Some(v)
+                    ::core::option::Option::Some(power)
                 } else {
                     // 2^-|k| = 5^|k| · 10^(scale − |k|); representable iff
                     // |k| ≤ scale.
-                    if (kk as u128) > scale as u128 {
+                    if (abs_exponent as u128) > scale as u128 {
                         return ::core::option::Option::None;
                     }
-                    let mut v = pow10_table(scale - kk as u32);
+                    let mut power = pow10_table(scale - abs_exponent as u32);
                     let five = lit(5);
                     let mut i: u128 = 0;
-                    while i < kk {
-                        if bit_length(v) + 3 >= W::BITS - 4 {
+                    while i < abs_exponent {
+                        if bit_length(power) + 3 >= W::BITS - 4 {
                             return ::core::option::Option::None;
                         }
-                        v = v * five;
+                        power = power * five;
                         i += 1;
                     }
-                    ::core::option::Option::Some(v)
+                    ::core::option::Option::Some(power)
                 }
             }
 
-            /// `k · c` where `k` is a signed range-reduction count.
+            /// `k · value` where `k` is a signed range-reduction count.
             #[inline]
-            fn scale_by_k(c: W, k: i128) -> W {
+            fn scale_by_k(value: W, k: i128) -> W {
                 if k >= 0 {
-                    mul_u(c, k as u128)
+                    mul_u(value, k as u128)
                 } else {
-                    -mul_u(c, k.unsigned_abs())
+                    -mul_u(value, k.unsigned_abs())
                 }
             }
 
             /// `π` const-folded at the base working scale `SCALE + GUARD`
             /// for this `(W, SCALE)` cell — no runtime divide. The common
             /// (non-Ziv-escalated) path fetches the baked constant; any
-            /// other `w` (a Ziv escalation) falls to the runtime
+            /// other `working_scale` (a Ziv escalation) falls to the runtime
             /// [`pi_with`].
             #[inline]
             pub(crate) fn pi_cf<const SCALE: u32>(
-                w: u32,
+                working_scale: u32,
                 mode: $crate::support::rounding::RoundingMode,
             ) -> W {
-                if w == SCALE + GUARD {
+                if working_scale == SCALE + GUARD {
                     // Hot path: source `π` from the per-scale oracle table
                     // keyed on the CONST working scale — const-folds to one
                     // entry per monomorphisation, zero-extends into `W`.
                     return $crate::consts::pi_by_scale::<W>(SCALE + GUARD, mode);
                 }
-                // Ziv-escalation path (`w != SCALE + GUARD`): a STATIC LOOKUP of
+                // Ziv-escalation path (`working_scale != SCALE + GUARD`): a
+                // STATIC LOOKUP of
                 // the table at the runtime working scale — not a recompute. The
                 // table covers the full Ziv band (W::BITS/8) for π.
-                $crate::consts::pi_by_working_scale::<W>(w, mode)
+                $crate::consts::pi_by_working_scale::<W>(working_scale, mode)
             }
 
             /// `ln 2` const-folded at the base working scale — see
             /// [`pi_cf`].
             #[inline]
             pub(crate) fn ln2_cf<const SCALE: u32>(
-                w: u32,
+                working_scale: u32,
                 mode: $crate::support::rounding::RoundingMode,
             ) -> W {
-                if w == SCALE + GUARD {
+                if working_scale == SCALE + GUARD {
                     // Hot path: source `ln 2` from the per-scale oracle
                     // table keyed on the CONST working scale — see `pi_cf`.
                     return $crate::consts::ln2_by_scale::<W>(SCALE + GUARD, mode);
                 }
                 // Ziv path: static lookup at the runtime working scale (table
                 // covers ln2's full Ziv band) — not a recompute.
-                $crate::consts::ln2_by_working_scale::<W>(w, mode)
+                $crate::consts::ln2_by_working_scale::<W>(working_scale, mode)
             }
 
             /// `ln 10` const-folded at the base working scale — see
             /// [`pi_cf`].
             #[inline]
             pub(crate) fn ln10_cf<const SCALE: u32>(
-                w: u32,
+                working_scale: u32,
                 mode: $crate::support::rounding::RoundingMode,
             ) -> W {
-                if w == SCALE + GUARD {
+                if working_scale == SCALE + GUARD {
                     // Hot path: source `ln 10` from the per-scale oracle
                     // table keyed on the CONST working scale — see `pi_cf`.
                     return $crate::consts::ln10_by_scale::<W>(SCALE + GUARD, mode);
                 }
                 // Ziv path: static lookup at the runtime working scale (table
                 // covers ln10's full Ziv band) — not a recompute.
-                $crate::consts::ln10_by_working_scale::<W>(w, mode)
+                $crate::consts::ln10_by_working_scale::<W>(working_scale, mode)
             }
 
 
-            /// `ln 2` at working scale `w`, rounded under the crate
+            /// `ln 2` at `working_scale`, rounded under the crate
             /// default mode from the per-width compile-time reference.
-            pub(crate) fn ln2(w: u32) -> W {
-                ln2_with(w, $crate::support::rounding::DEFAULT_ROUNDING_MODE)
+            pub(crate) fn ln2(working_scale: u32) -> W {
+                ln2_with(working_scale, $crate::support::rounding::DEFAULT_ROUNDING_MODE)
             }
-            /// `ln 2` at working scale `w`, rounded under `mode`. Static
+            /// `ln 2` at `working_scale`, rounded under `mode`. Static
             /// lookup of the unified per-scale table (System A), replacing
             /// the System-B `const_rounded` recompute off a per-width string.
-            pub(crate) fn ln2_with(w: u32, mode: $crate::support::rounding::RoundingMode) -> W {
-                $crate::consts::ln2_by_working_scale::<W>(w, mode)
+            pub(crate) fn ln2_with(
+                working_scale: u32,
+                mode: $crate::support::rounding::RoundingMode
+            ) -> W {
+                $crate::consts::ln2_by_working_scale::<W>(working_scale, mode)
             }
 
             /// Natural logarithm of a positive working-scale value.
             ///
             /// Range-reduces `v = 2^k · m` with `m ∈ [1, 2)`, evaluates
             /// `ln(m) = 2·artanh((m−1)/(m+1))`, returns `k·ln 2 + ln(m)`.
-            pub(crate) fn ln_fixed<const SCALE: u32>(v_w: W, w: u32) -> W {
+            pub(crate) fn ln_fixed<const SCALE: u32>(working_value: W, working_scale: u32) -> W {
                 // Delegates to the width-generic kernel
                 // (`exp_generic::ln_fixed`) — the single source for both the
                 // narrow primitive `W` and the wide composition `Wagm`
                 // (two-core split, Constitution rule 2: one generic algorithm).
-                // The const-folded `ln2_cf::<SCALE>(w)` is threaded in so this
+                // The const-folded `ln2_cf::<SCALE>(working_scale)` is threaded
+                // in so this
                 // primitive path keeps its compile-time `ln2` (the generic
                 // kernel itself takes `ln2` as a parameter, so it stays free of
                 // the `SCALE` const).
                 crate::algos::exp::exp_generic::ln_fixed::<W>(
-                    v_w,
-                    w,
-                    ln2_cf::<SCALE>(w, $crate::support::rounding::DEFAULT_ROUNDING_MODE),
+                    working_value,
+                    working_scale,
+                    ln2_cf::<SCALE>(working_scale, $crate::support::rounding::DEFAULT_ROUNDING_MODE),
                 )
             }
 
-            /// `log1p(t) = ln(1 + t)` at working scale `w`, evaluated
-            /// without ever forming `1 + t`.
+            /// `log1p(argument) = ln(1 + argument)` at `working_scale`,
+            /// evaluated without ever forming `1 + t`.
             ///
             /// Uses the Goldberg/Higham reformulation
             /// `log1p(t) = 2*artanh( t / (2 + t) )`. The argument
@@ -1132,24 +1178,28 @@ macro_rules! decl_wide_transcendental {
             /// same `O(1)` condition number on the whole near-zero range,
             /// removing the catastrophic cancellation of the naive
             /// `ln(1 + t)` (forming `1 + t` then reducing `m - 1`) at the
-            /// source. `t` is the working-scale gap supplied exactly by
-            /// the caller. Domain: `t > -1` (the caller guards this).
+            /// source. `argument` is the working-scale gap supplied exactly
+            /// by the caller. Domain: `argument > -1` (the caller guards
+            /// this).
             ///
             /// Reference: N. J. Higham, *Accuracy and Stability of
             /// Numerical Algorithms* 2nd ed. (2002), 1.14.1 and Problem
             /// 1.4; J.-M. Muller, *Elementary Functions* 3rd ed. (2016),
             /// 4.4.
-            pub(crate) fn log1p_fixed<S: $crate::int::types::traits::BigInt>(t: S, w: u32) -> S
+            pub(crate) fn log1p_fixed<S: $crate::int::types::traits::BigInt>(
+                argument: S,
+                working_scale: u32
+            ) -> S
             where
                 S::Scratch: $crate::int::types::compute_limbs::ComputeLimbs,
             {
                 // Forwards to the single generic source
                 // (`exp_generic::log1p_fixed`) — no per-tier copy of the
                 // artanh-reformulated series (Constitution rule 2).
-                $crate::algos::exp::exp_generic::log1p_fixed::<S>(t, w)
+                $crate::algos::exp::exp_generic::log1p_fixed::<S>(argument, working_scale)
             }
 
-            /// `expm1(s) = exp(s) - 1` at working scale `w`, evaluated as
+            /// `expm1(s) = exp(s) - 1` at `working_scale`, evaluated as
             /// the Taylor series with the leading `1` term dropped so the
             /// `exp(s) - 1` subtraction of two values both `~ 1` never
             /// occurs: `expm1(s) = s + s^2/2! + s^3/3! + ...`. For tiny
@@ -1162,24 +1212,27 @@ macro_rules! decl_wide_transcendental {
             ///
             /// Reference: J.-M. Muller, *Elementary Functions* 3rd ed.
             /// (2016), 4.4; Higham 1.14.1.
-            pub(crate) fn expm1_fixed(s: W, w: u32) -> W {
+            pub(crate) fn expm1_fixed(reduced_arg: W, working_scale: u32) -> W {
                 // Forwards to the single generic source
                 // (`exp_generic::expm1_fixed`) — no per-tier copy of the
                 // leading-term-dropped Taylor series (Constitution rule 2),
                 // mirroring `log1p_fixed` above.
-                $crate::algos::exp::exp_generic::expm1_fixed::<W>(s, w)
+                $crate::algos::exp::exp_generic::expm1_fixed::<W>(reduced_arg, working_scale)
             }
 
-            /// `ln 10` at working scale `w`, rounded under the crate
+            /// `ln 10` at `working_scale`, rounded under the crate
             /// default mode from the per-width compile-time reference.
-            pub(crate) fn ln10(w: u32) -> W {
-                ln10_with(w, $crate::support::rounding::DEFAULT_ROUNDING_MODE)
+            pub(crate) fn ln10(working_scale: u32) -> W {
+                ln10_with(working_scale, $crate::support::rounding::DEFAULT_ROUNDING_MODE)
             }
-            /// `ln 10` at working scale `w`, rounded under `mode`. Static
+            /// `ln 10` at `working_scale`, rounded under `mode`. Static
             /// lookup of the unified per-scale table (System A), replacing
             /// the System-B `const_rounded` recompute off a per-width string.
-            pub(crate) fn ln10_with(w: u32, mode: $crate::support::rounding::RoundingMode) -> W {
-                $crate::consts::ln10_by_working_scale::<W>(w, mode)
+            pub(crate) fn ln10_with(
+                working_scale: u32,
+                mode: $crate::support::rounding::RoundingMode
+            ) -> W {
+                $crate::consts::ln10_by_working_scale::<W>(working_scale, mode)
             }
 
             /// Natural log of a positive working-scale value via the
@@ -1197,8 +1250,9 @@ macro_rules! decl_wide_transcendental {
             /// asymptotically beats the artanh-series `ln_fixed`,
             /// which is linear in `p`.
             ///
-            /// Bit budget: this routine shifts `v_w` left by `m` bits.
-            /// `W` must have headroom for `bit_length(v_w) + m`; for
+            /// Bit budget: this routine shifts `working_value` left by `m`
+            /// bits.
+            /// `W` must have headroom for `bit_length(working_value) + m`; for
             /// every wide tier in this crate, `W` is sized so that
             /// holds with comfortable margin (see the macro header).
             ///
@@ -1214,16 +1268,21 @@ macro_rules! decl_wide_transcendental {
             /// Calling at the unlifted scale `w` exhibits the
             /// historical `~p/2` precision drop past `w ~ 40`
             /// described in Brent 1976 §3.
-            pub(crate) fn ln_fixed_agm<const SCALE: u32>(v_w: W, w: u32) -> W {
-                let one_w = one(w);
+            pub(crate) fn ln_fixed_agm<const SCALE: u32>(
+                working_value: W,
+                working_scale: u32
+            ) -> W {
+                let one_at_working_scale = one(working_scale);
                 // p_bits ≈ working-scale precision in bits, w · log2(10).
                 // 332/100 is the integer rational just above log2(10).
-                let p_bits = ((w as i32) * 332 + 99) / 100;
-                let bl_v = bit_length(v_w) as i32;
-                let bl_one = bit_length(one_w) as i32;
-                // We need s = v_w · 2^m with bit_length(s) ≥ p/2 + bl_one
-                // + safety_margin so that y = 4·one_w/s has bit_length
-                // ≤ bl_one − (p/2 + safety_margin). Brent's bound on
+                let p_bits = ((working_scale as i32) * 332 + 99) / 100;
+                let value_bits = bit_length(working_value) as i32;
+                let one_bits = bit_length(one_at_working_scale) as i32;
+                // We need s = working_value · 2^m with bit_length(s) ≥
+                // p/2 + one_bits
+                // + safety_margin so that y = 4·one_at_working_scale/s has
+                // bit_length
+                // ≤ one_bits − (p/2 + safety_margin). Brent's bound on
                 // the AGM error is `O(log(s)/s²)`, so log₂(s) needs an
                 // extra `½·log₂(p)` bits beyond `p/2` to push the
                 // residual error below one LSB at scale w. The
@@ -1234,50 +1293,52 @@ macro_rules! decl_wide_transcendental {
                 // `sqrt_fixed` accumulation contributes over
                 // `~log₂(p)` iterations.
                 let safety = 2 + ((p_bits.max(1) as u32).ilog2() / 2) as i32;
-                let mut m: i32 = (p_bits / 2) + safety + bl_one - bl_v;
+                let mut m: i32 = (p_bits / 2) + safety + one_bits - value_bits;
                 if m < 2 {
                     m = 2;
                 }
-                // Cap m so `s_w = v_w << m` fits in W and the
-                // `div(4·one_w, s_w, w)` numerator
-                // `4·one_w · 10^w = 4·10^(2w)` does too. The AGM
+                // Cap m so `s_w = working_value << m` fits in W and the
+                // `div(4·one_at_working_scale, s_w, working_scale)` numerator
+                // `4·one_at_working_scale · 10^w = 4·10^(2w)` does too. The AGM
                 // iteration that follows operates on `(a, b)` both
-                // bounded by `one_w` and does not see `s_w` after
+                // bounded by `one_at_working_scale` and does not see `s_w`
+                // after
                 // the divide, so `s_w` itself does not need to
                 // leave half-width headroom for the AGM mul — the
                 // bit-budget constraint that backs the AGM mul is
-                // `2·bl(one_w) ≤ W::BITS`, enforced via the
+                // `2·bl(one_at_working_scale) ≤ W::BITS`, enforced via the
                 // `guard_agm` lift selection at the caller.
-                let cap = (W::BITS as i32) - bl_v - 2;
-                if cap > 0 && m > cap {
-                    m = cap;
+                let shift_cap = (W::BITS as i32) - value_bits - 2;
+                if shift_cap > 0 && m > shift_cap {
+                    m = shift_cap;
                 }
                 debug_assert!(
                     m > 0,
                     "ln_fixed_agm: working-int width too small for this scale"
                 );
-                let s_w = v_w << (m as u32);
-                let y_w = div(lit(4) * one_w, s_w, w);
-                let mut a = one_w;
+                let s_w = working_value << (m as u32);
+                let y_w = div(lit(4) * one_at_working_scale, s_w, working_scale);
+                let mut a = one_at_working_scale;
                 let mut b = y_w;
                 let iter_cap = 80u32;
                 for _ in 0..iter_cap {
                     let next_a = (a + b) >> 1;
-                    let next_b = sqrt_fixed(mul(a, b, w), w);
-                    let d = if next_a >= next_b {
+                    let next_b = sqrt_fixed(mul(a, b, working_scale), working_scale);
+                    let diff = if next_a >= next_b {
                         next_a - next_b
                     } else {
                         next_b - next_a
                     };
                     a = next_a;
                     b = next_b;
-                    if d <= lit(2) {
+                    if diff <= lit(2) {
                         break;
                     }
                 }
-                let pi_w = pi_cf::<SCALE>(w, $crate::support::rounding::DEFAULT_ROUNDING_MODE);
-                let agm_part = div(pi_w, a + a, w);
-                agm_part - scale_by_k(ln2_cf::<SCALE>(w, $crate::support::rounding::DEFAULT_ROUNDING_MODE), m as i128)
+                let pi_at_working_scale =
+                    pi_cf::<SCALE>(working_scale, $crate::support::rounding::DEFAULT_ROUNDING_MODE);
+                let agm_part = div(pi_at_working_scale, a + a, working_scale);
+                agm_part - scale_by_k(ln2_cf::<SCALE>(working_scale, $crate::support::rounding::DEFAULT_ROUNDING_MODE), m as i128)
             }
 
             /// Exponential of a working-scale value via Newton's
@@ -1293,27 +1354,36 @@ macro_rules! decl_wide_transcendental {
             /// Range-reduces `v = k·ln 2 + s` first (same trick as
             /// `exp_fixed`) so the Newton seed and iterations stay in
             /// a small absolute range, then reassembles `2^k · exp(s)`.
-            pub(crate) fn exp_fixed_agm<const SCALE: u32>(v_w: W, w: u32) -> W {
-                let one_w = one(w);
-                let l2 = ln2_cf::<SCALE>(w, $crate::support::rounding::DEFAULT_ROUNDING_MODE);
-                let k = round_to_nearest_int(div(v_w, l2, w), w);
-                let s = v_w - scale_by_k(l2, k);
+            pub(crate) fn exp_fixed_agm<const SCALE: u32>(
+                working_value: W,
+                working_scale: u32
+            ) -> W {
+                let one_at_working_scale = one(working_scale);
+                let ln2_at_working_scale = ln2_cf::<SCALE>(
+                    working_scale,
+                    $crate::support::rounding::DEFAULT_ROUNDING_MODE
+                );
+                let k = round_to_nearest_int(
+                    div(working_value, ln2_at_working_scale, working_scale),
+                    working_scale
+                );
+                let reduced_arg = working_value - scale_by_k(ln2_at_working_scale, k);
                 // Newton seed: low-order Taylor (1 + s + s²/2). Within
                 // ~10⁻² of truth for |s| ≤ ln(2)/2 ≈ 0.347.
-                let s2 = mul(s, s, w);
-                let mut x = one_w + s + (s2 >> 1);
+                let reduced_arg_sq = mul(reduced_arg, reduced_arg, working_scale);
+                let mut x = one_at_working_scale + reduced_arg + (reduced_arg_sq >> 1);
                 if x <= lit(0) {
-                    x = one_w;
+                    x = one_at_working_scale;
                 }
                 let iter_cap = 80u32;
                 for _ in 0..iter_cap {
-                    let ln_x = ln_fixed_agm::<SCALE>(x, w);
-                    let delta = s - ln_x;
+                    let ln_x = ln_fixed_agm::<SCALE>(x, working_scale);
+                    let delta = reduced_arg - ln_x;
                     if delta.abs() <= lit(2) {
-                        x = mul(x, one_w + delta, w);
+                        x = mul(x, one_at_working_scale + delta, working_scale);
                         break;
                     }
-                    x = mul(x, one_w + delta, w);
+                    x = mul(x, one_at_working_scale + delta, working_scale);
                 }
                 if k >= 0 {
                     let shift = k as u32;
@@ -1333,7 +1403,7 @@ macro_rules! decl_wide_transcendental {
                 }
             }
 
-            /// `e^v` for a working-scale value `v`.
+            /// `e^v` for a `working_value`.
             ///
             /// Range-reduces `v = k·ln 2 + s` with `|s| ≤ ln 2 / 2`,
             /// then applies the "r/2^n" further reduction (n ≈ √p):
@@ -1350,7 +1420,7 @@ macro_rules! decl_wide_transcendental {
             /// (`float/src/exp.rs`); the trick traces back to Brent
             /// 1976 §3 ("binary-splitting for exp via repeated
             /// squaring of a reduced argument").
-            pub(crate) fn exp_fixed<const SCALE: u32>(v_w: W, w: u32) -> W {
+            pub(crate) fn exp_fixed<const SCALE: u32>(working_value: W, working_scale: u32) -> W {
                 #[cfg(feature = "perf-trace")]
                 let _exp_span =
                     $crate::tracing::info_span!(concat!(stringify!($Type), "::exp_fixed"))
@@ -1365,8 +1435,8 @@ macro_rules! decl_wide_transcendental {
                 // `hyper_fits_w` regime split the hyperbolics use. The
                 // normal / small regime keeps the fast `W` path — the check
                 // is a few leading-zero / shift ops.
-                if !exp_fits_w::<SCALE>(v_w, w) {
-                    return exp_fixed_wide(v_w, w);
+                if !exp_fits_w::<SCALE>(working_value, working_scale) {
+                    return exp_fixed_wide(working_value, working_scale);
                 }
 
                 // Cache 10^w once — used as divisor in every Taylor
@@ -1379,8 +1449,8 @@ macro_rules! decl_wide_transcendental {
                 let _reduce_span = $crate::tracing::info_span!("range_reduce").entered();
                 // Range reduction.
                 //
-                // Naively `s = v − k·ln 2` evaluated at the type's working
-                // scale `w` suffers catastrophic cancellation when `|v|`
+                // Naively `s = v − k·ln 2` evaluated at the type's
+                // `working_scale` suffers catastrophic cancellation when `|v|`
                 // is large: each absorbed leading bit of `v` is paid for
                 // by an LSB of `k·ln 2`, and the final `2^k` rescaling at
                 // the end amplifies any residual error in `s` back up by
@@ -1394,11 +1464,14 @@ macro_rules! decl_wide_transcendental {
                 // LSB drift the precision golden gate catches.
                 //
                 // Mitigation: bump the whole `exp_fixed` body to an
-                // extended working scale `w_ext = w + extra`, computed
-                // dynamically from `bit_length(|k|)`. `extra` is sized so
+                // `extended_working_scale = working_scale + extra_digits`,
+                // computed
+                // dynamically from `bit_length(|k|)`. `extra_digits` is sized
+                // so
                 // the post-squarings amplification by `2^k` against the
-                // residual `LSB_of_w_ext` lands inside the `GUARD` budget
-                // at narrowing time. `extra = ceil(|k|·log10(2)) + 6`
+                // residual LSB of the extended scale lands inside the `GUARD`
+                // budget
+                // at narrowing time. `extra_digits = ceil(|k|·log10(2)) + 6`
                 // suffices: the `+6` covers the Taylor-series-step
                 // accumulation, the post-Taylor `n` squarings, and the
                 // half-LSB error introduced by the final narrowing.
@@ -1407,12 +1480,18 @@ macro_rules! decl_wide_transcendental {
                 // Functions: Algorithms and Implementation* (3rd ed.,
                 // 2016), §11.1 — range-reduction error budget with the
                 // `2^k · exp(s)` reassembly.
-                let one_w_pre = one(w);
-                let l2_pre = ln2_cf::<SCALE>(w, $crate::support::rounding::DEFAULT_ROUNDING_MODE);
-                let pow10_w_pre = one_w_pre;
-                let k = round_to_nearest_int(div_cached(v_w, l2_pre, pow10_w_pre), w);
+                let one_at_working_scale = one(working_scale);
+                let ln2_at_working_scale = ln2_cf::<SCALE>(
+                    working_scale,
+                    $crate::support::rounding::DEFAULT_ROUNDING_MODE
+                );
+                let pow10_at_working_scale = one_at_working_scale;
+                let k = round_to_nearest_int(
+                    div_cached(working_value, ln2_at_working_scale, pow10_at_working_scale),
+                    working_scale
+                );
                 let abs_k_u128 = if k < 0 { -k } else { k } as u128;
-                let extra: u32 = if abs_k_u128 == 0 {
+                let extra_digits: u32 = if abs_k_u128 == 0 {
                     0
                 } else {
                     // The amplification of the LSB error in `k·ln 2` by
@@ -1425,7 +1504,7 @@ macro_rules! decl_wide_transcendental {
                     // `|k|·log10(2) = |k| · 30103 / 100000`. Round up:
                     let digits = (abs_k_u128 * 30103).div_ceil(100_000);
                     // Cap at the type's working width to avoid blowing up
-                    // `pow10(extra)`; if `|k|` is so large the result
+                    // `pow10(extra_digits)`; if `|k|` is so large the result
                     // would overflow storage anyway, the caller's
                     // `round_to_storage_with` will panic on narrowing.
                     let capped = digits.min((<W>::BITS / 4) as u128) as u32;
@@ -1436,50 +1515,66 @@ macro_rules! decl_wide_transcendental {
                     capped + 12 + (capped >> 2)
                 };
 
-                let w_ext = w + extra;
-                let v_ext = if extra == 0 { v_w } else { v_w * pow10(extra) };
-                let one_w = one(w_ext);
-                let l2 = ln2_cf::<SCALE>(w_ext, $crate::support::rounding::DEFAULT_ROUNDING_MODE);
-                let pow10_w = one_w;
-                let s = v_ext - scale_by_k(l2, k);
+                let extended_working_scale = working_scale + extra_digits;
+                let extended_working_value = if extra_digits == 0 {
+                    working_value
+                } else {
+                    working_value * pow10(extra_digits)
+                };
+                let one_at_extended_scale = one(extended_working_scale);
+                let ln2_at_extended_scale = ln2_cf::<SCALE>(
+                    extended_working_scale,
+                    $crate::support::rounding::DEFAULT_ROUNDING_MODE
+                );
+                let pow10_at_extended_scale = one_at_extended_scale;
+                let reduced_arg =
+                    extended_working_value - scale_by_k(ln2_at_extended_scale, k);
 
-                // From here on the body operates at `w_ext`; we narrow
-                // back to `w` after the final `2^k` reassembly so the
-                // caller's `round_to_storage_with(_, w, scale, _)` sees
-                // a value at the expected `w` scale.
-                let p_bits = w_ext.saturating_mul(3).saturating_add(1);
-                let mut n: u32 = 1;
-                while (n + 1) * (n + 1) <= p_bits {
-                    n += 1;
+                // From here on the body operates at the extended working
+                // scale; we narrow
+                // back to `working_scale` after the final `2^k` reassembly so
+                // the
+                // caller's `round_to_storage_with(_, working_scale, scale, _)`
+                // sees
+                // a value at the expected `working_scale`.
+                let p_bits = extended_working_scale.saturating_mul(3).saturating_add(1);
+                let mut squarings: u32 = 1;
+                while (squarings + 1) * (squarings + 1) <= p_bits {
+                    squarings += 1;
                 }
 
-                let s_red = s >> n;
+                let shifted_arg = reduced_arg >> squarings;
                 #[cfg(feature = "perf-trace")]
                 drop(_reduce_span);
 
                 #[cfg(feature = "perf-trace")]
                 let _taylor_span = $crate::tracing::info_span!("taylor_series").entered();
-                let mut sum = one_w + s_red;
-                let mut term = s_red;
-                let mut iter: u128 = 2;
+                let mut sum = one_at_extended_scale + shifted_arg;
+                let mut term = shifted_arg;
+                let mut term_index: u128 = 2;
                 loop {
                     // Taylor term: low-half u128-packed product
-                    // (`wrapping_mul_low_u128`) reduced by `÷10^(w_ext)`
+                    // (`wrapping_mul_low_u128`) reduced by
+                    // `÷10^extended_working_scale`
                     // through the fast MG `round_div_pow10` kernel (the
-                    // divisor is always exactly the power of ten `10^w_ext`).
+                    // divisor is always exactly the power of ten
+                    // `10^extended_working_scale`).
                     // Mirrors the blessed `exp_generic::exp_fixed` Taylor
                     // step; bit-identical to the prior `round_div` reduction
                     // (audited power-of-10 equivalence) at MG speed.
                     term = round_div_pow10(
-                        $crate::int::types::traits::BigInt::wrapping_mul_low_u128(term, s_red),
-                        w_ext,
-                    ) / lit(iter);
+                        $crate::int::types::traits::BigInt::wrapping_mul_low_u128(
+                            term,
+                            shifted_arg
+                        ),
+                        extended_working_scale,
+                    ) / lit(term_index);
                     if term == zero() {
                         break;
                     }
                     sum = sum + term;
-                    iter += 1;
-                    if iter > SERIES_CAP {
+                    term_index += 1;
+                    if term_index > SERIES_CAP {
                         break;
                     }
                 }
@@ -1490,19 +1585,21 @@ macro_rules! decl_wide_transcendental {
                 let _sqr_span = $crate::tracing::info_span!("postfix_squarings").entered();
                 let mut squared = sum;
                 let mut i = 0;
-                while i < n {
+                while i < squarings {
                     // Low-half symmetric SQUARE through the limb-width matcher
                     // (`wrapping_sqr_low_u128` → `int::policy::sqr_low`): the
                     // u128-packed `sqr_low_limb` on even work widths (half the
                     // limbs), bit-identical to the low-`BITS` of `x²`, reduced
-                    // by `÷10^(w_ext)` through the fast MG `round_div_pow10`
+                    // by `÷10^extended_working_scale` through the fast MG
+                    // `round_div_pow10`
                     // kernel (the divisor is always the power of ten
-                    // `10^w_ext`). The squaring sibling of the Taylor step;
+                    // `10^extended_working_scale`). The squaring sibling of the
+                    // Taylor step;
                     // bit-identical to the prior generic `round_div` at MG
                     // speed. Mirrors `exp_generic::exp_fixed`.
                     squared = round_div_pow10(
                         $crate::int::types::traits::BigInt::wrapping_sqr_low_u128(squared),
-                        w_ext,
+                        extended_working_scale,
                     );
                     i += 1;
                 }
@@ -1512,7 +1609,7 @@ macro_rules! decl_wide_transcendental {
 
                 #[cfg(feature = "perf-trace")]
                 let _reasm_span = $crate::tracing::info_span!("reassemble").entered();
-                let scaled_at_w_ext = if k >= 0 {
+                let scaled_at_extended_scale = if k >= 0 {
                     let shift = k as u32;
                     if bit_length(sum) + shift >= W::BITS {
                         panic!(concat!(
@@ -1537,10 +1634,10 @@ macro_rules! decl_wide_transcendental {
                     }
                     sum >> (neg_k as u32)
                 };
-                let result = if extra == 0 {
-                    scaled_at_w_ext
+                let exp_value = if extra_digits == 0 {
+                    scaled_at_extended_scale
                 } else {
-                    round_div_pow10(scaled_at_w_ext, extra)
+                    round_div_pow10(scaled_at_extended_scale, extra_digits)
                 };
                 // e^v > 0 for every finite v: a zero result here is genuine
                 // underflow of `e^(negative)` below the working resolution,
@@ -1556,10 +1653,10 @@ macro_rules! decl_wide_transcendental {
                 // lift overflowed; masking that as 1 would hide the defect.
                 // The `exp_fits_w` routing above sends those cases to the
                 // wider path before they reach here.
-                if k < 0 && result == zero() {
+                if k < 0 && exp_value == zero() {
                     lit(1)
                 } else {
-                    result
+                    exp_value
                 }
             }
 
@@ -1567,8 +1664,8 @@ macro_rules! decl_wide_transcendental {
             /// the wider work integer [`Wexp`] so the caller's
             /// working-scale lift + the internal `2^k` reassembly + the
             /// repeated-squaring peak all fit, then narrows the result
-            /// back to `W` exactly (the value is integral at scale `w`
-            /// — no rounding occurs in the narrowing).
+            /// back to `W` exactly (the value is integral at
+            /// `working_scale` — no rounding occurs in the narrowing).
             ///
             /// `Wexp` is the next-wider `Int` for every tier except
             /// D1232 (already widest); there `Wexp == W`, and the full
@@ -1576,18 +1673,23 @@ macro_rules! decl_wide_transcendental {
             /// peak at its `MAX_SCALE` anyway. Used by the near-overflow
             /// -edge `sinh`/`cosh`/`exp2`/`tanh` cells; the normal /
             /// small regime keeps the fast `exp_fixed` path on `W`.
-            pub(crate) fn exp_fixed_wide(v_w: W, w: u32) -> W {
-                let v_wide = $crate::int::types::traits::BigInt::resize_to::<Wexp>(v_w);
-                let r_wide =
-                    $crate::algos::exp::exp_generic::exp_fixed::<Wexp>(v_wide, w);
+            pub(crate) fn exp_fixed_wide(working_value: W, working_scale: u32) -> W {
+                let wide_working_value =
+                    $crate::int::types::traits::BigInt::resize_to::<Wexp>(working_value);
+                let wide_exp_value =
+                    $crate::algos::exp::exp_generic::exp_fixed::<Wexp>(
+                        wide_working_value,
+                        working_scale
+                    );
                 // Narrow back to the tier work integer, PANICKING (not
                 // truncating) if the `Wexp`-computed result is out of the
                 // tier's range — see `exp_generic::resize_or_panic`.
-                $crate::algos::exp::exp_generic::resize_or_panic::<Wexp, W>(r_wide)
+                $crate::algos::exp::exp_generic::resize_or_panic::<Wexp, W>(wide_exp_value)
             }
 
             /// Whether the hyperbolic composition fits the tier's own work
-            /// integer `W` at working scale `w` for the magnitude `av_w`
+            /// integer `W` at `working_scale` for the magnitude
+            /// `abs_working_value`
             /// (`= |x|·10^w`), so the fast per-tier kernels (cached `ln2` /
             /// `pow10` / `exp_fixed`) can run directly instead of lifting to
             /// [`Wexp`].
@@ -1595,23 +1697,33 @@ macro_rules! decl_wide_transcendental {
             /// Two intermediates must fit `W`:
             /// - the `1/e^|x|` reciprocal numerator `10^(2w)` — `2w` digits;
             /// - the `exp_fixed` internal peak — modelled by the width-generic
-            ///   `exp_generic::exp_peak_fits` (the true `2·w_ext` squaring +
+            ///   `exp_generic::exp_peak_fits` (the true twice-extended-scale
+            ///   squaring +
             ///   `2^k` reassembly peak; the single source the kernel's own
             ///   overflow guard uses).
             ///
-            /// The squaring peak `2·w_ext` already dominates `2w` (since
-            /// `w_ext ≥ w`), so the exp peak bounds the whole composition.
+            /// The squaring peak already dominates `2w` (the extended working
+            /// scale is never below `working_scale`), so the exp peak bounds
+            /// the whole composition.
             #[inline]
-            fn hyper_fits_w<S: $crate::int::types::traits::BigInt>(av_w: S, w: u32) -> bool {
-                $crate::algos::exp::exp_generic::exp_peak_fits::<S>(av_w, w)
+            fn hyper_fits_w<S: $crate::int::types::traits::BigInt>(
+                abs_working_value: S,
+                working_scale: u32
+            ) -> bool {
+                $crate::algos::exp::exp_generic::exp_peak_fits::<S>(
+                    abs_working_value,
+                    working_scale
+                )
             }
 
-            /// Whether a direct `exp_fixed(v_w, w)` fits the tier's own work
+            /// Whether a direct `exp_fixed(working_value, working_scale)` fits
+            /// the tier's own work
             /// integer `W`.
             ///
             /// Models the real `exp_fixed` squaring-reassembly peak via the
             /// width-generic `exp_generic::exp_peak_fits` (the single source
-            /// the kernel's own overflow guard uses): when the `2·w_ext`
+            /// the kernel's own overflow guard uses): when the
+            /// extended-working-scale
             /// square or the `2^k` reassembly would exceed `W`'s bit capacity
             /// the body would silently wrap (`wrapping_sqr_low_u128` truncates
             /// to the low bits, so an overflowed square returns 0), so the
@@ -1619,11 +1731,11 @@ macro_rules! decl_wide_transcendental {
             /// [`Wexp`] path instead. The normal / small regime keeps the
             /// fast `W` path.
             #[inline]
-            fn exp_fits_w<const SCALE: u32>(v_w: W, w: u32) -> bool {
-                $crate::algos::exp::exp_generic::exp_peak_fits::<W>(v_w, w)
+            fn exp_fits_w<const SCALE: u32>(working_value: W, working_scale: u32) -> bool {
+                $crate::algos::exp::exp_generic::exp_peak_fits::<W>(working_value, working_scale)
             }
 
-            /// `sinh(|x|)` at working scale `w` for a non-negative working
+            /// `sinh(|x|)` at `working_scale` for a non-negative working
             /// value. The normal / small regime runs the fast per-tier
             /// kernels directly on `W` (cached `ln2` / `pow10`); only the
             /// near-overflow-edge regime — where the `1/e^|x|` reciprocal
@@ -1632,50 +1744,62 @@ macro_rules! decl_wide_transcendental {
             /// lifts the whole composition to the wider [`Wexp`]. See
             /// [`hyper_fits_w`]. The caller reapplies the input sign (sinh
             /// is odd).
-            pub(crate) fn sinh_pos_wide<const SCALE: u32>(av_w: W, w: u32) -> W {
-                if hyper_fits_w(av_w, w) {
-                    let ex = exp_fixed::<SCALE>(av_w, w);
-                    let enx = div(one(w), ex, w);
-                    (ex - enx) >> 1
+            pub(crate) fn sinh_pos_wide<const SCALE: u32>(
+                abs_working_value: W,
+                working_scale: u32
+            ) -> W {
+                if hyper_fits_w(abs_working_value, working_scale) {
+                    let exp_x = exp_fixed::<SCALE>(abs_working_value, working_scale);
+                    let exp_neg_x = div(one(working_scale), exp_x, working_scale);
+                    (exp_x - exp_neg_x) >> 1
                 } else {
-                    let av_wide = $crate::int::types::traits::BigInt::resize_to::<Wexp>(av_w);
-                    let r = $crate::algos::exp::exp_generic::sinh_pos::<Wexp>(
-                        av_wide, w,
+                    let abs_wide_value =
+                        $crate::int::types::traits::BigInt::resize_to::<Wexp>(abs_working_value);
+                    let sinh_value = $crate::algos::exp::exp_generic::sinh_pos::<Wexp>(
+                        abs_wide_value, working_scale,
                     );
-                    $crate::algos::exp::exp_generic::resize_or_panic::<Wexp, W>(r)
+                    $crate::algos::exp::exp_generic::resize_or_panic::<Wexp, W>(sinh_value)
                 }
             }
 
-            /// `cosh(|x|) = (e^|x| + e^-|x|)/2` at working scale `w`. See
+            /// `cosh(|x|) = (e^|x| + e^-|x|)/2` at `working_scale`. See
             /// [`sinh_pos_wide`] for the `W`-vs-[`Wexp`] regime split.
-            pub(crate) fn cosh_pos_wide<const SCALE: u32>(av_w: W, w: u32) -> W {
-                if hyper_fits_w(av_w, w) {
-                    let ex = exp_fixed::<SCALE>(av_w, w);
-                    let enx = div(one(w), ex, w);
-                    (ex + enx) >> 1
+            pub(crate) fn cosh_pos_wide<const SCALE: u32>(
+                abs_working_value: W,
+                working_scale: u32
+            ) -> W {
+                if hyper_fits_w(abs_working_value, working_scale) {
+                    let exp_x = exp_fixed::<SCALE>(abs_working_value, working_scale);
+                    let exp_neg_x = div(one(working_scale), exp_x, working_scale);
+                    (exp_x + exp_neg_x) >> 1
                 } else {
-                    let av_wide = $crate::int::types::traits::BigInt::resize_to::<Wexp>(av_w);
-                    let r = $crate::algos::exp::exp_generic::cosh_pos::<Wexp>(
-                        av_wide, w,
+                    let abs_wide_value =
+                        $crate::int::types::traits::BigInt::resize_to::<Wexp>(abs_working_value);
+                    let cosh_value = $crate::algos::exp::exp_generic::cosh_pos::<Wexp>(
+                        abs_wide_value, working_scale,
                     );
-                    $crate::algos::exp::exp_generic::resize_or_panic::<Wexp, W>(r)
+                    $crate::algos::exp::exp_generic::resize_or_panic::<Wexp, W>(cosh_value)
                 }
             }
 
-            /// `tanh(|x|) = (e^|x| − e^-|x|)/(e^|x| + e^-|x|)` at working
-            /// scale `w`. See [`sinh_pos_wide`] for the regime split. The
+            /// `tanh(|x|) = (e^|x| − e^-|x|)/(e^|x| + e^-|x|)` at
+            /// `working_scale`. See [`sinh_pos_wide`] for the regime split. The
             /// caller reapplies the input sign (tanh is odd).
-            pub(crate) fn tanh_pos_wide<const SCALE: u32>(av_w: W, w: u32) -> W {
-                if hyper_fits_w(av_w, w) {
-                    let ex = exp_fixed::<SCALE>(av_w, w);
-                    let enx = div(one(w), ex, w);
-                    div(ex - enx, ex + enx, w)
+            pub(crate) fn tanh_pos_wide<const SCALE: u32>(
+                abs_working_value: W,
+                working_scale: u32
+            ) -> W {
+                if hyper_fits_w(abs_working_value, working_scale) {
+                    let exp_x = exp_fixed::<SCALE>(abs_working_value, working_scale);
+                    let exp_neg_x = div(one(working_scale), exp_x, working_scale);
+                    div(exp_x - exp_neg_x, exp_x + exp_neg_x, working_scale)
                 } else {
-                    let av_wide = $crate::int::types::traits::BigInt::resize_to::<Wexp>(av_w);
-                    let r = $crate::algos::exp::exp_generic::tanh_pos::<Wexp>(
-                        av_wide, w,
+                    let abs_wide_value =
+                        $crate::int::types::traits::BigInt::resize_to::<Wexp>(abs_working_value);
+                    let tanh_value = $crate::algos::exp::exp_generic::tanh_pos::<Wexp>(
+                        abs_wide_value, working_scale,
                     );
-                    $crate::algos::exp::exp_generic::resize_or_panic::<Wexp, W>(r)
+                    $crate::algos::exp::exp_generic::resize_or_panic::<Wexp, W>(tanh_value)
                 }
             }
 
@@ -1684,85 +1808,105 @@ macro_rules! decl_wide_transcendental {
             /// when it fits, else lift to `Wexp`), narrowing the `Wexp` result
             /// to `Wagm`. Bit-identical while `Wagm == $Work`. Used by the
             /// hyperbolic compositions in the two-core split.
-            pub(crate) fn sinh_pos_wide_agm(av_w: Wagm, w: u32) -> Wagm {
-                if hyper_fits_w(av_w, w) {
-                    let ex = $crate::algos::exp::exp_generic::exp_fixed::<Wagm>(av_w, w);
-                    let enx = div_agm(one_agm(w), ex, w);
-                    (ex - enx) >> 1
+            pub(crate) fn sinh_pos_wide_agm(abs_working_value: Wagm, working_scale: u32) -> Wagm {
+                if hyper_fits_w(abs_working_value, working_scale) {
+                    let exp_x = $crate::algos::exp::exp_generic::exp_fixed::<Wagm>(
+                        abs_working_value, working_scale
+                    );
+                    let exp_neg_x = div_agm(one_agm(working_scale), exp_x, working_scale);
+                    (exp_x - exp_neg_x) >> 1
                 } else {
-                    let av_wide = $crate::int::types::traits::BigInt::resize_to::<Wexp>(av_w);
-                    let r = $crate::algos::exp::exp_generic::sinh_pos::<Wexp>(av_wide, w);
-                    $crate::algos::exp::exp_generic::resize_or_panic::<Wexp, Wagm>(r)
+                    let abs_wide_value =
+                        $crate::int::types::traits::BigInt::resize_to::<Wexp>(abs_working_value);
+                    let sinh_value = $crate::algos::exp::exp_generic::sinh_pos::<Wexp>(
+                        abs_wide_value, working_scale
+                    );
+                    $crate::algos::exp::exp_generic::resize_or_panic::<Wexp, Wagm>(sinh_value)
                 }
             }
-            pub(crate) fn cosh_pos_wide_agm(av_w: Wagm, w: u32) -> Wagm {
-                if hyper_fits_w(av_w, w) {
-                    let ex = $crate::algos::exp::exp_generic::exp_fixed::<Wagm>(av_w, w);
-                    let enx = div_agm(one_agm(w), ex, w);
-                    (ex + enx) >> 1
+            pub(crate) fn cosh_pos_wide_agm(abs_working_value: Wagm, working_scale: u32) -> Wagm {
+                if hyper_fits_w(abs_working_value, working_scale) {
+                    let exp_x = $crate::algos::exp::exp_generic::exp_fixed::<Wagm>(
+                        abs_working_value, working_scale
+                    );
+                    let exp_neg_x = div_agm(one_agm(working_scale), exp_x, working_scale);
+                    (exp_x + exp_neg_x) >> 1
                 } else {
-                    let av_wide = $crate::int::types::traits::BigInt::resize_to::<Wexp>(av_w);
-                    let r = $crate::algos::exp::exp_generic::cosh_pos::<Wexp>(av_wide, w);
-                    $crate::algos::exp::exp_generic::resize_or_panic::<Wexp, Wagm>(r)
+                    let abs_wide_value =
+                        $crate::int::types::traits::BigInt::resize_to::<Wexp>(abs_working_value);
+                    let cosh_value = $crate::algos::exp::exp_generic::cosh_pos::<Wexp>(
+                        abs_wide_value, working_scale
+                    );
+                    $crate::algos::exp::exp_generic::resize_or_panic::<Wexp, Wagm>(cosh_value)
                 }
             }
-            pub(crate) fn tanh_pos_wide_agm(av_w: Wagm, w: u32) -> Wagm {
-                if hyper_fits_w(av_w, w) {
-                    let ex = $crate::algos::exp::exp_generic::exp_fixed::<Wagm>(av_w, w);
-                    let enx = div_agm(one_agm(w), ex, w);
-                    div_agm(ex - enx, ex + enx, w)
+            pub(crate) fn tanh_pos_wide_agm(abs_working_value: Wagm, working_scale: u32) -> Wagm {
+                if hyper_fits_w(abs_working_value, working_scale) {
+                    let exp_x = $crate::algos::exp::exp_generic::exp_fixed::<Wagm>(
+                        abs_working_value, working_scale
+                    );
+                    let exp_neg_x = div_agm(one_agm(working_scale), exp_x, working_scale);
+                    div_agm(exp_x - exp_neg_x, exp_x + exp_neg_x, working_scale)
                 } else {
-                    let av_wide = $crate::int::types::traits::BigInt::resize_to::<Wexp>(av_w);
-                    let r = $crate::algos::exp::exp_generic::tanh_pos::<Wexp>(av_wide, w);
-                    $crate::algos::exp::exp_generic::resize_or_panic::<Wexp, Wagm>(r)
+                    let abs_wide_value =
+                        $crate::int::types::traits::BigInt::resize_to::<Wexp>(abs_working_value);
+                    let tanh_value = $crate::algos::exp::exp_generic::tanh_pos::<Wexp>(
+                        abs_wide_value, working_scale
+                    );
+                    $crate::algos::exp::exp_generic::resize_or_panic::<Wexp, Wagm>(tanh_value)
                 }
             }
 
-            /// `π` at working scale `w`, rounded under the crate default
+            /// `π` at `working_scale`, rounded under the crate default
             /// mode from the per-width compile-time reference.
-            pub(crate) fn pi(w: u32) -> W {
-                pi_with(w, $crate::support::rounding::DEFAULT_ROUNDING_MODE)
+            pub(crate) fn pi(working_scale: u32) -> W {
+                pi_with(working_scale, $crate::support::rounding::DEFAULT_ROUNDING_MODE)
             }
-            /// `π` at working scale `w`, rounded under `mode`.
-            pub(crate) fn pi_with(w: u32, mode: $crate::support::rounding::RoundingMode) -> W {
-                $crate::consts::pi_by_working_scale::<W>(w, mode)
+            /// `π` at `working_scale`, rounded under `mode`.
+            pub(crate) fn pi_with(
+                working_scale: u32,
+                mode: $crate::support::rounding::RoundingMode
+            ) -> W {
+                $crate::consts::pi_by_working_scale::<W>(working_scale, mode)
             }
 
-            /// `π/2` at working scale `w`. Routes `π` through the
-            /// const-folded [`pi_cf`] so the common (`w == SCALE + GUARD`)
+            /// `π/2` at `working_scale`. Routes `π` through the
+            /// const-folded [`pi_cf`] so the common
+            /// (`working_scale == SCALE + GUARD`)
             /// path reads the baked constant rather than re-running the
             /// runtime divide.
-            pub(crate) fn half_pi<const SCALE: u32>(w: u32) -> W {
-                pi_cf::<SCALE>(w, $crate::support::rounding::DEFAULT_ROUNDING_MODE) >> 1
+            pub(crate) fn half_pi<const SCALE: u32>(working_scale: u32) -> W {
+                pi_cf::<SCALE>(working_scale, $crate::support::rounding::DEFAULT_ROUNDING_MODE) >> 1
             }
 
-            /// `180/π` (degrees per radian) at working scale `w`, sourced
+            /// `180/π` (degrees per radian) at `working_scale`, sourced
             /// from the per-scale oracle table. On the common
-            /// (`w == SCALE + GUARD`) path the const-folded
+            /// (`working_scale == SCALE + GUARD`) path the const-folded
             /// [`crate::consts::deg_per_rad_by_scale`]
             /// reads the baked entry keyed on the const scale; any other
-            /// `w` (no Ziv escalation reaches this in the angle kernels,
+            /// `working_scale` (no Ziv escalation reaches this in the angle
+            /// kernels,
             /// but keep it total) falls to the runtime-keyed `by_working_scale`.
             pub(crate) fn deg_per_rad_cf<const SCALE: u32>(
-                w: u32,
+                working_scale: u32,
                 mode: $crate::support::rounding::RoundingMode,
             ) -> W {
-                if w == SCALE + GUARD {
+                if working_scale == SCALE + GUARD {
                     return $crate::consts::deg_per_rad_by_scale::<W>(SCALE + GUARD, mode);
                 }
-                $crate::consts::deg_per_rad_by_working_scale::<W>(w, mode)
+                $crate::consts::deg_per_rad_by_working_scale::<W>(working_scale, mode)
             }
 
-            /// `π/180` (radians per degree) at working scale `w` — see
+            /// `π/180` (radians per degree) at `working_scale` — see
             /// [`deg_per_rad_cf`].
             pub(crate) fn rad_per_deg_cf<const SCALE: u32>(
-                w: u32,
+                working_scale: u32,
                 mode: $crate::support::rounding::RoundingMode,
             ) -> W {
-                if w == SCALE + GUARD {
+                if working_scale == SCALE + GUARD {
                     return $crate::consts::rad_per_deg_by_scale::<W>(SCALE + GUARD, mode);
                 }
-                $crate::consts::rad_per_deg_by_working_scale::<W>(w, mode)
+                $crate::consts::rad_per_deg_by_working_scale::<W>(working_scale, mode)
             }
 
             /// Sine of a working-scale value.
@@ -1771,15 +1915,16 @@ macro_rules! decl_wide_transcendental {
             /// (`trig_generic::sin_fixed`) — the single source for the
             /// tier work integer `W` and the SCALE-derived work rungs
             /// (Constitution rule 2: one generic algorithm). The
-            /// const-folded `pi_cf::<SCALE>(w)` is threaded in so this
+            /// const-folded `pi_cf::<SCALE>(working_scale)` is threaded in so
+            /// this
             /// primitive path keeps its compile-time `π` (the generic
             /// kernel takes `π` as a parameter, so it stays free of the
             /// `SCALE` const) — the same shape as [`ln_fixed`]'s `ln2`.
-            pub(crate) fn sin_fixed<const SCALE: u32>(v_w: W, w: u32) -> W {
+            pub(crate) fn sin_fixed<const SCALE: u32>(working_value: W, working_scale: u32) -> W {
                 $crate::algos::trig::trig_generic::sin_fixed::<W>(
-                    v_w,
-                    w,
-                    pi_cf::<SCALE>(w, $crate::support::rounding::DEFAULT_ROUNDING_MODE),
+                    working_value,
+                    working_scale,
+                    pi_cf::<SCALE>(working_scale, $crate::support::rounding::DEFAULT_ROUNDING_MODE),
                 )
             }
 
@@ -1788,11 +1933,14 @@ macro_rules! decl_wide_transcendental {
             /// Taylor evaluations. Delegates to the width-generic kernel
             /// (`trig_generic::sin_cos_fixed`) with the const-folded `π`
             /// threaded in — see [`sin_fixed`].
-            pub(crate) fn sin_cos_fixed<const SCALE: u32>(v_w: W, w: u32) -> (W, W) {
+            pub(crate) fn sin_cos_fixed<const SCALE: u32>(
+                working_value: W,
+                working_scale: u32
+            ) -> (W, W) {
                 $crate::algos::trig::trig_generic::sin_cos_fixed::<W>(
-                    v_w,
-                    w,
-                    pi_cf::<SCALE>(w, $crate::support::rounding::DEFAULT_ROUNDING_MODE),
+                    working_value,
+                    working_scale,
+                    pi_cf::<SCALE>(working_scale, $crate::support::rounding::DEFAULT_ROUNDING_MODE),
                 )
             }
 
@@ -1801,11 +1949,11 @@ macro_rules! decl_wide_transcendental {
             /// sqrt. Delegates to the width-generic kernel
             /// (`trig_generic::cos_fixed`) with the const-folded `π`
             /// threaded in — see [`sin_fixed`].
-            pub(crate) fn cos_fixed<const SCALE: u32>(v_w: W, w: u32) -> W {
+            pub(crate) fn cos_fixed<const SCALE: u32>(working_value: W, working_scale: u32) -> W {
                 $crate::algos::trig::trig_generic::cos_fixed::<W>(
-                    v_w,
-                    w,
-                    pi_cf::<SCALE>(w, $crate::support::rounding::DEFAULT_ROUNDING_MODE),
+                    working_value,
+                    working_scale,
+                    pi_cf::<SCALE>(working_scale, $crate::support::rounding::DEFAULT_ROUNDING_MODE),
                 )
             }
 
@@ -1816,16 +1964,17 @@ macro_rules! decl_wide_transcendental {
             /// (`trig_generic::atan_fixed`) — the single source for the
             /// tier work integer `W` and the SCALE-derived work rungs
             /// (Constitution rule 2: one generic algorithm). The
-            /// const-folded `pi_cf::<SCALE>(w)` is threaded in so this
+            /// const-folded `pi_cf::<SCALE>(working_scale)` is threaded in so
+            /// this
             /// primitive path keeps its compile-time `π` (the generic
             /// kernel takes `π` as a parameter and uses only its `π/2`
             /// half for the reciprocal-fold complement) — the same
             /// shape as [`sin_fixed`].
-            pub(crate) fn atan_fixed<const SCALE: u32>(v_w: W, w: u32) -> W {
+            pub(crate) fn atan_fixed<const SCALE: u32>(working_value: W, working_scale: u32) -> W {
                 $crate::algos::trig::trig_generic::atan_fixed::<W>(
-                    v_w,
-                    w,
-                    pi_cf::<SCALE>(w, $crate::support::rounding::DEFAULT_ROUNDING_MODE),
+                    working_value,
+                    working_scale,
+                    pi_cf::<SCALE>(working_scale, $crate::support::rounding::DEFAULT_ROUNDING_MODE),
                 )
             }
 
@@ -1835,8 +1984,8 @@ macro_rules! decl_wide_transcendental {
             // (`algos::ln::ln_tang`, `algos::exp::exp_tang`) drive the
             // table through the `WideTrigCore::{ln,exp}_table_entry`
             // trait methods, which forward here. Each entry is a pure
-            // function of its `(w, idx[, M])` key and is computed on the
-            // stack on demand — one slot per call, no stored table.
+            // function of its `(working_scale, idx[, M])` key and is computed
+            // on the stack on demand — one slot per call, no stored table.
 
             /// Tang ln table size — `ln(1 + i/M)`, `i ∈ [0, M]`.
             const LN_TANG_M: u32 = 128;
@@ -1864,46 +2013,58 @@ macro_rules! decl_wide_transcendental {
             mod tang_table {
                 use super::*;
 
-                /// `ln(1 + idx/M)` at working scale `w` (`idx ∈ [0, M]`),
+                /// `ln(1 + idx/M)` at `working_scale` (`idx ∈ [0, M]`),
                 /// from the baked binary Tang table. idx = 0 → ln(1) = 0.
                 #[inline]
-                pub(super) fn ln_table_entry<const SCALE: u32>(w: u32, idx: usize) -> W {
-                    $crate::algos::support::ln_tang_table::ln_table_entry_baked::<W>(w, idx, pow10_table(w))
+                pub(super) fn ln_table_entry<const SCALE: u32>(
+                    working_scale: u32,
+                    idx: usize
+                ) -> W {
+                    $crate::algos::support::ln_tang_table::ln_table_entry_baked::<W>(working_scale, idx, pow10_table(working_scale))
                 }
 
-                /// `exp(idx · ln2 / m)` at working scale `w`
-                /// (`idx ∈ [0, m)`), from the baked binary Tang table.
+                /// `exp(idx · ln2 / m)` at `working_scale`
+                /// (`idx ∈ [0, table_size)`), from the baked binary Tang
+                /// table.
                 /// idx = 0 → exp(0) = 1. Replaces the per-call
                 /// `exp_fixed` Series recompute. The `SCALE` const is
                 /// unused on the baked path (the binary table is
                 /// scale-independent); kept on the signature to match the
                 /// trait forwarder.
                 #[inline]
-                pub(super) fn exp_table_entry<const SCALE: u32>(w: u32, idx: usize, m: u32) -> W {
-                    $crate::algos::support::exp_tang_table::exp_table_entry_baked::<W>(w, idx, m, pow10_table(w))
+                pub(super) fn exp_table_entry<const SCALE: u32>(
+                    working_scale: u32,
+                    idx: usize,
+                    table_size: u32
+                ) -> W {
+                    $crate::algos::support::exp_tang_table::exp_table_entry_baked::<W>(working_scale, idx, table_size, pow10_table(working_scale))
                 }
 
                 /// `(sin(c_j), cos(c_j))` with `c_j = idx · π / (4·m)` at
-                /// working scale `w` (`idx ∈ [0, m]`), from the baked
+                /// `working_scale` (`idx ∈ [0, table_size]`), from the baked
                 /// binary Tang table. idx = 0 → (sin 0, cos 0) = (0, 1).
                 ///
                 /// BAKED binary Tang store: each `(sin, cos)` pair is
                 /// precomputed ONCE by an mpmath oracle as binary
                 /// fixed-point `round(value · 2^B)` (committed rodata in
                 /// `algos::support::sincos_tang_table`), then SLICED +
-                /// reconstructed to working scale `w` per call (one
+                /// reconstructed to `working_scale` per call (one
                 /// multiply + one shift per component) — far cheaper than
                 /// the `sin_cos_fixed` Series it replaces. `SCALE` is
                 /// unused on the baked path (the binary table is
                 /// scale-independent); it is kept on the signature only to
                 /// match the trait forwarder.
                 #[inline]
-                pub(super) fn sincos_table_entry<const SCALE: u32>(w: u32, idx: usize, m: u32) -> (W, W) {
+                pub(super) fn sincos_table_entry<const SCALE: u32>(
+                    working_scale: u32,
+                    idx: usize,
+                    table_size: u32
+                ) -> (W, W) {
                     $crate::algos::support::sincos_tang_table::sincos_table_entry_baked::<W>(
-                        w,
+                        working_scale,
                         idx,
-                        m,
-                        pow10_table(w),
+                        table_size,
+                        pow10_table(working_scale),
                     )
                 }
             }
@@ -1933,52 +2094,62 @@ macro_rules! decl_wide_transcendental {
             #[cfg(test)]
             pub(crate) fn ln_table_baked_vs_series(tier: &str) {
                 // Extra guard digits at which the `ln_fixed` Series has
-                // fully converged relative to the target scale `w`.
+                // fully converged relative to the target working scale.
                 const REF_EXTRA: u32 = 40;
                 // Correctly-rounded `round(ln(1+idx/M) · 10^w)` reference:
-                // Series at `w + REF_EXTRA`, narrowed back to `w` by a
+                // Series at `working_scale + REF_EXTRA`, narrowed back to
+                // `working_scale` by a
                 // round-half-up divide by `10^REF_EXTRA`.
-                fn ref_slot(w: u32, idx: usize) -> W {
+                fn ref_slot(working_scale: u32, idx: usize) -> W {
                     if idx == 0 {
                         return zero();
                     }
-                    let w_hi = w + REF_EXTRA;
-                    let one_hi = one(w_hi);
-                    let scaled = (one_hi * lit(idx as u128)) / lit(128u128);
-                    let hi = ln_fixed::<0>(one_hi + scaled, w_hi);
-                    // narrow w_hi -> w, round half up (values are positive).
-                    let p = pow10(REF_EXTRA);
-                    let half = p / lit(2);
-                    (hi + half) / p
+                    let ref_working_scale = working_scale + REF_EXTRA;
+                    let one_at_ref_scale = one(ref_working_scale);
+                    let scaled = (one_at_ref_scale * lit(idx as u128)) / lit(128u128);
+                    let ln_at_ref_scale =
+                        ln_fixed::<0>(one_at_ref_scale + scaled, ref_working_scale);
+                    // narrow the reference scale down, round half up (values
+                    // are positive).
+                    let narrowing_divisor = pow10(REF_EXTRA);
+                    let half = narrowing_divisor / lit(2);
+                    (ln_at_ref_scale + half) / narrowing_divisor
                 }
                 // The directed/nearest narrowing caps the WORKING scale at
                 // `W::BITS / 8` decimal digits (the baked accessor handles
                 // the full cap). The Series REFERENCE, however, runs at
-                // `w + REF_EXTRA` and forms wide `sqrt_fixed` scratch that
+                // `working_scale + REF_EXTRA` and forms wide `sqrt_fixed`
+                // scratch that
                 // needs ~`4·w` headroom, so we can only build a converged
-                // reference well below the cap. Sample `w` up to a quarter
+                // reference well below the cap. Sample the working scale up to
+                // a quarter
                 // of `W::BITS / 8` (leaving ample `sqrt_fixed` headroom) —
                 // that already spans every common `w = SCALE + GUARD` for
                 // the tier plus a healthy slice of the Ziv band.
                 let cap = <W as $crate::int::types::traits::BigInt>::BITS / 8;
-                let max_w = (cap / 4).saturating_sub(REF_EXTRA).max(GUARD);
-                let tol = lit(2); // working LSBs of allowed disagreement
+                let max_working_scale = (cap / 4).saturating_sub(REF_EXTRA).max(GUARD);
+                let tolerance = lit(2); // working LSBs of allowed disagreement
                 let mut max_diff: W = zero();
-                let mut w = GUARD; // smallest reachable working scale (SCALE=0)
-                while w <= max_w {
+                // smallest reachable working scale (SCALE=0)
+                let mut working_scale = GUARD;
+                while working_scale <= max_working_scale {
                     for idx in 0..=128usize {
-                        let baked = $crate::algos::support::ln_tang_table::ln_table_entry_baked::<W>(w, idx, pow10_table(w));
-                        let refv = ref_slot(w, idx);
-                        let diff = if baked >= refv { baked - refv } else { refv - baked };
+                        let baked = $crate::algos::support::ln_tang_table::ln_table_entry_baked::<W>(working_scale, idx, pow10_table(working_scale));
+                        let reference = ref_slot(working_scale, idx);
+                        let diff = if baked >= reference {
+                            baked - reference
+                        } else {
+                            reference - baked
+                        };
                         if diff > max_diff {
                             max_diff = diff;
                         }
                         assert!(
-                            diff <= tol,
-                            "{tier}: baked ln_table_entry disagrees with converged Series at w={w} i={idx} by {diff:?} working LSBs (tol {tol:?})"
+                            diff <= tolerance,
+                            "{tier}: baked ln_table_entry disagrees with converged Series at w={working_scale} i={idx} by {diff:?} working LSBs (tol {tolerance:?})"
                         );
                     }
-                    w += if w < GUARD + 6 { 1 } else { 37 };
+                    working_scale += if working_scale < GUARD + 6 { 1 } else { 37 };
                 }
                 // Separately exercise the BAKED accessor right up to the
                 // full directed-narrow cap `W::BITS / 8` (where no Series
@@ -1986,20 +2157,20 @@ macro_rules! decl_wide_transcendental {
                 // `slot_hi · 10^w` never overflows `W` at the production
                 // ceiling. A panic here = an overflow; the values are
                 // checked for monotone sanity (0 < L_1 < L_64 < L_128).
-                let mut wc = max_w;
-                while wc <= cap {
-                    let z = $crate::algos::support::ln_tang_table::ln_table_entry_baked::<W>(wc, 0, pow10_table(wc));
-                    let a = $crate::algos::support::ln_tang_table::ln_table_entry_baked::<W>(wc, 1, pow10_table(wc));
-                    let b = $crate::algos::support::ln_tang_table::ln_table_entry_baked::<W>(wc, 64, pow10_table(wc));
-                    let c = $crate::algos::support::ln_tang_table::ln_table_entry_baked::<W>(wc, 128, pow10_table(wc));
+                let mut cap_working_scale = max_working_scale;
+                while cap_working_scale <= cap {
+                    let slot_0 = $crate::algos::support::ln_tang_table::ln_table_entry_baked::<W>(cap_working_scale, 0, pow10_table(cap_working_scale));
+                    let slot_1 = $crate::algos::support::ln_tang_table::ln_table_entry_baked::<W>(cap_working_scale, 1, pow10_table(cap_working_scale));
+                    let slot_64 = $crate::algos::support::ln_tang_table::ln_table_entry_baked::<W>(cap_working_scale, 64, pow10_table(cap_working_scale));
+                    let slot_128 = $crate::algos::support::ln_tang_table::ln_table_entry_baked::<W>(cap_working_scale, 128, pow10_table(cap_working_scale));
                     assert!(
-                        z == zero() && a > zero() && b > a && c > b,
-                        "{tier}: baked ln_table_entry not sane at cap w={wc}"
+                        slot_0 == zero() && slot_1 > zero() && slot_64 > slot_1 && slot_128 > slot_64,
+                        "{tier}: baked ln_table_entry not sane at cap w={cap_working_scale}"
                     );
-                    if wc == cap { break; }
-                    wc = (wc + 53).min(cap);
+                    if cap_working_scale == cap { break; }
+                    cap_working_scale = (cap_working_scale + 53).min(cap);
                 }
-                eprintln!("ln_table_baked_vs_series {tier}: max |baked-ref| = {max_diff:?} working LSBs (tol {tol:?}, ref max_w {max_w}, cap {cap})");
+                eprintln!("ln_table_baked_vs_series {tier}: max |baked-ref| = {max_diff:?} working LSBs (tol {tolerance:?}, ref max_w {max_working_scale}, cap {cap})");
             }
 
             /// Differential validity wall for the baked binary Tang
@@ -2025,52 +2196,60 @@ macro_rules! decl_wide_transcendental {
             pub(crate) fn sincos_table_baked_vs_series(tier: &str) {
                 use crate::algos::support::sincos_tang_table::SINCOS_TANG_M;
                 // Extra guard digits at which the `sin_cos_fixed` Series has
-                // fully converged relative to the target scale `w`.
+                // fully converged relative to the target working scale.
                 const REF_EXTRA: u32 = 40;
-                let m = SINCOS_TANG_M;
+                let table_size = SINCOS_TANG_M;
                 // Correctly-rounded `round(value · 10^w)` reference pair:
-                // `sin_cos_fixed` at `w + REF_EXTRA`, narrowed back to `w`
+                // `sin_cos_fixed` at `working_scale + REF_EXTRA`, narrowed
+                // back to `working_scale`
                 // by a round-half-up divide by `10^REF_EXTRA`. For idx = 0
                 // the pair is exactly `(0, 10^w)`.
-                fn ref_pair(w: u32, idx: usize, m: u32) -> (W, W) {
+                fn ref_pair(working_scale: u32, idx: usize, table_size: u32) -> (W, W) {
                     if idx == 0 {
-                        return (zero(), one(w));
+                        return (zero(), one(working_scale));
                     }
-                    let w_hi = w + REF_EXTRA;
-                    let cj_hi = (pi_cf::<0>(w_hi, $crate::support::rounding::DEFAULT_ROUNDING_MODE)
+                    let ref_working_scale = working_scale + REF_EXTRA;
+                    let cj_at_ref_scale = (pi_cf::<0>(ref_working_scale, $crate::support::rounding::DEFAULT_ROUNDING_MODE)
                         * lit(idx as u128))
-                        / lit((4 * m) as u128);
-                    let (s_hi, c_hi) = sin_cos_fixed::<0>(cj_hi, w_hi);
-                    let p = pow10(REF_EXTRA);
-                    let half = p / lit(2);
-                    ((s_hi + half) / p, (c_hi + half) / p)
+                        / lit((4 * table_size) as u128);
+                    let (sin_at_ref_scale, cos_at_ref_scale) =
+                        sin_cos_fixed::<0>(cj_at_ref_scale, ref_working_scale);
+                    let narrowing_divisor = pow10(REF_EXTRA);
+                    let half = narrowing_divisor / lit(2);
+                    (
+                        (sin_at_ref_scale + half) / narrowing_divisor,
+                        (cos_at_ref_scale + half) / narrowing_divisor
+                    )
                 }
                 // Match `ln_table_baked_vs_series`: the directed/nearest
                 // narrowing caps the WORKING scale at `W::BITS / 8` decimal
                 // digits (the baked accessor handles the full cap). The
-                // Series REFERENCE runs at `w + REF_EXTRA` and forms wide
-                // scratch, so we sample `w` up to a quarter of `W::BITS / 8`
+                // Series REFERENCE runs at `working_scale + REF_EXTRA` and
+                // forms wide
+                // scratch, so we sample the working scale up to a quarter of
+                // `W::BITS / 8`
                 // — already spanning every common `w = SCALE + GUARD` plus a
                 // healthy slice of the Ziv band.
                 let cap = <W as $crate::int::types::traits::BigInt>::BITS / 8;
-                let max_w = (cap / 4).saturating_sub(REF_EXTRA).max(GUARD);
-                let tol = lit(2); // working LSBs of allowed disagreement
+                let max_working_scale = (cap / 4).saturating_sub(REF_EXTRA).max(GUARD);
+                let tolerance = lit(2); // working LSBs of allowed disagreement
                 let mut max_diff: W = zero();
-                let mut w = GUARD; // smallest reachable working scale (SCALE=0)
-                while w <= max_w {
-                    for idx in 0..=(m as usize) {
-                        let (bs, bc) = $crate::algos::support::sincos_tang_table::sincos_table_entry_baked::<W>(w, idx, m, pow10_table(w));
-                        let (rs, rc) = ref_pair(w, idx, m);
-                        let ds = if bs >= rs { bs - rs } else { rs - bs };
-                        let dc = if bc >= rc { bc - rc } else { rc - bc };
-                        if ds > max_diff { max_diff = ds; }
-                        if dc > max_diff { max_diff = dc; }
+                // smallest reachable working scale (SCALE=0)
+                let mut working_scale = GUARD;
+                while working_scale <= max_working_scale {
+                    for idx in 0..=(table_size as usize) {
+                        let (baked_sin, baked_cos) = $crate::algos::support::sincos_tang_table::sincos_table_entry_baked::<W>(working_scale, idx, table_size, pow10_table(working_scale));
+                        let (ref_sin, ref_cos) = ref_pair(working_scale, idx, table_size);
+                        let sin_diff = if baked_sin >= ref_sin { baked_sin - ref_sin } else { ref_sin - baked_sin };
+                        let cos_diff = if baked_cos >= ref_cos { baked_cos - ref_cos } else { ref_cos - baked_cos };
+                        if sin_diff > max_diff { max_diff = sin_diff; }
+                        if cos_diff > max_diff { max_diff = cos_diff; }
                         assert!(
-                            ds <= tol && dc <= tol,
-                            "{tier}: baked sincos_table_entry disagrees with converged Series at w={w} idx={idx} by (sin {ds:?}, cos {dc:?}) working LSBs (tol {tol:?})"
+                            sin_diff <= tolerance && cos_diff <= tolerance,
+                            "{tier}: baked sincos_table_entry disagrees with converged Series at w={working_scale} idx={idx} by (sin {sin_diff:?}, cos {cos_diff:?}) working LSBs (tol {tolerance:?})"
                         );
                     }
-                    w += if w < GUARD + 6 { 1 } else { 37 };
+                    working_scale += if working_scale < GUARD + 6 { 1 } else { 37 };
                 }
                 // Separately exercise the BAKED accessor right up to the
                 // full directed-narrow cap `W::BITS / 8` (where no Series
@@ -2081,31 +2260,31 @@ macro_rules! decl_wide_transcendental {
                 // `c_h = π/8` at idx = M/2 (sin < cos, both > 0), and
                 // `c_M = π/4` at idx = M (sin = cos = √2/2 exactly), all
                 // strictly inside `(0, 10^wc)`; and idx = 0 → `(0, 10^wc)`.
-                let mut wc = max_w;
-                while wc <= cap {
-                    let pw = pow10_table(wc);
-                    let (z_s, z_c) = $crate::algos::support::sincos_tang_table::sincos_table_entry_baked::<W>(wc, 0, m, pw);
-                    let (a_s, a_c) = $crate::algos::support::sincos_tang_table::sincos_table_entry_baked::<W>(wc, 1, m, pw);
-                    let (h_s, h_c) = $crate::algos::support::sincos_tang_table::sincos_table_entry_baked::<W>(wc, (m / 2) as usize, m, pw);
-                    let (m_s, m_c) = $crate::algos::support::sincos_tang_table::sincos_table_entry_baked::<W>(wc, m as usize, m, pw);
+                let mut cap_working_scale = max_working_scale;
+                while cap_working_scale <= cap {
+                    let one_at_cap = pow10_table(cap_working_scale);
+                    let (sin_0, cos_0) = $crate::algos::support::sincos_tang_table::sincos_table_entry_baked::<W>(cap_working_scale, 0, table_size, one_at_cap);
+                    let (sin_1, cos_1) = $crate::algos::support::sincos_tang_table::sincos_table_entry_baked::<W>(cap_working_scale, 1, table_size, one_at_cap);
+                    let (sin_half, cos_half) = $crate::algos::support::sincos_tang_table::sincos_table_entry_baked::<W>(cap_working_scale, (table_size / 2) as usize, table_size, one_at_cap);
+                    let (sin_max, cos_max) = $crate::algos::support::sincos_tang_table::sincos_table_entry_baked::<W>(cap_working_scale, table_size as usize, table_size, one_at_cap);
                     assert!(
                         // idx = 0 → (0, 1):
-                        z_s == zero() && z_c == pw
+                        sin_0 == zero() && cos_0 == one_at_cap
                             // idx = 1 (near 0): 0 < sin < cos < 1:
-                            && a_s > zero() && a_s < a_c && a_c < pw
+                            && sin_1 > zero() && sin_1 < cos_1 && cos_1 < one_at_cap
                             // idx = M/2 (π/8): sin and cos increase/decrease
                             // monotonically from idx=1, both strictly in (0,1),
                             // sin still < cos:
-                            && h_s > a_s && h_s < h_c && h_c < a_c && h_c < pw
+                            && sin_half > sin_1 && sin_half < cos_half && cos_half < cos_1 && cos_half < one_at_cap
                             // idx = M (π/4): sin = cos = √2/2, both > the
                             // idx=M/2 sin and < the idx=M/2 cos:
-                            && m_s == m_c && m_s > h_s && m_c < h_c && m_s < pw,
-                        "{tier}: baked sincos_table_entry not sane at cap w={wc}"
+                            && sin_max == cos_max && sin_max > sin_half && cos_max < cos_half && sin_max < one_at_cap,
+                        "{tier}: baked sincos_table_entry not sane at cap w={cap_working_scale}"
                     );
-                    if wc == cap { break; }
-                    wc = (wc + 53).min(cap);
+                    if cap_working_scale == cap { break; }
+                    cap_working_scale = (cap_working_scale + 53).min(cap);
                 }
-                eprintln!("sincos_table_baked_vs_series {tier}: max |baked-ref| = {max_diff:?} working LSBs (tol {tol:?}, ref max_w {max_w}, cap {cap})");
+                eprintln!("sincos_table_baked_vs_series {tier}: max |baked-ref| = {max_diff:?} working LSBs (tol {tolerance:?}, ref max_w {max_working_scale}, cap {cap})");
             }
 
             /// Differential validity wall for the baked binary Tang `exp`
@@ -2132,54 +2311,63 @@ macro_rules! decl_wide_transcendental {
             pub(crate) fn exp_table_baked_vs_series(tier: &str) {
                 const M: u32 = $exp_tang_m;
                 // Extra guard digits at which the `exp_fixed` Series has
-                // fully converged relative to the target scale `w`.
+                // fully converged relative to the target working scale.
                 const REF_EXTRA: u32 = 40;
                 // Correctly-rounded `round(exp(idx·ln2/M) · 10^w)`
-                // reference: Series at `w + REF_EXTRA`, narrowed back to `w`
+                // reference: Series at `working_scale + REF_EXTRA`, narrowed
+                // back to `working_scale`
                 // by a round-half-up divide by `10^REF_EXTRA`. exp(c_j) > 0,
                 // so the positive-narrowing bias applies.
-                fn ref_slot(w: u32, idx: usize, m: u32) -> W {
+                fn ref_slot(working_scale: u32, idx: usize, table_size: u32) -> W {
                     if idx == 0 {
-                        return one(w);
+                        return one(working_scale);
                     }
-                    let w_hi = w + REF_EXTRA;
-                    let cj_hi = (ln2_cf::<0>(w_hi, $crate::support::rounding::DEFAULT_ROUNDING_MODE)
-                        * lit(idx as u128)) / lit(m as u128);
-                    let hi = exp_fixed::<0>(cj_hi, w_hi);
-                    // narrow w_hi -> w, round half up (values are positive).
-                    let p = pow10(REF_EXTRA);
-                    let half = p / lit(2);
-                    (hi + half) / p
+                    let ref_working_scale = working_scale + REF_EXTRA;
+                    let cj_at_ref_scale = (ln2_cf::<0>(ref_working_scale, $crate::support::rounding::DEFAULT_ROUNDING_MODE)
+                        * lit(idx as u128)) / lit(table_size as u128);
+                    let exp_at_ref_scale = exp_fixed::<0>(cj_at_ref_scale, ref_working_scale);
+                    // narrow the reference scale down, round half up (values
+                    // are positive).
+                    let narrowing_divisor = pow10(REF_EXTRA);
+                    let half = narrowing_divisor / lit(2);
+                    (exp_at_ref_scale + half) / narrowing_divisor
                 }
-                // Sample `w` up to a safe fraction of the directed-narrow
+                // Sample the working scale up to a safe fraction of the
+                // directed-narrow
                 // cap `W::BITS / 8`. The Series REFERENCE runs at
-                // `w + REF_EXTRA` and the `exp_fixed` reduction forms wide
+                // `working_scale + REF_EXTRA` and the `exp_fixed` reduction
+                // forms wide
                 // internal scratch, so we keep a generous headroom (a
                 // quarter of the cap) — that already spans every common
                 // `w = SCALE + GUARD` for the tier plus a slice of the Ziv
                 // band. The baked accessor itself is exercised to the full
                 // cap by the `ln` wall's cap sweep (same conversion shape).
                 let cap = <W as $crate::int::types::traits::BigInt>::BITS / 8;
-                let max_w = (cap / 4).saturating_sub(REF_EXTRA).max(GUARD);
-                let tol = lit(2); // working LSBs of allowed disagreement
+                let max_working_scale = (cap / 4).saturating_sub(REF_EXTRA).max(GUARD);
+                let tolerance = lit(2); // working LSBs of allowed disagreement
                 let mut max_diff: W = zero();
-                let mut w = GUARD; // smallest reachable working scale (SCALE=0)
-                while w <= max_w {
+                // smallest reachable working scale (SCALE=0)
+                let mut working_scale = GUARD;
+                while working_scale <= max_working_scale {
                     for idx in 0..M as usize {
-                        let baked = $crate::algos::support::exp_tang_table::exp_table_entry_baked::<W>(w, idx, M, pow10_table(w));
-                        let refv = ref_slot(w, idx, M);
-                        let diff = if baked >= refv { baked - refv } else { refv - baked };
+                        let baked = $crate::algos::support::exp_tang_table::exp_table_entry_baked::<W>(working_scale, idx, M, pow10_table(working_scale));
+                        let reference = ref_slot(working_scale, idx, M);
+                        let diff = if baked >= reference {
+                            baked - reference
+                        } else {
+                            reference - baked
+                        };
                         if diff > max_diff {
                             max_diff = diff;
                         }
                         assert!(
-                            diff <= tol,
-                            "{tier}: baked exp_table_entry disagrees with converged Series at w={w} idx={idx} M={M} by {diff:?} working LSBs (tol {tol:?})"
+                            diff <= tolerance,
+                            "{tier}: baked exp_table_entry disagrees with converged Series at w={working_scale} idx={idx} M={M} by {diff:?} working LSBs (tol {tolerance:?})"
                         );
                     }
-                    w += if w < GUARD + 6 { 1 } else { 37 };
+                    working_scale += if working_scale < GUARD + 6 { 1 } else { 37 };
                 }
-                eprintln!("exp_table_baked_vs_series {tier}: max |baked-ref| = {max_diff:?} working LSBs (tol {tol:?}, M {M}, ref max_w {max_w}, cap {cap})");
+                eprintln!("exp_table_baked_vs_series {tier}: max |baked-ref| = {max_diff:?} working LSBs (tol {tolerance:?}, M {M}, ref max_w {max_working_scale}, cap {cap})");
             }
 
             /// Zero-sized per-tier marker implementing
@@ -2230,12 +2418,12 @@ macro_rules! decl_wide_transcendental {
                 }
                 #[inline]
                 fn round_to_storage_with(
-                    v: W,
-                    w: u32,
+                    working_value: W,
+                    working_scale: u32,
                     target: u32,
                     mode: $crate::support::rounding::RoundingMode,
                 ) -> $Storage {
-                    round_to_storage_with(v, w, target, mode)
+                    round_to_storage_with(working_value, working_scale, target, mode)
                 }
                 #[inline]
                 fn to_work_scaled_agm(raw: $Storage, working_digits: u32) -> Wagm {
@@ -2243,158 +2431,203 @@ macro_rules! decl_wide_transcendental {
                 }
                 #[inline]
                 fn round_to_storage_with_agm(
-                    v: Wagm,
-                    w: u32,
+                    working_value: Wagm,
+                    working_scale: u32,
                     target: u32,
                     mode: $crate::support::rounding::RoundingMode,
                 ) -> $Storage {
-                    round_to_storage_with_g::<Wagm>(v, w, target, mode)
+                    round_to_storage_with_g::<Wagm>(working_value, working_scale, target, mode)
                 }
                 #[inline]
                 fn round_to_storage_directed(
-                    base_guard: u32,
+                    base_guard_digits: u32,
                     target: u32,
                     mode: $crate::support::rounding::RoundingMode,
                     recompute: &mut dyn FnMut(u32) -> W,
                 ) -> $Storage {
-                    round_to_storage_directed(base_guard, target, mode, recompute)
+                    round_to_storage_directed(base_guard_digits, target, mode, recompute)
                 }
                 #[inline]
                 fn round_to_storage_directed_never_exact(
-                    base_guard: u32,
+                    base_guard_digits: u32,
                     target: u32,
                     mode: $crate::support::rounding::RoundingMode,
                     recompute: &mut dyn FnMut(u32) -> W,
                 ) -> $Storage {
-                    round_to_storage_directed_never_exact(base_guard, target, mode, recompute)
+                    round_to_storage_directed_never_exact(
+                        base_guard_digits,
+                        target,
+                        mode,
+                        recompute
+                    )
                 }
                 #[inline]
-                fn exp_fixed<const SCALE: u32>(v_w: W, w: u32) -> W {
-                    exp_fixed::<SCALE>(v_w, w)
+                fn exp_fixed<const SCALE: u32>(working_value: W, working_scale: u32) -> W {
+                    exp_fixed::<SCALE>(working_value, working_scale)
                 }
                 #[inline]
-                fn ln_fixed<const SCALE: u32>(v_w: W, w: u32) -> W {
-                    ln_fixed::<SCALE>(v_w, w)
+                fn ln_fixed<const SCALE: u32>(working_value: W, working_scale: u32) -> W {
+                    ln_fixed::<SCALE>(working_value, working_scale)
                 }
                 #[inline]
-                fn sin_fixed<const SCALE: u32>(v_w: W, w: u32) -> W {
-                    sin_fixed::<SCALE>(v_w, w)
+                fn sin_fixed<const SCALE: u32>(working_value: W, working_scale: u32) -> W {
+                    sin_fixed::<SCALE>(working_value, working_scale)
                 }
                 #[inline]
-                fn cos_fixed<const SCALE: u32>(v_w: W, w: u32) -> W {
-                    cos_fixed::<SCALE>(v_w, w)
+                fn cos_fixed<const SCALE: u32>(working_value: W, working_scale: u32) -> W {
+                    cos_fixed::<SCALE>(working_value, working_scale)
                 }
                 #[inline]
-                fn sin_cos_fixed<const SCALE: u32>(v_w: W, w: u32) -> (W, W) {
-                    sin_cos_fixed::<SCALE>(v_w, w)
+                fn sin_cos_fixed<const SCALE: u32>(
+                    working_value: W,
+                    working_scale: u32
+                ) -> (W, W) {
+                    sin_cos_fixed::<SCALE>(working_value, working_scale)
                 }
                 #[inline]
-                fn atan_fixed<const SCALE: u32>(v_w: W, w: u32) -> W {
-                    atan_fixed::<SCALE>(v_w, w)
+                fn atan_fixed<const SCALE: u32>(working_value: W, working_scale: u32) -> W {
+                    atan_fixed::<SCALE>(working_value, working_scale)
                 }
                 #[inline]
-                fn div(a: W, b: W, w: u32) -> W {
-                    div(a, b, w)
+                fn div(numerator: W, divisor: W, working_scale: u32) -> W {
+                    div(numerator, divisor, working_scale)
                 }
                 #[inline]
-                fn mul(a: W, b: W, w: u32) -> W {
-                    mul(a, b, w)
+                fn mul(lhs: W, rhs: W, working_scale: u32) -> W {
+                    mul(lhs, rhs, working_scale)
                 }
                 #[inline]
-                fn sqrt_fixed(v: W, w: u32) -> W {
-                    sqrt_fixed(v, w)
+                fn sqrt_fixed(value: W, working_scale: u32) -> W {
+                    sqrt_fixed(value, working_scale)
                 }
                 #[inline]
-                fn log1p_fixed(t: W, w: u32) -> W {
-                    log1p_fixed(t, w)
+                fn log1p_fixed(argument: W, working_scale: u32) -> W {
+                    log1p_fixed(argument, working_scale)
                 }
                 #[inline]
-                fn bit_length(v: W) -> u32 {
-                    bit_length(v)
+                fn bit_length(value: W) -> u32 {
+                    bit_length(value)
                 }
                 #[inline]
                 fn exp_result_int_digits(mag_at_scale: W, scale: u32) -> u32 {
                     exp_result_int_digits(mag_at_scale, scale)
                 }
                 #[inline]
-                fn sinh_pos_wide<const SCALE: u32>(av_w: W, w: u32) -> W {
-                    sinh_pos_wide::<SCALE>(av_w, w)
+                fn sinh_pos_wide<const SCALE: u32>(
+                    abs_working_value: W,
+                    working_scale: u32
+                ) -> W {
+                    sinh_pos_wide::<SCALE>(abs_working_value, working_scale)
                 }
                 #[inline]
-                fn cosh_pos_wide<const SCALE: u32>(av_w: W, w: u32) -> W {
-                    cosh_pos_wide::<SCALE>(av_w, w)
+                fn cosh_pos_wide<const SCALE: u32>(
+                    abs_working_value: W,
+                    working_scale: u32
+                ) -> W {
+                    cosh_pos_wide::<SCALE>(abs_working_value, working_scale)
                 }
                 #[inline]
-                fn tanh_pos_wide<const SCALE: u32>(av_w: W, w: u32) -> W {
-                    tanh_pos_wide::<SCALE>(av_w, w)
+                fn tanh_pos_wide<const SCALE: u32>(
+                    abs_working_value: W,
+                    working_scale: u32
+                ) -> W {
+                    tanh_pos_wide::<SCALE>(abs_working_value, working_scale)
                 }
                 #[inline]
-                fn ln_fixed_routed_agm<const SCALE: u32>(v_w: Wagm, w: u32) -> Wagm {
-                    ln_fixed_routed_agm::<SCALE>(v_w, w)
+                fn ln_fixed_routed_agm<const SCALE: u32>(
+                    working_value: Wagm,
+                    working_scale: u32
+                ) -> Wagm {
+                    ln_fixed_routed_agm::<SCALE>(working_value, working_scale)
                 }
                 fn round_to_storage_directed_near_special(
-                    base_guard: u32,
+                    base_guard_digits: u32,
                     target: u32,
                     mode: $crate::support::rounding::RoundingMode,
                     recompute: &mut dyn FnMut(u32) -> W,
                 ) -> $Storage {
-                    round_to_storage_directed_near_special(base_guard, target, mode, recompute)
+                    round_to_storage_directed_near_special(
+                        base_guard_digits,
+                        target,
+                        mode,
+                        recompute
+                    )
                 }
                 #[inline]
-                fn one(w: u32) -> W {
-                    one(w)
+                fn one(working_scale: u32) -> W {
+                    one(working_scale)
                 }
                 #[inline]
-                fn lit(n: u128) -> W {
-                    lit(n)
+                fn lit(value: u128) -> W {
+                    lit(value)
                 }
                 #[inline]
-                fn ln2<const SCALE: u32>(w: u32) -> W {
-                    ln2_cf::<SCALE>(w, $crate::support::rounding::DEFAULT_ROUNDING_MODE)
+                fn ln2<const SCALE: u32>(working_scale: u32) -> W {
+                    ln2_cf::<SCALE>(
+                        working_scale,
+                        $crate::support::rounding::DEFAULT_ROUNDING_MODE
+                    )
                 }
                 #[inline]
-                fn div_cached(a: W, b: W, pow10_w: W) -> W {
-                    div_cached(a, b, pow10_w)
+                fn div_cached(numerator: W, divisor: W, cached_pow10: W) -> W {
+                    div_cached(numerator, divisor, cached_pow10)
                 }
                 #[inline]
-                fn round_to_nearest_int(v: W, w: u32) -> i128 {
-                    round_to_nearest_int(v, w)
+                fn round_to_nearest_int(working_value: W, working_scale: u32) -> i128 {
+                    round_to_nearest_int(working_value, working_scale)
                 }
                 #[inline]
-                fn pow10(n: u32) -> W {
-                    pow10(n)
+                fn pow10(exponent: u32) -> W {
+                    pow10(exponent)
                 }
                 #[inline]
                 fn w_bits() -> u32 {
                     <W as $crate::int::types::traits::BigInt>::BITS
                 }
                 #[inline]
-                fn ln_table_entry<const SCALE: u32>(w: u32, idx: usize) -> W {
-                    tang_table::ln_table_entry::<SCALE>(w, idx)
+                fn ln_table_entry<const SCALE: u32>(working_scale: u32, idx: usize) -> W {
+                    tang_table::ln_table_entry::<SCALE>(working_scale, idx)
                 }
                 #[inline]
-                fn exp_table_entry<const SCALE: u32>(w: u32, idx: usize, m: u32) -> W {
-                    tang_table::exp_table_entry::<SCALE>(w, idx, m)
+                fn exp_table_entry<const SCALE: u32>(
+                    working_scale: u32,
+                    idx: usize,
+                    table_size: u32
+                ) -> W {
+                    tang_table::exp_table_entry::<SCALE>(working_scale, idx, table_size)
                 }
                 #[inline]
-                fn pi<const SCALE: u32>(w: u32) -> W {
-                    pi_cf::<SCALE>(w, $crate::support::rounding::DEFAULT_ROUNDING_MODE)
+                fn pi<const SCALE: u32>(working_scale: u32) -> W {
+                    pi_cf::<SCALE>(
+                        working_scale,
+                        $crate::support::rounding::DEFAULT_ROUNDING_MODE
+                    )
                 }
                 #[inline]
-                fn half_pi<const SCALE: u32>(w: u32) -> W {
-                    half_pi::<SCALE>(w)
+                fn half_pi<const SCALE: u32>(working_scale: u32) -> W {
+                    half_pi::<SCALE>(working_scale)
                 }
                 #[inline]
-                fn deg_per_rad<const SCALE: u32>(w: u32) -> W {
-                    deg_per_rad_cf::<SCALE>(w, $crate::support::rounding::DEFAULT_ROUNDING_MODE)
+                fn deg_per_rad<const SCALE: u32>(working_scale: u32) -> W {
+                    deg_per_rad_cf::<SCALE>(
+                        working_scale,
+                        $crate::support::rounding::DEFAULT_ROUNDING_MODE
+                    )
                 }
                 #[inline]
-                fn rad_per_deg<const SCALE: u32>(w: u32) -> W {
-                    rad_per_deg_cf::<SCALE>(w, $crate::support::rounding::DEFAULT_ROUNDING_MODE)
+                fn rad_per_deg<const SCALE: u32>(working_scale: u32) -> W {
+                    rad_per_deg_cf::<SCALE>(
+                        working_scale,
+                        $crate::support::rounding::DEFAULT_ROUNDING_MODE
+                    )
                 }
                 #[inline]
-                fn sincos_table_entry<const SCALE: u32>(w: u32, idx: usize, m: u32) -> (W, W) {
-                    tang_table::sincos_table_entry::<SCALE>(w, idx, m)
+                fn sincos_table_entry<const SCALE: u32>(
+                    working_scale: u32,
+                    idx: usize,
+                    table_size: u32
+                ) -> (W, W) {
+                    tang_table::sincos_table_entry::<SCALE>(working_scale, idx, table_size)
                 }
             }
 
@@ -2434,7 +2667,8 @@ macro_rules! decl_wide_transcendental {
             // dominant tier value here because the working-scale routed
             // surface is single-source-per-tier.
 
-            /// Tang/Series-routed working-scale `ln(v_w) -> v_w` for this
+            /// Tang/Series-routed working-scale `ln` of a `working_value` for
+            /// this
             /// tier. Bit-equivalent to the previous direct `ln_fixed`
             /// call wherever the policy routes Series; routes through
             /// the shared `tang_ln_fixed` surface (the same one
@@ -2448,27 +2682,34 @@ macro_rules! decl_wide_transcendental {
             /// matcher's Tang routing (the Class-G remediation).
             #[cfg(feature = "_wide-support")]
             #[inline]
-            pub(crate) fn ln_fixed_routed<const SCALE: u32>(v_w: W, w: u32) -> W {
+            pub(crate) fn ln_fixed_routed<const SCALE: u32>(
+                working_value: W,
+                working_scale: u32
+            ) -> W {
                 if const { $crate::policy::ln::is_tang::<$n_limbs, SCALE>() } {
                     // INTERNAL_EXTRA = true: run at extended working scale
-                    // `w + 12` and residual-preserving narrow back to `w`,
+                    // `working_scale + 12` and residual-preserving narrow back
+                    // to `working_scale`,
                     // so the directed-rounding Ziv escalation in the caller
                     // (e.g. asinh_strict_with @ MAX scale) sees a residual
                     // sign bit-identical to Series's `ln_fixed`. Mirrors the
                     // `true, true` flags every `policy::ln::tang_routed`
                     // arm now uses.
-                    $crate::algos::ln::ln_tang::tang_ln_fixed::<Core, $ln_tang_cap, false, SCALE>(v_w, w)
+                    $crate::algos::ln::ln_tang::tang_ln_fixed::<Core, $ln_tang_cap, false, SCALE>(working_value, working_scale)
                 } else {
-                    ln_fixed::<SCALE>(v_w, w)
+                    ln_fixed::<SCALE>(working_value, working_scale)
                 }
             }
             #[cfg(not(feature = "_wide-support"))]
             #[inline]
-            pub(crate) fn ln_fixed_routed<const SCALE: u32>(v_w: W, w: u32) -> W {
-                ln_fixed::<SCALE>(v_w, w)
+            pub(crate) fn ln_fixed_routed<const SCALE: u32>(
+                working_value: W,
+                working_scale: u32
+            ) -> W {
+                ln_fixed::<SCALE>(working_value, working_scale)
             }
 
-            /// Tang/Series-routed working-scale `exp(v_w) -> v_w` for
+            /// Tang/Series-routed working-scale `exp` of a `working_value` for
             /// this tier. Bit-equivalent to the previous direct
             /// `exp_fixed` call wherever the policy routes Series;
             /// routes through `tang_exp_fixed::<Core, M, true>` (the
@@ -2487,17 +2728,23 @@ macro_rules! decl_wide_transcendental {
             /// large-`|k|` case.
             #[cfg(feature = "_wide-support")]
             #[inline]
-            pub(crate) fn exp_fixed_routed<const SCALE: u32>(v_w: W, w: u32) -> W {
+            pub(crate) fn exp_fixed_routed<const SCALE: u32>(
+                working_value: W,
+                working_scale: u32
+            ) -> W {
                 if const { $crate::policy::exp::is_tang::<$n_limbs, SCALE>() } {
-                    $crate::algos::exp::exp_tang::tang_exp_fixed::<Core, $exp_tang_m, true, SCALE>(v_w, w)
+                    $crate::algos::exp::exp_tang::tang_exp_fixed::<Core, $exp_tang_m, true, SCALE>(working_value, working_scale)
                 } else {
-                    exp_fixed::<SCALE>(v_w, w)
+                    exp_fixed::<SCALE>(working_value, working_scale)
                 }
             }
             #[cfg(not(feature = "_wide-support"))]
             #[inline]
-            pub(crate) fn exp_fixed_routed<const SCALE: u32>(v_w: W, w: u32) -> W {
-                exp_fixed::<SCALE>(v_w, w)
+            pub(crate) fn exp_fixed_routed<const SCALE: u32>(
+                working_value: W,
+                working_scale: u32
+            ) -> W {
+                exp_fixed::<SCALE>(working_value, working_scale)
             }
 
             // ── Wagm (composition / AGM wide-work) bridges ─────────────
@@ -2520,68 +2767,80 @@ macro_rules! decl_wide_transcendental {
                     * $crate::algos::exp::exp_generic::pow10::<Wagm>(working_digits)
             }
             #[inline]
-            pub(crate) fn one_agm(w: u32) -> Wagm {
-                $crate::algos::exp::exp_generic::pow10::<Wagm>(w)
+            pub(crate) fn one_agm(working_scale: u32) -> Wagm {
+                $crate::algos::exp::exp_generic::pow10::<Wagm>(working_scale)
             }
             #[inline]
             pub(crate) fn zero_agm() -> Wagm {
                 <Wagm as $crate::int::types::traits::BigInt>::ZERO
             }
             #[inline]
-            pub(crate) fn round_to_storage_agm(v: Wagm, w: u32, target: u32) -> $Storage {
+            pub(crate) fn round_to_storage_agm(
+                working_value: Wagm,
+                working_scale: u32,
+                target: u32
+            ) -> $Storage {
                 round_to_storage_with_g::<Wagm>(
-                    v,
-                    w,
+                    working_value,
+                    working_scale,
                     target,
                     $crate::support::rounding::DEFAULT_ROUNDING_MODE,
                 )
             }
             #[inline]
-            pub(crate) fn div_agm(a: Wagm, b: Wagm, w: u32) -> Wagm {
-                $crate::algos::exp::exp_generic::div::<Wagm>(a, b, w)
+            pub(crate) fn div_agm(numerator: Wagm, divisor: Wagm, working_scale: u32) -> Wagm {
+                $crate::algos::exp::exp_generic::div::<Wagm>(numerator, divisor, working_scale)
             }
             #[inline]
-            pub(crate) fn round_to_nearest_int_agm(v: Wagm, w: u32) -> i128 {
-                $crate::algos::exp::exp_generic::round_to_nearest_int::<Wagm>(v, w)
+            pub(crate) fn round_to_nearest_int_agm(
+                working_value: Wagm,
+                working_scale: u32
+            ) -> i128 {
+                $crate::algos::exp::exp_generic::round_to_nearest_int::<Wagm>(
+                    working_value,
+                    working_scale
+                )
             }
             #[inline]
-            pub(crate) fn mul_agm(a: Wagm, b: Wagm, w: u32) -> Wagm {
-                $crate::algos::exp::exp_generic::mul::<Wagm>(a, b, w)
+            pub(crate) fn mul_agm(lhs: Wagm, rhs: Wagm, working_scale: u32) -> Wagm {
+                $crate::algos::exp::exp_generic::mul::<Wagm>(lhs, rhs, working_scale)
             }
             #[inline]
-            pub(crate) fn sqrt_fixed_agm(v: Wagm, w: u32) -> Wagm {
-                $crate::algos::exp::exp_generic::sqrt_fixed::<Wagm>(v, w)
+            pub(crate) fn sqrt_fixed_agm(value: Wagm, working_scale: u32) -> Wagm {
+                $crate::algos::exp::exp_generic::sqrt_fixed::<Wagm>(value, working_scale)
             }
             /// `ln 2` const-folded at the base working scale for the
             /// wide composition core — the `Wagm` sibling of [`ln2_cf`].
-            /// On the common path (`w == SCALE + GUARD`) the lookup keys
+            /// On the common path (`working_scale == SCALE + GUARD`) the
+            /// lookup keys
             /// on the CONST working scale and folds to one table entry per
             /// monomorphisation; the Ziv-escalation path falls back to the
             /// runtime static lookup. Bit-identical to a bare
-            /// `ln2_by_working_scale::<Wagm>(w, mode)` (same table entry,
+            /// `ln2_by_working_scale::<Wagm>(working_scale, mode)` (same table
+            /// entry,
             /// same rounding) — it only recovers the const-fold.
             #[inline]
             pub(crate) fn ln2_cf_agm<const SCALE: u32>(
-                w: u32,
+                working_scale: u32,
                 mode: $crate::support::rounding::RoundingMode,
             ) -> Wagm {
-                if w == SCALE + GUARD {
+                if working_scale == SCALE + GUARD {
                     return $crate::consts::ln2_by_scale::<Wagm>(SCALE + GUARD, mode);
                 }
-                $crate::consts::ln2_by_working_scale::<Wagm>(w, mode)
+                $crate::consts::ln2_by_working_scale::<Wagm>(working_scale, mode)
             }
             /// `ln 10` const-folded at the base working scale for the wide
             /// composition core — the `Wagm` sibling of [`ln10_cf`]. See
             /// [`ln2_cf_agm`]; bit-identical to `ln10_by_working_scale`.
             #[inline]
             pub(crate) fn ln10_cf_agm<const SCALE: u32>(
-                w: u32,
+                working_scale: u32,
                 mode: $crate::support::rounding::RoundingMode,
             ) -> Wagm {
-                if w == SCALE + GUARD {
+                if working_scale == SCALE + GUARD {
                     return $crate::consts::ln10_by_scale::<Wagm>(SCALE + GUARD, mode);
                 }
-                $crate::consts::ln10_by_working_scale::<Wagm>(w, mode)
+                $crate::consts::ln10_by_working_scale::<Wagm>(working_scale, mode)
             }
             /// Series `ln(v) -> v` at `Wagm` (the `Wagm` sibling of the
             /// Series-only `ln_fixed`) — used where a composition pins Series
@@ -2589,41 +2848,45 @@ macro_rules! decl_wide_transcendental {
             /// (the Brent-Salamin AGM ln). `ln 2` from the unified table at
             /// `Wagm` under the feature-flagged default rounding mode.
             #[inline]
-            pub(crate) fn ln_fixed_series_agm(v_w: Wagm, w: u32) -> Wagm {
+            pub(crate) fn ln_fixed_series_agm(working_value: Wagm, working_scale: u32) -> Wagm {
                 $crate::algos::exp::exp_generic::ln_fixed::<Wagm>(
-                    v_w,
-                    w,
+                    working_value,
+                    working_scale,
                     $crate::consts::ln2_by_working_scale::<Wagm>(
-                        w,
+                        working_scale,
                         $crate::support::rounding::DEFAULT_ROUNDING_MODE,
                     ),
                 )
             }
-            /// Tang/Series-routed `ln(v) -> v` at the wide composition work
+            /// Tang/Series-routed `ln` of a `working_value` at the wide
+            /// composition work
             /// width `Wagm` — the `Wagm` sibling of [`ln_fixed_routed`],
             /// calling the SAME generic kernels (`tang_ln_fixed_g` /
             /// `exp_generic::ln_fixed`) with `ln 2` from the unified table at
             /// `Wagm` (the crate's feature-flagged default rounding mode).
             #[cfg(feature = "_wide-support")]
             #[inline]
-            pub(crate) fn ln_fixed_routed_agm<const SCALE: u32>(v_w: Wagm, w: u32) -> Wagm {
+            pub(crate) fn ln_fixed_routed_agm<const SCALE: u32>(
+                working_value: Wagm,
+                working_scale: u32
+            ) -> Wagm {
                 if const { $crate::policy::ln::is_tang::<$n_limbs, SCALE>() } {
                     $crate::algos::ln::ln_tang::tang_ln_fixed_g::<Wagm, $ln_tang_cap, false>(
-                        v_w,
-                        w,
-                        |ww| {
+                        working_value,
+                        working_scale,
+                        |inner_working_scale| {
                             ln2_cf_agm::<SCALE>(
-                                ww,
+                                inner_working_scale,
                                 $crate::support::rounding::DEFAULT_ROUNDING_MODE,
                             )
                         },
                     )
                 } else {
                     $crate::algos::exp::exp_generic::ln_fixed::<Wagm>(
-                        v_w,
-                        w,
+                        working_value,
+                        working_scale,
                         ln2_cf_agm::<SCALE>(
-                            w,
+                            working_scale,
                             $crate::support::rounding::DEFAULT_ROUNDING_MODE,
                         ),
                     )
@@ -2631,43 +2894,56 @@ macro_rules! decl_wide_transcendental {
             }
             #[cfg(not(feature = "_wide-support"))]
             #[inline]
-            pub(crate) fn ln_fixed_routed_agm<const SCALE: u32>(v_w: Wagm, w: u32) -> Wagm {
+            pub(crate) fn ln_fixed_routed_agm<const SCALE: u32>(
+                working_value: Wagm,
+                working_scale: u32
+            ) -> Wagm {
                 $crate::algos::exp::exp_generic::ln_fixed::<Wagm>(
-                    v_w,
-                    w,
+                    working_value,
+                    working_scale,
                     ln2_cf_agm::<SCALE>(
-                        w,
+                        working_scale,
                         $crate::support::rounding::DEFAULT_ROUNDING_MODE,
                     ),
                 )
             }
-            /// Tang/Series-routed `exp(v) -> v` at the wide composition work
+            /// Tang/Series-routed `exp` of a `working_value` at the wide
+            /// composition work
             /// width `Wagm` — the `Wagm` sibling of [`exp_fixed_routed`],
             /// calling the SAME generic kernels (`tang_exp_fixed_g` /
             /// `exp_generic::exp_fixed`) with `ln 2` from the unified table at
             /// `Wagm` (the crate's feature-flagged default rounding mode).
             #[cfg(feature = "_wide-support")]
             #[inline]
-            pub(crate) fn exp_fixed_routed_agm<const SCALE: u32>(v_w: Wagm, w: u32) -> Wagm {
+            pub(crate) fn exp_fixed_routed_agm<const SCALE: u32>(
+                working_value: Wagm,
+                working_scale: u32
+            ) -> Wagm {
                 if const { $crate::policy::exp::is_tang::<$n_limbs, SCALE>() } {
                     $crate::algos::exp::exp_tang::tang_exp_fixed_g::<Wagm, $exp_tang_m, true>(
-                        v_w,
-                        w,
-                        |ww| {
+                        working_value,
+                        working_scale,
+                        |inner_working_scale| {
                             ln2_cf_agm::<SCALE>(
-                                ww,
+                                inner_working_scale,
                                 $crate::support::rounding::DEFAULT_ROUNDING_MODE,
                             )
                         },
                     )
                 } else {
-                    $crate::algos::exp::exp_generic::exp_fixed::<Wagm>(v_w, w)
+                    $crate::algos::exp::exp_generic::exp_fixed::<Wagm>(
+                        working_value,
+                        working_scale
+                    )
                 }
             }
             #[cfg(not(feature = "_wide-support"))]
             #[inline]
-            pub(crate) fn exp_fixed_routed_agm<const SCALE: u32>(v_w: Wagm, w: u32) -> Wagm {
-                $crate::algos::exp::exp_generic::exp_fixed::<Wagm>(v_w, w)
+            pub(crate) fn exp_fixed_routed_agm<const SCALE: u32>(
+                working_value: Wagm,
+                working_scale: u32
+            ) -> Wagm {
+                $crate::algos::exp::exp_generic::exp_fixed::<Wagm>(working_value, working_scale)
             }
             /// `Wagm` sibling of [`exp_fixed_wide`]: the near-overflow exp
             /// path that lifts to `Wexp` for the squaring peak, then narrows
@@ -2675,12 +2951,16 @@ macro_rules! decl_wide_transcendental {
             /// the SAME generic kernel, so it is bit-identical while
             /// `Wagm == $Work`.
             #[inline]
-            pub(crate) fn exp_fixed_wide_agm(v_w: Wagm, w: u32) -> Wagm {
-                let v_wide = $crate::int::types::traits::BigInt::resize_to::<Wexp>(v_w);
-                let r_wide = $crate::algos::exp::exp_generic::exp_fixed::<Wexp>(v_wide, w);
+            pub(crate) fn exp_fixed_wide_agm(working_value: Wagm, working_scale: u32) -> Wagm {
+                let wide_working_value =
+                    $crate::int::types::traits::BigInt::resize_to::<Wexp>(working_value);
+                let wide_exp_value = $crate::algos::exp::exp_generic::exp_fixed::<Wexp>(
+                    wide_working_value,
+                    working_scale
+                );
                 // Narrow back to `Wagm`, panicking on an out-of-range result
                 // rather than truncating — see `exp_generic::resize_or_panic`.
-                $crate::algos::exp::exp_generic::resize_or_panic::<Wexp, Wagm>(r_wide)
+                $crate::algos::exp::exp_generic::resize_or_panic::<Wexp, Wagm>(wide_exp_value)
             }
             /// `Wagm` sibling of the macro `exp_fixed`: the GATED Series exp —
             /// the fast `Wagm` kernel when the squaring peak fits, else the
@@ -2688,11 +2968,17 @@ macro_rules! decl_wide_transcendental {
             /// `exp_fixed_agm` (the Brent-Salamin AGM exp). Bit-identical to
             /// `exp_fixed::<SCALE>` on `W` while `Wagm == $Work`.
             #[inline]
-            pub(crate) fn exp_fixed_series_agm(v_w: Wagm, w: u32) -> Wagm {
-                if $crate::algos::exp::exp_generic::exp_peak_fits::<Wagm>(v_w, w) {
-                    $crate::algos::exp::exp_generic::exp_fixed::<Wagm>(v_w, w)
+            pub(crate) fn exp_fixed_series_agm(working_value: Wagm, working_scale: u32) -> Wagm {
+                if $crate::algos::exp::exp_generic::exp_peak_fits::<Wagm>(
+                    working_value,
+                    working_scale
+                ) {
+                    $crate::algos::exp::exp_generic::exp_fixed::<Wagm>(
+                        working_value,
+                        working_scale
+                    )
                 } else {
-                    exp_fixed_wide_agm(v_w, w)
+                    exp_fixed_wide_agm(working_value, working_scale)
                 }
             }
 
@@ -2712,43 +2998,51 @@ macro_rules! decl_wide_transcendental {
             #[inline]
             pub(crate) fn log_strict_with_kernel<const SCALE: u32>(
                 raw: $Storage,
-                braw: $Storage,
+                base_raw: $Storage,
                 mode: $crate::support::rounding::RoundingMode,
             ) -> $Storage {
-                let z = $crate::macros::wide_roots::wide_lit!($Storage, "0");
-                if raw <= z {
+                let zero_raw = $crate::macros::wide_roots::wide_lit!($Storage, "0");
+                if raw <= zero_raw {
                     panic!(concat!(
                         stringify!($Type),
                         "::log: argument must be positive"
                     ));
                 }
-                if braw <= z {
+                if base_raw <= zero_raw {
                     panic!(concat!(stringify!($Type), "::log: base must be positive"));
                 }
                 // Probe at the base guard to reject base == 1. Two-core:
                 // the composition runs on the wide `Wagm` work int.
-                let w0 = SCALE + GUARD;
-                let ln_b0 = ln_fixed_routed_agm::<SCALE>(to_work_agm(braw), w0);
-                if ln_b0 == zero_agm() {
+                let base_working_scale = SCALE + GUARD;
+                let probe_ln_base =
+                    ln_fixed_routed_agm::<SCALE>(to_work_agm(base_raw), base_working_scale);
+                if probe_ln_base == zero_agm() {
                     panic!(concat!(stringify!($Type), "::log: base must not equal 1"));
                 }
                 // Exact-power pin: `self == base^k` ⇒ result is exactly
                 // the integer `k` (see `log10_strict_with`).
                 {
-                    let r0 = div_agm(ln_fixed_routed_agm::<SCALE>(to_work_agm(raw), w0), ln_b0, w0);
-                    let k = round_to_nearest_int_agm(r0, w0);
-                    if log_is_exact_int::<Wagm>(to_work_scaled_agm(raw, 0), to_work_scaled_agm(braw, 0), SCALE, k) {
-                        return exact_int_at_scale(k, SCALE);
+                    let probe_ratio = div_agm(
+                        ln_fixed_routed_agm::<SCALE>(to_work_agm(raw), base_working_scale),
+                        probe_ln_base,
+                        base_working_scale
+                    );
+                    let exponent = round_to_nearest_int_agm(probe_ratio, base_working_scale);
+                    if log_is_exact_int::<Wagm>(to_work_scaled_agm(raw, 0), to_work_scaled_agm(base_raw, 0), SCALE, exponent) {
+                        return exact_int_at_scale(exponent, SCALE);
                     }
                 }
                 // Route the final narrowing through the directed-rounding
                 // Ziv escalation: recompute `ln(self)/ln(base)` at the
                 // requested guard so Trunc/Floor/Ceiling decide on the
                 // true residual sign, not the base-guard approximation.
-                round_to_storage_directed::<Wagm>(GUARD, SCALE, mode, |guard| {
-                    let w = SCALE + guard;
-                    let ln_b = ln_fixed_routed_agm::<SCALE>(to_work_scaled_agm(braw, guard), w);
-                    div_agm(ln_fixed_routed_agm::<SCALE>(to_work_scaled_agm(raw, guard), w), ln_b, w)
+                round_to_storage_directed::<Wagm>(GUARD, SCALE, mode, |guard_digits| {
+                    let working_scale = SCALE + guard_digits;
+                    let ln_base = ln_fixed_routed_agm::<SCALE>(
+                        to_work_scaled_agm(base_raw, guard_digits),
+                        working_scale
+                    );
+                    div_agm(ln_fixed_routed_agm::<SCALE>(to_work_scaled_agm(raw, guard_digits), working_scale), ln_base, working_scale)
                 })
             }
 
@@ -2760,28 +3054,31 @@ macro_rules! decl_wide_transcendental {
             #[inline]
             pub(crate) fn log_approx_with_kernel<const SCALE: u32>(
                 raw: $Storage,
-                braw: $Storage,
+                base_raw: $Storage,
                 working_digits: u32,
                 mode: $crate::support::rounding::RoundingMode,
             ) -> $Storage {
-                let z = $crate::macros::wide_roots::wide_lit!($Storage, "0");
-                if raw <= z {
+                let zero_raw = $crate::macros::wide_roots::wide_lit!($Storage, "0");
+                if raw <= zero_raw {
                     panic!(concat!(
                         stringify!($Type),
                         "::log: argument must be positive"
                     ));
                 }
-                if braw <= z {
+                if base_raw <= zero_raw {
                     panic!(concat!(stringify!($Type), "::log: base must be positive"));
                 }
-                let w = SCALE + working_digits;
+                let working_scale = SCALE + working_digits;
                 // Two-core: composition runs on the wide `Wagm` work int.
-                let ln_b = ln_fixed_routed_agm::<SCALE>(to_work_scaled_agm(braw, working_digits), w);
-                if ln_b == zero_agm() {
+                let ln_base = ln_fixed_routed_agm::<SCALE>(
+                    to_work_scaled_agm(base_raw, working_digits),
+                    working_scale
+                );
+                if ln_base == zero_agm() {
                     panic!(concat!(stringify!($Type), "::log: base must not equal 1"));
                 }
-                let r = div_agm(ln_fixed_routed_agm::<SCALE>(to_work_scaled_agm(raw, working_digits), w), ln_b, w);
-                round_to_storage_with_g::<Wagm>(r, w, SCALE, mode)
+                let log_value = div_agm(ln_fixed_routed_agm::<SCALE>(to_work_scaled_agm(raw, working_digits), working_scale), ln_base, working_scale);
+                round_to_storage_with_g::<Wagm>(log_value, working_scale, SCALE, mode)
             }
 
             /// Strict-guard `log2(x)` under `mode`, on raw storage.
@@ -2798,24 +3095,27 @@ macro_rules! decl_wide_transcendental {
                 }
                 {
                     // Two-core: composition runs on the wide `Wagm` work int.
-                    let w0 = SCALE + GUARD;
-                    let r0 = div_agm(
-                        ln_fixed_routed_agm::<SCALE>(to_work_agm(raw), w0),
-                        ln2_cf_agm::<SCALE>(w0, $crate::support::rounding::DEFAULT_ROUNDING_MODE),
-                        w0,
+                    let base_working_scale = SCALE + GUARD;
+                    let probe_ratio = div_agm(
+                        ln_fixed_routed_agm::<SCALE>(to_work_agm(raw), base_working_scale),
+                        ln2_cf_agm::<SCALE>(base_working_scale, $crate::support::rounding::DEFAULT_ROUNDING_MODE),
+                        base_working_scale,
                     );
-                    let k = round_to_nearest_int_agm(r0, w0);
+                    let exponent = round_to_nearest_int_agm(probe_ratio, base_working_scale);
                     let base2 = one_agm(SCALE) + one_agm(SCALE);
-                    if log_is_exact_int::<Wagm>(to_work_scaled_agm(raw, 0), base2, SCALE, k) {
-                        return exact_int_at_scale(k, SCALE);
+                    if log_is_exact_int::<Wagm>(to_work_scaled_agm(raw, 0), base2, SCALE, exponent) {
+                        return exact_int_at_scale(exponent, SCALE);
                     }
                 }
-                round_to_storage_directed::<Wagm>(GUARD, SCALE, mode, |guard| {
-                    let w = SCALE + guard;
+                round_to_storage_directed::<Wagm>(GUARD, SCALE, mode, |guard_digits| {
+                    let working_scale = SCALE + guard_digits;
                     div_agm(
-                        ln_fixed_routed_agm::<SCALE>(to_work_scaled_agm(raw, guard), w),
-                        ln2_cf_agm::<SCALE>(w, $crate::support::rounding::DEFAULT_ROUNDING_MODE),
-                        w,
+                        ln_fixed_routed_agm::<SCALE>(
+                            to_work_scaled_agm(raw, guard_digits),
+                            working_scale
+                        ),
+                        ln2_cf_agm::<SCALE>(working_scale, $crate::support::rounding::DEFAULT_ROUNDING_MODE),
+                        working_scale,
                     )
                 })
             }
@@ -2833,9 +3133,9 @@ macro_rules! decl_wide_transcendental {
                 if raw <= $crate::macros::wide_roots::wide_lit!($Storage, "0") {
                     panic!(concat!(stringify!($Type), "::log2: argument must be positive"));
                 }
-                let w = SCALE + working_digits;
-                let r = div_agm(ln_fixed_routed_agm::<SCALE>(to_work_scaled_agm(raw, working_digits), w), ln2_cf_agm::<SCALE>(w, $crate::support::rounding::DEFAULT_ROUNDING_MODE), w);
-                round_to_storage_with_g::<Wagm>(r, w, SCALE, mode)
+                let working_scale = SCALE + working_digits;
+                let log2_value = div_agm(ln_fixed_routed_agm::<SCALE>(to_work_scaled_agm(raw, working_digits), working_scale), ln2_cf_agm::<SCALE>(working_scale, $crate::support::rounding::DEFAULT_ROUNDING_MODE), working_scale);
+                round_to_storage_with_g::<Wagm>(log2_value, working_scale, SCALE, mode)
             }
 
             /// Strict-guard `log10(x)` under `mode`, on raw storage.
@@ -2849,24 +3149,27 @@ macro_rules! decl_wide_transcendental {
                 }
                 {
                     // Two-core: composition runs on the wide `Wagm` work int.
-                    let w0 = SCALE + GUARD;
-                    let r0 = div_agm(
-                        ln_fixed_routed_agm::<SCALE>(to_work_agm(raw), w0),
-                        ln10_cf_agm::<SCALE>(w0, $crate::support::rounding::DEFAULT_ROUNDING_MODE),
-                        w0,
+                    let base_working_scale = SCALE + GUARD;
+                    let probe_ratio = div_agm(
+                        ln_fixed_routed_agm::<SCALE>(to_work_agm(raw), base_working_scale),
+                        ln10_cf_agm::<SCALE>(base_working_scale, $crate::support::rounding::DEFAULT_ROUNDING_MODE),
+                        base_working_scale,
                     );
-                    let k = round_to_nearest_int_agm(r0, w0);
+                    let exponent = round_to_nearest_int_agm(probe_ratio, base_working_scale);
                     let base10 = one_agm(SCALE + 1);
-                    if log_is_exact_int::<Wagm>(to_work_scaled_agm(raw, 0), base10, SCALE, k) {
-                        return exact_int_at_scale(k, SCALE);
+                    if log_is_exact_int::<Wagm>(to_work_scaled_agm(raw, 0), base10, SCALE, exponent) {
+                        return exact_int_at_scale(exponent, SCALE);
                     }
                 }
-                round_to_storage_directed::<Wagm>(GUARD, SCALE, mode, |guard| {
-                    let w = SCALE + guard;
+                round_to_storage_directed::<Wagm>(GUARD, SCALE, mode, |guard_digits| {
+                    let working_scale = SCALE + guard_digits;
                     div_agm(
-                        ln_fixed_routed_agm::<SCALE>(to_work_scaled_agm(raw, guard), w),
-                        ln10_cf_agm::<SCALE>(w, $crate::support::rounding::DEFAULT_ROUNDING_MODE),
-                        w,
+                        ln_fixed_routed_agm::<SCALE>(
+                            to_work_scaled_agm(raw, guard_digits),
+                            working_scale
+                        ),
+                        ln10_cf_agm::<SCALE>(working_scale, $crate::support::rounding::DEFAULT_ROUNDING_MODE),
+                        working_scale,
                     )
                 })
             }
@@ -2884,9 +3187,9 @@ macro_rules! decl_wide_transcendental {
                 if raw <= $crate::macros::wide_roots::wide_lit!($Storage, "0") {
                     panic!(concat!(stringify!($Type), "::log10: argument must be positive"));
                 }
-                let w = SCALE + working_digits;
-                let r = div_agm(ln_fixed_routed_agm::<SCALE>(to_work_scaled_agm(raw, working_digits), w), ln10_cf_agm::<SCALE>(w, $crate::support::rounding::DEFAULT_ROUNDING_MODE), w);
-                round_to_storage_with_g::<Wagm>(r, w, SCALE, mode)
+                let working_scale = SCALE + working_digits;
+                let log10_value = div_agm(ln_fixed_routed_agm::<SCALE>(to_work_scaled_agm(raw, working_digits), working_scale), ln10_cf_agm::<SCALE>(working_scale, $crate::support::rounding::DEFAULT_ROUNDING_MODE), working_scale);
+                round_to_storage_with_g::<Wagm>(log10_value, working_scale, SCALE, mode)
             }
 
             /// Strict-guard `exp2(x) = 2^x` under `mode`, on raw storage.
@@ -2901,14 +3204,14 @@ macro_rules! decl_wide_transcendental {
                 if raw == $crate::macros::wide_roots::wide_lit!($Storage, "0") {
                     return <$Storage as $crate::int::types::traits::BigInt>::TEN.pow(SCALE);
                 }
-                if let ::core::option::Option::Some(v) = exp2_exact_pin(raw, SCALE, mode) {
-                    return v;
+                if let ::core::option::Option::Some(pinned) = exp2_exact_pin(raw, SCALE, mode) {
+                    return pinned;
                 }
                 let k_lift = exp2_result_int_digits(raw, SCALE);
-                let base_guard = GUARD + k_lift;
+                let base_guard_digits = GUARD + k_lift;
                 // Two-core: composition runs on the wide `Wagm` work int.
-                round_to_storage_directed::<Wagm>(base_guard, SCALE, mode, |guard| {
-                    let w = SCALE + guard;
+                round_to_storage_directed::<Wagm>(base_guard_digits, SCALE, mode, |guard_digits| {
+                    let working_scale = SCALE + guard_digits;
                     // Form the `x·ln 2` argument with the wide multiply in
                     // `Wexp` — the work integer `exp_fixed` runs the series in,
                     // and the width `exp_lift_cap` sized the `k_lift` lift
@@ -2926,20 +3229,23 @@ macro_rules! decl_wide_transcendental {
                     // exactly as the natural `exp` does. In-range cells stay
                     // bit-identical: the argument value itself fits `Wagm`;
                     // only its squared-scale intermediate did not.
-                    let arg = $crate::algos::exp::exp_generic::mul::<Wexp>(
+                    let exp_arg = $crate::algos::exp::exp_generic::mul::<Wexp>(
                         $crate::int::types::traits::BigInt::resize_to::<Wexp>(
-                            to_work_scaled_agm(raw, guard),
+                            to_work_scaled_agm(raw, guard_digits),
                         ),
                         $crate::int::types::traits::BigInt::resize_to::<Wexp>(
                             ln2_cf_agm::<SCALE>(
-                                w,
+                                working_scale,
                                 $crate::support::rounding::DEFAULT_ROUNDING_MODE,
                             ),
                         ),
-                        w,
+                        working_scale,
                     );
                     $crate::algos::exp::exp_generic::resize_or_panic::<Wexp, Wagm>(
-                        $crate::algos::exp::exp_generic::exp_fixed::<Wexp>(arg, w),
+                        $crate::algos::exp::exp_generic::exp_fixed::<Wexp>(
+                            exp_arg,
+                            working_scale
+                        ),
                     )
                 })
             }
@@ -2957,11 +3263,11 @@ macro_rules! decl_wide_transcendental {
                 if raw == $crate::macros::wide_roots::wide_lit!($Storage, "0") {
                     return <$Storage as $crate::int::types::traits::BigInt>::TEN.pow(SCALE);
                 }
-                let w = SCALE + working_digits;
+                let working_scale = SCALE + working_digits;
                 // Two-core: composition runs on the wide `Wagm` work int.
-                let arg = mul_agm(to_work_scaled_agm(raw, working_digits), ln2_cf_agm::<SCALE>(w, $crate::support::rounding::DEFAULT_ROUNDING_MODE), w);
-                let r = exp_fixed_routed_agm::<SCALE>(arg, w);
-                round_to_storage_with_g::<Wagm>(r, w, SCALE, mode)
+                let exp_arg = mul_agm(to_work_scaled_agm(raw, working_digits), ln2_cf_agm::<SCALE>(working_scale, $crate::support::rounding::DEFAULT_ROUNDING_MODE), working_scale);
+                let exp2_value = exp_fixed_routed_agm::<SCALE>(exp_arg, working_scale);
+                round_to_storage_with_g::<Wagm>(exp2_value, working_scale, SCALE, mode)
             }
         }
 
@@ -3083,12 +3389,12 @@ macro_rules! decl_wide_transcendental {
                 // storage-scale ULP budget. The final
                 // `round_to_storage` narrows the wider working
                 // result back to `SCALE`.
-                let w_prime = SCALE + $core::GUARD + $core::guard_agm(SCALE);
-                let r = $core::ln_fixed_agm::<SCALE>(
+                let lifted_working_scale = SCALE + $core::GUARD + $core::guard_agm(SCALE);
+                let ln_value = $core::ln_fixed_agm::<SCALE>(
                     $core::to_work_scaled(raw, $core::GUARD + $core::guard_agm(SCALE)),
-                    w_prime,
+                    lifted_working_scale,
                 );
-                Self::from_bits($core::round_to_storage(r, w_prime, SCALE))
+                Self::from_bits($core::round_to_storage(ln_value, lifted_working_scale, SCALE))
             }
 
             /// `e^self` via Newton's iteration on `ln_fixed_agm`.
@@ -3118,9 +3424,16 @@ macro_rules! decl_wide_transcendental {
                 let raw_w = $core::to_work_scaled(raw, 0);
                 let k_lift = $core::exp_agm_k_lift_from_w(raw_w, SCALE);
                 let lift = $core::GUARD + $core::guard_agm(SCALE) + k_lift;
-                let w_prime = SCALE + lift;
-                let r = $core::exp_fixed_agm::<SCALE>($core::to_work_scaled(raw, lift), w_prime);
-                Self::from_bits($core::round_to_storage(r, w_prime, SCALE))
+                let lifted_working_scale = SCALE + lift;
+                let exp_value = $core::exp_fixed_agm::<SCALE>(
+                    $core::to_work_scaled(raw, lift),
+                    lifted_working_scale
+                );
+                Self::from_bits($core::round_to_storage(
+                    exp_value,
+                    lifted_working_scale,
+                    SCALE
+                ))
             }
 
             /// Logarithm of `self` in the given `base`, as
@@ -3388,30 +3701,44 @@ macro_rules! decl_wide_transcendental {
                 if raw == $crate::macros::wide_roots::wide_lit!($Storage, "0") {
                     return Self::ZERO;
                 }
-                let w = SCALE + $core::GUARD;
+                let working_scale = SCALE + $core::GUARD;
                 // Two-core: composition runs on the wide `Wagm` work int.
-                let one_w = $core::one_agm(w);
-                let v = $core::to_work_agm(raw);
-                let ax = if v < $core::zero_agm() { -v } else { v };
+                let one_at_working_scale = $core::one_agm(working_scale);
+                let working_value = $core::to_work_agm(raw);
+                let abs_working_value = if working_value < $core::zero_agm() {
+                    -working_value
+                } else {
+                    working_value
+                };
                 // asinh @ MAX scale (input ±1) loses sub-w precision in the
                 // sqrt step before ln; tang_ln_fixed's INTERNAL_EXTRA
                 // residue-signal can't detect that caller-side loss. Keep
                 // on Series (`ln_fixed_agm`) until ln_fixed_routed gains a
                 // PRE_RESIDUE flag (memory project_050_asinh_max_tang_residue).
-                let inner = if ax >= one_w {
-                    let inv = $core::div_agm(one_w, ax, w);
-                    let root = $core::sqrt_fixed_agm(one_w + $core::mul_agm(inv, inv, w), w);
-                    $core::ln_fixed_series_agm(ax, w) + $core::ln_fixed_series_agm(one_w + root, w)
+                let inner = if abs_working_value >= one_at_working_scale {
+                    let reciprocal =
+                        $core::div_agm(one_at_working_scale, abs_working_value, working_scale);
+                    let root = $core::sqrt_fixed_agm(
+                        one_at_working_scale
+                            + $core::mul_agm(reciprocal, reciprocal, working_scale),
+                        working_scale
+                    );
+                    $core::ln_fixed_series_agm(abs_working_value, working_scale)
+                        + $core::ln_fixed_series_agm(one_at_working_scale + root, working_scale)
                 } else {
-                    let root = $core::sqrt_fixed_agm($core::mul_agm(ax, ax, w) + one_w, w);
-                    $core::ln_fixed_series_agm(ax + root, w)
+                    let root = $core::sqrt_fixed_agm(
+                        $core::mul_agm(abs_working_value, abs_working_value, working_scale)
+                            + one_at_working_scale,
+                        working_scale
+                    );
+                    $core::ln_fixed_series_agm(abs_working_value + root, working_scale)
                 };
                 let signed = if raw < $crate::macros::wide_roots::wide_lit!($Storage, "0") {
                     -inner
                 } else {
                     inner
                 };
-                Self::from_bits($core::round_to_storage_agm(signed, w, SCALE))
+                Self::from_bits($core::round_to_storage_agm(signed, working_scale, SCALE))
             }
 
             /// Inverse hyperbolic cosine, as `ln(x + √(x² − 1))`,
@@ -3420,30 +3747,38 @@ macro_rules! decl_wide_transcendental {
             #[inline]
             #[must_use]
             pub fn acosh_strict(self) -> Self {
-                let w = SCALE + $core::GUARD;
+                let working_scale = SCALE + $core::GUARD;
                 // Two-core: composition runs on the wide `Wagm` work int.
-                let one_w = $core::one_agm(w);
-                let v = $core::to_work_agm(self.to_bits());
-                if v < one_w {
+                let one_at_working_scale = $core::one_agm(working_scale);
+                let working_value = $core::to_work_agm(self.to_bits());
+                if working_value < one_at_working_scale {
                     panic!(concat!(stringify!($Type), "::acosh: argument must be >= 1"));
                 }
-                let two_w = one_w + one_w;
-                let inner = if v >= two_w {
-                    let inv = $core::div_agm(one_w, v, w);
-                    let root = $core::sqrt_fixed_agm(one_w - $core::mul_agm(inv, inv, w), w);
-                    $core::ln_fixed_routed_agm::<SCALE>(v, w) + $core::ln_fixed_routed_agm::<SCALE>(one_w + root, w)
+                let two_at_working_scale = one_at_working_scale + one_at_working_scale;
+                let inner = if working_value >= two_at_working_scale {
+                    let reciprocal =
+                        $core::div_agm(one_at_working_scale, working_value, working_scale);
+                    let root = $core::sqrt_fixed_agm(
+                        one_at_working_scale
+                            - $core::mul_agm(reciprocal, reciprocal, working_scale),
+                        working_scale
+                    );
+                    $core::ln_fixed_routed_agm::<SCALE>(working_value, working_scale) + $core::ln_fixed_routed_agm::<SCALE>(one_at_working_scale + root, working_scale)
                 } else {
                     // Near 1: acosh(1+t) = log1p(t + sqrt(t*(t+2))).
-                    // `t = v - one_w` is the exact gap above 1, so
+                    // The gap above 1 is exact, so
                     // `v^2 - 1 = (v-1)*(v+1) = t*(t+2)` is formed without
-                    // the catastrophic cancellation of `mul(v,v) - one_w`
+                    // the catastrophic cancellation of `mul(v,v) - 1`
                     // as `v -> 1`, and `log1p` avoids re-forming `1 + arg`
                     // when the gap (hence `arg`) is tiny.
-                    let t = v - one_w;
-                    let root = $core::sqrt_fixed_agm($core::mul_agm(t, t + two_w, w), w);
-                    $core::log1p_fixed::<$core::Wagm>(t + root, w)
+                    let gap = working_value - one_at_working_scale;
+                    let root = $core::sqrt_fixed_agm(
+                        $core::mul_agm(gap, gap + two_at_working_scale, working_scale),
+                        working_scale
+                    );
+                    $core::log1p_fixed::<$core::Wagm>(gap + root, working_scale)
                 };
-                Self::from_bits($core::round_to_storage_agm(inner, w, SCALE))
+                Self::from_bits($core::round_to_storage_agm(inner, working_scale, SCALE))
             }
 
             /// Inverse hyperbolic tangent, as `ln((1+x)/(1−x)) / 2`,
@@ -3452,27 +3787,32 @@ macro_rules! decl_wide_transcendental {
             #[inline]
             #[must_use]
             pub fn atanh_strict(self) -> Self {
-                let w = SCALE + $core::GUARD;
+                let working_scale = SCALE + $core::GUARD;
                 // Two-core: the composition runs on the wide `Wagm` work int
                 // (its ln + the gap-form subtraction), narrowing back to
                 // storage at the end — so a narrowed primitive `$Work` does
                 // not clip the composition's precision.
-                let one_w = $core::one_agm(w);
-                let v = $core::to_work_agm(self.to_bits());
-                let ax = if v < $core::zero_agm() { -v } else { v };
-                if ax >= one_w {
+                let one_at_working_scale = $core::one_agm(working_scale);
+                let working_value = $core::to_work_agm(self.to_bits());
+                let abs_working_value = if working_value < $core::zero_agm() {
+                    -working_value
+                } else {
+                    working_value
+                };
+                if abs_working_value >= one_at_working_scale {
                     panic!(concat!(
                         stringify!($Type),
                         "::atanh: argument out of domain (-1, 1)"
                     ));
                 }
                 // Gap form: atanh(x) = (1/2)*[ln(1+x) - ln(1-x)].
-                // `one_w - v` is the exact working-scale gap (`v` is the
+                // `one_at_working_scale - working_value` is the exact
+                // working-scale gap (`working_value` is the
                 // storage input lifted by appending guard zeros), so
                 // neither `ln_fixed` argument suffers the `(1-x)`
                 // catastrophic cancellation the ratio form does near +-1.
-                let r = ($core::ln_fixed_routed_agm::<SCALE>(one_w + v, w) - $core::ln_fixed_routed_agm::<SCALE>(one_w - v, w)) >> 1;
-                Self::from_bits($core::round_to_storage_agm(r, w, SCALE))
+                let atanh_value = ($core::ln_fixed_routed_agm::<SCALE>(one_at_working_scale + working_value, working_scale) - $core::ln_fixed_routed_agm::<SCALE>(one_at_working_scale - working_value, working_scale)) >> 1;
+                Self::from_bits($core::round_to_storage_agm(atanh_value, working_scale, SCALE))
             }
 
             /// Convert radians to degrees: `self · (180 / π)`. Strict
@@ -3481,19 +3821,19 @@ macro_rules! decl_wide_transcendental {
             #[inline]
             #[must_use]
             pub fn to_degrees_strict(self) -> Self {
-                let w = SCALE + $core::GUARD;
-                let v = $core::to_work(self.to_bits());
+                let working_scale = SCALE + $core::GUARD;
+                let working_value = $core::to_work(self.to_bits());
                 // `x * 180/π`: multiply by the const-folded `deg_per_rad`
                 // (180/π) constant instead of dividing by the runtime-
-                // recomputed `pi(w)`. Same value, but no per-call π
+                // recomputed `pi(working_scale)`. Same value, but no per-call π
                 // rescale (`const_rounded`) and no divide — mirrors
                 // `to_radians_strict`'s `pi_cf` multiply path.
-                let r = $core::mul(
-                    v,
-                    $core::deg_per_rad_cf::<SCALE>(w, $crate::support::rounding::DEFAULT_ROUNDING_MODE),
-                    w,
+                let degrees = $core::mul(
+                    working_value,
+                    $core::deg_per_rad_cf::<SCALE>(working_scale, $crate::support::rounding::DEFAULT_ROUNDING_MODE),
+                    working_scale,
                 );
-                Self::from_bits($core::round_to_storage(r, w, SCALE))
+                Self::from_bits($core::round_to_storage(degrees, working_scale, SCALE))
             }
 
             /// Convert degrees to radians: `self · (π / 180)`. Strict
@@ -3504,14 +3844,14 @@ macro_rules! decl_wide_transcendental {
             #[inline]
             #[must_use]
             pub fn to_radians_strict(self) -> Self {
-                let w = SCALE + $core::GUARD;
-                let v = $core::to_work(self.to_bits());
-                let r = $core::mul(
-                    v,
-                    $core::pi_cf::<SCALE>(w, $crate::support::rounding::DEFAULT_ROUNDING_MODE),
-                    w,
+                let working_scale = SCALE + $core::GUARD;
+                let working_value = $core::to_work(self.to_bits());
+                let radians = $core::mul(
+                    working_value,
+                    $core::pi_cf::<SCALE>(working_scale, $crate::support::rounding::DEFAULT_ROUNDING_MODE),
+                    working_scale,
                 ) / $crate::macros::wide_roots::wide_lit!($Work, "180");
-                Self::from_bits($core::round_to_storage(r, w, SCALE))
+                Self::from_bits($core::round_to_storage(radians, working_scale, SCALE))
             }
 
             // ---- Mode-aware siblings ----
@@ -3558,12 +3898,17 @@ macro_rules! decl_wide_transcendental {
                         "::ln_agm: argument must be positive"
                     ));
                 }
-                let w_prime = SCALE + $core::GUARD + $core::guard_agm(SCALE);
-                let r = $core::ln_fixed_agm::<SCALE>(
+                let lifted_working_scale = SCALE + $core::GUARD + $core::guard_agm(SCALE);
+                let ln_value = $core::ln_fixed_agm::<SCALE>(
                     $core::to_work_scaled(raw, $core::GUARD + $core::guard_agm(SCALE)),
-                    w_prime,
+                    lifted_working_scale,
                 );
-                Self::from_bits($core::round_to_storage_with(r, w_prime, SCALE, mode))
+                Self::from_bits($core::round_to_storage_with(
+                    ln_value,
+                    lifted_working_scale,
+                    SCALE,
+                    mode
+                ))
             }
 
             /// Mode-aware sibling of [`Self::exp_strict_agm`].
@@ -3581,9 +3926,17 @@ macro_rules! decl_wide_transcendental {
                 let raw_w = $core::to_work_scaled(raw, 0);
                 let k_lift = $core::exp_agm_k_lift_from_w(raw_w, SCALE);
                 let lift = $core::GUARD + $core::guard_agm(SCALE) + k_lift;
-                let w_prime = SCALE + lift;
-                let r = $core::exp_fixed_agm::<SCALE>($core::to_work_scaled(raw, lift), w_prime);
-                Self::from_bits($core::round_to_storage_with(r, w_prime, SCALE, mode))
+                let lifted_working_scale = SCALE + lift;
+                let exp_value = $core::exp_fixed_agm::<SCALE>(
+                    $core::to_work_scaled(raw, lift),
+                    lifted_working_scale
+                );
+                Self::from_bits($core::round_to_storage_with(
+                    exp_value,
+                    lifted_working_scale,
+                    SCALE,
+                    mode
+                ))
             }
 
             /// Mode-aware sibling of [`Self::log_strict`].
@@ -3662,7 +4015,7 @@ macro_rules! decl_wide_transcendental {
                 // Trunc by 1 LSB. `None` (fractional base/exponent, or a
                 // positive power out of range) defers to the composition below,
                 // which panics uniformly on a genuinely out-of-range result.
-                if let ::core::option::Option::Some(v) =
+                if let ::core::option::Option::Some(pinned) =
                     $crate::algos::pow::powi_exact::powi_exact_pin::<$Storage, SCALE>(
                         raw,
                         exp.to_bits(),
@@ -3670,27 +4023,27 @@ macro_rules! decl_wide_transcendental {
                         mode,
                     )
                 {
-                    return Self::from_bits(v);
+                    return Self::from_bits(pinned);
                 }
                 // Fractional-base integer-exponent fast path — see
                 // [`Self::powf_strict`]; here under the caller's `mode`.
-                if let ::core::option::Option::Some(n) =
+                if let ::core::option::Option::Some(integer_exponent) =
                     $crate::algos::pow::powi_exact::exp_as_small_int_raw::<$Storage, SCALE>(
                         exp.to_bits(),
                     )
                 {
-                    if n == 0 {
+                    if integer_exponent == 0 {
                         return Self::ONE;
                     }
-                    if let ::core::option::Option::Some(v) =
+                    if let ::core::option::Option::Some(pinned) =
                         $crate::algos::pow::powi_exact::powi_terminating_pin::<$Storage, SCALE>(
                             raw,
-                            n,
+                            integer_exponent,
                             <$Storage>::MAX,
                             mode,
                         )
                     {
-                        return Self::from_bits(v);
+                        return Self::from_bits(pinned);
                     }
                 }
                 // x^0.5 ≡ √x. The exp(0.5·ln x) chain loses a sub-ULP at a
@@ -3700,12 +4053,12 @@ macro_rules! decl_wide_transcendental {
                 // so route the exact-half exponent through it.
                 {
                     let two = $crate::macros::wide_roots::wide_lit!($Storage, "2");
-                    let mult = Self::multiplier();
-                    if exp.to_bits() == mult / two {
+                    let multiplier = Self::multiplier();
+                    if exp.to_bits() == multiplier / two {
                         return self.sqrt_strict_with(mode);
                     }
                 }
-                let eraw = exp.to_bits();
+                let exponent_raw = exp.to_bits();
                 // Large-result lift. `x^y = exp(y·ln x)` carries
                 // `~|y·ln x|·log10(e)` integer digits; size the working
                 // lift from a base-guard probe of the exp argument so the
@@ -3714,9 +4067,16 @@ macro_rules! decl_wide_transcendental {
                 // Two-core: composition runs on the wide `Wagm` work int
                 // (the exp argument `y·ln x` can exceed a narrowed `$Work`).
                 let k_lift = {
-                    let w0 = SCALE + $core::GUARD;
-                    let ln_x0 = $core::ln_fixed_routed_agm::<SCALE>($core::to_work_agm(raw), w0);
-                    let arg0 = $core::mul_agm($core::to_work_agm(eraw), ln_x0, w0);
+                    let base_working_scale = SCALE + $core::GUARD;
+                    let probe_ln_x = $core::ln_fixed_routed_agm::<SCALE>(
+                        $core::to_work_agm(raw),
+                        base_working_scale
+                    );
+                    let probe_exp_arg = $core::mul_agm(
+                        $core::to_work_agm(exponent_raw),
+                        probe_ln_x,
+                        base_working_scale
+                    );
                     // Analytic storage-overflow gate, BEFORE the
                     // result-sized lift below: a deep-overflow argument
                     // (`e^arg` provably past storage) would size `k_lift`
@@ -3729,8 +4089,8 @@ macro_rules! decl_wide_transcendental {
                     // SUFFICIENT bound, so no representable cell fires it
                     // (see `algos::pow::powf_overflow_gate`).
                     if $crate::algos::pow::powf_overflow_gate::powf_overflow_gate_g::<$core::Wagm>(
-                        arg0,
-                        w0,
+                        probe_exp_arg,
+                        base_working_scale,
                         <$Storage as $crate::int::types::traits::BigInt>::BITS,
                         SCALE,
                     ) {
@@ -3739,12 +4099,13 @@ macro_rules! decl_wide_transcendental {
                             SCALE,
                         );
                     }
-                    // `arg0` is the exp argument at scale `w0`; narrow it
+                    // `probe_exp_arg` is the exp argument at the base working
+                    // scale; narrow it
                     // to scale `SCALE` to feed the `e^|·|` digit sizer
                     // (squaring-safe capped).
                     let arg_at_scale = $core::round_to_storage_with_g::<$core::Wagm>(
-                        arg0,
-                        w0,
+                        probe_exp_arg,
+                        base_working_scale,
                         SCALE,
                         $crate::support::rounding::RoundingMode::Trunc,
                     );
@@ -3767,16 +4128,16 @@ macro_rules! decl_wide_transcendental {
                         $core::exp_result_int_digits::<$core::Wagm>($core::to_work_scaled_agm(arg_at_scale, 0), SCALE)
                     }
                 };
-                let base_guard = $core::GUARD + k_lift;
+                let base_guard_digits = $core::GUARD + k_lift;
                 Self::from_bits($core::round_to_storage_directed::<$core::Wagm>(
-                    base_guard,
+                    base_guard_digits,
                     SCALE,
                     mode,
-                    |guard| {
-                        let w = SCALE + guard;
-                        let ln_x = $core::ln_fixed_routed_agm::<SCALE>($core::to_work_scaled_agm(raw, guard), w);
-                        let y = $core::to_work_scaled_agm(eraw, guard);
-                        $core::exp_fixed_routed_agm::<SCALE>($core::mul_agm(y, ln_x, w), w)
+                    |guard_digits| {
+                        let working_scale = SCALE + guard_digits;
+                        let ln_x = $core::ln_fixed_routed_agm::<SCALE>($core::to_work_scaled_agm(raw, guard_digits), working_scale);
+                        let exponent_w = $core::to_work_scaled_agm(exponent_raw, guard_digits);
+                        $core::exp_fixed_routed_agm::<SCALE>($core::mul_agm(exponent_w, ln_x, working_scale), working_scale)
                     },
                 ))
             }
@@ -3929,16 +4290,17 @@ macro_rules! decl_wide_transcendental {
                 self,
                 mode: $crate::support::rounding::RoundingMode,
             ) -> Self {
-                let w = SCALE + $core::GUARD;
-                let v = $core::to_work(self.to_bits());
+                let working_scale = SCALE + $core::GUARD;
+                let working_value = $core::to_work(self.to_bits());
                 // See `to_degrees_strict`: const-folded `deg_per_rad`
-                // multiply, no runtime `pi(w)` recompute, no divide.
-                let r = $core::mul(
-                    v,
-                    $core::deg_per_rad_cf::<SCALE>(w, $crate::support::rounding::DEFAULT_ROUNDING_MODE),
-                    w,
+                // multiply, no runtime `pi(working_scale)` recompute, no
+                // divide.
+                let degrees = $core::mul(
+                    working_value,
+                    $core::deg_per_rad_cf::<SCALE>(working_scale, $crate::support::rounding::DEFAULT_ROUNDING_MODE),
+                    working_scale,
                 );
-                Self::from_bits($core::round_to_storage_with(r, w, SCALE, mode))
+                Self::from_bits($core::round_to_storage_with(degrees, working_scale, SCALE, mode))
             }
 
             /// Mode-aware sibling of [`Self::to_radians_strict`].
@@ -3948,14 +4310,14 @@ macro_rules! decl_wide_transcendental {
                 self,
                 mode: $crate::support::rounding::RoundingMode,
             ) -> Self {
-                let w = SCALE + $core::GUARD;
-                let v = $core::to_work(self.to_bits());
-                let r = $core::mul(
-                    v,
-                    $core::pi_cf::<SCALE>(w, $crate::support::rounding::DEFAULT_ROUNDING_MODE),
-                    w,
+                let working_scale = SCALE + $core::GUARD;
+                let working_value = $core::to_work(self.to_bits());
+                let radians = $core::mul(
+                    working_value,
+                    $core::pi_cf::<SCALE>(working_scale, $crate::support::rounding::DEFAULT_ROUNDING_MODE),
+                    working_scale,
                 ) / $crate::macros::wide_roots::wide_lit!($Work, "180");
-                Self::from_bits($core::round_to_storage_with(r, w, SCALE, mode))
+                Self::from_bits($core::round_to_storage_with(radians, working_scale, SCALE, mode))
             }
 
             /// Mode-aware sibling of [`Self::sin_cos_strict`].
@@ -3969,18 +4331,19 @@ macro_rules! decl_wide_transcendental {
                 // near-tie escape (a deciding digit can sit below the
                 // fixed w - the asin(3e-60) family), falling to the
                 // Ziv-escalated single-function path when inside the band.
-                let w = SCALE + $core::GUARD;
-                let (s, c) = $core::sin_cos_fixed::<SCALE>($core::to_work(self.to_bits()), w);
+                let working_scale = SCALE + $core::GUARD;
+                let (sin_w, cos_w) =
+                    $core::sin_cos_fixed::<SCALE>($core::to_work(self.to_bits()), working_scale);
                 let sin_bits = match $crate::algos::support::wide_trig_core::round_to_storage_clear_of_tie_g::<$Storage, _>(
-                    s, w, SCALE, mode, <$Storage>::MAX, <$Storage>::MIN,
+                    sin_w, working_scale, SCALE, mode, <$Storage>::MAX, <$Storage>::MIN,
                 ) {
-                    ::core::option::Option::Some(st) => st,
+                    ::core::option::Option::Some(narrowed) => narrowed,
                     ::core::option::Option::None => self.sin_strict_with(mode).to_bits(),
                 };
                 let cos_bits = match $crate::algos::support::wide_trig_core::round_to_storage_clear_of_tie_g::<$Storage, _>(
-                    c, w, SCALE, mode, <$Storage>::MAX, <$Storage>::MIN,
+                    cos_w, working_scale, SCALE, mode, <$Storage>::MAX, <$Storage>::MIN,
                 ) {
-                    ::core::option::Option::Some(st) => st,
+                    ::core::option::Option::Some(narrowed) => narrowed,
                     ::core::option::Option::None => self.cos_strict_with(mode).to_bits(),
                 };
                 (Self::from_bits(sin_bits), Self::from_bits(cos_bits))
@@ -3998,23 +4361,24 @@ macro_rules! decl_wide_transcendental {
                 // rational partials on rounding boundaries), falling to
                 // the analytically-pinned / Ziv-escalated single-function
                 // path when inside the band.
-                let w = SCALE + $core::GUARD;
+                let working_scale = SCALE + $core::GUARD;
                 // Two-core: composition runs on the wide `Wagm` work int.
-                let v = $core::to_work_agm(self.to_bits());
-                let ex = $core::exp_fixed_series_agm(v, w);
-                let enx = $core::div_agm($core::one_agm(w), ex, w);
-                let sinh = (ex - enx) >> 1;
-                let cosh = (ex + enx) >> 1;
+                let working_value = $core::to_work_agm(self.to_bits());
+                let exp_x = $core::exp_fixed_series_agm(working_value, working_scale);
+                let exp_neg_x =
+                    $core::div_agm($core::one_agm(working_scale), exp_x, working_scale);
+                let sinh_value = (exp_x - exp_neg_x) >> 1;
+                let cosh_value = (exp_x + exp_neg_x) >> 1;
                 let sinh_bits = match $crate::algos::support::wide_trig_core::round_to_storage_clear_of_tie_g::<$Storage, $core::Wagm>(
-                    sinh, w, SCALE, mode, <$Storage>::MAX, <$Storage>::MIN,
+                    sinh_value, working_scale, SCALE, mode, <$Storage>::MAX, <$Storage>::MIN,
                 ) {
-                    ::core::option::Option::Some(st) => st,
+                    ::core::option::Option::Some(narrowed) => narrowed,
                     ::core::option::Option::None => self.sinh_strict_with(mode).to_bits(),
                 };
                 let cosh_bits = match $crate::algos::support::wide_trig_core::round_to_storage_clear_of_tie_g::<$Storage, $core::Wagm>(
-                    cosh, w, SCALE, mode, <$Storage>::MAX, <$Storage>::MIN,
+                    cosh_value, working_scale, SCALE, mode, <$Storage>::MAX, <$Storage>::MIN,
                 ) {
-                    ::core::option::Option::Some(st) => st,
+                    ::core::option::Option::Some(narrowed) => narrowed,
                     ::core::option::Option::None => self.cosh_strict_with(mode).to_bits(),
                 };
                 (Self::from_bits(sinh_bits), Self::from_bits(cosh_bits))
@@ -4054,9 +4418,9 @@ macro_rules! decl_wide_transcendental {
                         "::ln: argument must be positive"
                     ));
                 }
-                let w = SCALE + working_digits;
-                let r = $core::ln_fixed_routed::<SCALE>($core::to_work_scaled(raw, working_digits), w);
-                Self::from_bits($core::round_to_storage_with(r, w, SCALE, mode))
+                let working_scale = SCALE + working_digits;
+                let ln_value = $core::ln_fixed_routed::<SCALE>($core::to_work_scaled(raw, working_digits), working_scale);
+                Self::from_bits($core::round_to_storage_with(ln_value, working_scale, SCALE, mode))
             }
 
             /// `ln(1 + self)` with caller-chosen guard digits.
@@ -4217,9 +4581,9 @@ macro_rules! decl_wide_transcendental {
                 if raw == $crate::macros::wide_roots::wide_lit!($Storage, "0") {
                     return Self::ONE;
                 }
-                let w = SCALE + working_digits;
-                let r = $core::exp_fixed_routed::<SCALE>($core::to_work_scaled(raw, working_digits), w);
-                Self::from_bits($core::round_to_storage_with(r, w, SCALE, mode))
+                let working_scale = SCALE + working_digits;
+                let exp_value = $core::exp_fixed_routed::<SCALE>($core::to_work_scaled(raw, working_digits), working_scale);
+                Self::from_bits($core::round_to_storage_with(exp_value, working_scale, SCALE, mode))
             }
 
             /// `2ˣ` with caller-chosen guard digits.
@@ -4270,12 +4634,12 @@ macro_rules! decl_wide_transcendental {
                 if raw <= $crate::macros::wide_roots::wide_lit!($Storage, "0") {
                     return Self::ZERO;
                 }
-                let w = SCALE + working_digits;
+                let working_scale = SCALE + working_digits;
                 // Two-core: composition runs on the wide `Wagm` work int.
-                let ln_x = $core::ln_fixed_routed_agm::<SCALE>($core::to_work_scaled_agm(raw, working_digits), w);
-                let y = $core::to_work_scaled_agm(exp.to_bits(), working_digits);
-                let r = $core::exp_fixed_routed_agm::<SCALE>($core::mul_agm(y, ln_x, w), w);
-                Self::from_bits($core::round_to_storage_with_g::<$core::Wagm>(r, w, SCALE, mode))
+                let ln_x = $core::ln_fixed_routed_agm::<SCALE>($core::to_work_scaled_agm(raw, working_digits), working_scale);
+                let exponent_w = $core::to_work_scaled_agm(exp.to_bits(), working_digits);
+                let powf_value = $core::exp_fixed_routed_agm::<SCALE>($core::mul_agm(exponent_w, ln_x, working_scale), working_scale);
+                Self::from_bits($core::round_to_storage_with_g::<$core::Wagm>(powf_value, working_scale, SCALE, mode))
             }
 
             /// Sine with caller-chosen guard digits.
@@ -4299,9 +4663,9 @@ macro_rules! decl_wide_transcendental {
                 if working_digits == $core::GUARD {
                     return self.sin_strict_with(mode);
                 }
-                let w = SCALE + working_digits;
-                let r = $core::sin_fixed::<SCALE>($core::to_work_scaled(self.to_bits(), working_digits), w);
-                Self::from_bits($core::round_to_storage_with(r, w, SCALE, mode))
+                let working_scale = SCALE + working_digits;
+                let sin_value = $core::sin_fixed::<SCALE>($core::to_work_scaled(self.to_bits(), working_digits), working_scale);
+                Self::from_bits($core::round_to_storage_with(sin_value, working_scale, SCALE, mode))
             }
 
             /// Cosine with caller-chosen guard digits.
@@ -4325,10 +4689,10 @@ macro_rules! decl_wide_transcendental {
                 if working_digits == $core::GUARD {
                     return self.cos_strict_with(mode);
                 }
-                let w = SCALE + working_digits;
-                let arg = $core::to_work_scaled(self.to_bits(), working_digits) + $core::half_pi::<SCALE>(w);
-                let r = $core::sin_fixed::<SCALE>(arg, w);
-                Self::from_bits($core::round_to_storage_with(r, w, SCALE, mode))
+                let working_scale = SCALE + working_digits;
+                let shifted_arg = $core::to_work_scaled(self.to_bits(), working_digits) + $core::half_pi::<SCALE>(working_scale);
+                let cos_value = $core::sin_fixed::<SCALE>(shifted_arg, working_scale);
+                Self::from_bits($core::round_to_storage_with(cos_value, working_scale, SCALE, mode))
             }
 
             /// Joint sine/cosine with caller-chosen guard digits.
@@ -4352,12 +4716,12 @@ macro_rules! decl_wide_transcendental {
                 if working_digits == $core::GUARD {
                     return self.sin_cos_strict_with(mode);
                 }
-                let w = SCALE + working_digits;
-                let (s, c) =
-                    $core::sin_cos_fixed::<SCALE>($core::to_work_scaled(self.to_bits(), working_digits), w);
+                let working_scale = SCALE + working_digits;
+                let (sin_w, cos_w) =
+                    $core::sin_cos_fixed::<SCALE>($core::to_work_scaled(self.to_bits(), working_digits), working_scale);
                 (
-                    Self::from_bits($core::round_to_storage_with(s, w, SCALE, mode)),
-                    Self::from_bits($core::round_to_storage_with(c, w, SCALE, mode)),
+                    Self::from_bits($core::round_to_storage_with(sin_w, working_scale, SCALE, mode)),
+                    Self::from_bits($core::round_to_storage_with(cos_w, working_scale, SCALE, mode)),
                 )
             }
 
@@ -4382,17 +4746,17 @@ macro_rules! decl_wide_transcendental {
                 if working_digits == $core::GUARD {
                     return self.tan_strict_with(mode);
                 }
-                let w = SCALE + working_digits;
+                let working_scale = SCALE + working_digits;
                 let (sin_w, cos_w) =
-                    $core::sin_cos_fixed::<SCALE>($core::to_work_scaled(self.to_bits(), working_digits), w);
+                    $core::sin_cos_fixed::<SCALE>($core::to_work_scaled(self.to_bits(), working_digits), working_scale);
                 if cos_w == $core::zero() {
                     panic!(concat!(
                         stringify!($Type),
                         "::tan: cosine is zero (argument is an odd multiple of pi/2)"
                     ));
                 }
-                let r = $core::div(sin_w, cos_w, w);
-                Self::from_bits($core::round_to_storage_with(r, w, SCALE, mode))
+                let tan_value = $core::div(sin_w, cos_w, working_scale);
+                Self::from_bits($core::round_to_storage_with(tan_value, working_scale, SCALE, mode))
             }
 
             /// Arctangent with caller-chosen guard digits.
@@ -4416,9 +4780,9 @@ macro_rules! decl_wide_transcendental {
                 if working_digits == $core::GUARD {
                     return self.atan_strict_with(mode);
                 }
-                let w = SCALE + working_digits;
-                let r = $core::atan_fixed::<SCALE>($core::to_work_scaled(self.to_bits(), working_digits), w);
-                Self::from_bits($core::round_to_storage_with(r, w, SCALE, mode))
+                let working_scale = SCALE + working_digits;
+                let atan_value = $core::atan_fixed::<SCALE>($core::to_work_scaled(self.to_bits(), working_digits), working_scale);
+                Self::from_bits($core::round_to_storage_with(atan_value, working_scale, SCALE, mode))
             }
 
             /// Arcsine with caller-chosen guard digits.
@@ -4442,37 +4806,52 @@ macro_rules! decl_wide_transcendental {
                 if working_digits == $core::GUARD {
                     return self.asin_strict_with(mode);
                 }
-                let w = SCALE + working_digits;
-                let one_w = $core::one(w);
-                let v = $core::to_work_scaled(self.to_bits(), working_digits);
-                let abs_v = if v < $core::zero() { -v } else { v };
-                if abs_v > one_w {
+                let working_scale = SCALE + working_digits;
+                let one_at_working_scale = $core::one(working_scale);
+                let working_value = $core::to_work_scaled(self.to_bits(), working_digits);
+                let abs_working_value = if working_value < $core::zero() {
+                    -working_value
+                } else {
+                    working_value
+                };
+                if abs_working_value > one_at_working_scale {
                     panic!(concat!(
                         stringify!($Type),
                         "::asin: argument out of domain [-1, 1]"
                     ));
                 }
-                let half_w = one_w >> 1;
-                let r = if abs_v == one_w {
-                    let hp = $core::half_pi::<SCALE>(w);
-                    if v < $core::zero() { -hp } else { hp }
-                } else if abs_v <= half_w {
-                    let denom = $core::sqrt_fixed(one_w - $core::mul(v, v, w), w);
-                    $core::atan_fixed::<SCALE>($core::div(v, denom, w), w)
+                let half_at_working_scale = one_at_working_scale >> 1;
+                let asin_value = if abs_working_value == one_at_working_scale {
+                    let half_pi_w = $core::half_pi::<SCALE>(working_scale);
+                    if working_value < $core::zero() { -half_pi_w } else { half_pi_w }
+                } else if abs_working_value <= half_at_working_scale {
+                    let divisor = $core::sqrt_fixed(
+                        one_at_working_scale
+                            - $core::mul(working_value, working_value, working_scale),
+                        working_scale
+                    );
+                    $core::atan_fixed::<SCALE>(
+                        $core::div(working_value, divisor, working_scale),
+                        working_scale
+                    )
                 } else {
-                    let inner = (one_w - abs_v) >> 1;
-                    let inner_sqrt = $core::sqrt_fixed(inner, w);
-                    let inner_denom =
-                        $core::sqrt_fixed(one_w - $core::mul(inner_sqrt, inner_sqrt, w), w);
-                    let inner_asin = $core::atan_fixed::<SCALE>($core::div(inner_sqrt, inner_denom, w), w);
-                    let result_abs = $core::half_pi::<SCALE>(w) - inner_asin - inner_asin;
-                    if v < $core::zero() {
-                        -result_abs
+                    let inner = (one_at_working_scale - abs_working_value) >> 1;
+                    let inner_sqrt = $core::sqrt_fixed(inner, working_scale);
+                    let inner_divisor = $core::sqrt_fixed(
+                        one_at_working_scale
+                            - $core::mul(inner_sqrt, inner_sqrt, working_scale),
+                        working_scale
+                    );
+                    let inner_asin = $core::atan_fixed::<SCALE>($core::div(inner_sqrt, inner_divisor, working_scale), working_scale);
+                    let abs_asin =
+                        $core::half_pi::<SCALE>(working_scale) - inner_asin - inner_asin;
+                    if working_value < $core::zero() {
+                        -abs_asin
                     } else {
-                        result_abs
+                        abs_asin
                     }
                 };
-                Self::from_bits($core::round_to_storage_with(r, w, SCALE, mode))
+                Self::from_bits($core::round_to_storage_with(asin_value, working_scale, SCALE, mode))
             }
 
             /// Arccosine with caller-chosen guard digits.
@@ -4496,38 +4875,53 @@ macro_rules! decl_wide_transcendental {
                 if working_digits == $core::GUARD {
                     return self.acos_strict_with(mode);
                 }
-                let w = SCALE + working_digits;
-                let one_w = $core::one(w);
-                let v = $core::to_work_scaled(self.to_bits(), working_digits);
-                let abs_v = if v < $core::zero() { -v } else { v };
-                if abs_v > one_w {
+                let working_scale = SCALE + working_digits;
+                let one_at_working_scale = $core::one(working_scale);
+                let working_value = $core::to_work_scaled(self.to_bits(), working_digits);
+                let abs_working_value = if working_value < $core::zero() {
+                    -working_value
+                } else {
+                    working_value
+                };
+                if abs_working_value > one_at_working_scale {
                     panic!(concat!(
                         stringify!($Type),
                         "::acos: argument out of domain [-1, 1]"
                     ));
                 }
-                let half_w = one_w >> 1;
-                let asin_w = if abs_v == one_w {
-                    let hp = $core::half_pi::<SCALE>(w);
-                    if v < $core::zero() { -hp } else { hp }
-                } else if abs_v <= half_w {
-                    let denom = $core::sqrt_fixed(one_w - $core::mul(v, v, w), w);
-                    $core::atan_fixed::<SCALE>($core::div(v, denom, w), w)
+                let half_at_working_scale = one_at_working_scale >> 1;
+                let asin_w = if abs_working_value == one_at_working_scale {
+                    let half_pi_w = $core::half_pi::<SCALE>(working_scale);
+                    if working_value < $core::zero() { -half_pi_w } else { half_pi_w }
+                } else if abs_working_value <= half_at_working_scale {
+                    let divisor = $core::sqrt_fixed(
+                        one_at_working_scale
+                            - $core::mul(working_value, working_value, working_scale),
+                        working_scale
+                    );
+                    $core::atan_fixed::<SCALE>(
+                        $core::div(working_value, divisor, working_scale),
+                        working_scale
+                    )
                 } else {
-                    let inner = (one_w - abs_v) >> 1;
-                    let inner_sqrt = $core::sqrt_fixed(inner, w);
-                    let inner_denom =
-                        $core::sqrt_fixed(one_w - $core::mul(inner_sqrt, inner_sqrt, w), w);
-                    let inner_asin = $core::atan_fixed::<SCALE>($core::div(inner_sqrt, inner_denom, w), w);
-                    let result_abs = $core::half_pi::<SCALE>(w) - inner_asin - inner_asin;
-                    if v < $core::zero() {
-                        -result_abs
+                    let inner = (one_at_working_scale - abs_working_value) >> 1;
+                    let inner_sqrt = $core::sqrt_fixed(inner, working_scale);
+                    let inner_divisor = $core::sqrt_fixed(
+                        one_at_working_scale
+                            - $core::mul(inner_sqrt, inner_sqrt, working_scale),
+                        working_scale
+                    );
+                    let inner_asin = $core::atan_fixed::<SCALE>($core::div(inner_sqrt, inner_divisor, working_scale), working_scale);
+                    let abs_asin =
+                        $core::half_pi::<SCALE>(working_scale) - inner_asin - inner_asin;
+                    if working_value < $core::zero() {
+                        -abs_asin
                     } else {
-                        result_abs
+                        abs_asin
                     }
                 };
-                let r = $core::half_pi::<SCALE>(w) - asin_w;
-                Self::from_bits($core::round_to_storage_with(r, w, SCALE, mode))
+                let acos_value = $core::half_pi::<SCALE>(working_scale) - asin_w;
+                Self::from_bits($core::round_to_storage_with(acos_value, working_scale, SCALE, mode))
             }
 
             /// Four-quadrant arctangent with caller-chosen guard digits.
@@ -4553,34 +4947,38 @@ macro_rules! decl_wide_transcendental {
                 if working_digits == $core::GUARD {
                     return self.atan2_strict_with(other, mode);
                 }
-                let w = SCALE + working_digits;
-                let z = $crate::macros::wide_roots::wide_lit!($Storage, "0");
-                let yraw = self.to_bits();
-                let xraw = other.to_bits();
-                let r = if xraw == z {
-                    if yraw > z {
-                        $core::half_pi::<SCALE>(w)
-                    } else if yraw < z {
-                        -$core::half_pi::<SCALE>(w)
+                let working_scale = SCALE + working_digits;
+                let zero_raw = $crate::macros::wide_roots::wide_lit!($Storage, "0");
+                let y_raw = self.to_bits();
+                let x_raw = other.to_bits();
+                let atan2_value = if x_raw == zero_raw {
+                    if y_raw > zero_raw {
+                        $core::half_pi::<SCALE>(working_scale)
+                    } else if y_raw < zero_raw {
+                        -$core::half_pi::<SCALE>(working_scale)
                     } else {
                         $core::zero()
                     }
                 } else {
-                    let y = $core::to_work_scaled(yraw, working_digits);
-                    let x = $core::to_work_scaled(xraw, working_digits);
-                    let base = $core::atan_fixed::<SCALE>($core::div(y, x, w), w);
-                    // const-folded `π` (baked, no per-call `pi(w)` rescale);
+                    let y_w = $core::to_work_scaled(y_raw, working_digits);
+                    let x_w = $core::to_work_scaled(x_raw, working_digits);
+                    let principal = $core::atan_fixed::<SCALE>(
+                        $core::div(y_w, x_w, working_scale),
+                        working_scale
+                    );
+                    // const-folded `π` (baked, no per-call `pi(working_scale)`
+                    // rescale);
                     // `SCALE` is the impl's const so this folds to the table entry.
-                    let pi_w = $core::pi_cf::<SCALE>(w, $crate::support::rounding::DEFAULT_ROUNDING_MODE);
-                    if xraw > z {
-                        base
-                    } else if yraw >= z {
-                        base + pi_w
+                    let pi_at_working_scale = $core::pi_cf::<SCALE>(working_scale, $crate::support::rounding::DEFAULT_ROUNDING_MODE);
+                    if x_raw > zero_raw {
+                        principal
+                    } else if y_raw >= zero_raw {
+                        principal + pi_at_working_scale
                     } else {
-                        base - pi_w
+                        principal - pi_at_working_scale
                     }
                 };
-                Self::from_bits($core::round_to_storage_with(r, w, SCALE, mode))
+                Self::from_bits($core::round_to_storage_with(atan2_value, working_scale, SCALE, mode))
             }
 
             /// Hyperbolic sine with caller-chosen guard digits.
@@ -4604,13 +5002,14 @@ macro_rules! decl_wide_transcendental {
                 if working_digits == $core::GUARD {
                     return self.sinh_strict_with(mode);
                 }
-                let w = SCALE + working_digits;
+                let working_scale = SCALE + working_digits;
                 // Two-core: composition runs on the wide `Wagm` work int.
-                let v = $core::to_work_scaled_agm(self.to_bits(), working_digits);
-                let ex = $core::exp_fixed_series_agm(v, w);
-                let enx = $core::div_agm($core::one_agm(w), ex, w);
-                let r = (ex - enx) >> 1;
-                Self::from_bits($core::round_to_storage_with_g::<$core::Wagm>(r, w, SCALE, mode))
+                let working_value = $core::to_work_scaled_agm(self.to_bits(), working_digits);
+                let exp_x = $core::exp_fixed_series_agm(working_value, working_scale);
+                let exp_neg_x =
+                    $core::div_agm($core::one_agm(working_scale), exp_x, working_scale);
+                let sinh_value = (exp_x - exp_neg_x) >> 1;
+                Self::from_bits($core::round_to_storage_with_g::<$core::Wagm>(sinh_value, working_scale, SCALE, mode))
             }
 
             /// Hyperbolic cosine with caller-chosen guard digits.
@@ -4634,13 +5033,14 @@ macro_rules! decl_wide_transcendental {
                 if working_digits == $core::GUARD {
                     return self.cosh_strict_with(mode);
                 }
-                let w = SCALE + working_digits;
+                let working_scale = SCALE + working_digits;
                 // Two-core: composition runs on the wide `Wagm` work int.
-                let v = $core::to_work_scaled_agm(self.to_bits(), working_digits);
-                let ex = $core::exp_fixed_series_agm(v, w);
-                let enx = $core::div_agm($core::one_agm(w), ex, w);
-                let r = (ex + enx) >> 1;
-                Self::from_bits($core::round_to_storage_with_g::<$core::Wagm>(r, w, SCALE, mode))
+                let working_value = $core::to_work_scaled_agm(self.to_bits(), working_digits);
+                let exp_x = $core::exp_fixed_series_agm(working_value, working_scale);
+                let exp_neg_x =
+                    $core::div_agm($core::one_agm(working_scale), exp_x, working_scale);
+                let cosh_value = (exp_x + exp_neg_x) >> 1;
+                Self::from_bits($core::round_to_storage_with_g::<$core::Wagm>(cosh_value, working_scale, SCALE, mode))
             }
 
             /// Hyperbolic tangent with caller-chosen guard digits.
@@ -4664,13 +5064,15 @@ macro_rules! decl_wide_transcendental {
                 if working_digits == $core::GUARD {
                     return self.tanh_strict_with(mode);
                 }
-                let w = SCALE + working_digits;
+                let working_scale = SCALE + working_digits;
                 // Two-core: composition runs on the wide `Wagm` work int.
-                let v = $core::to_work_scaled_agm(self.to_bits(), working_digits);
-                let ex = $core::exp_fixed_series_agm(v, w);
-                let enx = $core::div_agm($core::one_agm(w), ex, w);
-                let r = $core::div_agm(ex - enx, ex + enx, w);
-                Self::from_bits($core::round_to_storage_with_g::<$core::Wagm>(r, w, SCALE, mode))
+                let working_value = $core::to_work_scaled_agm(self.to_bits(), working_digits);
+                let exp_x = $core::exp_fixed_series_agm(working_value, working_scale);
+                let exp_neg_x =
+                    $core::div_agm($core::one_agm(working_scale), exp_x, working_scale);
+                let tanh_value =
+                    $core::div_agm(exp_x - exp_neg_x, exp_x + exp_neg_x, working_scale);
+                Self::from_bits($core::round_to_storage_with_g::<$core::Wagm>(tanh_value, working_scale, SCALE, mode))
             }
 
             /// Joint sinh/cosh with caller-chosen guard digits.
@@ -4694,16 +5096,17 @@ macro_rules! decl_wide_transcendental {
                 if working_digits == $core::GUARD {
                     return self.sinh_cosh_strict_with(mode);
                 }
-                let w = SCALE + working_digits;
+                let working_scale = SCALE + working_digits;
                 // Two-core: composition runs on the wide `Wagm` work int.
-                let v = $core::to_work_scaled_agm(self.to_bits(), working_digits);
-                let ex = $core::exp_fixed_series_agm(v, w);
-                let enx = $core::div_agm($core::one_agm(w), ex, w);
-                let sinh = (ex - enx) >> 1;
-                let cosh = (ex + enx) >> 1;
+                let working_value = $core::to_work_scaled_agm(self.to_bits(), working_digits);
+                let exp_x = $core::exp_fixed_series_agm(working_value, working_scale);
+                let exp_neg_x =
+                    $core::div_agm($core::one_agm(working_scale), exp_x, working_scale);
+                let sinh_value = (exp_x - exp_neg_x) >> 1;
+                let cosh_value = (exp_x + exp_neg_x) >> 1;
                 (
-                    Self::from_bits($core::round_to_storage_with_g::<$core::Wagm>(sinh, w, SCALE, mode)),
-                    Self::from_bits($core::round_to_storage_with_g::<$core::Wagm>(cosh, w, SCALE, mode)),
+                    Self::from_bits($core::round_to_storage_with_g::<$core::Wagm>(sinh_value, working_scale, SCALE, mode)),
+                    Self::from_bits($core::round_to_storage_with_g::<$core::Wagm>(cosh_value, working_scale, SCALE, mode)),
                 )
             }
 
@@ -4732,30 +5135,44 @@ macro_rules! decl_wide_transcendental {
                 if raw == $crate::macros::wide_roots::wide_lit!($Storage, "0") {
                     return Self::ZERO;
                 }
-                let w = SCALE + working_digits;
+                let working_scale = SCALE + working_digits;
                 // Two-core: composition runs on the wide `Wagm` work int.
-                let one_w = $core::one_agm(w);
-                let v = $core::to_work_scaled_agm(raw, working_digits);
-                let ax = if v < $core::zero_agm() { -v } else { v };
+                let one_at_working_scale = $core::one_agm(working_scale);
+                let working_value = $core::to_work_scaled_agm(raw, working_digits);
+                let abs_working_value = if working_value < $core::zero_agm() {
+                    -working_value
+                } else {
+                    working_value
+                };
                 // asinh @ MAX scale (input ±1) loses sub-w precision in the
                 // sqrt step before ln; tang_ln_fixed's INTERNAL_EXTRA
                 // residue-signal can't detect that caller-side loss. Keep
                 // on Series (`ln_fixed_series_agm`) until ln_fixed_routed gains
                 // a PRE_RESIDUE flag (memory project_050_asinh_max_tang_residue).
-                let inner = if ax >= one_w {
-                    let inv = $core::div_agm(one_w, ax, w);
-                    let root = $core::sqrt_fixed_agm(one_w + $core::mul_agm(inv, inv, w), w);
-                    $core::ln_fixed_series_agm(ax, w) + $core::ln_fixed_series_agm(one_w + root, w)
+                let inner = if abs_working_value >= one_at_working_scale {
+                    let reciprocal =
+                        $core::div_agm(one_at_working_scale, abs_working_value, working_scale);
+                    let root = $core::sqrt_fixed_agm(
+                        one_at_working_scale
+                            + $core::mul_agm(reciprocal, reciprocal, working_scale),
+                        working_scale
+                    );
+                    $core::ln_fixed_series_agm(abs_working_value, working_scale)
+                        + $core::ln_fixed_series_agm(one_at_working_scale + root, working_scale)
                 } else {
-                    let root = $core::sqrt_fixed_agm($core::mul_agm(ax, ax, w) + one_w, w);
-                    $core::ln_fixed_series_agm(ax + root, w)
+                    let root = $core::sqrt_fixed_agm(
+                        $core::mul_agm(abs_working_value, abs_working_value, working_scale)
+                            + one_at_working_scale,
+                        working_scale
+                    );
+                    $core::ln_fixed_series_agm(abs_working_value + root, working_scale)
                 };
                 let signed = if raw < $crate::macros::wide_roots::wide_lit!($Storage, "0") {
                     -inner
                 } else {
                     inner
                 };
-                Self::from_bits($core::round_to_storage_with_g::<$core::Wagm>(signed, w, SCALE, mode))
+                Self::from_bits($core::round_to_storage_with_g::<$core::Wagm>(signed, working_scale, SCALE, mode))
             }
 
             /// Inverse hyperbolic cosine with caller-chosen guard digits.
@@ -4779,30 +5196,38 @@ macro_rules! decl_wide_transcendental {
                 if working_digits == $core::GUARD {
                     return self.acosh_strict_with(mode);
                 }
-                let w = SCALE + working_digits;
+                let working_scale = SCALE + working_digits;
                 // Two-core: composition runs on the wide `Wagm` work int.
-                let one_w = $core::one_agm(w);
-                let v = $core::to_work_scaled_agm(self.to_bits(), working_digits);
-                if v < one_w {
+                let one_at_working_scale = $core::one_agm(working_scale);
+                let working_value = $core::to_work_scaled_agm(self.to_bits(), working_digits);
+                if working_value < one_at_working_scale {
                     panic!(concat!(stringify!($Type), "::acosh: argument must be >= 1"));
                 }
-                let two_w = one_w + one_w;
-                let inner = if v >= two_w {
-                    let inv = $core::div_agm(one_w, v, w);
-                    let root = $core::sqrt_fixed_agm(one_w - $core::mul_agm(inv, inv, w), w);
-                    $core::ln_fixed_routed_agm::<SCALE>(v, w) + $core::ln_fixed_routed_agm::<SCALE>(one_w + root, w)
+                let two_at_working_scale = one_at_working_scale + one_at_working_scale;
+                let inner = if working_value >= two_at_working_scale {
+                    let reciprocal =
+                        $core::div_agm(one_at_working_scale, working_value, working_scale);
+                    let root = $core::sqrt_fixed_agm(
+                        one_at_working_scale
+                            - $core::mul_agm(reciprocal, reciprocal, working_scale),
+                        working_scale
+                    );
+                    $core::ln_fixed_routed_agm::<SCALE>(working_value, working_scale) + $core::ln_fixed_routed_agm::<SCALE>(one_at_working_scale + root, working_scale)
                 } else {
                     // Near 1: acosh(1+t) = log1p(t + sqrt(t*(t+2))).
-                    // `t = v - one_w` is the exact gap above 1, so
+                    // The gap above 1 is exact, so
                     // `v^2 - 1 = (v-1)*(v+1) = t*(t+2)` is formed without
-                    // the catastrophic cancellation of `mul(v,v) - one_w`
+                    // the catastrophic cancellation of `mul(v,v) - 1`
                     // as `v -> 1`, and `log1p` avoids re-forming `1 + arg`
                     // when the gap (hence `arg`) is tiny.
-                    let t = v - one_w;
-                    let root = $core::sqrt_fixed_agm($core::mul_agm(t, t + two_w, w), w);
-                    $core::log1p_fixed::<$core::Wagm>(t + root, w)
+                    let gap = working_value - one_at_working_scale;
+                    let root = $core::sqrt_fixed_agm(
+                        $core::mul_agm(gap, gap + two_at_working_scale, working_scale),
+                        working_scale
+                    );
+                    $core::log1p_fixed::<$core::Wagm>(gap + root, working_scale)
                 };
-                Self::from_bits($core::round_to_storage_with_g::<$core::Wagm>(inner, w, SCALE, mode))
+                Self::from_bits($core::round_to_storage_with_g::<$core::Wagm>(inner, working_scale, SCALE, mode))
             }
 
             /// Inverse hyperbolic tangent with caller-chosen guard digits.
@@ -4826,24 +5251,29 @@ macro_rules! decl_wide_transcendental {
                 if working_digits == $core::GUARD {
                     return self.atanh_strict_with(mode);
                 }
-                let w = SCALE + working_digits;
+                let working_scale = SCALE + working_digits;
                 // Two-core: composition runs on the wide `Wagm` work int.
-                let one_w = $core::one_agm(w);
-                let v = $core::to_work_scaled_agm(self.to_bits(), working_digits);
-                let ax = if v < $core::zero_agm() { -v } else { v };
-                if ax >= one_w {
+                let one_at_working_scale = $core::one_agm(working_scale);
+                let working_value = $core::to_work_scaled_agm(self.to_bits(), working_digits);
+                let abs_working_value = if working_value < $core::zero_agm() {
+                    -working_value
+                } else {
+                    working_value
+                };
+                if abs_working_value >= one_at_working_scale {
                     panic!(concat!(
                         stringify!($Type),
                         "::atanh: argument out of domain (-1, 1)"
                     ));
                 }
                 // Gap form: atanh(x) = (1/2)*[ln(1+x) - ln(1-x)].
-                // `one_w - v` is the exact working-scale gap (`v` is the
+                // `one_at_working_scale - working_value` is the exact
+                // working-scale gap (`working_value` is the
                 // storage input lifted by appending guard zeros), so
                 // neither `ln_fixed` argument suffers the `(1-x)`
                 // catastrophic cancellation the ratio form does near +-1.
-                let r = ($core::ln_fixed_routed_agm::<SCALE>(one_w + v, w) - $core::ln_fixed_routed_agm::<SCALE>(one_w - v, w)) >> 1;
-                Self::from_bits($core::round_to_storage_with_g::<$core::Wagm>(r, w, SCALE, mode))
+                let atanh_value = ($core::ln_fixed_routed_agm::<SCALE>(one_at_working_scale + working_value, working_scale) - $core::ln_fixed_routed_agm::<SCALE>(one_at_working_scale - working_value, working_scale)) >> 1;
+                Self::from_bits($core::round_to_storage_with_g::<$core::Wagm>(atanh_value, working_scale, SCALE, mode))
             }
 
             /// Radians-to-degrees with caller-chosen guard digits.
@@ -4867,21 +5297,21 @@ macro_rules! decl_wide_transcendental {
                 if working_digits == $core::GUARD {
                     return self.to_degrees_strict_with(mode);
                 }
-                let w = SCALE + working_digits;
-                let v = $core::to_work_scaled(self.to_bits(), working_digits);
+                let working_scale = SCALE + working_digits;
+                let working_value = $core::to_work_scaled(self.to_bits(), working_digits);
                 debug_assert!(
-                    $core::bit_length(v) + 8 < <$Work>::BITS,
+                    $core::bit_length(working_value) + 8 < <$Work>::BITS,
                     concat!(
                         stringify!($Type),
                         "::to_degrees: |self| * 180 overflows the working integer"
                     )
                 );
-                let r = $core::div(
-                    v * $crate::macros::wide_roots::wide_lit!($Work, "180"),
-                    $core::pi_cf::<SCALE>(w, $crate::support::rounding::DEFAULT_ROUNDING_MODE),
-                    w,
+                let degrees = $core::div(
+                    working_value * $crate::macros::wide_roots::wide_lit!($Work, "180"),
+                    $core::pi_cf::<SCALE>(working_scale, $crate::support::rounding::DEFAULT_ROUNDING_MODE),
+                    working_scale,
                 );
-                Self::from_bits($core::round_to_storage_with(r, w, SCALE, mode))
+                Self::from_bits($core::round_to_storage_with(degrees, working_scale, SCALE, mode))
             }
 
             /// Degrees-to-radians with caller-chosen guard digits.
@@ -4905,11 +5335,11 @@ macro_rules! decl_wide_transcendental {
                 if working_digits == $core::GUARD {
                     return self.to_radians_strict_with(mode);
                 }
-                let w = SCALE + working_digits;
-                let v = $core::to_work_scaled(self.to_bits(), working_digits);
-                let r = $core::mul(v, $core::pi_cf::<SCALE>(w, $crate::support::rounding::DEFAULT_ROUNDING_MODE), w)
+                let working_scale = SCALE + working_digits;
+                let working_value = $core::to_work_scaled(self.to_bits(), working_digits);
+                let radians = $core::mul(working_value, $core::pi_cf::<SCALE>(working_scale, $crate::support::rounding::DEFAULT_ROUNDING_MODE), working_scale)
                     / $crate::macros::wide_roots::wide_lit!($Work, "180");
-                Self::from_bits($core::round_to_storage_with(r, w, SCALE, mode))
+                Self::from_bits($core::round_to_storage_with(radians, working_scale, SCALE, mode))
             }
         }
 
@@ -5192,99 +5622,99 @@ mod tests {
         }
 
         for raw in positives {
-            let n = crate::D::<crate::int::types::Int<2>, 6>::from_bits(crate::int::types::Int::<2>::from_i128(raw as i128));
-            let w = crate::D::<crate::int::types::Int<4>, 6>::from_bits(crate::int::types::Int::<4>::from_i128(
+            let narrow = crate::D::<crate::int::types::Int<2>, 6>::from_bits(crate::int::types::Int::<2>::from_i128(raw as i128));
+            let wide = crate::D::<crate::int::types::Int<4>, 6>::from_bits(crate::int::types::Int::<4>::from_i128(
                 raw as i128,
             ));
             agree(
                 "ln",
                 raw,
-                w.ln_strict().to_bits().as_i128(),
-                n.ln_strict().to_bits().as_i128(),
+                wide.ln_strict().to_bits().as_i128(),
+                narrow.ln_strict().to_bits().as_i128(),
             );
             agree(
                 "log2",
                 raw,
-                w.log2_strict().to_bits().as_i128(),
-                n.log2_strict().to_bits().as_i128(),
+                wide.log2_strict().to_bits().as_i128(),
+                narrow.log2_strict().to_bits().as_i128(),
             );
             agree(
                 "log10",
                 raw,
-                w.log10_strict().to_bits().as_i128(),
-                n.log10_strict().to_bits().as_i128(),
+                wide.log10_strict().to_bits().as_i128(),
+                narrow.log10_strict().to_bits().as_i128(),
             );
         }
         for raw in all {
-            let n = crate::D::<crate::int::types::Int<2>, 6>::from_bits(crate::int::types::Int::<2>::from_i128(raw as i128));
-            let w = crate::D::<crate::int::types::Int<4>, 6>::from_bits(crate::int::types::Int::<4>::from_i128(
+            let narrow = crate::D::<crate::int::types::Int<2>, 6>::from_bits(crate::int::types::Int::<2>::from_i128(raw as i128));
+            let wide = crate::D::<crate::int::types::Int<4>, 6>::from_bits(crate::int::types::Int::<4>::from_i128(
                 raw as i128,
             ));
             agree(
                 "exp",
                 raw,
-                w.exp_strict().to_bits().as_i128(),
-                n.exp_strict().to_bits().as_i128(),
+                wide.exp_strict().to_bits().as_i128(),
+                narrow.exp_strict().to_bits().as_i128(),
             );
             agree(
                 "sin",
                 raw,
-                w.sin_strict().to_bits().as_i128(),
-                n.sin_strict().to_bits().as_i128(),
+                wide.sin_strict().to_bits().as_i128(),
+                narrow.sin_strict().to_bits().as_i128(),
             );
             agree(
                 "cos",
                 raw,
-                w.cos_strict().to_bits().as_i128(),
-                n.cos_strict().to_bits().as_i128(),
+                wide.cos_strict().to_bits().as_i128(),
+                narrow.cos_strict().to_bits().as_i128(),
             );
             agree(
                 "atan",
                 raw,
-                w.atan_strict().to_bits().as_i128(),
-                n.atan_strict().to_bits().as_i128(),
+                wide.atan_strict().to_bits().as_i128(),
+                narrow.atan_strict().to_bits().as_i128(),
             );
             agree(
                 "sinh",
                 raw,
-                w.sinh_strict().to_bits().as_i128(),
-                n.sinh_strict().to_bits().as_i128(),
+                wide.sinh_strict().to_bits().as_i128(),
+                narrow.sinh_strict().to_bits().as_i128(),
             );
             agree(
                 "cosh",
                 raw,
-                w.cosh_strict().to_bits().as_i128(),
-                n.cosh_strict().to_bits().as_i128(),
+                wide.cosh_strict().to_bits().as_i128(),
+                narrow.cosh_strict().to_bits().as_i128(),
             );
             agree(
                 "tanh",
                 raw,
-                w.tanh_strict().to_bits().as_i128(),
-                n.tanh_strict().to_bits().as_i128(),
+                wide.tanh_strict().to_bits().as_i128(),
+                narrow.tanh_strict().to_bits().as_i128(),
             );
         }
         for raw in unit_range {
-            let n = crate::D::<crate::int::types::Int<2>, 6>::from_bits(crate::int::types::Int::<2>::from_i128(raw as i128));
-            let w = crate::D::<crate::int::types::Int<4>, 6>::from_bits(crate::int::types::Int::<4>::from_i128(
+            let narrow = crate::D::<crate::int::types::Int<2>, 6>::from_bits(crate::int::types::Int::<2>::from_i128(raw as i128));
+            let wide = crate::D::<crate::int::types::Int<4>, 6>::from_bits(crate::int::types::Int::<4>::from_i128(
                 raw as i128,
             ));
             agree(
                 "asin",
                 raw,
-                w.asin_strict().to_bits().as_i128(),
-                n.asin_strict().to_bits().as_i128(),
+                wide.asin_strict().to_bits().as_i128(),
+                narrow.asin_strict().to_bits().as_i128(),
             );
             agree(
                 "acos",
                 raw,
-                w.acos_strict().to_bits().as_i128(),
-                n.acos_strict().to_bits().as_i128(),
+                wide.acos_strict().to_bits().as_i128(),
+                narrow.acos_strict().to_bits().as_i128(),
             );
             agree(
                 "atanh",
                 raw,
-                w.atanh_strict().to_bits().as_i128(),
-                n.atanh_strict().to_bits().as_i128(),
+                wide.atanh_strict().to_bits().as_i128(),
+                narrow.atanh_strict().to_bits().as_i128(),
             );
         }
     }
@@ -5337,25 +5767,25 @@ mod tests {
         }
 
         for raw in positives {
-            let w = crate::D::<crate::int::types::Int<4>, 6>::from_bits(crate::int::types::Int::<4>::from_i128(
+            let wide = crate::D::<crate::int::types::Int<4>, 6>::from_bits(crate::int::types::Int::<4>::from_i128(
                 raw as i128,
             ));
             agree(
                 "ln",
                 raw,
-                w.ln_strict_agm().to_bits().as_i128(),
-                w.ln_strict().to_bits().as_i128(),
+                wide.ln_strict_agm().to_bits().as_i128(),
+                wide.ln_strict().to_bits().as_i128(),
             );
         }
         for raw in all {
-            let w = crate::D::<crate::int::types::Int<4>, 6>::from_bits(crate::int::types::Int::<4>::from_i128(
+            let wide = crate::D::<crate::int::types::Int<4>, 6>::from_bits(crate::int::types::Int::<4>::from_i128(
                 raw as i128,
             ));
             agree(
                 "exp",
                 raw,
-                w.exp_strict_agm().to_bits().as_i128(),
-                w.exp_strict().to_bits().as_i128(),
+                wide.exp_strict_agm().to_bits().as_i128(),
+                wide.exp_strict().to_bits().as_i128(),
             );
         }
     }
@@ -5398,14 +5828,14 @@ mod tests {
         // A clean way: positive number with HTE rounding up. exp(1) =
         // 2.7182818... at SCALE=6: 2.718281 cut, fractional 0.8 →
         // HTE rounds up to 2.718282, Trunc keeps 2.718281.
-        let n = crate::D::<crate::int::types::Int<4>, 6>::ONE;
-        let hte = n.exp_strict_with(RoundingMode::HalfToEven);
-        let trunc = n.exp_strict_with(RoundingMode::Trunc);
+        let argument = crate::D::<crate::int::types::Int<4>, 6>::ONE;
+        let half_to_even = argument.exp_strict_with(RoundingMode::HalfToEven);
+        let trunc = argument.exp_strict_with(RoundingMode::Trunc);
         assert!(
-            hte.to_bits().as_i128() - trunc.to_bits().as_i128() == 1
-                || hte.to_bits().as_i128() - trunc.to_bits().as_i128() == 0,
+            half_to_even.to_bits().as_i128() - trunc.to_bits().as_i128() == 1
+                || half_to_even.to_bits().as_i128() - trunc.to_bits().as_i128() == 0,
             "exp(1) HTE vs Trunc: hte={}, trunc={}",
-            hte,
+            half_to_even,
             trunc,
         );
         // HalfToEven matches the canonical *_strict (which uses
@@ -5416,7 +5846,7 @@ mod tests {
             || cfg!(feature = "rounding-floor")
             || cfg!(feature = "rounding-ceiling"))
         {
-            assert_eq!(hte, n.exp_strict());
+            assert_eq!(half_to_even, argument.exp_strict());
         }
     }
 
@@ -5429,17 +5859,17 @@ mod tests {
     fn wide_agm_moderate_scale_round_trip() {
         #[cfg(feature = "d76")]
         {
-            let x = crate::D::<crate::int::types::Int<4>, 20>::try_from(3_i128).unwrap();
-            let back = x.ln_strict_agm().exp_strict_agm();
-            let delta = (back.to_bits().as_i128() - x.to_bits().as_i128()).abs();
+            let value = crate::D::<crate::int::types::Int<4>, 20>::try_from(3_i128).unwrap();
+            let back = value.ln_strict_agm().exp_strict_agm();
+            let delta = (back.to_bits().as_i128() - value.to_bits().as_i128()).abs();
             assert!(delta <= 8, "AGM exp(ln(3)) at D76<20> delta {delta}");
         }
 
         #[cfg(feature = "d153")]
         {
-            let y = crate::D::<crate::int::types::Int<8>, 20>::try_from(2_i128).unwrap();
-            let back = y.exp_strict_agm().ln_strict_agm();
-            let delta = (back.to_bits().as_i128() - y.to_bits().as_i128()).abs();
+            let value = crate::D::<crate::int::types::Int<8>, 20>::try_from(2_i128).unwrap();
+            let back = value.exp_strict_agm().ln_strict_agm();
+            let delta = (back.to_bits().as_i128() - value.to_bits().as_i128()).abs();
             assert!(delta <= 8, "AGM ln(exp(2)) at D153<20> delta {delta}");
         }
     }
@@ -5454,18 +5884,18 @@ mod tests {
         // result fits i128 comfortably, so compare there.
         #[cfg(feature = "d76")]
         {
-            let x = crate::D::<crate::int::types::Int<4>, 50>::try_from(3_i128).unwrap();
-            let back = x.ln_strict().exp_strict();
-            let delta = (back.to_bits().as_i128() - x.to_bits().as_i128()).abs();
+            let value = crate::D::<crate::int::types::Int<4>, 50>::try_from(3_i128).unwrap();
+            let back = value.ln_strict().exp_strict();
+            let delta = (back.to_bits().as_i128() - value.to_bits().as_i128()).abs();
             assert!(delta <= 8, "exp(ln(3)) at D76<50> delta {delta}");
         }
 
         // D307<150>: deep scale, only the wide core can serve it.
         #[cfg(feature = "d307")]
         {
-            let y = crate::D::<crate::int::types::Int<16>, 150>::try_from(2_i128).unwrap();
-            let back = y.exp_strict().ln_strict();
-            let delta = (back.to_bits().as_i128() - y.to_bits().as_i128()).abs();
+            let value = crate::D::<crate::int::types::Int<16>, 150>::try_from(2_i128).unwrap();
+            let back = value.exp_strict().ln_strict();
+            let delta = (back.to_bits().as_i128() - value.to_bits().as_i128()).abs();
             assert!(delta <= 8, "ln(exp(2)) at D307<150> delta {delta}");
         }
     }

--- a/src/policy/add.rs
+++ b/src/policy/add.rs
@@ -87,14 +87,14 @@ const fn select<const N: usize, const SCALE: u32>() -> Select<N> {
 /// Not `const fn`: matches the existing non-`const` `Add` operator on
 /// `D<Int<N>, SCALE>`.
 #[inline]
-pub(crate) fn dispatch<const N: usize, const SCALE: u32>(a: Int<N>, b: Int<N>) -> Int<N> {
+pub(crate) fn dispatch<const N: usize, const SCALE: u32>(lhs: Int<N>, rhs: Int<N>) -> Int<N> {
     let algo = match const { select::<N, SCALE>() } {
-        Select::ByAlgorithm(a) => a,
+        Select::ByAlgorithm(algorithm) => algorithm,
         Select::ByValue(_) => Algorithm::IntLayer,
     };
     match algo {
         Algorithm::IntLayer | Algorithm::Schoolbook => {
-            crate::algos::add::add_int_layer::add_int_layer(a, b)
+            crate::algos::add::add_int_layer::add_int_layer(lhs, rhs)
         }
     }
 }

--- a/src/policy/cbrt.rs
+++ b/src/policy/cbrt.rs
@@ -156,14 +156,14 @@ const fn select<const N: usize, const SCALE: u32>() -> Select<N> {
         // 8·N` gate sits just inside the win region (every routed cell wins,
         // none below is regressed). At the benchmarked max-scale (S-1) cells this
         // recovers 1.4–2.9× over the slice (bit-identical, all six modes).
-        (6, s) if s >= 48 => Select::ByAlgorithm(Algorithm::Native), // D115, W=18
-        (8, s) if s >= 64 => Select::ByAlgorithm(Algorithm::Native), // D153, W=24
-        (12, s) if s >= 96 => Select::ByAlgorithm(Algorithm::Native), // D230, W=36
-        (16, s) if s >= 128 => Select::ByAlgorithm(Algorithm::Native), // D307, W=48
-        (24, s) if s >= 192 => Select::ByAlgorithm(Algorithm::Native), // D462, W=72
-        (32, s) if s >= 256 => Select::ByAlgorithm(Algorithm::Native), // D616, W=96
-        (48, s) if s >= 384 => Select::ByAlgorithm(Algorithm::Native), // D924, W=144
-        (64, s) if s >= 512 => Select::ByAlgorithm(Algorithm::Native), // D1232, W=192
+        (6, scale) if scale >= 48 => Select::ByAlgorithm(Algorithm::Native), // D115, W=18
+        (8, scale) if scale >= 64 => Select::ByAlgorithm(Algorithm::Native), // D153, W=24
+        (12, scale) if scale >= 96 => Select::ByAlgorithm(Algorithm::Native), // D230, W=36
+        (16, scale) if scale >= 128 => Select::ByAlgorithm(Algorithm::Native), // D307, W=48
+        (24, scale) if scale >= 192 => Select::ByAlgorithm(Algorithm::Native), // D462, W=72
+        (32, scale) if scale >= 256 => Select::ByAlgorithm(Algorithm::Native), // D616, W=96
+        (48, scale) if scale >= 384 => Select::ByAlgorithm(Algorithm::Native), // D924, W=144
+        (64, scale) if scale >= 512 => Select::ByAlgorithm(Algorithm::Native), // D1232, W=192
         // Everything else (wider tiers at low/mid scales) — generic Newton
         // over the int layer's width-agnostic slice `icbrt`.
         _ => Select::ByAlgorithm(Algorithm::Newton),
@@ -192,8 +192,8 @@ where
         return Int::<N>::ZERO;
     }
     let algo = match const { select::<N, SCALE>() } {
-        Select::ByAlgorithm(a) => a,
-        Select::ByValue(f) => f(&raw),
+        Select::ByAlgorithm(algorithm) => algorithm,
+        Select::ByValue(choose) => choose(&raw),
     };
     match algo {
         Algorithm::Newton => cbrt::cbrt_newton::cbrt_newton::<N>(raw, SCALE, mode),

--- a/src/policy/dcmp.rs
+++ b/src/policy/dcmp.rs
@@ -99,29 +99,30 @@ const fn select<const N: usize, const S1: u32, const S2: u32>() -> Select<N> {
 /// Cross-width same-scale comparison: delegates to `Int::cmp_cross`.
 #[inline]
 const fn cmp_cross_same_scale<const N: usize, const M: usize>(
-    a: Int<N>,
-    b: Int<M>,
+    lhs: Int<N>,
+    rhs: Int<M>,
 ) -> core::cmp::Ordering {
-    a.cmp_cross(b)
+    lhs.cmp_cross(rhs)
 }
 
-/// Cross-width cross-scale comparison. `a` has scale `S1`, `b` has `S2`.
-/// Logical values are `a/10^S1` and `b/10^S2`. Scales to the lower operand's
-/// denominator (dividing the higher-scale storage) so the comparison is
-/// overflow-free and uses only `Int::cmp_cross_scaled`.
+/// Cross-width cross-scale comparison. `lhs` has scale `S1`, `rhs` has `S2`.
+/// Logical values are `lhs/10^S1` and `rhs/10^S2`. Scales to the lower
+/// operand's denominator (dividing the higher-scale storage) so the comparison
+/// is overflow-free and uses only `Int::cmp_cross_scaled`.
 #[inline]
 const fn cmp_cross_scaled_diff<const N: usize, const M: usize, const S1: u32, const S2: u32>(
-    a: Int<N>,
-    b: Int<M>,
+    lhs: Int<N>,
+    rhs: Int<M>,
 ) -> core::cmp::Ordering {
-    // S1 > S2: compare a vs b·10^(S1−S2) — equivalently, scale DOWN `a`'s
-    // counterpart: `cmp_cross_scaled(a, b, S1−S2)` means `a` vs `b`
-    // scaled up by `10^d`, matching `a/10^S1` vs `b/10^S2` after ×10^S1.
+    // S1 > S2: compare lhs vs rhs·10^(S1−S2) — equivalently, scale DOWN
+    // `lhs`'s counterpart: `cmp_cross_scaled(lhs, rhs, S1−S2)` means `lhs` vs
+    // `rhs` scaled up by `10^d`, matching `lhs/10^S1` vs `rhs/10^S2` after
+    // ×10^S1.
     if S1 > S2 {
-        a.cmp_cross_scaled(b, S1 - S2)
+        lhs.cmp_cross_scaled(rhs, S1 - S2)
     } else {
-        // S2 > S1: compare b vs a·10^(S2−S1) → reverse.
-        b.cmp_cross_scaled(a, S2 - S1).reverse()
+        // S2 > S1: compare rhs vs lhs·10^(S2−S1) → reverse.
+        rhs.cmp_cross_scaled(lhs, S2 - S1).reverse()
     }
 }
 
@@ -141,15 +142,15 @@ pub(crate) const fn dcmp_dispatch<
     const S1: u32,
     const S2: u32,
 >(
-    a: Int<N>,
-    b: Int<M>,
+    lhs: Int<N>,
+    rhs: Int<M>,
 ) -> core::cmp::Ordering {
     let algo = match const { select::<N, S1, S2>() } {
-        Select::ByAlgorithm(a) => a,
+        Select::ByAlgorithm(algorithm) => algorithm,
         Select::ByValue(_) => Algorithm::SameScale,
     };
     match algo {
-        Algorithm::SameScale => cmp_cross_same_scale::<N, M>(a, b),
-        Algorithm::ScaledDiff => cmp_cross_scaled_diff::<N, M, S1, S2>(a, b),
+        Algorithm::SameScale => cmp_cross_same_scale::<N, M>(lhs, rhs),
+        Algorithm::ScaledDiff => cmp_cross_scaled_diff::<N, M, S1, S2>(lhs, rhs),
     }
 }

--- a/src/policy/deq.rs
+++ b/src/policy/deq.rs
@@ -85,22 +85,22 @@ const fn select<const N: usize, const S1: u32, const S2: u32>() -> Select<N> {
 
 /// Cross-width same-scale equality: plain integer equal on raw storage.
 #[inline]
-const fn eq_same_scale<const N: usize, const M: usize>(a: Int<N>, b: Int<M>) -> bool {
+const fn eq_same_scale<const N: usize, const M: usize>(lhs: Int<N>, rhs: Int<M>) -> bool {
     // Same scale: values are equal iff storage is equal (after cross-width
     // sign-extension). Delegate to the cross-scale comparator keyed at
     // d=0 — or equivalently, call cmp_cross and test for Equal.
     use core::cmp::Ordering;
-    matches!(a.cmp_cross(b), Ordering::Equal)
+    matches!(lhs.cmp_cross(rhs), Ordering::Equal)
 }
 
 /// Cross-width cross-scale equality: test that the comparison is `Equal`.
 #[inline]
 const fn eq_scaled_diff<const N: usize, const M: usize, const S1: u32, const S2: u32>(
-    a: Int<N>,
-    b: Int<M>,
+    lhs: Int<N>,
+    rhs: Int<M>,
 ) -> bool {
     use core::cmp::Ordering;
-    matches!(dcmp_dispatch::<N, M, S1, S2>(a, b), Ordering::Equal)
+    matches!(dcmp_dispatch::<N, M, S1, S2>(lhs, rhs), Ordering::Equal)
 }
 
 // ── 4. the dispatcher: fold the verdict, then dispatch ────────────────
@@ -118,15 +118,15 @@ pub(crate) const fn deq_dispatch<
     const S1: u32,
     const S2: u32,
 >(
-    a: Int<N>,
-    b: Int<M>,
+    lhs: Int<N>,
+    rhs: Int<M>,
 ) -> bool {
     let algo = match const { select::<N, S1, S2>() } {
-        Select::ByAlgorithm(a) => a,
+        Select::ByAlgorithm(algorithm) => algorithm,
         Select::ByValue(_) => Algorithm::SameScale,
     };
     match algo {
-        Algorithm::SameScale => eq_same_scale::<N, M>(a, b),
-        Algorithm::ScaledDiff => eq_scaled_diff::<N, M, S1, S2>(a, b),
+        Algorithm::SameScale => eq_same_scale::<N, M>(lhs, rhs),
+        Algorithm::ScaledDiff => eq_scaled_diff::<N, M, S1, S2>(lhs, rhs),
     }
 }

--- a/src/policy/div.rs
+++ b/src/policy/div.rs
@@ -112,8 +112,8 @@ const fn select<const N: usize, const SCALE: u32>() -> Select<N> {
 #[inline]
 #[must_use]
 pub(crate) fn dispatch<const N: usize, const SCALE: u32>(
-    a: Int<N>,
-    b: Int<N>,
+    dividend: Int<N>,
+    divisor: Int<N>,
     mode: RoundingMode,
 ) -> Int<N>
 where
@@ -123,20 +123,24 @@ where
     // (N, SCALE) via the `const` block — a bare `TEN.pow(SCALE)` call runs
     // the int pow square-and-multiply at RUNTIME (the exponent reaches the
     // method as a plain `u32`), so the `const {}` is load-bearing.
-    let mult: Int<N> = const { <Int<N>>::TEN.pow(SCALE) };
+    let multiplier: Int<N> = const { <Int<N>>::TEN.pow(SCALE) };
     let algo = match const { select::<N, SCALE>() } {
-        Select::ByAlgorithm(a) => a,
-        Select::ByValue(f) => f(&a, &b),
+        Select::ByAlgorithm(algorithm) => algorithm,
+        Select::ByValue(choose) => choose(&dividend, &divisor),
     };
     match algo {
         Algorithm::Native => {
-            crate::algos::div::div_native::div_native::<N, SCALE>(a, b, mode)
+            crate::algos::div::div_native::div_native::<N, SCALE>(dividend, divisor, mode)
         }
         Algorithm::WidenScale => {
-            crate::algos::div::div_widen_scale::div_widen_scale::<N>(a, b, mult, mode)
+            crate::algos::div::div_widen_scale::div_widen_scale::<N>(
+                dividend, divisor, multiplier, mode
+            )
         }
         Algorithm::Schoolbook => {
-            crate::algos::div::div_schoolbook::div_schoolbook::<N>(a, b, mult, mode)
+            crate::algos::div::div_schoolbook::div_schoolbook::<N>(
+                dividend, divisor, multiplier, mode
+            )
         }
     }
 }

--- a/src/policy/exp.rs
+++ b/src/policy/exp.rs
@@ -138,8 +138,8 @@ fn wide_tang_gate<const N: usize, const SCALE: u32>(raw: &Int<N>) -> Algorithm {
 #[inline]
 fn resolve<const N: usize, const SCALE: u32>(raw: &Int<N>) -> Algorithm {
     match const { select::<N, SCALE>() } {
-        Select::ByAlgorithm(a) => a,
-        Select::ByValue(f) => f(raw),
+        Select::ByAlgorithm(algorithm) => algorithm,
+        Select::ByValue(choose) => choose(raw),
     }
 }
 
@@ -338,11 +338,11 @@ fn tang_routed<const N: usize, const SCALE: u32>(raw: Int<N>, mode: RoundingMode
         // SCALEs implicitly bounds `|x|` to the small-`|k|` regime.
         #[cfg(any(feature = "d57", feature = "wide"))]
         3 => {
-            let r = raw.resize_to::<Int<3>>();
+            let raw_d57 = raw.resize_to::<Int<3>>();
             let out = match SCALE {
-                0..=44 => crate::algos::exp::exp_tang::exp_tang::<crate::types::widths::wide_trig_d57::Core, SCALE, 128, 8, true, true, false>(r, mode),
-                45..=56 => crate::algos::exp::exp_tang::exp_tang::<crate::types::widths::wide_trig_d57::Core, SCALE, 512, 30, true, true, false>(r, mode),
-                _ => crate::algos::support::wide_trig_core::exp_series::<crate::types::widths::wide_trig_d57::Core, SCALE>(r, mode),
+                0..=44 => crate::algos::exp::exp_tang::exp_tang::<crate::types::widths::wide_trig_d57::Core, SCALE, 128, 8, true, true, false>(raw_d57, mode),
+                45..=56 => crate::algos::exp::exp_tang::exp_tang::<crate::types::widths::wide_trig_d57::Core, SCALE, 512, 30, true, true, false>(raw_d57, mode),
+                _ => crate::algos::support::wide_trig_core::exp_series::<crate::types::widths::wide_trig_d57::Core, SCALE>(raw_d57, mode),
             };
             Some(out.resize_to::<Int<N>>())
         }
@@ -470,13 +470,16 @@ mod series_rung_tests {
     #[cfg(feature = "d307")]
     fn d307_exp_rung_matches_tier_kernel() {
         type Core = crate::types::widths::wide_trig_d307::Core;
-        for v in ["0", "0.5", "1", "1.5", "9.9", "-1", "-9.9", "0.0000000001", "50", "-50"] {
-            let x: crate::D307<19> = v.parse().unwrap();
+        for input in ["0", "0.5", "1", "1.5", "9.9", "-1", "-9.9", "0.0000000001", "50", "-50"] {
+            let value: crate::D307<19> = input.parse().unwrap();
             for mode in ALL_MODES {
                 assert_eq!(
-                    super::series_at_rung::<Core, 19>(x.to_bits(), mode),
-                    crate::algos::support::wide_trig_core::exp_series::<Core, 19>(x.to_bits(), mode),
-                    "exp({v}) mode {mode:?}"
+                    super::series_at_rung::<Core, 19>(value.to_bits(), mode),
+                    crate::algos::support::wide_trig_core::exp_series::<Core, 19>(
+                        value.to_bits(),
+                        mode
+                    ),
+                    "exp({input}) mode {mode:?}"
                 );
             }
         }

--- a/src/policy/expm1.rs
+++ b/src/policy/expm1.rs
@@ -119,8 +119,8 @@ fn classify<const N: usize, const SCALE: u32>(raw: &Int<N>) -> Algorithm {
 #[inline]
 fn resolve<const N: usize, const SCALE: u32>(raw: &Int<N>) -> Algorithm {
     match const { select::<N, SCALE>() } {
-        Select::ByAlgorithm(a) => a,
-        Select::ByValue(f) => f(raw),
+        Select::ByAlgorithm(algorithm) => algorithm,
+        Select::ByValue(choose) => choose(raw),
     }
 }
 
@@ -170,17 +170,17 @@ fn narrow_strict<const N: usize, const SCALE: u32>(
     algo: Algorithm,
     mode: RoundingMode,
 ) -> Int<N> {
-    let v = raw.resize_to::<Int<2>>();
+    let raw_narrow = raw.resize_to::<Int<2>>();
     let out = match algo {
         Algorithm::Series => expm1_series_g::<Int<2>, WZiv, SCALE>(
-            v,
+            raw_narrow,
             NARROW_GUARD,
             Int::<2>::MAX,
             Int::<2>::MIN,
             mode,
         ),
         Algorithm::WithExp => expm1_with_exp_g::<Int<2>, WZiv, SCALE>(
-            v,
+            raw_narrow,
             NARROW_GUARD,
             Int::<2>::MAX,
             Int::<2>::MIN,
@@ -198,17 +198,17 @@ fn narrow_approx<const N: usize, const SCALE: u32>(
     algo: Algorithm,
     mode: RoundingMode,
 ) -> Int<N> {
-    let v = raw.resize_to::<Int<2>>();
+    let raw_narrow = raw.resize_to::<Int<2>>();
     let out = match algo {
         Algorithm::Series => expm1_series_approx_g::<Int<2>, WZiv, SCALE>(
-            v,
+            raw_narrow,
             working_digits,
             Int::<2>::MAX,
             Int::<2>::MIN,
             mode,
         ),
         Algorithm::WithExp => expm1_with_exp_approx_g::<Int<2>, WZiv, SCALE>(
-            v,
+            raw_narrow,
             working_digits,
             Int::<2>::MAX,
             Int::<2>::MIN,

--- a/src/policy/hypot.rs
+++ b/src/policy/hypot.rs
@@ -91,15 +91,15 @@ const fn select<const N: usize, const SCALE: u32>() -> Select<N> {
 #[inline]
 #[must_use]
 pub(crate) fn dispatch<const N: usize, const SCALE: u32>(
-    a: Int<N>,
-    b: Int<N>,
+    lhs: Int<N>,
+    rhs: Int<N>,
     mode: RoundingMode,
 ) -> Int<N>
 where
     Limbs<N>: ComputeLimbs,
 {
     // `SCALE` is used only to label the out-of-range panic.
-    checked_dispatch::<N, SCALE>(a, b, mode).unwrap_or_else(|| {
+    checked_dispatch::<N, SCALE>(lhs, rhs, mode).unwrap_or_else(|| {
         crate::support::diagnostics::overflow_panic_with_scale("hypot", SCALE)
     })
 }
@@ -111,8 +111,8 @@ where
 #[inline]
 #[must_use]
 pub(crate) fn checked_dispatch<const N: usize, const SCALE: u32>(
-    a: Int<N>,
-    b: Int<N>,
+    lhs: Int<N>,
+    rhs: Int<N>,
     mode: RoundingMode,
 ) -> Option<Int<N>>
 where
@@ -121,12 +121,12 @@ where
     // Both operands carry the same `10^SCALE`, so it divides out of the
     // root.
     let algo = match const { select::<N, SCALE>() } {
-        Select::ByAlgorithm(a) => a,
-        Select::ByValue(f) => f(&a),
+        Select::ByAlgorithm(algorithm) => algorithm,
+        Select::ByValue(choose) => choose(&lhs),
     };
     match algo {
         Algorithm::Pythagoras | Algorithm::Schoolbook => {
-            hypot::hypot_pythagoras::hypot_pythagoras::<N>(a, b, mode)
+            hypot::hypot_pythagoras::hypot_pythagoras::<N>(lhs, rhs, mode)
         }
     }
 }

--- a/src/policy/ln.rs
+++ b/src/policy/ln.rs
@@ -90,8 +90,8 @@ const fn select<const N: usize, const SCALE: u32>() -> Select<N> {
 #[inline]
 fn resolve<const N: usize, const SCALE: u32>(raw: &Int<N>) -> Algorithm {
     match const { select::<N, SCALE>() } {
-        Select::ByAlgorithm(a) => a,
-        Select::ByValue(f) => f(raw),
+        Select::ByAlgorithm(algorithm) => algorithm,
+        Select::ByValue(choose) => choose(raw),
     }
 }
 

--- a/src/policy/log.rs
+++ b/src/policy/log.rs
@@ -69,8 +69,8 @@ pub(crate) fn checked_dispatch<const N: usize, const SCALE: u32>(
     mode: RoundingMode,
 ) -> Option<Int<N>> {
     let algo = match const { select::<N, SCALE>() } {
-        Select::ByAlgorithm(a) => a,
-        Select::ByValue(f) => f(&raw),
+        Select::ByAlgorithm(algorithm) => algorithm,
+        Select::ByValue(choose) => choose(&raw),
     };
     match algo {
         Algorithm::LnDivide => ln_divide_routed::<N, SCALE>(raw, braw, mode),
@@ -87,8 +87,8 @@ pub(crate) fn dispatch_with<const N: usize, const SCALE: u32>(
     mode: RoundingMode,
 ) -> Int<N> {
     let algo = match const { select::<N, SCALE>() } {
-        Select::ByAlgorithm(a) => a,
-        Select::ByValue(f) => f(&raw),
+        Select::ByAlgorithm(algorithm) => algorithm,
+        Select::ByValue(choose) => choose(&raw),
     };
     match algo {
         Algorithm::LnDivide => ln_divide_with_routed::<N, SCALE>(raw, braw, working_digits, mode),

--- a/src/policy/log1p.rs
+++ b/src/policy/log1p.rs
@@ -99,8 +99,8 @@ fn classify<const N: usize, const SCALE: u32>(raw: &Int<N>) -> Algorithm {
 #[inline]
 fn resolve<const N: usize, const SCALE: u32>(raw: &Int<N>) -> Algorithm {
     match const { select::<N, SCALE>() } {
-        Select::ByAlgorithm(a) => a,
-        Select::ByValue(f) => f(raw),
+        Select::ByAlgorithm(algorithm) => algorithm,
+        Select::ByValue(choose) => choose(raw),
     }
 }
 
@@ -147,17 +147,17 @@ fn narrow_strict<const N: usize, const SCALE: u32>(
     algo: Algorithm,
     mode: RoundingMode,
 ) -> Int<N> {
-    let v = raw.resize_to::<Int<2>>();
+    let raw_narrow = raw.resize_to::<Int<2>>();
     let out = match algo {
         Algorithm::Artanh => log1p_artanh_g::<Int<2>, WZiv, SCALE>(
-            v,
+            raw_narrow,
             NARROW_GUARD,
             Int::<2>::MAX,
             Int::<2>::MIN,
             mode,
         ),
         Algorithm::WithLn => log1p_with_ln_g::<Int<2>, WZiv, SCALE>(
-            v,
+            raw_narrow,
             NARROW_GUARD,
             Int::<2>::MAX,
             Int::<2>::MIN,
@@ -175,17 +175,17 @@ fn narrow_approx<const N: usize, const SCALE: u32>(
     algo: Algorithm,
     mode: RoundingMode,
 ) -> Int<N> {
-    let v = raw.resize_to::<Int<2>>();
+    let raw_narrow = raw.resize_to::<Int<2>>();
     let out = match algo {
         Algorithm::Artanh => log1p_artanh_approx_g::<Int<2>, WZiv, SCALE>(
-            v,
+            raw_narrow,
             working_digits,
             Int::<2>::MAX,
             Int::<2>::MIN,
             mode,
         ),
         Algorithm::WithLn => log1p_with_ln_approx_g::<Int<2>, WZiv, SCALE>(
-            v,
+            raw_narrow,
             working_digits,
             Int::<2>::MAX,
             Int::<2>::MIN,

--- a/src/policy/mul.rs
+++ b/src/policy/mul.rs
@@ -112,26 +112,26 @@ const fn select<const N: usize, const SCALE: u32>() -> Select<N> {
 #[inline]
 #[must_use]
 pub(crate) fn dispatch<const N: usize, const SCALE: u32>(
-    a: Int<N>,
-    b: Int<N>,
+    lhs: Int<N>,
+    rhs: Int<N>,
     mode: RoundingMode,
 ) -> Int<N>
 where
     Limbs<N>: ComputeLimbs,
 {
     let algo = match const { select::<N, SCALE>() } {
-        Select::ByAlgorithm(a) => a,
-        Select::ByValue(f) => f(&a, &b),
+        Select::ByAlgorithm(algorithm) => algorithm,
+        Select::ByValue(choose) => choose(&lhs, &rhs),
     };
     match algo {
         Algorithm::Native => {
-            crate::algos::mul::mul_native::mul_native::<N, SCALE>(a, b, mode)
+            crate::algos::mul::mul_native::mul_native::<N, SCALE>(lhs, rhs, mode)
         }
         Algorithm::WidenDivide => {
-            crate::algos::mul::mul_widen_divide::mul_widen_divide::<N, SCALE>(a, b, mode)
+            crate::algos::mul::mul_widen_divide::mul_widen_divide::<N, SCALE>(lhs, rhs, mode)
         }
         Algorithm::Schoolbook => {
-            crate::algos::mul::mul_schoolbook::mul_schoolbook::<N, SCALE>(a, b, mode)
+            crate::algos::mul::mul_schoolbook::mul_schoolbook::<N, SCALE>(lhs, rhs, mode)
         }
     }
 }

--- a/src/policy/neg.rs
+++ b/src/policy/neg.rs
@@ -86,14 +86,14 @@ const fn select<const N: usize, const SCALE: u32>() -> Select<N> {
 /// Not `const fn`: matches the existing non-`const` `Neg` operator on
 /// `D<Int<N>, SCALE>`.
 #[inline]
-pub(crate) fn dispatch<const N: usize, const SCALE: u32>(a: Int<N>) -> Int<N> {
+pub(crate) fn dispatch<const N: usize, const SCALE: u32>(value: Int<N>) -> Int<N> {
     let algo = match const { select::<N, SCALE>() } {
-        Select::ByAlgorithm(a) => a,
+        Select::ByAlgorithm(algorithm) => algorithm,
         Select::ByValue(_) => Algorithm::IntLayer,
     };
     match algo {
         Algorithm::IntLayer | Algorithm::Schoolbook => {
-            crate::algos::neg::neg_int_layer::neg_int_layer(a)
+            crate::algos::neg::neg_int_layer::neg_int_layer(value)
         }
     }
 }

--- a/src/policy/pow.rs
+++ b/src/policy/pow.rs
@@ -53,8 +53,8 @@ pub(crate) fn dispatch<const N: usize, const SCALE: u32>(
     mode: RoundingMode,
 ) -> Int<N> {
     let algo = match const { select::<N, SCALE>() } {
-        Select::ByAlgorithm(a) => a,
-        Select::ByValue(f) => f(&base),
+        Select::ByAlgorithm(algorithm) => algorithm,
+        Select::ByValue(choose) => choose(&base),
     };
     match algo {
         Algorithm::ExpWithLn => exp_with_ln_routed::<N, SCALE>(base, exponent, mode),

--- a/src/policy/rem.rs
+++ b/src/policy/rem.rs
@@ -112,18 +112,21 @@ const fn select<const N: usize, const SCALE: u32>() -> Select<N> {
 /// Not `const fn`: matches the existing non-`const` `Rem` operator on
 /// `D<Int<N>, SCALE>`.
 #[inline]
-pub(crate) fn dispatch<const N: usize, const SCALE: u32>(a: Int<N>, b: Int<N>) -> Int<N>
+pub(crate) fn dispatch<const N: usize, const SCALE: u32>(
+    dividend: Int<N>,
+    divisor: Int<N>
+) -> Int<N>
 where
     crate::int::types::compute_limbs::Limbs<N>: crate::int::types::compute_limbs::ComputeLimbs,
 {
     let algo = match const { select::<N, SCALE>() } {
-        Select::ByAlgorithm(a) => a,
+        Select::ByAlgorithm(algorithm) => algorithm,
         Select::ByValue(_) => Algorithm::IntLayer,
     };
     match algo {
-        Algorithm::Native => crate::algos::rem::rem_native::rem_native(a, b),
+        Algorithm::Native => crate::algos::rem::rem_native::rem_native(dividend, divisor),
         Algorithm::IntLayer | Algorithm::Schoolbook => {
-            crate::algos::rem::rem_int_layer::rem_int_layer(a, b)
+            crate::algos::rem::rem_int_layer::rem_int_layer(dividend, divisor)
         }
     }
 }

--- a/src/policy/sqrt.rs
+++ b/src/policy/sqrt.rs
@@ -155,8 +155,8 @@ const fn select<const N: usize, const SCALE: u32>() -> Select<N> {
         // (Class I "continuous win-region" gate); each cell routed to
         // Native is bit-identical to Newton across all six modes and a
         // measured win.
-        (6, s) if s >= 24 => Select::ByAlgorithm(Algorithm::Native), // D115, W=12
-        (8, s) if s >= 32 => Select::ByAlgorithm(Algorithm::Native), // D153, W=16
+        (6, scale) if scale >= 24 => Select::ByAlgorithm(Algorithm::Native), // D115, W=12
+        (8, scale) if scale >= 32 => Select::ByAlgorithm(Algorithm::Native), // D153, W=16
         // Per-tier crossovers tightened by adaptive-bisection in
         // `root_kernel_ab.rs` (cores 18-19): the conservative
         // `s >= 4N` heuristic placed several thresholds INSIDE the slice
@@ -165,12 +165,12 @@ const fn select<const N: usize, const SCALE: u32>() -> Select<N> {
         // routed cells just above the gate. The refined thresholds below
         // sit at the true bisected crossover per tier; the architecture-
         // review Class I check (continuous win-region) requires this.
-        (12, s) if s >= 70 => Select::ByAlgorithm(Algorithm::Native), // D230, W=24
-        (16, s) if s >= 64 => Select::ByAlgorithm(Algorithm::Native), // D307, W=32
-        (24, s) if s >= 96 => Select::ByAlgorithm(Algorithm::Native), // D462, W=48
-        (32, s) if s >= 160 => Select::ByAlgorithm(Algorithm::Native), // D616, W=64
-        (48, s) if s >= 260 => Select::ByAlgorithm(Algorithm::Native), // D924, W=96
-        (64, s) if s >= 256 => Select::ByAlgorithm(Algorithm::Native), // D1232, W=128
+        (12, scale) if scale >= 70 => Select::ByAlgorithm(Algorithm::Native), // D230, W=24
+        (16, scale) if scale >= 64 => Select::ByAlgorithm(Algorithm::Native), // D307, W=32
+        (24, scale) if scale >= 96 => Select::ByAlgorithm(Algorithm::Native), // D462, W=48
+        (32, scale) if scale >= 160 => Select::ByAlgorithm(Algorithm::Native), // D616, W=64
+        (48, scale) if scale >= 260 => Select::ByAlgorithm(Algorithm::Native), // D924, W=96
+        (64, scale) if scale >= 256 => Select::ByAlgorithm(Algorithm::Native), // D1232, W=128
         // Everything else (wider tiers at low/mid scales) — generic Newton
         // over the int layer's width-agnostic slice `isqrt`.
         _ => Select::ByAlgorithm(Algorithm::Newton),
@@ -199,8 +199,8 @@ where
         return Int::<N>::ZERO;
     }
     let algo = match const { select::<N, SCALE>() } {
-        Select::ByAlgorithm(a) => a,
-        Select::ByValue(f) => f(&raw),
+        Select::ByAlgorithm(algorithm) => algorithm,
+        Select::ByValue(choose) => choose(&raw),
     };
     match algo {
         Algorithm::Newton => sqrt::sqrt_newton::sqrt_newton::<N>(raw, SCALE, mode),

--- a/src/policy/sub.rs
+++ b/src/policy/sub.rs
@@ -87,14 +87,14 @@ const fn select<const N: usize, const SCALE: u32>() -> Select<N> {
 /// Not `const fn`: matches the existing non-`const` `Sub` operator on
 /// `D<Int<N>, SCALE>`.
 #[inline]
-pub(crate) fn dispatch<const N: usize, const SCALE: u32>(a: Int<N>, b: Int<N>) -> Int<N> {
+pub(crate) fn dispatch<const N: usize, const SCALE: u32>(lhs: Int<N>, rhs: Int<N>) -> Int<N> {
     let algo = match const { select::<N, SCALE>() } {
-        Select::ByAlgorithm(a) => a,
+        Select::ByAlgorithm(algorithm) => algorithm,
         Select::ByValue(_) => Algorithm::IntLayer,
     };
     match algo {
         Algorithm::IntLayer | Algorithm::Schoolbook => {
-            crate::algos::sub::sub_int_layer::sub_int_layer(a, b)
+            crate::algos::sub::sub_int_layer::sub_int_layer(lhs, rhs)
         }
     }
 }

--- a/src/policy/to_degrees.rs
+++ b/src/policy/to_degrees.rs
@@ -40,8 +40,8 @@ const fn select<const N: usize, const SCALE: u32>() -> Select<N> {
 #[must_use]
 pub(crate) fn dispatch<const N: usize, const SCALE: u32>(raw: Int<N>, mode: RoundingMode) -> Int<N> {
     let algo = match const { select::<N, SCALE>() } {
-        Select::ByAlgorithm(a) => a,
-        Select::ByValue(f) => f(&raw),
+        Select::ByAlgorithm(algorithm) => algorithm,
+        Select::ByValue(choose) => choose(&raw),
     };
     match algo {
         Algorithm::MulPiRatio => mul_pi_ratio_routed::<N, SCALE>(raw, mode),

--- a/src/policy/to_radians.rs
+++ b/src/policy/to_radians.rs
@@ -40,8 +40,8 @@ const fn select<const N: usize, const SCALE: u32>() -> Select<N> {
 #[must_use]
 pub(crate) fn dispatch<const N: usize, const SCALE: u32>(raw: Int<N>, mode: RoundingMode) -> Int<N> {
     let algo = match const { select::<N, SCALE>() } {
-        Select::ByAlgorithm(a) => a,
-        Select::ByValue(f) => f(&raw),
+        Select::ByAlgorithm(algorithm) => algorithm,
+        Select::ByValue(choose) => choose(&raw),
     };
     match algo {
         Algorithm::MulPiRatio => mul_pi_ratio_routed::<N, SCALE>(raw, mode),

--- a/src/policy/trig.rs
+++ b/src/policy/trig.rs
@@ -186,8 +186,8 @@ pub(crate) mod forward {
     #[inline]
     pub(crate) fn resolve<const N: usize, const SCALE: u32>(raw: &Int<N>) -> Algorithm {
         match const { select::<N, SCALE>() } {
-            Select::ByAlgorithm(a) => a,
-            Select::ByValue(f) => f(raw),
+            Select::ByAlgorithm(algorithm) => algorithm,
+            Select::ByValue(choose) => choose(raw),
         }
     }
 
@@ -195,8 +195,8 @@ pub(crate) mod forward {
     #[inline]
     pub(crate) fn resolve_tan<const N: usize, const SCALE: u32>(raw: &Int<N>) -> Algorithm {
         match const { select_tan::<N, SCALE>() } {
-            Select::ByAlgorithm(a) => a,
-            Select::ByValue(f) => f(raw),
+            Select::ByAlgorithm(algorithm) => algorithm,
+            Select::ByValue(choose) => choose(raw),
         }
     }
 }
@@ -253,8 +253,8 @@ pub(crate) mod inverse {
     #[inline]
     pub(crate) fn resolve<const N: usize, const SCALE: u32>(raw: &Int<N>) -> Algorithm {
         match const { select::<N, SCALE>() } {
-            Select::ByAlgorithm(a) => a,
-            Select::ByValue(f) => f(raw),
+            Select::ByAlgorithm(algorithm) => algorithm,
+            Select::ByValue(choose) => choose(raw),
         }
     }
 }
@@ -311,8 +311,8 @@ pub(crate) mod hyper {
     #[inline]
     pub(crate) fn resolve<const N: usize, const SCALE: u32>(raw: &Int<N>) -> Algorithm {
         match const { select::<N, SCALE>() } {
-            Select::ByAlgorithm(a) => a,
-            Select::ByValue(f) => f(raw),
+            Select::ByAlgorithm(algorithm) => algorithm,
+            Select::ByValue(choose) => choose(raw),
         }
     }
 }
@@ -566,8 +566,8 @@ pub(crate) mod inverse_rung {
 #[inline]
 fn hyper_band_in_range<const N: usize, const SCALE: u32>(raw: &crate::int::types::Int<N>) -> bool {
     let zero = crate::int::types::Int::<N>::ZERO;
-    let a = if *raw < zero { zero - *raw } else { *raw };
-    a <= crate::int::types::Int::<N>::from_i128(2)
+    let abs_raw = if *raw < zero { zero - *raw } else { *raw };
+    abs_raw <= crate::int::types::Int::<N>::from_i128(2)
         * crate::consts::pow10::dispatch::<crate::int::types::Int<N>>(SCALE)
 }
 
@@ -758,15 +758,16 @@ mod borrow_d57 {
     use crate::types::widths::wide_trig_d57;
 
     #[inline]
-    fn narrow<const SCALE: u32>(raw_wide: Int<3>, op: &'static str) -> Int<2> {
+    fn narrow<const SCALE: u32>(raw_wide: Int<3>, method: &'static str) -> Int<2> {
         let wide = crate::D::<crate::int::types::Int<3>, SCALE>::from_bits(raw_wide);
-        let r: crate::D<crate::int::types::Int<2>, SCALE> = wide.try_into().unwrap_or_else(|_| {
-            panic!(
-                "{op}: result out of range — produced {wide}, D38<{SCALE}> represents only |x| < 1.7e{}",
-                38_i32 - SCALE as i32,
-            )
-        });
-        r.0
+        let narrowed: crate::D<crate::int::types::Int<2>, SCALE> =
+            wide.try_into().unwrap_or_else(|_| {
+                panic!(
+                    "{method}: result out of range — produced {wide}, D38<{SCALE}> represents only |x| < 1.7e{}",
+                    38_i32 - SCALE as i32,
+                )
+            });
+        narrowed.0
     }
 
     #[inline]
@@ -933,56 +934,56 @@ macro_rules! impl_narrow_trig {
                 $sin_s(self, mode)
             }
             #[inline]
-            pub(crate) fn policy_sin_with(self, wd: u32, mode: RoundingMode) -> Self {
-                $sin_w(self, wd, mode)
+            pub(crate) fn policy_sin_with(self, working_digits: u32, mode: RoundingMode) -> Self {
+                $sin_w(self, working_digits, mode)
             }
             #[inline]
             pub(crate) fn policy_cos(self, mode: RoundingMode) -> Self {
                 $cos_s(self, mode)
             }
             #[inline]
-            pub(crate) fn policy_cos_with(self, wd: u32, mode: RoundingMode) -> Self {
-                $cos_w(self, wd, mode)
+            pub(crate) fn policy_cos_with(self, working_digits: u32, mode: RoundingMode) -> Self {
+                $cos_w(self, working_digits, mode)
             }
             #[inline]
             pub(crate) fn policy_tan(self, mode: RoundingMode) -> Self {
                 $tan_s(self, mode)
             }
             #[inline]
-            pub(crate) fn policy_tan_with(self, wd: u32, mode: RoundingMode) -> Self {
-                $tan_w(self, wd, mode)
+            pub(crate) fn policy_tan_with(self, working_digits: u32, mode: RoundingMode) -> Self {
+                $tan_w(self, working_digits, mode)
             }
             #[inline]
             pub(crate) fn policy_atan(self, mode: RoundingMode) -> Self {
                 $atan_s(self, mode)
             }
             #[inline]
-            pub(crate) fn policy_atan_with(self, wd: u32, mode: RoundingMode) -> Self {
-                $atan_w(self, wd, mode)
+            pub(crate) fn policy_atan_with(self, working_digits: u32, mode: RoundingMode) -> Self {
+                $atan_w(self, working_digits, mode)
             }
             #[inline]
             pub(crate) fn policy_asin(self, mode: RoundingMode) -> Self {
                 $asin_s(self, mode)
             }
             #[inline]
-            pub(crate) fn policy_asin_with(self, wd: u32, mode: RoundingMode) -> Self {
-                $asin_w(self, wd, mode)
+            pub(crate) fn policy_asin_with(self, working_digits: u32, mode: RoundingMode) -> Self {
+                $asin_w(self, working_digits, mode)
             }
             #[inline]
             pub(crate) fn policy_acos(self, mode: RoundingMode) -> Self {
                 $acos_s(self, mode)
             }
             #[inline]
-            pub(crate) fn policy_acos_with(self, wd: u32, mode: RoundingMode) -> Self {
-                $acos_w(self, wd, mode)
+            pub(crate) fn policy_acos_with(self, working_digits: u32, mode: RoundingMode) -> Self {
+                $acos_w(self, working_digits, mode)
             }
             #[inline]
             pub(crate) fn policy_atan2(self, other: Self, mode: RoundingMode) -> Self {
                 $atan2_s(self, other, mode)
             }
             #[inline]
-            pub(crate) fn policy_atan2_with(self, other: Self, wd: u32, mode: RoundingMode) -> Self {
-                $atan2_w(self, other, wd, mode)
+            pub(crate) fn policy_atan2_with(self, other: Self, working_digits: u32, mode: RoundingMode) -> Self {
+                $atan2_w(self, other, working_digits, mode)
             }
 
             // Hyperbolics and angle conversions widen → D38 → narrow.
@@ -999,9 +1000,9 @@ macro_rules! impl_narrow_trig {
                 )
             }
             #[inline]
-            pub(crate) fn policy_sinh_with(self, wd: u32, mode: RoundingMode) -> Self {
+            pub(crate) fn policy_sinh_with(self, working_digits: u32, mode: RoundingMode) -> Self {
                 let wide: $crate::D<$crate::int::types::Int<2>, SCALE> = self.into();
-                ::core::convert::TryInto::try_into(wide.sinh_approx_with(wd, mode)).unwrap_or_else(
+                ::core::convert::TryInto::try_into(wide.sinh_approx_with(working_digits, mode)).unwrap_or_else(
                     |_| {
                         crate::support::diagnostics::overflow_panic_with_scale(
                             concat!(stringify!($T), "::sinh"),
@@ -1023,9 +1024,9 @@ macro_rules! impl_narrow_trig {
                 )
             }
             #[inline]
-            pub(crate) fn policy_cosh_with(self, wd: u32, mode: RoundingMode) -> Self {
+            pub(crate) fn policy_cosh_with(self, working_digits: u32, mode: RoundingMode) -> Self {
                 let wide: $crate::D<$crate::int::types::Int<2>, SCALE> = self.into();
-                ::core::convert::TryInto::try_into(wide.cosh_approx_with(wd, mode)).unwrap_or_else(
+                ::core::convert::TryInto::try_into(wide.cosh_approx_with(working_digits, mode)).unwrap_or_else(
                     |_| {
                         crate::support::diagnostics::overflow_panic_with_scale(
                             concat!(stringify!($T), "::cosh"),
@@ -1047,9 +1048,9 @@ macro_rules! impl_narrow_trig {
                 )
             }
             #[inline]
-            pub(crate) fn policy_tanh_with(self, wd: u32, mode: RoundingMode) -> Self {
+            pub(crate) fn policy_tanh_with(self, working_digits: u32, mode: RoundingMode) -> Self {
                 let wide: $crate::D<$crate::int::types::Int<2>, SCALE> = self.into();
-                ::core::convert::TryInto::try_into(wide.tanh_approx_with(wd, mode)).unwrap_or_else(
+                ::core::convert::TryInto::try_into(wide.tanh_approx_with(working_digits, mode)).unwrap_or_else(
                     |_| {
                         crate::support::diagnostics::overflow_panic_with_scale(
                             concat!(stringify!($T), "::tanh"),
@@ -1071,9 +1072,9 @@ macro_rules! impl_narrow_trig {
                 )
             }
             #[inline]
-            pub(crate) fn policy_asinh_with(self, wd: u32, mode: RoundingMode) -> Self {
+            pub(crate) fn policy_asinh_with(self, working_digits: u32, mode: RoundingMode) -> Self {
                 let wide: $crate::D<$crate::int::types::Int<2>, SCALE> = self.into();
-                ::core::convert::TryInto::try_into(wide.asinh_approx_with(wd, mode)).unwrap_or_else(
+                ::core::convert::TryInto::try_into(wide.asinh_approx_with(working_digits, mode)).unwrap_or_else(
                     |_| {
                         crate::support::diagnostics::overflow_panic_with_scale(
                             concat!(stringify!($T), "::asinh"),
@@ -1095,9 +1096,9 @@ macro_rules! impl_narrow_trig {
                 )
             }
             #[inline]
-            pub(crate) fn policy_acosh_with(self, wd: u32, mode: RoundingMode) -> Self {
+            pub(crate) fn policy_acosh_with(self, working_digits: u32, mode: RoundingMode) -> Self {
                 let wide: $crate::D<$crate::int::types::Int<2>, SCALE> = self.into();
-                ::core::convert::TryInto::try_into(wide.acosh_approx_with(wd, mode)).unwrap_or_else(
+                ::core::convert::TryInto::try_into(wide.acosh_approx_with(working_digits, mode)).unwrap_or_else(
                     |_| {
                         crate::support::diagnostics::overflow_panic_with_scale(
                             concat!(stringify!($T), "::acosh"),
@@ -1119,9 +1120,9 @@ macro_rules! impl_narrow_trig {
                 )
             }
             #[inline]
-            pub(crate) fn policy_atanh_with(self, wd: u32, mode: RoundingMode) -> Self {
+            pub(crate) fn policy_atanh_with(self, working_digits: u32, mode: RoundingMode) -> Self {
                 let wide: $crate::D<$crate::int::types::Int<2>, SCALE> = self.into();
-                ::core::convert::TryInto::try_into(wide.atanh_approx_with(wd, mode)).unwrap_or_else(
+                ::core::convert::TryInto::try_into(wide.atanh_approx_with(working_digits, mode)).unwrap_or_else(
                     |_| {
                         crate::support::diagnostics::overflow_panic_with_scale(
                             concat!(stringify!($T), "::atanh"),
@@ -1135,8 +1136,8 @@ macro_rules! impl_narrow_trig {
                 Self::from_bits(crate::policy::to_degrees::dispatch::<_, SCALE>(self.to_bits(), mode))
             }
             #[inline]
-            pub(crate) fn policy_to_degrees_with(self, wd: u32, mode: RoundingMode) -> Self {
-                let _ = wd;
+            pub(crate) fn policy_to_degrees_with(self, working_digits: u32, mode: RoundingMode) -> Self {
+                let _ = working_digits;
                 Self::from_bits(crate::policy::to_degrees::dispatch::<_, SCALE>(self.to_bits(), mode))
             }
             #[inline]
@@ -1144,8 +1145,8 @@ macro_rules! impl_narrow_trig {
                 Self::from_bits(crate::policy::to_radians::dispatch::<_, SCALE>(self.to_bits(), mode))
             }
             #[inline]
-            pub(crate) fn policy_to_radians_with(self, wd: u32, mode: RoundingMode) -> Self {
-                let _ = wd;
+            pub(crate) fn policy_to_radians_with(self, working_digits: u32, mode: RoundingMode) -> Self {
+                let _ = working_digits;
                 Self::from_bits(crate::policy::to_radians::dispatch::<_, SCALE>(self.to_bits(), mode))
             }
         }
@@ -1197,8 +1198,8 @@ macro_rules! d38_hyperbolic_and_angle {
             })
         }
         #[inline]
-        pub(crate) fn policy_sinh_with(self, wd: u32, mode: RoundingMode) -> Self {
-            Self(trig::trig_series_2limb::sinh_with(self.0, SCALE, wd, mode))
+        pub(crate) fn policy_sinh_with(self, working_digits: u32, mode: RoundingMode) -> Self {
+            Self(trig::trig_series_2limb::sinh_with(self.0, SCALE, working_digits, mode))
         }
         #[inline]
         pub(crate) fn policy_cosh(self, mode: RoundingMode) -> Self {
@@ -1209,8 +1210,8 @@ macro_rules! d38_hyperbolic_and_angle {
             })
         }
         #[inline]
-        pub(crate) fn policy_cosh_with(self, wd: u32, mode: RoundingMode) -> Self {
-            Self(trig::trig_series_2limb::cosh_with(self.0, SCALE, wd, mode))
+        pub(crate) fn policy_cosh_with(self, working_digits: u32, mode: RoundingMode) -> Self {
+            Self(trig::trig_series_2limb::cosh_with(self.0, SCALE, working_digits, mode))
         }
         #[inline]
         pub(crate) fn policy_tanh(self, mode: RoundingMode) -> Self {
@@ -1221,40 +1222,40 @@ macro_rules! d38_hyperbolic_and_angle {
             })
         }
         #[inline]
-        pub(crate) fn policy_tanh_with(self, wd: u32, mode: RoundingMode) -> Self {
-            Self(trig::trig_series_2limb::tanh_with(self.0, SCALE, wd, mode))
+        pub(crate) fn policy_tanh_with(self, working_digits: u32, mode: RoundingMode) -> Self {
+            Self(trig::trig_series_2limb::tanh_with(self.0, SCALE, working_digits, mode))
         }
         #[inline]
         pub(crate) fn policy_asinh(self, mode: RoundingMode) -> Self {
             Self(trig::trig_series_2limb::asinh_strict::<SCALE>(self.0, mode))
         }
         #[inline]
-        pub(crate) fn policy_asinh_with(self, wd: u32, mode: RoundingMode) -> Self {
-            Self(trig::trig_series_2limb::asinh_with(self.0, SCALE, wd, mode))
+        pub(crate) fn policy_asinh_with(self, working_digits: u32, mode: RoundingMode) -> Self {
+            Self(trig::trig_series_2limb::asinh_with(self.0, SCALE, working_digits, mode))
         }
         #[inline]
         pub(crate) fn policy_acosh(self, mode: RoundingMode) -> Self {
             Self(trig::trig_series_2limb::acosh_strict::<SCALE>(self.0, mode))
         }
         #[inline]
-        pub(crate) fn policy_acosh_with(self, wd: u32, mode: RoundingMode) -> Self {
-            Self(trig::trig_series_2limb::acosh_with(self.0, SCALE, wd, mode))
+        pub(crate) fn policy_acosh_with(self, working_digits: u32, mode: RoundingMode) -> Self {
+            Self(trig::trig_series_2limb::acosh_with(self.0, SCALE, working_digits, mode))
         }
         #[inline]
         pub(crate) fn policy_atanh(self, mode: RoundingMode) -> Self {
             Self(trig::trig_series_2limb::atanh_strict::<SCALE>(self.0, mode))
         }
         #[inline]
-        pub(crate) fn policy_atanh_with(self, wd: u32, mode: RoundingMode) -> Self {
-            Self(trig::trig_series_2limb::atanh_with(self.0, SCALE, wd, mode))
+        pub(crate) fn policy_atanh_with(self, working_digits: u32, mode: RoundingMode) -> Self {
+            Self(trig::trig_series_2limb::atanh_with(self.0, SCALE, working_digits, mode))
         }
         #[inline]
         pub(crate) fn policy_to_degrees(self, mode: RoundingMode) -> Self {
             Self::from_bits(crate::policy::to_degrees::dispatch::<_, SCALE>(self.to_bits(), mode))
         }
         #[inline]
-        pub(crate) fn policy_to_degrees_with(self, wd: u32, mode: RoundingMode) -> Self {
-            let _ = wd;
+        pub(crate) fn policy_to_degrees_with(self, working_digits: u32, mode: RoundingMode) -> Self {
+            let _ = working_digits;
             Self::from_bits(crate::policy::to_degrees::dispatch::<_, SCALE>(self.to_bits(), mode))
         }
         #[inline]
@@ -1262,8 +1263,8 @@ macro_rules! d38_hyperbolic_and_angle {
             Self::from_bits(crate::policy::to_radians::dispatch::<_, SCALE>(self.to_bits(), mode))
         }
         #[inline]
-        pub(crate) fn policy_to_radians_with(self, wd: u32, mode: RoundingMode) -> Self {
-            let _ = wd;
+        pub(crate) fn policy_to_radians_with(self, working_digits: u32, mode: RoundingMode) -> Self {
+            let _ = working_digits;
             Self::from_bits(crate::policy::to_radians::dispatch::<_, SCALE>(self.to_bits(), mode))
         }
     };
@@ -1285,8 +1286,8 @@ macro_rules! d38_forward_fixed {
             })
         }
         #[inline]
-        pub(crate) fn policy_sin_with(self, wd: u32, mode: RoundingMode) -> Self {
-            Self(trig::trig_series_2limb::sin_with::<SCALE>(self.0, wd, mode))
+        pub(crate) fn policy_sin_with(self, working_digits: u32, mode: RoundingMode) -> Self {
+            Self(trig::trig_series_2limb::sin_with::<SCALE>(self.0, working_digits, mode))
         }
         #[inline]
         pub(crate) fn policy_cos(self, mode: RoundingMode) -> Self {
@@ -1299,8 +1300,8 @@ macro_rules! d38_forward_fixed {
             })
         }
         #[inline]
-        pub(crate) fn policy_cos_with(self, wd: u32, mode: RoundingMode) -> Self {
-            Self(trig::trig_series_2limb::cos_with::<SCALE>(self.0, wd, mode))
+        pub(crate) fn policy_cos_with(self, working_digits: u32, mode: RoundingMode) -> Self {
+            Self(trig::trig_series_2limb::cos_with::<SCALE>(self.0, working_digits, mode))
         }
         #[inline]
         pub(crate) fn policy_tan(self, mode: RoundingMode) -> Self {
@@ -1313,8 +1314,8 @@ macro_rules! d38_forward_fixed {
             })
         }
         #[inline]
-        pub(crate) fn policy_tan_with(self, wd: u32, mode: RoundingMode) -> Self {
-            Self(trig::trig_series_2limb::tan_with::<SCALE>(self.0, wd, mode))
+        pub(crate) fn policy_tan_with(self, working_digits: u32, mode: RoundingMode) -> Self {
+            Self(trig::trig_series_2limb::tan_with::<SCALE>(self.0, working_digits, mode))
         }
     };
 }
@@ -1333,7 +1334,7 @@ impl<const SCALE: u32> crate::D<crate::int::types::Int<2>, SCALE> {
         })
     }
     #[inline]
-    pub(crate) fn policy_atan_with(self, _wd: u32, mode: RoundingMode) -> Self {
+    pub(crate) fn policy_atan_with(self, _working_digits: u32, mode: RoundingMode) -> Self {
         Self(borrow_d57::atan_strict::<SCALE>(self.0, mode))
     }
     #[inline]
@@ -1345,7 +1346,7 @@ impl<const SCALE: u32> crate::D<crate::int::types::Int<2>, SCALE> {
         })
     }
     #[inline]
-    pub(crate) fn policy_asin_with(self, _wd: u32, mode: RoundingMode) -> Self {
+    pub(crate) fn policy_asin_with(self, _working_digits: u32, mode: RoundingMode) -> Self {
         Self(borrow_d57::asin_strict::<SCALE>(self.0, mode))
     }
     #[inline]
@@ -1357,7 +1358,7 @@ impl<const SCALE: u32> crate::D<crate::int::types::Int<2>, SCALE> {
         })
     }
     #[inline]
-    pub(crate) fn policy_acos_with(self, _wd: u32, mode: RoundingMode) -> Self {
+    pub(crate) fn policy_acos_with(self, _working_digits: u32, mode: RoundingMode) -> Self {
         Self(borrow_d57::acos_strict::<SCALE>(self.0, mode))
     }
     #[inline]
@@ -1371,7 +1372,7 @@ impl<const SCALE: u32> crate::D<crate::int::types::Int<2>, SCALE> {
         })
     }
     #[inline]
-    pub(crate) fn policy_atan2_with(self, other: Self, _wd: u32, mode: RoundingMode) -> Self {
+    pub(crate) fn policy_atan2_with(self, other: Self, _working_digits: u32, mode: RoundingMode) -> Self {
         Self(borrow_d57::atan2_strict::<SCALE>(self.0, other.0, mode))
     }
 
@@ -1392,8 +1393,8 @@ impl<const SCALE: u32> crate::D<crate::int::types::Int<2>, SCALE> {
         })
     }
     #[inline]
-    pub(crate) fn policy_atan_with(self, wd: u32, mode: RoundingMode) -> Self {
-        Self(trig::trig_series_2limb::atan_with::<SCALE>(self.0, wd, mode))
+    pub(crate) fn policy_atan_with(self, working_digits: u32, mode: RoundingMode) -> Self {
+        Self(trig::trig_series_2limb::atan_with::<SCALE>(self.0, working_digits, mode))
     }
     #[inline]
     pub(crate) fn policy_asin(self, mode: RoundingMode) -> Self {
@@ -1404,8 +1405,8 @@ impl<const SCALE: u32> crate::D<crate::int::types::Int<2>, SCALE> {
         })
     }
     #[inline]
-    pub(crate) fn policy_asin_with(self, wd: u32, mode: RoundingMode) -> Self {
-        Self(trig::trig_series_2limb::asin_with::<SCALE>(self.0, wd, mode))
+    pub(crate) fn policy_asin_with(self, working_digits: u32, mode: RoundingMode) -> Self {
+        Self(trig::trig_series_2limb::asin_with::<SCALE>(self.0, working_digits, mode))
     }
     #[inline]
     pub(crate) fn policy_acos(self, mode: RoundingMode) -> Self {
@@ -1416,8 +1417,8 @@ impl<const SCALE: u32> crate::D<crate::int::types::Int<2>, SCALE> {
         })
     }
     #[inline]
-    pub(crate) fn policy_acos_with(self, wd: u32, mode: RoundingMode) -> Self {
-        Self(trig::trig_series_2limb::acos_with::<SCALE>(self.0, wd, mode))
+    pub(crate) fn policy_acos_with(self, working_digits: u32, mode: RoundingMode) -> Self {
+        Self(trig::trig_series_2limb::acos_with::<SCALE>(self.0, working_digits, mode))
     }
     #[inline]
     pub(crate) fn policy_atan2(self, other: Self, mode: RoundingMode) -> Self {
@@ -1430,8 +1431,8 @@ impl<const SCALE: u32> crate::D<crate::int::types::Int<2>, SCALE> {
         })
     }
     #[inline]
-    pub(crate) fn policy_atan2_with(self, other: Self, wd: u32, mode: RoundingMode) -> Self {
-        Self(trig::trig_series_2limb::atan2_with::<SCALE>(self.0, other.0, wd, mode))
+    pub(crate) fn policy_atan2_with(self, other: Self, working_digits: u32, mode: RoundingMode) -> Self {
+        Self(trig::trig_series_2limb::atan2_with::<SCALE>(self.0, other.0, working_digits, mode))
     }
 
     d38_hyperbolic_and_angle!();
@@ -1468,7 +1469,7 @@ macro_rules! wide_trig_inverse_inherent {
             }
         }
         #[inline]
-        pub(crate) fn policy_asin_with(self, _wd: u32, mode: RoundingMode) -> Self {
+        pub(crate) fn policy_asin_with(self, _working_digits: u32, mode: RoundingMode) -> Self {
             Self(inverse_rung::asin_strict::<$Core, SCALE>(self.0, mode))
         }
         #[inline]
@@ -1480,7 +1481,7 @@ macro_rules! wide_trig_inverse_inherent {
             }
         }
         #[inline]
-        pub(crate) fn policy_acos_with(self, _wd: u32, mode: RoundingMode) -> Self {
+        pub(crate) fn policy_acos_with(self, _working_digits: u32, mode: RoundingMode) -> Self {
             Self(inverse_rung::acos_strict::<$Core, SCALE>(self.0, mode))
         }
         #[inline]
@@ -1492,7 +1493,7 @@ macro_rules! wide_trig_inverse_inherent {
             }
         }
         #[inline]
-        pub(crate) fn policy_atan2_with(self, other: Self, _wd: u32, mode: RoundingMode) -> Self {
+        pub(crate) fn policy_atan2_with(self, other: Self, _working_digits: u32, mode: RoundingMode) -> Self {
             Self(inverse_rung::atan2_strict::<$Core, SCALE>(self.0, other.0, mode))
         }
     };
@@ -1507,7 +1508,7 @@ macro_rules! wide_trig_extra_inherent {
             Self(extra_rung::asinh_strict::<$Core, SCALE>(self.0, mode))
         }
         #[inline]
-        pub(crate) fn policy_asinh_with(self, _wd: u32, mode: RoundingMode) -> Self {
+        pub(crate) fn policy_asinh_with(self, _working_digits: u32, mode: RoundingMode) -> Self {
             Self(extra_rung::asinh_strict::<$Core, SCALE>(self.0, mode))
         }
         #[inline]
@@ -1515,7 +1516,7 @@ macro_rules! wide_trig_extra_inherent {
             Self(extra_rung::acosh_strict::<$Core, SCALE>(self.0, mode))
         }
         #[inline]
-        pub(crate) fn policy_acosh_with(self, _wd: u32, mode: RoundingMode) -> Self {
+        pub(crate) fn policy_acosh_with(self, _working_digits: u32, mode: RoundingMode) -> Self {
             Self(extra_rung::acosh_strict::<$Core, SCALE>(self.0, mode))
         }
         #[inline]
@@ -1523,7 +1524,7 @@ macro_rules! wide_trig_extra_inherent {
             Self(extra_rung::atanh_strict::<$Core, SCALE>(self.0, mode))
         }
         #[inline]
-        pub(crate) fn policy_atanh_with(self, _wd: u32, mode: RoundingMode) -> Self {
+        pub(crate) fn policy_atanh_with(self, _working_digits: u32, mode: RoundingMode) -> Self {
             Self(extra_rung::atanh_strict::<$Core, SCALE>(self.0, mode))
         }
         #[inline]
@@ -1531,8 +1532,8 @@ macro_rules! wide_trig_extra_inherent {
             Self::from_bits(crate::policy::to_degrees::dispatch::<_, SCALE>(self.to_bits(), mode))
         }
         #[inline]
-        pub(crate) fn policy_to_degrees_with(self, wd: u32, mode: RoundingMode) -> Self {
-            let _ = wd;
+        pub(crate) fn policy_to_degrees_with(self, working_digits: u32, mode: RoundingMode) -> Self {
+            let _ = working_digits;
             Self::from_bits(crate::policy::to_degrees::dispatch::<_, SCALE>(self.to_bits(), mode))
         }
         #[inline]
@@ -1540,8 +1541,8 @@ macro_rules! wide_trig_extra_inherent {
             Self::from_bits(crate::policy::to_radians::dispatch::<_, SCALE>(self.to_bits(), mode))
         }
         #[inline]
-        pub(crate) fn policy_to_radians_with(self, wd: u32, mode: RoundingMode) -> Self {
-            let _ = wd;
+        pub(crate) fn policy_to_radians_with(self, working_digits: u32, mode: RoundingMode) -> Self {
+            let _ = working_digits;
             Self::from_bits(crate::policy::to_radians::dispatch::<_, SCALE>(self.to_bits(), mode))
         }
     };
@@ -1561,7 +1562,7 @@ macro_rules! wide_trig_hyper_inherent {
             }
         }
         #[inline]
-        pub(crate) fn policy_sinh_with(self, _wd: u32, mode: RoundingMode) -> Self {
+        pub(crate) fn policy_sinh_with(self, _working_digits: u32, mode: RoundingMode) -> Self {
             Self(hyper_rung::sinh_strict::<$Core, SCALE>(self.0, mode))
         }
         #[inline]
@@ -1573,7 +1574,7 @@ macro_rules! wide_trig_hyper_inherent {
             }
         }
         #[inline]
-        pub(crate) fn policy_cosh_with(self, _wd: u32, mode: RoundingMode) -> Self {
+        pub(crate) fn policy_cosh_with(self, _working_digits: u32, mode: RoundingMode) -> Self {
             Self(hyper_rung::cosh_strict::<$Core, SCALE>(self.0, mode))
         }
         #[inline]
@@ -1585,7 +1586,7 @@ macro_rules! wide_trig_hyper_inherent {
             }
         }
         #[inline]
-        pub(crate) fn policy_tanh_with(self, _wd: u32, mode: RoundingMode) -> Self {
+        pub(crate) fn policy_tanh_with(self, _working_digits: u32, mode: RoundingMode) -> Self {
             Self(hyper_rung::tanh_strict::<$Core, SCALE>(self.0, mode))
         }
     };
@@ -1613,7 +1614,7 @@ macro_rules! wide_trig_forward_series {
             })
         }
         #[inline]
-        pub(crate) fn policy_sin_with(self, _wd: u32, mode: RoundingMode) -> Self {
+        pub(crate) fn policy_sin_with(self, _working_digits: u32, mode: RoundingMode) -> Self {
             Self(forward_rung::sin_strict::<$Core, SCALE, { <$Core as crate::algos::support::wide_trig_core::WideTrigCore>::GUARD }>(self.0, mode))
         }
         #[inline]
@@ -1631,7 +1632,7 @@ macro_rules! wide_trig_forward_series {
             })
         }
         #[inline]
-        pub(crate) fn policy_cos_with(self, _wd: u32, mode: RoundingMode) -> Self {
+        pub(crate) fn policy_cos_with(self, _working_digits: u32, mode: RoundingMode) -> Self {
             Self(forward_rung::cos_strict::<$Core, SCALE, { <$Core as crate::algos::support::wide_trig_core::WideTrigCore>::GUARD }>(self.0, mode))
         }
         #[inline]
@@ -1649,7 +1650,7 @@ macro_rules! wide_trig_forward_series {
             })
         }
         #[inline]
-        pub(crate) fn policy_tan_with(self, _wd: u32, mode: RoundingMode) -> Self {
+        pub(crate) fn policy_tan_with(self, _working_digits: u32, mode: RoundingMode) -> Self {
             Self(forward_rung::tan_strict::<$Core, SCALE, { <$Core as crate::algos::support::wide_trig_core::WideTrigCore>::GUARD }, true, true>(self.0, mode))
         }
         #[inline]
@@ -1667,7 +1668,7 @@ macro_rules! wide_trig_forward_series {
             })
         }
         #[inline]
-        pub(crate) fn policy_atan_with(self, _wd: u32, mode: RoundingMode) -> Self {
+        pub(crate) fn policy_atan_with(self, _working_digits: u32, mode: RoundingMode) -> Self {
             Self(forward_rung::atan_strict::<$Core, SCALE, { <$Core as crate::algos::support::wide_trig_core::WideTrigCore>::GUARD }, true>(self.0, mode))
         }
     };
@@ -1701,7 +1702,7 @@ impl<const SCALE: u32> crate::D<crate::int::types::Int<3>, SCALE> {
         })
     }
     #[inline]
-    pub(crate) fn policy_sin_with(self, _wd: u32, mode: RoundingMode) -> Self {
+    pub(crate) fn policy_sin_with(self, _working_digits: u32, mode: RoundingMode) -> Self {
         self.policy_sin(mode)
     }
     #[inline]
@@ -1721,7 +1722,7 @@ impl<const SCALE: u32> crate::D<crate::int::types::Int<3>, SCALE> {
         })
     }
     #[inline]
-    pub(crate) fn policy_cos_with(self, _wd: u32, mode: RoundingMode) -> Self {
+    pub(crate) fn policy_cos_with(self, _working_digits: u32, mode: RoundingMode) -> Self {
         self.policy_cos(mode)
     }
     #[inline]
@@ -1739,7 +1740,7 @@ impl<const SCALE: u32> crate::D<crate::int::types::Int<3>, SCALE> {
         })
     }
     #[inline]
-    pub(crate) fn policy_tan_with(self, _wd: u32, mode: RoundingMode) -> Self {
+    pub(crate) fn policy_tan_with(self, _working_digits: u32, mode: RoundingMode) -> Self {
         self.policy_tan(mode)
     }
     #[inline]
@@ -1758,7 +1759,7 @@ impl<const SCALE: u32> crate::D<crate::int::types::Int<3>, SCALE> {
         })
     }
     #[inline]
-    pub(crate) fn policy_atan_with(self, _wd: u32, mode: RoundingMode) -> Self {
+    pub(crate) fn policy_atan_with(self, _working_digits: u32, mode: RoundingMode) -> Self {
         self.policy_atan(mode)
     }
 
@@ -1776,7 +1777,7 @@ impl<const SCALE: u32> crate::D<crate::int::types::Int<3>, SCALE> {
         })
     }
     #[inline]
-    pub(crate) fn policy_asin_with(self, _wd: u32, mode: RoundingMode) -> Self {
+    pub(crate) fn policy_asin_with(self, _working_digits: u32, mode: RoundingMode) -> Self {
         self.policy_asin(mode)
     }
     #[inline]
@@ -1791,7 +1792,7 @@ impl<const SCALE: u32> crate::D<crate::int::types::Int<3>, SCALE> {
         })
     }
     #[inline]
-    pub(crate) fn policy_acos_with(self, _wd: u32, mode: RoundingMode) -> Self {
+    pub(crate) fn policy_acos_with(self, _working_digits: u32, mode: RoundingMode) -> Self {
         self.policy_acos(mode)
     }
     #[inline]
@@ -1808,7 +1809,7 @@ impl<const SCALE: u32> crate::D<crate::int::types::Int<3>, SCALE> {
         })
     }
     #[inline]
-    pub(crate) fn policy_atan2_with(self, other: Self, _wd: u32, mode: RoundingMode) -> Self {
+    pub(crate) fn policy_atan2_with(self, other: Self, _working_digits: u32, mode: RoundingMode) -> Self {
         self.policy_atan2(other, mode)
     }
 
@@ -1826,7 +1827,7 @@ impl<const SCALE: u32> crate::D<crate::int::types::Int<3>, SCALE> {
         })
     }
     #[inline]
-    pub(crate) fn policy_sinh_with(self, _wd: u32, mode: RoundingMode) -> Self {
+    pub(crate) fn policy_sinh_with(self, _working_digits: u32, mode: RoundingMode) -> Self {
         self.policy_sinh(mode)
     }
     #[inline]
@@ -1841,7 +1842,7 @@ impl<const SCALE: u32> crate::D<crate::int::types::Int<3>, SCALE> {
         })
     }
     #[inline]
-    pub(crate) fn policy_cosh_with(self, _wd: u32, mode: RoundingMode) -> Self {
+    pub(crate) fn policy_cosh_with(self, _working_digits: u32, mode: RoundingMode) -> Self {
         self.policy_cosh(mode)
     }
     #[inline]
@@ -1856,7 +1857,7 @@ impl<const SCALE: u32> crate::D<crate::int::types::Int<3>, SCALE> {
         })
     }
     #[inline]
-    pub(crate) fn policy_tanh_with(self, _wd: u32, mode: RoundingMode) -> Self {
+    pub(crate) fn policy_tanh_with(self, _working_digits: u32, mode: RoundingMode) -> Self {
         self.policy_tanh(mode)
     }
 
@@ -1891,7 +1892,7 @@ impl<const SCALE: u32> crate::D<crate::int::types::Int<6>, SCALE> {
         })
     }
     #[inline]
-    pub(crate) fn policy_sinh_with(self, _wd: u32, mode: RoundingMode) -> Self {
+    pub(crate) fn policy_sinh_with(self, _working_digits: u32, mode: RoundingMode) -> Self {
         self.policy_sinh(mode)
     }
     #[inline]
@@ -1906,7 +1907,7 @@ impl<const SCALE: u32> crate::D<crate::int::types::Int<6>, SCALE> {
         })
     }
     #[inline]
-    pub(crate) fn policy_cosh_with(self, _wd: u32, mode: RoundingMode) -> Self {
+    pub(crate) fn policy_cosh_with(self, _working_digits: u32, mode: RoundingMode) -> Self {
         self.policy_cosh(mode)
     }
     #[inline]
@@ -1921,7 +1922,7 @@ impl<const SCALE: u32> crate::D<crate::int::types::Int<6>, SCALE> {
         })
     }
     #[inline]
-    pub(crate) fn policy_tanh_with(self, _wd: u32, mode: RoundingMode) -> Self {
+    pub(crate) fn policy_tanh_with(self, _working_digits: u32, mode: RoundingMode) -> Self {
         self.policy_tanh(mode)
     }
 
@@ -1944,7 +1945,7 @@ impl<const SCALE: u32> crate::D<crate::int::types::Int<8>, SCALE> {
         })
     }
     #[inline]
-    pub(crate) fn policy_sin_with(self, _wd: u32, mode: RoundingMode) -> Self {
+    pub(crate) fn policy_sin_with(self, _working_digits: u32, mode: RoundingMode) -> Self {
         self.policy_sin(mode)
     }
     #[inline]
@@ -1959,7 +1960,7 @@ impl<const SCALE: u32> crate::D<crate::int::types::Int<8>, SCALE> {
         })
     }
     #[inline]
-    pub(crate) fn policy_cos_with(self, _wd: u32, mode: RoundingMode) -> Self {
+    pub(crate) fn policy_cos_with(self, _working_digits: u32, mode: RoundingMode) -> Self {
         self.policy_cos(mode)
     }
     #[inline]
@@ -1974,7 +1975,7 @@ impl<const SCALE: u32> crate::D<crate::int::types::Int<8>, SCALE> {
         })
     }
     #[inline]
-    pub(crate) fn policy_tan_with(self, _wd: u32, mode: RoundingMode) -> Self {
+    pub(crate) fn policy_tan_with(self, _working_digits: u32, mode: RoundingMode) -> Self {
         self.policy_tan(mode)
     }
     #[inline]
@@ -1989,7 +1990,7 @@ impl<const SCALE: u32> crate::D<crate::int::types::Int<8>, SCALE> {
         })
     }
     #[inline]
-    pub(crate) fn policy_atan_with(self, _wd: u32, mode: RoundingMode) -> Self {
+    pub(crate) fn policy_atan_with(self, _working_digits: u32, mode: RoundingMode) -> Self {
         self.policy_atan(mode)
     }
 
@@ -2007,7 +2008,7 @@ impl<const SCALE: u32> crate::D<crate::int::types::Int<8>, SCALE> {
         })
     }
     #[inline]
-    pub(crate) fn policy_sinh_with(self, _wd: u32, mode: RoundingMode) -> Self {
+    pub(crate) fn policy_sinh_with(self, _working_digits: u32, mode: RoundingMode) -> Self {
         self.policy_sinh(mode)
     }
     #[inline]
@@ -2022,7 +2023,7 @@ impl<const SCALE: u32> crate::D<crate::int::types::Int<8>, SCALE> {
         })
     }
     #[inline]
-    pub(crate) fn policy_cosh_with(self, _wd: u32, mode: RoundingMode) -> Self {
+    pub(crate) fn policy_cosh_with(self, _working_digits: u32, mode: RoundingMode) -> Self {
         self.policy_cosh(mode)
     }
     #[inline]
@@ -2037,7 +2038,7 @@ impl<const SCALE: u32> crate::D<crate::int::types::Int<8>, SCALE> {
         })
     }
     #[inline]
-    pub(crate) fn policy_tanh_with(self, _wd: u32, mode: RoundingMode) -> Self {
+    pub(crate) fn policy_tanh_with(self, _working_digits: u32, mode: RoundingMode) -> Self {
         self.policy_tanh(mode)
     }
 
@@ -2069,7 +2070,7 @@ impl<const SCALE: u32> crate::D<crate::int::types::Int<16>, SCALE> {
         })
     }
     #[inline]
-    pub(crate) fn policy_sin_with(self, _wd: u32, mode: RoundingMode) -> Self {
+    pub(crate) fn policy_sin_with(self, _working_digits: u32, mode: RoundingMode) -> Self {
         self.policy_sin(mode)
     }
     #[inline]
@@ -2084,7 +2085,7 @@ impl<const SCALE: u32> crate::D<crate::int::types::Int<16>, SCALE> {
         })
     }
     #[inline]
-    pub(crate) fn policy_cos_with(self, _wd: u32, mode: RoundingMode) -> Self {
+    pub(crate) fn policy_cos_with(self, _working_digits: u32, mode: RoundingMode) -> Self {
         self.policy_cos(mode)
     }
     #[inline]
@@ -2099,7 +2100,7 @@ impl<const SCALE: u32> crate::D<crate::int::types::Int<16>, SCALE> {
         })
     }
     #[inline]
-    pub(crate) fn policy_tan_with(self, _wd: u32, mode: RoundingMode) -> Self {
+    pub(crate) fn policy_tan_with(self, _working_digits: u32, mode: RoundingMode) -> Self {
         self.policy_tan(mode)
     }
     #[inline]
@@ -2114,7 +2115,7 @@ impl<const SCALE: u32> crate::D<crate::int::types::Int<16>, SCALE> {
         })
     }
     #[inline]
-    pub(crate) fn policy_atan_with(self, _wd: u32, mode: RoundingMode) -> Self {
+    pub(crate) fn policy_atan_with(self, _working_digits: u32, mode: RoundingMode) -> Self {
         self.policy_atan(mode)
     }
 
@@ -2132,7 +2133,7 @@ impl<const SCALE: u32> crate::D<crate::int::types::Int<16>, SCALE> {
         })
     }
     #[inline]
-    pub(crate) fn policy_sinh_with(self, _wd: u32, mode: RoundingMode) -> Self {
+    pub(crate) fn policy_sinh_with(self, _working_digits: u32, mode: RoundingMode) -> Self {
         self.policy_sinh(mode)
     }
     #[inline]
@@ -2147,7 +2148,7 @@ impl<const SCALE: u32> crate::D<crate::int::types::Int<16>, SCALE> {
         })
     }
     #[inline]
-    pub(crate) fn policy_cosh_with(self, _wd: u32, mode: RoundingMode) -> Self {
+    pub(crate) fn policy_cosh_with(self, _working_digits: u32, mode: RoundingMode) -> Self {
         self.policy_cosh(mode)
     }
     #[inline]
@@ -2162,7 +2163,7 @@ impl<const SCALE: u32> crate::D<crate::int::types::Int<16>, SCALE> {
         })
     }
     #[inline]
-    pub(crate) fn policy_tanh_with(self, _wd: u32, mode: RoundingMode) -> Self {
+    pub(crate) fn policy_tanh_with(self, _working_digits: u32, mode: RoundingMode) -> Self {
         self.policy_tanh(mode)
     }
 
@@ -2185,7 +2186,7 @@ impl<const SCALE: u32> crate::D<crate::int::types::Int<24>, SCALE> {
         })
     }
     #[inline]
-    pub(crate) fn policy_sin_with(self, _wd: u32, mode: RoundingMode) -> Self {
+    pub(crate) fn policy_sin_with(self, _working_digits: u32, mode: RoundingMode) -> Self {
         self.policy_sin(mode)
     }
     #[inline]
@@ -2200,7 +2201,7 @@ impl<const SCALE: u32> crate::D<crate::int::types::Int<24>, SCALE> {
         })
     }
     #[inline]
-    pub(crate) fn policy_cos_with(self, _wd: u32, mode: RoundingMode) -> Self {
+    pub(crate) fn policy_cos_with(self, _working_digits: u32, mode: RoundingMode) -> Self {
         self.policy_cos(mode)
     }
     #[inline]
@@ -2215,7 +2216,7 @@ impl<const SCALE: u32> crate::D<crate::int::types::Int<24>, SCALE> {
         })
     }
     #[inline]
-    pub(crate) fn policy_tan_with(self, _wd: u32, mode: RoundingMode) -> Self {
+    pub(crate) fn policy_tan_with(self, _working_digits: u32, mode: RoundingMode) -> Self {
         self.policy_tan(mode)
     }
     #[inline]
@@ -2230,7 +2231,7 @@ impl<const SCALE: u32> crate::D<crate::int::types::Int<24>, SCALE> {
         })
     }
     #[inline]
-    pub(crate) fn policy_atan_with(self, _wd: u32, mode: RoundingMode) -> Self {
+    pub(crate) fn policy_atan_with(self, _working_digits: u32, mode: RoundingMode) -> Self {
         self.policy_atan(mode)
     }
 
@@ -2302,31 +2303,31 @@ pub(crate) fn sin_dispatch<const N: usize, const SCALE: u32>(raw: Int<N>, mode: 
 
 #[inline]
 #[must_use]
-pub(crate) fn sin_dispatch_with<const N: usize, const SCALE: u32>(raw: Int<N>, wd: u32, mode: RoundingMode) -> Int<N> {
+pub(crate) fn sin_dispatch_with<const N: usize, const SCALE: u32>(raw: Int<N>, working_digits: u32, mode: RoundingMode) -> Int<N> {
     match N {
-        1 => crate::D::<crate::int::types::Int<1>, SCALE>(raw.resize_to::<crate::int::types::Int<1>>()).policy_sin_with(wd, mode).0.resize_to::<Int<N>>(),
-        2 => crate::D::<crate::int::types::Int<2>, SCALE>(raw.resize_to::<crate::int::types::Int<2>>()).policy_sin_with(wd, mode).0.resize_to::<Int<N>>(),
+        1 => crate::D::<crate::int::types::Int<1>, SCALE>(raw.resize_to::<crate::int::types::Int<1>>()).policy_sin_with(working_digits, mode).0.resize_to::<Int<N>>(),
+        2 => crate::D::<crate::int::types::Int<2>, SCALE>(raw.resize_to::<crate::int::types::Int<2>>()).policy_sin_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d57", feature = "wide"))]
-        3 => crate::D::<crate::int::types::Int<3>, SCALE>(raw.resize_to::<crate::int::types::Int<3>>()).policy_sin_with(wd, mode).0.resize_to::<Int<N>>(),
+        3 => crate::D::<crate::int::types::Int<3>, SCALE>(raw.resize_to::<crate::int::types::Int<3>>()).policy_sin_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d76", feature = "wide"))]
-        4 => crate::D::<crate::int::types::Int<4>, SCALE>(raw.resize_to::<crate::int::types::Int<4>>()).policy_sin_with(wd, mode).0.resize_to::<Int<N>>(),
+        4 => crate::D::<crate::int::types::Int<4>, SCALE>(raw.resize_to::<crate::int::types::Int<4>>()).policy_sin_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d115", feature = "wide"))]
-        6 => crate::D::<crate::int::types::Int<6>, SCALE>(raw.resize_to::<crate::int::types::Int<6>>()).policy_sin_with(wd, mode).0.resize_to::<Int<N>>(),
+        6 => crate::D::<crate::int::types::Int<6>, SCALE>(raw.resize_to::<crate::int::types::Int<6>>()).policy_sin_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d153", feature = "wide"))]
-        8 => crate::D::<crate::int::types::Int<8>, SCALE>(raw.resize_to::<crate::int::types::Int<8>>()).policy_sin_with(wd, mode).0.resize_to::<Int<N>>(),
+        8 => crate::D::<crate::int::types::Int<8>, SCALE>(raw.resize_to::<crate::int::types::Int<8>>()).policy_sin_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d230", feature = "wide"))]
-        12 => crate::D::<crate::int::types::Int<12>, SCALE>(raw.resize_to::<crate::int::types::Int<12>>()).policy_sin_with(wd, mode).0.resize_to::<Int<N>>(),
+        12 => crate::D::<crate::int::types::Int<12>, SCALE>(raw.resize_to::<crate::int::types::Int<12>>()).policy_sin_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d307", feature = "wide", feature = "x-wide"))]
-        16 => crate::D::<crate::int::types::Int<16>, SCALE>(raw.resize_to::<crate::int::types::Int<16>>()).policy_sin_with(wd, mode).0.resize_to::<Int<N>>(),
+        16 => crate::D::<crate::int::types::Int<16>, SCALE>(raw.resize_to::<crate::int::types::Int<16>>()).policy_sin_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d462", feature = "x-wide"))]
-        24 => crate::D::<crate::int::types::Int<24>, SCALE>(raw.resize_to::<crate::int::types::Int<24>>()).policy_sin_with(wd, mode).0.resize_to::<Int<N>>(),
+        24 => crate::D::<crate::int::types::Int<24>, SCALE>(raw.resize_to::<crate::int::types::Int<24>>()).policy_sin_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d616", feature = "x-wide"))]
-        32 => crate::D::<crate::int::types::Int<32>, SCALE>(raw.resize_to::<crate::int::types::Int<32>>()).policy_sin_with(wd, mode).0.resize_to::<Int<N>>(),
+        32 => crate::D::<crate::int::types::Int<32>, SCALE>(raw.resize_to::<crate::int::types::Int<32>>()).policy_sin_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d924", feature = "xx-wide"))]
-        48 => crate::D::<crate::int::types::Int<48>, SCALE>(raw.resize_to::<crate::int::types::Int<48>>()).policy_sin_with(wd, mode).0.resize_to::<Int<N>>(),
+        48 => crate::D::<crate::int::types::Int<48>, SCALE>(raw.resize_to::<crate::int::types::Int<48>>()).policy_sin_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d1232", feature = "xx-wide"))]
-        64 => crate::D::<crate::int::types::Int<64>, SCALE>(raw.resize_to::<crate::int::types::Int<64>>()).policy_sin_with(wd, mode).0.resize_to::<Int<N>>(),
-        _ => crate::D::<crate::int::types::Int<2>, SCALE>(raw.resize_to::<crate::int::types::Int<2>>()).policy_sin_with(wd, mode).0.resize_to::<Int<N>>(),
+        64 => crate::D::<crate::int::types::Int<64>, SCALE>(raw.resize_to::<crate::int::types::Int<64>>()).policy_sin_with(working_digits, mode).0.resize_to::<Int<N>>(),
+        _ => crate::D::<crate::int::types::Int<2>, SCALE>(raw.resize_to::<crate::int::types::Int<2>>()).policy_sin_with(working_digits, mode).0.resize_to::<Int<N>>(),
     }
 }
 
@@ -2362,31 +2363,31 @@ pub(crate) fn cos_dispatch<const N: usize, const SCALE: u32>(raw: Int<N>, mode: 
 
 #[inline]
 #[must_use]
-pub(crate) fn cos_dispatch_with<const N: usize, const SCALE: u32>(raw: Int<N>, wd: u32, mode: RoundingMode) -> Int<N> {
+pub(crate) fn cos_dispatch_with<const N: usize, const SCALE: u32>(raw: Int<N>, working_digits: u32, mode: RoundingMode) -> Int<N> {
     match N {
-        1 => crate::D::<crate::int::types::Int<1>, SCALE>(raw.resize_to::<crate::int::types::Int<1>>()).policy_cos_with(wd, mode).0.resize_to::<Int<N>>(),
-        2 => crate::D::<crate::int::types::Int<2>, SCALE>(raw.resize_to::<crate::int::types::Int<2>>()).policy_cos_with(wd, mode).0.resize_to::<Int<N>>(),
+        1 => crate::D::<crate::int::types::Int<1>, SCALE>(raw.resize_to::<crate::int::types::Int<1>>()).policy_cos_with(working_digits, mode).0.resize_to::<Int<N>>(),
+        2 => crate::D::<crate::int::types::Int<2>, SCALE>(raw.resize_to::<crate::int::types::Int<2>>()).policy_cos_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d57", feature = "wide"))]
-        3 => crate::D::<crate::int::types::Int<3>, SCALE>(raw.resize_to::<crate::int::types::Int<3>>()).policy_cos_with(wd, mode).0.resize_to::<Int<N>>(),
+        3 => crate::D::<crate::int::types::Int<3>, SCALE>(raw.resize_to::<crate::int::types::Int<3>>()).policy_cos_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d76", feature = "wide"))]
-        4 => crate::D::<crate::int::types::Int<4>, SCALE>(raw.resize_to::<crate::int::types::Int<4>>()).policy_cos_with(wd, mode).0.resize_to::<Int<N>>(),
+        4 => crate::D::<crate::int::types::Int<4>, SCALE>(raw.resize_to::<crate::int::types::Int<4>>()).policy_cos_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d115", feature = "wide"))]
-        6 => crate::D::<crate::int::types::Int<6>, SCALE>(raw.resize_to::<crate::int::types::Int<6>>()).policy_cos_with(wd, mode).0.resize_to::<Int<N>>(),
+        6 => crate::D::<crate::int::types::Int<6>, SCALE>(raw.resize_to::<crate::int::types::Int<6>>()).policy_cos_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d153", feature = "wide"))]
-        8 => crate::D::<crate::int::types::Int<8>, SCALE>(raw.resize_to::<crate::int::types::Int<8>>()).policy_cos_with(wd, mode).0.resize_to::<Int<N>>(),
+        8 => crate::D::<crate::int::types::Int<8>, SCALE>(raw.resize_to::<crate::int::types::Int<8>>()).policy_cos_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d230", feature = "wide"))]
-        12 => crate::D::<crate::int::types::Int<12>, SCALE>(raw.resize_to::<crate::int::types::Int<12>>()).policy_cos_with(wd, mode).0.resize_to::<Int<N>>(),
+        12 => crate::D::<crate::int::types::Int<12>, SCALE>(raw.resize_to::<crate::int::types::Int<12>>()).policy_cos_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d307", feature = "wide", feature = "x-wide"))]
-        16 => crate::D::<crate::int::types::Int<16>, SCALE>(raw.resize_to::<crate::int::types::Int<16>>()).policy_cos_with(wd, mode).0.resize_to::<Int<N>>(),
+        16 => crate::D::<crate::int::types::Int<16>, SCALE>(raw.resize_to::<crate::int::types::Int<16>>()).policy_cos_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d462", feature = "x-wide"))]
-        24 => crate::D::<crate::int::types::Int<24>, SCALE>(raw.resize_to::<crate::int::types::Int<24>>()).policy_cos_with(wd, mode).0.resize_to::<Int<N>>(),
+        24 => crate::D::<crate::int::types::Int<24>, SCALE>(raw.resize_to::<crate::int::types::Int<24>>()).policy_cos_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d616", feature = "x-wide"))]
-        32 => crate::D::<crate::int::types::Int<32>, SCALE>(raw.resize_to::<crate::int::types::Int<32>>()).policy_cos_with(wd, mode).0.resize_to::<Int<N>>(),
+        32 => crate::D::<crate::int::types::Int<32>, SCALE>(raw.resize_to::<crate::int::types::Int<32>>()).policy_cos_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d924", feature = "xx-wide"))]
-        48 => crate::D::<crate::int::types::Int<48>, SCALE>(raw.resize_to::<crate::int::types::Int<48>>()).policy_cos_with(wd, mode).0.resize_to::<Int<N>>(),
+        48 => crate::D::<crate::int::types::Int<48>, SCALE>(raw.resize_to::<crate::int::types::Int<48>>()).policy_cos_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d1232", feature = "xx-wide"))]
-        64 => crate::D::<crate::int::types::Int<64>, SCALE>(raw.resize_to::<crate::int::types::Int<64>>()).policy_cos_with(wd, mode).0.resize_to::<Int<N>>(),
-        _ => crate::D::<crate::int::types::Int<2>, SCALE>(raw.resize_to::<crate::int::types::Int<2>>()).policy_cos_with(wd, mode).0.resize_to::<Int<N>>(),
+        64 => crate::D::<crate::int::types::Int<64>, SCALE>(raw.resize_to::<crate::int::types::Int<64>>()).policy_cos_with(working_digits, mode).0.resize_to::<Int<N>>(),
+        _ => crate::D::<crate::int::types::Int<2>, SCALE>(raw.resize_to::<crate::int::types::Int<2>>()).policy_cos_with(working_digits, mode).0.resize_to::<Int<N>>(),
     }
 }
 
@@ -2422,31 +2423,31 @@ pub(crate) fn tan_dispatch<const N: usize, const SCALE: u32>(raw: Int<N>, mode: 
 
 #[inline]
 #[must_use]
-pub(crate) fn tan_dispatch_with<const N: usize, const SCALE: u32>(raw: Int<N>, wd: u32, mode: RoundingMode) -> Int<N> {
+pub(crate) fn tan_dispatch_with<const N: usize, const SCALE: u32>(raw: Int<N>, working_digits: u32, mode: RoundingMode) -> Int<N> {
     match N {
-        1 => crate::D::<crate::int::types::Int<1>, SCALE>(raw.resize_to::<crate::int::types::Int<1>>()).policy_tan_with(wd, mode).0.resize_to::<Int<N>>(),
-        2 => crate::D::<crate::int::types::Int<2>, SCALE>(raw.resize_to::<crate::int::types::Int<2>>()).policy_tan_with(wd, mode).0.resize_to::<Int<N>>(),
+        1 => crate::D::<crate::int::types::Int<1>, SCALE>(raw.resize_to::<crate::int::types::Int<1>>()).policy_tan_with(working_digits, mode).0.resize_to::<Int<N>>(),
+        2 => crate::D::<crate::int::types::Int<2>, SCALE>(raw.resize_to::<crate::int::types::Int<2>>()).policy_tan_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d57", feature = "wide"))]
-        3 => crate::D::<crate::int::types::Int<3>, SCALE>(raw.resize_to::<crate::int::types::Int<3>>()).policy_tan_with(wd, mode).0.resize_to::<Int<N>>(),
+        3 => crate::D::<crate::int::types::Int<3>, SCALE>(raw.resize_to::<crate::int::types::Int<3>>()).policy_tan_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d76", feature = "wide"))]
-        4 => crate::D::<crate::int::types::Int<4>, SCALE>(raw.resize_to::<crate::int::types::Int<4>>()).policy_tan_with(wd, mode).0.resize_to::<Int<N>>(),
+        4 => crate::D::<crate::int::types::Int<4>, SCALE>(raw.resize_to::<crate::int::types::Int<4>>()).policy_tan_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d115", feature = "wide"))]
-        6 => crate::D::<crate::int::types::Int<6>, SCALE>(raw.resize_to::<crate::int::types::Int<6>>()).policy_tan_with(wd, mode).0.resize_to::<Int<N>>(),
+        6 => crate::D::<crate::int::types::Int<6>, SCALE>(raw.resize_to::<crate::int::types::Int<6>>()).policy_tan_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d153", feature = "wide"))]
-        8 => crate::D::<crate::int::types::Int<8>, SCALE>(raw.resize_to::<crate::int::types::Int<8>>()).policy_tan_with(wd, mode).0.resize_to::<Int<N>>(),
+        8 => crate::D::<crate::int::types::Int<8>, SCALE>(raw.resize_to::<crate::int::types::Int<8>>()).policy_tan_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d230", feature = "wide"))]
-        12 => crate::D::<crate::int::types::Int<12>, SCALE>(raw.resize_to::<crate::int::types::Int<12>>()).policy_tan_with(wd, mode).0.resize_to::<Int<N>>(),
+        12 => crate::D::<crate::int::types::Int<12>, SCALE>(raw.resize_to::<crate::int::types::Int<12>>()).policy_tan_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d307", feature = "wide", feature = "x-wide"))]
-        16 => crate::D::<crate::int::types::Int<16>, SCALE>(raw.resize_to::<crate::int::types::Int<16>>()).policy_tan_with(wd, mode).0.resize_to::<Int<N>>(),
+        16 => crate::D::<crate::int::types::Int<16>, SCALE>(raw.resize_to::<crate::int::types::Int<16>>()).policy_tan_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d462", feature = "x-wide"))]
-        24 => crate::D::<crate::int::types::Int<24>, SCALE>(raw.resize_to::<crate::int::types::Int<24>>()).policy_tan_with(wd, mode).0.resize_to::<Int<N>>(),
+        24 => crate::D::<crate::int::types::Int<24>, SCALE>(raw.resize_to::<crate::int::types::Int<24>>()).policy_tan_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d616", feature = "x-wide"))]
-        32 => crate::D::<crate::int::types::Int<32>, SCALE>(raw.resize_to::<crate::int::types::Int<32>>()).policy_tan_with(wd, mode).0.resize_to::<Int<N>>(),
+        32 => crate::D::<crate::int::types::Int<32>, SCALE>(raw.resize_to::<crate::int::types::Int<32>>()).policy_tan_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d924", feature = "xx-wide"))]
-        48 => crate::D::<crate::int::types::Int<48>, SCALE>(raw.resize_to::<crate::int::types::Int<48>>()).policy_tan_with(wd, mode).0.resize_to::<Int<N>>(),
+        48 => crate::D::<crate::int::types::Int<48>, SCALE>(raw.resize_to::<crate::int::types::Int<48>>()).policy_tan_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d1232", feature = "xx-wide"))]
-        64 => crate::D::<crate::int::types::Int<64>, SCALE>(raw.resize_to::<crate::int::types::Int<64>>()).policy_tan_with(wd, mode).0.resize_to::<Int<N>>(),
-        _ => crate::D::<crate::int::types::Int<2>, SCALE>(raw.resize_to::<crate::int::types::Int<2>>()).policy_tan_with(wd, mode).0.resize_to::<Int<N>>(),
+        64 => crate::D::<crate::int::types::Int<64>, SCALE>(raw.resize_to::<crate::int::types::Int<64>>()).policy_tan_with(working_digits, mode).0.resize_to::<Int<N>>(),
+        _ => crate::D::<crate::int::types::Int<2>, SCALE>(raw.resize_to::<crate::int::types::Int<2>>()).policy_tan_with(working_digits, mode).0.resize_to::<Int<N>>(),
     }
 }
 
@@ -2482,31 +2483,31 @@ pub(crate) fn atan_dispatch<const N: usize, const SCALE: u32>(raw: Int<N>, mode:
 
 #[inline]
 #[must_use]
-pub(crate) fn atan_dispatch_with<const N: usize, const SCALE: u32>(raw: Int<N>, wd: u32, mode: RoundingMode) -> Int<N> {
+pub(crate) fn atan_dispatch_with<const N: usize, const SCALE: u32>(raw: Int<N>, working_digits: u32, mode: RoundingMode) -> Int<N> {
     match N {
-        1 => crate::D::<crate::int::types::Int<1>, SCALE>(raw.resize_to::<crate::int::types::Int<1>>()).policy_atan_with(wd, mode).0.resize_to::<Int<N>>(),
-        2 => crate::D::<crate::int::types::Int<2>, SCALE>(raw.resize_to::<crate::int::types::Int<2>>()).policy_atan_with(wd, mode).0.resize_to::<Int<N>>(),
+        1 => crate::D::<crate::int::types::Int<1>, SCALE>(raw.resize_to::<crate::int::types::Int<1>>()).policy_atan_with(working_digits, mode).0.resize_to::<Int<N>>(),
+        2 => crate::D::<crate::int::types::Int<2>, SCALE>(raw.resize_to::<crate::int::types::Int<2>>()).policy_atan_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d57", feature = "wide"))]
-        3 => crate::D::<crate::int::types::Int<3>, SCALE>(raw.resize_to::<crate::int::types::Int<3>>()).policy_atan_with(wd, mode).0.resize_to::<Int<N>>(),
+        3 => crate::D::<crate::int::types::Int<3>, SCALE>(raw.resize_to::<crate::int::types::Int<3>>()).policy_atan_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d76", feature = "wide"))]
-        4 => crate::D::<crate::int::types::Int<4>, SCALE>(raw.resize_to::<crate::int::types::Int<4>>()).policy_atan_with(wd, mode).0.resize_to::<Int<N>>(),
+        4 => crate::D::<crate::int::types::Int<4>, SCALE>(raw.resize_to::<crate::int::types::Int<4>>()).policy_atan_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d115", feature = "wide"))]
-        6 => crate::D::<crate::int::types::Int<6>, SCALE>(raw.resize_to::<crate::int::types::Int<6>>()).policy_atan_with(wd, mode).0.resize_to::<Int<N>>(),
+        6 => crate::D::<crate::int::types::Int<6>, SCALE>(raw.resize_to::<crate::int::types::Int<6>>()).policy_atan_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d153", feature = "wide"))]
-        8 => crate::D::<crate::int::types::Int<8>, SCALE>(raw.resize_to::<crate::int::types::Int<8>>()).policy_atan_with(wd, mode).0.resize_to::<Int<N>>(),
+        8 => crate::D::<crate::int::types::Int<8>, SCALE>(raw.resize_to::<crate::int::types::Int<8>>()).policy_atan_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d230", feature = "wide"))]
-        12 => crate::D::<crate::int::types::Int<12>, SCALE>(raw.resize_to::<crate::int::types::Int<12>>()).policy_atan_with(wd, mode).0.resize_to::<Int<N>>(),
+        12 => crate::D::<crate::int::types::Int<12>, SCALE>(raw.resize_to::<crate::int::types::Int<12>>()).policy_atan_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d307", feature = "wide", feature = "x-wide"))]
-        16 => crate::D::<crate::int::types::Int<16>, SCALE>(raw.resize_to::<crate::int::types::Int<16>>()).policy_atan_with(wd, mode).0.resize_to::<Int<N>>(),
+        16 => crate::D::<crate::int::types::Int<16>, SCALE>(raw.resize_to::<crate::int::types::Int<16>>()).policy_atan_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d462", feature = "x-wide"))]
-        24 => crate::D::<crate::int::types::Int<24>, SCALE>(raw.resize_to::<crate::int::types::Int<24>>()).policy_atan_with(wd, mode).0.resize_to::<Int<N>>(),
+        24 => crate::D::<crate::int::types::Int<24>, SCALE>(raw.resize_to::<crate::int::types::Int<24>>()).policy_atan_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d616", feature = "x-wide"))]
-        32 => crate::D::<crate::int::types::Int<32>, SCALE>(raw.resize_to::<crate::int::types::Int<32>>()).policy_atan_with(wd, mode).0.resize_to::<Int<N>>(),
+        32 => crate::D::<crate::int::types::Int<32>, SCALE>(raw.resize_to::<crate::int::types::Int<32>>()).policy_atan_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d924", feature = "xx-wide"))]
-        48 => crate::D::<crate::int::types::Int<48>, SCALE>(raw.resize_to::<crate::int::types::Int<48>>()).policy_atan_with(wd, mode).0.resize_to::<Int<N>>(),
+        48 => crate::D::<crate::int::types::Int<48>, SCALE>(raw.resize_to::<crate::int::types::Int<48>>()).policy_atan_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d1232", feature = "xx-wide"))]
-        64 => crate::D::<crate::int::types::Int<64>, SCALE>(raw.resize_to::<crate::int::types::Int<64>>()).policy_atan_with(wd, mode).0.resize_to::<Int<N>>(),
-        _ => crate::D::<crate::int::types::Int<2>, SCALE>(raw.resize_to::<crate::int::types::Int<2>>()).policy_atan_with(wd, mode).0.resize_to::<Int<N>>(),
+        64 => crate::D::<crate::int::types::Int<64>, SCALE>(raw.resize_to::<crate::int::types::Int<64>>()).policy_atan_with(working_digits, mode).0.resize_to::<Int<N>>(),
+        _ => crate::D::<crate::int::types::Int<2>, SCALE>(raw.resize_to::<crate::int::types::Int<2>>()).policy_atan_with(working_digits, mode).0.resize_to::<Int<N>>(),
     }
 }
 
@@ -2542,31 +2543,31 @@ pub(crate) fn asin_dispatch<const N: usize, const SCALE: u32>(raw: Int<N>, mode:
 
 #[inline]
 #[must_use]
-pub(crate) fn asin_dispatch_with<const N: usize, const SCALE: u32>(raw: Int<N>, wd: u32, mode: RoundingMode) -> Int<N> {
+pub(crate) fn asin_dispatch_with<const N: usize, const SCALE: u32>(raw: Int<N>, working_digits: u32, mode: RoundingMode) -> Int<N> {
     match N {
-        1 => crate::D::<crate::int::types::Int<1>, SCALE>(raw.resize_to::<crate::int::types::Int<1>>()).policy_asin_with(wd, mode).0.resize_to::<Int<N>>(),
-        2 => crate::D::<crate::int::types::Int<2>, SCALE>(raw.resize_to::<crate::int::types::Int<2>>()).policy_asin_with(wd, mode).0.resize_to::<Int<N>>(),
+        1 => crate::D::<crate::int::types::Int<1>, SCALE>(raw.resize_to::<crate::int::types::Int<1>>()).policy_asin_with(working_digits, mode).0.resize_to::<Int<N>>(),
+        2 => crate::D::<crate::int::types::Int<2>, SCALE>(raw.resize_to::<crate::int::types::Int<2>>()).policy_asin_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d57", feature = "wide"))]
-        3 => crate::D::<crate::int::types::Int<3>, SCALE>(raw.resize_to::<crate::int::types::Int<3>>()).policy_asin_with(wd, mode).0.resize_to::<Int<N>>(),
+        3 => crate::D::<crate::int::types::Int<3>, SCALE>(raw.resize_to::<crate::int::types::Int<3>>()).policy_asin_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d76", feature = "wide"))]
-        4 => crate::D::<crate::int::types::Int<4>, SCALE>(raw.resize_to::<crate::int::types::Int<4>>()).policy_asin_with(wd, mode).0.resize_to::<Int<N>>(),
+        4 => crate::D::<crate::int::types::Int<4>, SCALE>(raw.resize_to::<crate::int::types::Int<4>>()).policy_asin_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d115", feature = "wide"))]
-        6 => crate::D::<crate::int::types::Int<6>, SCALE>(raw.resize_to::<crate::int::types::Int<6>>()).policy_asin_with(wd, mode).0.resize_to::<Int<N>>(),
+        6 => crate::D::<crate::int::types::Int<6>, SCALE>(raw.resize_to::<crate::int::types::Int<6>>()).policy_asin_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d153", feature = "wide"))]
-        8 => crate::D::<crate::int::types::Int<8>, SCALE>(raw.resize_to::<crate::int::types::Int<8>>()).policy_asin_with(wd, mode).0.resize_to::<Int<N>>(),
+        8 => crate::D::<crate::int::types::Int<8>, SCALE>(raw.resize_to::<crate::int::types::Int<8>>()).policy_asin_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d230", feature = "wide"))]
-        12 => crate::D::<crate::int::types::Int<12>, SCALE>(raw.resize_to::<crate::int::types::Int<12>>()).policy_asin_with(wd, mode).0.resize_to::<Int<N>>(),
+        12 => crate::D::<crate::int::types::Int<12>, SCALE>(raw.resize_to::<crate::int::types::Int<12>>()).policy_asin_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d307", feature = "wide", feature = "x-wide"))]
-        16 => crate::D::<crate::int::types::Int<16>, SCALE>(raw.resize_to::<crate::int::types::Int<16>>()).policy_asin_with(wd, mode).0.resize_to::<Int<N>>(),
+        16 => crate::D::<crate::int::types::Int<16>, SCALE>(raw.resize_to::<crate::int::types::Int<16>>()).policy_asin_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d462", feature = "x-wide"))]
-        24 => crate::D::<crate::int::types::Int<24>, SCALE>(raw.resize_to::<crate::int::types::Int<24>>()).policy_asin_with(wd, mode).0.resize_to::<Int<N>>(),
+        24 => crate::D::<crate::int::types::Int<24>, SCALE>(raw.resize_to::<crate::int::types::Int<24>>()).policy_asin_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d616", feature = "x-wide"))]
-        32 => crate::D::<crate::int::types::Int<32>, SCALE>(raw.resize_to::<crate::int::types::Int<32>>()).policy_asin_with(wd, mode).0.resize_to::<Int<N>>(),
+        32 => crate::D::<crate::int::types::Int<32>, SCALE>(raw.resize_to::<crate::int::types::Int<32>>()).policy_asin_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d924", feature = "xx-wide"))]
-        48 => crate::D::<crate::int::types::Int<48>, SCALE>(raw.resize_to::<crate::int::types::Int<48>>()).policy_asin_with(wd, mode).0.resize_to::<Int<N>>(),
+        48 => crate::D::<crate::int::types::Int<48>, SCALE>(raw.resize_to::<crate::int::types::Int<48>>()).policy_asin_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d1232", feature = "xx-wide"))]
-        64 => crate::D::<crate::int::types::Int<64>, SCALE>(raw.resize_to::<crate::int::types::Int<64>>()).policy_asin_with(wd, mode).0.resize_to::<Int<N>>(),
-        _ => crate::D::<crate::int::types::Int<2>, SCALE>(raw.resize_to::<crate::int::types::Int<2>>()).policy_asin_with(wd, mode).0.resize_to::<Int<N>>(),
+        64 => crate::D::<crate::int::types::Int<64>, SCALE>(raw.resize_to::<crate::int::types::Int<64>>()).policy_asin_with(working_digits, mode).0.resize_to::<Int<N>>(),
+        _ => crate::D::<crate::int::types::Int<2>, SCALE>(raw.resize_to::<crate::int::types::Int<2>>()).policy_asin_with(working_digits, mode).0.resize_to::<Int<N>>(),
     }
 }
 
@@ -2602,31 +2603,31 @@ pub(crate) fn acos_dispatch<const N: usize, const SCALE: u32>(raw: Int<N>, mode:
 
 #[inline]
 #[must_use]
-pub(crate) fn acos_dispatch_with<const N: usize, const SCALE: u32>(raw: Int<N>, wd: u32, mode: RoundingMode) -> Int<N> {
+pub(crate) fn acos_dispatch_with<const N: usize, const SCALE: u32>(raw: Int<N>, working_digits: u32, mode: RoundingMode) -> Int<N> {
     match N {
-        1 => crate::D::<crate::int::types::Int<1>, SCALE>(raw.resize_to::<crate::int::types::Int<1>>()).policy_acos_with(wd, mode).0.resize_to::<Int<N>>(),
-        2 => crate::D::<crate::int::types::Int<2>, SCALE>(raw.resize_to::<crate::int::types::Int<2>>()).policy_acos_with(wd, mode).0.resize_to::<Int<N>>(),
+        1 => crate::D::<crate::int::types::Int<1>, SCALE>(raw.resize_to::<crate::int::types::Int<1>>()).policy_acos_with(working_digits, mode).0.resize_to::<Int<N>>(),
+        2 => crate::D::<crate::int::types::Int<2>, SCALE>(raw.resize_to::<crate::int::types::Int<2>>()).policy_acos_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d57", feature = "wide"))]
-        3 => crate::D::<crate::int::types::Int<3>, SCALE>(raw.resize_to::<crate::int::types::Int<3>>()).policy_acos_with(wd, mode).0.resize_to::<Int<N>>(),
+        3 => crate::D::<crate::int::types::Int<3>, SCALE>(raw.resize_to::<crate::int::types::Int<3>>()).policy_acos_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d76", feature = "wide"))]
-        4 => crate::D::<crate::int::types::Int<4>, SCALE>(raw.resize_to::<crate::int::types::Int<4>>()).policy_acos_with(wd, mode).0.resize_to::<Int<N>>(),
+        4 => crate::D::<crate::int::types::Int<4>, SCALE>(raw.resize_to::<crate::int::types::Int<4>>()).policy_acos_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d115", feature = "wide"))]
-        6 => crate::D::<crate::int::types::Int<6>, SCALE>(raw.resize_to::<crate::int::types::Int<6>>()).policy_acos_with(wd, mode).0.resize_to::<Int<N>>(),
+        6 => crate::D::<crate::int::types::Int<6>, SCALE>(raw.resize_to::<crate::int::types::Int<6>>()).policy_acos_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d153", feature = "wide"))]
-        8 => crate::D::<crate::int::types::Int<8>, SCALE>(raw.resize_to::<crate::int::types::Int<8>>()).policy_acos_with(wd, mode).0.resize_to::<Int<N>>(),
+        8 => crate::D::<crate::int::types::Int<8>, SCALE>(raw.resize_to::<crate::int::types::Int<8>>()).policy_acos_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d230", feature = "wide"))]
-        12 => crate::D::<crate::int::types::Int<12>, SCALE>(raw.resize_to::<crate::int::types::Int<12>>()).policy_acos_with(wd, mode).0.resize_to::<Int<N>>(),
+        12 => crate::D::<crate::int::types::Int<12>, SCALE>(raw.resize_to::<crate::int::types::Int<12>>()).policy_acos_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d307", feature = "wide", feature = "x-wide"))]
-        16 => crate::D::<crate::int::types::Int<16>, SCALE>(raw.resize_to::<crate::int::types::Int<16>>()).policy_acos_with(wd, mode).0.resize_to::<Int<N>>(),
+        16 => crate::D::<crate::int::types::Int<16>, SCALE>(raw.resize_to::<crate::int::types::Int<16>>()).policy_acos_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d462", feature = "x-wide"))]
-        24 => crate::D::<crate::int::types::Int<24>, SCALE>(raw.resize_to::<crate::int::types::Int<24>>()).policy_acos_with(wd, mode).0.resize_to::<Int<N>>(),
+        24 => crate::D::<crate::int::types::Int<24>, SCALE>(raw.resize_to::<crate::int::types::Int<24>>()).policy_acos_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d616", feature = "x-wide"))]
-        32 => crate::D::<crate::int::types::Int<32>, SCALE>(raw.resize_to::<crate::int::types::Int<32>>()).policy_acos_with(wd, mode).0.resize_to::<Int<N>>(),
+        32 => crate::D::<crate::int::types::Int<32>, SCALE>(raw.resize_to::<crate::int::types::Int<32>>()).policy_acos_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d924", feature = "xx-wide"))]
-        48 => crate::D::<crate::int::types::Int<48>, SCALE>(raw.resize_to::<crate::int::types::Int<48>>()).policy_acos_with(wd, mode).0.resize_to::<Int<N>>(),
+        48 => crate::D::<crate::int::types::Int<48>, SCALE>(raw.resize_to::<crate::int::types::Int<48>>()).policy_acos_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d1232", feature = "xx-wide"))]
-        64 => crate::D::<crate::int::types::Int<64>, SCALE>(raw.resize_to::<crate::int::types::Int<64>>()).policy_acos_with(wd, mode).0.resize_to::<Int<N>>(),
-        _ => crate::D::<crate::int::types::Int<2>, SCALE>(raw.resize_to::<crate::int::types::Int<2>>()).policy_acos_with(wd, mode).0.resize_to::<Int<N>>(),
+        64 => crate::D::<crate::int::types::Int<64>, SCALE>(raw.resize_to::<crate::int::types::Int<64>>()).policy_acos_with(working_digits, mode).0.resize_to::<Int<N>>(),
+        _ => crate::D::<crate::int::types::Int<2>, SCALE>(raw.resize_to::<crate::int::types::Int<2>>()).policy_acos_with(working_digits, mode).0.resize_to::<Int<N>>(),
     }
 }
 
@@ -2662,31 +2663,31 @@ pub(crate) fn sinh_dispatch<const N: usize, const SCALE: u32>(raw: Int<N>, mode:
 
 #[inline]
 #[must_use]
-pub(crate) fn sinh_dispatch_with<const N: usize, const SCALE: u32>(raw: Int<N>, wd: u32, mode: RoundingMode) -> Int<N> {
+pub(crate) fn sinh_dispatch_with<const N: usize, const SCALE: u32>(raw: Int<N>, working_digits: u32, mode: RoundingMode) -> Int<N> {
     match N {
-        1 => crate::D::<crate::int::types::Int<1>, SCALE>(raw.resize_to::<crate::int::types::Int<1>>()).policy_sinh_with(wd, mode).0.resize_to::<Int<N>>(),
-        2 => crate::D::<crate::int::types::Int<2>, SCALE>(raw.resize_to::<crate::int::types::Int<2>>()).policy_sinh_with(wd, mode).0.resize_to::<Int<N>>(),
+        1 => crate::D::<crate::int::types::Int<1>, SCALE>(raw.resize_to::<crate::int::types::Int<1>>()).policy_sinh_with(working_digits, mode).0.resize_to::<Int<N>>(),
+        2 => crate::D::<crate::int::types::Int<2>, SCALE>(raw.resize_to::<crate::int::types::Int<2>>()).policy_sinh_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d57", feature = "wide"))]
-        3 => crate::D::<crate::int::types::Int<3>, SCALE>(raw.resize_to::<crate::int::types::Int<3>>()).policy_sinh_with(wd, mode).0.resize_to::<Int<N>>(),
+        3 => crate::D::<crate::int::types::Int<3>, SCALE>(raw.resize_to::<crate::int::types::Int<3>>()).policy_sinh_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d76", feature = "wide"))]
-        4 => crate::D::<crate::int::types::Int<4>, SCALE>(raw.resize_to::<crate::int::types::Int<4>>()).policy_sinh_with(wd, mode).0.resize_to::<Int<N>>(),
+        4 => crate::D::<crate::int::types::Int<4>, SCALE>(raw.resize_to::<crate::int::types::Int<4>>()).policy_sinh_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d115", feature = "wide"))]
-        6 => crate::D::<crate::int::types::Int<6>, SCALE>(raw.resize_to::<crate::int::types::Int<6>>()).policy_sinh_with(wd, mode).0.resize_to::<Int<N>>(),
+        6 => crate::D::<crate::int::types::Int<6>, SCALE>(raw.resize_to::<crate::int::types::Int<6>>()).policy_sinh_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d153", feature = "wide"))]
-        8 => crate::D::<crate::int::types::Int<8>, SCALE>(raw.resize_to::<crate::int::types::Int<8>>()).policy_sinh_with(wd, mode).0.resize_to::<Int<N>>(),
+        8 => crate::D::<crate::int::types::Int<8>, SCALE>(raw.resize_to::<crate::int::types::Int<8>>()).policy_sinh_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d230", feature = "wide"))]
-        12 => crate::D::<crate::int::types::Int<12>, SCALE>(raw.resize_to::<crate::int::types::Int<12>>()).policy_sinh_with(wd, mode).0.resize_to::<Int<N>>(),
+        12 => crate::D::<crate::int::types::Int<12>, SCALE>(raw.resize_to::<crate::int::types::Int<12>>()).policy_sinh_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d307", feature = "wide", feature = "x-wide"))]
-        16 => crate::D::<crate::int::types::Int<16>, SCALE>(raw.resize_to::<crate::int::types::Int<16>>()).policy_sinh_with(wd, mode).0.resize_to::<Int<N>>(),
+        16 => crate::D::<crate::int::types::Int<16>, SCALE>(raw.resize_to::<crate::int::types::Int<16>>()).policy_sinh_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d462", feature = "x-wide"))]
-        24 => crate::D::<crate::int::types::Int<24>, SCALE>(raw.resize_to::<crate::int::types::Int<24>>()).policy_sinh_with(wd, mode).0.resize_to::<Int<N>>(),
+        24 => crate::D::<crate::int::types::Int<24>, SCALE>(raw.resize_to::<crate::int::types::Int<24>>()).policy_sinh_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d616", feature = "x-wide"))]
-        32 => crate::D::<crate::int::types::Int<32>, SCALE>(raw.resize_to::<crate::int::types::Int<32>>()).policy_sinh_with(wd, mode).0.resize_to::<Int<N>>(),
+        32 => crate::D::<crate::int::types::Int<32>, SCALE>(raw.resize_to::<crate::int::types::Int<32>>()).policy_sinh_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d924", feature = "xx-wide"))]
-        48 => crate::D::<crate::int::types::Int<48>, SCALE>(raw.resize_to::<crate::int::types::Int<48>>()).policy_sinh_with(wd, mode).0.resize_to::<Int<N>>(),
+        48 => crate::D::<crate::int::types::Int<48>, SCALE>(raw.resize_to::<crate::int::types::Int<48>>()).policy_sinh_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d1232", feature = "xx-wide"))]
-        64 => crate::D::<crate::int::types::Int<64>, SCALE>(raw.resize_to::<crate::int::types::Int<64>>()).policy_sinh_with(wd, mode).0.resize_to::<Int<N>>(),
-        _ => crate::D::<crate::int::types::Int<2>, SCALE>(raw.resize_to::<crate::int::types::Int<2>>()).policy_sinh_with(wd, mode).0.resize_to::<Int<N>>(),
+        64 => crate::D::<crate::int::types::Int<64>, SCALE>(raw.resize_to::<crate::int::types::Int<64>>()).policy_sinh_with(working_digits, mode).0.resize_to::<Int<N>>(),
+        _ => crate::D::<crate::int::types::Int<2>, SCALE>(raw.resize_to::<crate::int::types::Int<2>>()).policy_sinh_with(working_digits, mode).0.resize_to::<Int<N>>(),
     }
 }
 
@@ -2722,31 +2723,31 @@ pub(crate) fn cosh_dispatch<const N: usize, const SCALE: u32>(raw: Int<N>, mode:
 
 #[inline]
 #[must_use]
-pub(crate) fn cosh_dispatch_with<const N: usize, const SCALE: u32>(raw: Int<N>, wd: u32, mode: RoundingMode) -> Int<N> {
+pub(crate) fn cosh_dispatch_with<const N: usize, const SCALE: u32>(raw: Int<N>, working_digits: u32, mode: RoundingMode) -> Int<N> {
     match N {
-        1 => crate::D::<crate::int::types::Int<1>, SCALE>(raw.resize_to::<crate::int::types::Int<1>>()).policy_cosh_with(wd, mode).0.resize_to::<Int<N>>(),
-        2 => crate::D::<crate::int::types::Int<2>, SCALE>(raw.resize_to::<crate::int::types::Int<2>>()).policy_cosh_with(wd, mode).0.resize_to::<Int<N>>(),
+        1 => crate::D::<crate::int::types::Int<1>, SCALE>(raw.resize_to::<crate::int::types::Int<1>>()).policy_cosh_with(working_digits, mode).0.resize_to::<Int<N>>(),
+        2 => crate::D::<crate::int::types::Int<2>, SCALE>(raw.resize_to::<crate::int::types::Int<2>>()).policy_cosh_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d57", feature = "wide"))]
-        3 => crate::D::<crate::int::types::Int<3>, SCALE>(raw.resize_to::<crate::int::types::Int<3>>()).policy_cosh_with(wd, mode).0.resize_to::<Int<N>>(),
+        3 => crate::D::<crate::int::types::Int<3>, SCALE>(raw.resize_to::<crate::int::types::Int<3>>()).policy_cosh_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d76", feature = "wide"))]
-        4 => crate::D::<crate::int::types::Int<4>, SCALE>(raw.resize_to::<crate::int::types::Int<4>>()).policy_cosh_with(wd, mode).0.resize_to::<Int<N>>(),
+        4 => crate::D::<crate::int::types::Int<4>, SCALE>(raw.resize_to::<crate::int::types::Int<4>>()).policy_cosh_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d115", feature = "wide"))]
-        6 => crate::D::<crate::int::types::Int<6>, SCALE>(raw.resize_to::<crate::int::types::Int<6>>()).policy_cosh_with(wd, mode).0.resize_to::<Int<N>>(),
+        6 => crate::D::<crate::int::types::Int<6>, SCALE>(raw.resize_to::<crate::int::types::Int<6>>()).policy_cosh_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d153", feature = "wide"))]
-        8 => crate::D::<crate::int::types::Int<8>, SCALE>(raw.resize_to::<crate::int::types::Int<8>>()).policy_cosh_with(wd, mode).0.resize_to::<Int<N>>(),
+        8 => crate::D::<crate::int::types::Int<8>, SCALE>(raw.resize_to::<crate::int::types::Int<8>>()).policy_cosh_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d230", feature = "wide"))]
-        12 => crate::D::<crate::int::types::Int<12>, SCALE>(raw.resize_to::<crate::int::types::Int<12>>()).policy_cosh_with(wd, mode).0.resize_to::<Int<N>>(),
+        12 => crate::D::<crate::int::types::Int<12>, SCALE>(raw.resize_to::<crate::int::types::Int<12>>()).policy_cosh_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d307", feature = "wide", feature = "x-wide"))]
-        16 => crate::D::<crate::int::types::Int<16>, SCALE>(raw.resize_to::<crate::int::types::Int<16>>()).policy_cosh_with(wd, mode).0.resize_to::<Int<N>>(),
+        16 => crate::D::<crate::int::types::Int<16>, SCALE>(raw.resize_to::<crate::int::types::Int<16>>()).policy_cosh_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d462", feature = "x-wide"))]
-        24 => crate::D::<crate::int::types::Int<24>, SCALE>(raw.resize_to::<crate::int::types::Int<24>>()).policy_cosh_with(wd, mode).0.resize_to::<Int<N>>(),
+        24 => crate::D::<crate::int::types::Int<24>, SCALE>(raw.resize_to::<crate::int::types::Int<24>>()).policy_cosh_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d616", feature = "x-wide"))]
-        32 => crate::D::<crate::int::types::Int<32>, SCALE>(raw.resize_to::<crate::int::types::Int<32>>()).policy_cosh_with(wd, mode).0.resize_to::<Int<N>>(),
+        32 => crate::D::<crate::int::types::Int<32>, SCALE>(raw.resize_to::<crate::int::types::Int<32>>()).policy_cosh_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d924", feature = "xx-wide"))]
-        48 => crate::D::<crate::int::types::Int<48>, SCALE>(raw.resize_to::<crate::int::types::Int<48>>()).policy_cosh_with(wd, mode).0.resize_to::<Int<N>>(),
+        48 => crate::D::<crate::int::types::Int<48>, SCALE>(raw.resize_to::<crate::int::types::Int<48>>()).policy_cosh_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d1232", feature = "xx-wide"))]
-        64 => crate::D::<crate::int::types::Int<64>, SCALE>(raw.resize_to::<crate::int::types::Int<64>>()).policy_cosh_with(wd, mode).0.resize_to::<Int<N>>(),
-        _ => crate::D::<crate::int::types::Int<2>, SCALE>(raw.resize_to::<crate::int::types::Int<2>>()).policy_cosh_with(wd, mode).0.resize_to::<Int<N>>(),
+        64 => crate::D::<crate::int::types::Int<64>, SCALE>(raw.resize_to::<crate::int::types::Int<64>>()).policy_cosh_with(working_digits, mode).0.resize_to::<Int<N>>(),
+        _ => crate::D::<crate::int::types::Int<2>, SCALE>(raw.resize_to::<crate::int::types::Int<2>>()).policy_cosh_with(working_digits, mode).0.resize_to::<Int<N>>(),
     }
 }
 
@@ -2782,31 +2783,31 @@ pub(crate) fn tanh_dispatch<const N: usize, const SCALE: u32>(raw: Int<N>, mode:
 
 #[inline]
 #[must_use]
-pub(crate) fn tanh_dispatch_with<const N: usize, const SCALE: u32>(raw: Int<N>, wd: u32, mode: RoundingMode) -> Int<N> {
+pub(crate) fn tanh_dispatch_with<const N: usize, const SCALE: u32>(raw: Int<N>, working_digits: u32, mode: RoundingMode) -> Int<N> {
     match N {
-        1 => crate::D::<crate::int::types::Int<1>, SCALE>(raw.resize_to::<crate::int::types::Int<1>>()).policy_tanh_with(wd, mode).0.resize_to::<Int<N>>(),
-        2 => crate::D::<crate::int::types::Int<2>, SCALE>(raw.resize_to::<crate::int::types::Int<2>>()).policy_tanh_with(wd, mode).0.resize_to::<Int<N>>(),
+        1 => crate::D::<crate::int::types::Int<1>, SCALE>(raw.resize_to::<crate::int::types::Int<1>>()).policy_tanh_with(working_digits, mode).0.resize_to::<Int<N>>(),
+        2 => crate::D::<crate::int::types::Int<2>, SCALE>(raw.resize_to::<crate::int::types::Int<2>>()).policy_tanh_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d57", feature = "wide"))]
-        3 => crate::D::<crate::int::types::Int<3>, SCALE>(raw.resize_to::<crate::int::types::Int<3>>()).policy_tanh_with(wd, mode).0.resize_to::<Int<N>>(),
+        3 => crate::D::<crate::int::types::Int<3>, SCALE>(raw.resize_to::<crate::int::types::Int<3>>()).policy_tanh_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d76", feature = "wide"))]
-        4 => crate::D::<crate::int::types::Int<4>, SCALE>(raw.resize_to::<crate::int::types::Int<4>>()).policy_tanh_with(wd, mode).0.resize_to::<Int<N>>(),
+        4 => crate::D::<crate::int::types::Int<4>, SCALE>(raw.resize_to::<crate::int::types::Int<4>>()).policy_tanh_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d115", feature = "wide"))]
-        6 => crate::D::<crate::int::types::Int<6>, SCALE>(raw.resize_to::<crate::int::types::Int<6>>()).policy_tanh_with(wd, mode).0.resize_to::<Int<N>>(),
+        6 => crate::D::<crate::int::types::Int<6>, SCALE>(raw.resize_to::<crate::int::types::Int<6>>()).policy_tanh_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d153", feature = "wide"))]
-        8 => crate::D::<crate::int::types::Int<8>, SCALE>(raw.resize_to::<crate::int::types::Int<8>>()).policy_tanh_with(wd, mode).0.resize_to::<Int<N>>(),
+        8 => crate::D::<crate::int::types::Int<8>, SCALE>(raw.resize_to::<crate::int::types::Int<8>>()).policy_tanh_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d230", feature = "wide"))]
-        12 => crate::D::<crate::int::types::Int<12>, SCALE>(raw.resize_to::<crate::int::types::Int<12>>()).policy_tanh_with(wd, mode).0.resize_to::<Int<N>>(),
+        12 => crate::D::<crate::int::types::Int<12>, SCALE>(raw.resize_to::<crate::int::types::Int<12>>()).policy_tanh_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d307", feature = "wide", feature = "x-wide"))]
-        16 => crate::D::<crate::int::types::Int<16>, SCALE>(raw.resize_to::<crate::int::types::Int<16>>()).policy_tanh_with(wd, mode).0.resize_to::<Int<N>>(),
+        16 => crate::D::<crate::int::types::Int<16>, SCALE>(raw.resize_to::<crate::int::types::Int<16>>()).policy_tanh_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d462", feature = "x-wide"))]
-        24 => crate::D::<crate::int::types::Int<24>, SCALE>(raw.resize_to::<crate::int::types::Int<24>>()).policy_tanh_with(wd, mode).0.resize_to::<Int<N>>(),
+        24 => crate::D::<crate::int::types::Int<24>, SCALE>(raw.resize_to::<crate::int::types::Int<24>>()).policy_tanh_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d616", feature = "x-wide"))]
-        32 => crate::D::<crate::int::types::Int<32>, SCALE>(raw.resize_to::<crate::int::types::Int<32>>()).policy_tanh_with(wd, mode).0.resize_to::<Int<N>>(),
+        32 => crate::D::<crate::int::types::Int<32>, SCALE>(raw.resize_to::<crate::int::types::Int<32>>()).policy_tanh_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d924", feature = "xx-wide"))]
-        48 => crate::D::<crate::int::types::Int<48>, SCALE>(raw.resize_to::<crate::int::types::Int<48>>()).policy_tanh_with(wd, mode).0.resize_to::<Int<N>>(),
+        48 => crate::D::<crate::int::types::Int<48>, SCALE>(raw.resize_to::<crate::int::types::Int<48>>()).policy_tanh_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d1232", feature = "xx-wide"))]
-        64 => crate::D::<crate::int::types::Int<64>, SCALE>(raw.resize_to::<crate::int::types::Int<64>>()).policy_tanh_with(wd, mode).0.resize_to::<Int<N>>(),
-        _ => crate::D::<crate::int::types::Int<2>, SCALE>(raw.resize_to::<crate::int::types::Int<2>>()).policy_tanh_with(wd, mode).0.resize_to::<Int<N>>(),
+        64 => crate::D::<crate::int::types::Int<64>, SCALE>(raw.resize_to::<crate::int::types::Int<64>>()).policy_tanh_with(working_digits, mode).0.resize_to::<Int<N>>(),
+        _ => crate::D::<crate::int::types::Int<2>, SCALE>(raw.resize_to::<crate::int::types::Int<2>>()).policy_tanh_with(working_digits, mode).0.resize_to::<Int<N>>(),
     }
 }
 
@@ -2842,31 +2843,31 @@ pub(crate) fn asinh_dispatch<const N: usize, const SCALE: u32>(raw: Int<N>, mode
 
 #[inline]
 #[must_use]
-pub(crate) fn asinh_dispatch_with<const N: usize, const SCALE: u32>(raw: Int<N>, wd: u32, mode: RoundingMode) -> Int<N> {
+pub(crate) fn asinh_dispatch_with<const N: usize, const SCALE: u32>(raw: Int<N>, working_digits: u32, mode: RoundingMode) -> Int<N> {
     match N {
-        1 => crate::D::<crate::int::types::Int<1>, SCALE>(raw.resize_to::<crate::int::types::Int<1>>()).policy_asinh_with(wd, mode).0.resize_to::<Int<N>>(),
-        2 => crate::D::<crate::int::types::Int<2>, SCALE>(raw.resize_to::<crate::int::types::Int<2>>()).policy_asinh_with(wd, mode).0.resize_to::<Int<N>>(),
+        1 => crate::D::<crate::int::types::Int<1>, SCALE>(raw.resize_to::<crate::int::types::Int<1>>()).policy_asinh_with(working_digits, mode).0.resize_to::<Int<N>>(),
+        2 => crate::D::<crate::int::types::Int<2>, SCALE>(raw.resize_to::<crate::int::types::Int<2>>()).policy_asinh_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d57", feature = "wide"))]
-        3 => crate::D::<crate::int::types::Int<3>, SCALE>(raw.resize_to::<crate::int::types::Int<3>>()).policy_asinh_with(wd, mode).0.resize_to::<Int<N>>(),
+        3 => crate::D::<crate::int::types::Int<3>, SCALE>(raw.resize_to::<crate::int::types::Int<3>>()).policy_asinh_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d76", feature = "wide"))]
-        4 => crate::D::<crate::int::types::Int<4>, SCALE>(raw.resize_to::<crate::int::types::Int<4>>()).policy_asinh_with(wd, mode).0.resize_to::<Int<N>>(),
+        4 => crate::D::<crate::int::types::Int<4>, SCALE>(raw.resize_to::<crate::int::types::Int<4>>()).policy_asinh_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d115", feature = "wide"))]
-        6 => crate::D::<crate::int::types::Int<6>, SCALE>(raw.resize_to::<crate::int::types::Int<6>>()).policy_asinh_with(wd, mode).0.resize_to::<Int<N>>(),
+        6 => crate::D::<crate::int::types::Int<6>, SCALE>(raw.resize_to::<crate::int::types::Int<6>>()).policy_asinh_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d153", feature = "wide"))]
-        8 => crate::D::<crate::int::types::Int<8>, SCALE>(raw.resize_to::<crate::int::types::Int<8>>()).policy_asinh_with(wd, mode).0.resize_to::<Int<N>>(),
+        8 => crate::D::<crate::int::types::Int<8>, SCALE>(raw.resize_to::<crate::int::types::Int<8>>()).policy_asinh_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d230", feature = "wide"))]
-        12 => crate::D::<crate::int::types::Int<12>, SCALE>(raw.resize_to::<crate::int::types::Int<12>>()).policy_asinh_with(wd, mode).0.resize_to::<Int<N>>(),
+        12 => crate::D::<crate::int::types::Int<12>, SCALE>(raw.resize_to::<crate::int::types::Int<12>>()).policy_asinh_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d307", feature = "wide", feature = "x-wide"))]
-        16 => crate::D::<crate::int::types::Int<16>, SCALE>(raw.resize_to::<crate::int::types::Int<16>>()).policy_asinh_with(wd, mode).0.resize_to::<Int<N>>(),
+        16 => crate::D::<crate::int::types::Int<16>, SCALE>(raw.resize_to::<crate::int::types::Int<16>>()).policy_asinh_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d462", feature = "x-wide"))]
-        24 => crate::D::<crate::int::types::Int<24>, SCALE>(raw.resize_to::<crate::int::types::Int<24>>()).policy_asinh_with(wd, mode).0.resize_to::<Int<N>>(),
+        24 => crate::D::<crate::int::types::Int<24>, SCALE>(raw.resize_to::<crate::int::types::Int<24>>()).policy_asinh_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d616", feature = "x-wide"))]
-        32 => crate::D::<crate::int::types::Int<32>, SCALE>(raw.resize_to::<crate::int::types::Int<32>>()).policy_asinh_with(wd, mode).0.resize_to::<Int<N>>(),
+        32 => crate::D::<crate::int::types::Int<32>, SCALE>(raw.resize_to::<crate::int::types::Int<32>>()).policy_asinh_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d924", feature = "xx-wide"))]
-        48 => crate::D::<crate::int::types::Int<48>, SCALE>(raw.resize_to::<crate::int::types::Int<48>>()).policy_asinh_with(wd, mode).0.resize_to::<Int<N>>(),
+        48 => crate::D::<crate::int::types::Int<48>, SCALE>(raw.resize_to::<crate::int::types::Int<48>>()).policy_asinh_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d1232", feature = "xx-wide"))]
-        64 => crate::D::<crate::int::types::Int<64>, SCALE>(raw.resize_to::<crate::int::types::Int<64>>()).policy_asinh_with(wd, mode).0.resize_to::<Int<N>>(),
-        _ => crate::D::<crate::int::types::Int<2>, SCALE>(raw.resize_to::<crate::int::types::Int<2>>()).policy_asinh_with(wd, mode).0.resize_to::<Int<N>>(),
+        64 => crate::D::<crate::int::types::Int<64>, SCALE>(raw.resize_to::<crate::int::types::Int<64>>()).policy_asinh_with(working_digits, mode).0.resize_to::<Int<N>>(),
+        _ => crate::D::<crate::int::types::Int<2>, SCALE>(raw.resize_to::<crate::int::types::Int<2>>()).policy_asinh_with(working_digits, mode).0.resize_to::<Int<N>>(),
     }
 }
 
@@ -2902,31 +2903,31 @@ pub(crate) fn acosh_dispatch<const N: usize, const SCALE: u32>(raw: Int<N>, mode
 
 #[inline]
 #[must_use]
-pub(crate) fn acosh_dispatch_with<const N: usize, const SCALE: u32>(raw: Int<N>, wd: u32, mode: RoundingMode) -> Int<N> {
+pub(crate) fn acosh_dispatch_with<const N: usize, const SCALE: u32>(raw: Int<N>, working_digits: u32, mode: RoundingMode) -> Int<N> {
     match N {
-        1 => crate::D::<crate::int::types::Int<1>, SCALE>(raw.resize_to::<crate::int::types::Int<1>>()).policy_acosh_with(wd, mode).0.resize_to::<Int<N>>(),
-        2 => crate::D::<crate::int::types::Int<2>, SCALE>(raw.resize_to::<crate::int::types::Int<2>>()).policy_acosh_with(wd, mode).0.resize_to::<Int<N>>(),
+        1 => crate::D::<crate::int::types::Int<1>, SCALE>(raw.resize_to::<crate::int::types::Int<1>>()).policy_acosh_with(working_digits, mode).0.resize_to::<Int<N>>(),
+        2 => crate::D::<crate::int::types::Int<2>, SCALE>(raw.resize_to::<crate::int::types::Int<2>>()).policy_acosh_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d57", feature = "wide"))]
-        3 => crate::D::<crate::int::types::Int<3>, SCALE>(raw.resize_to::<crate::int::types::Int<3>>()).policy_acosh_with(wd, mode).0.resize_to::<Int<N>>(),
+        3 => crate::D::<crate::int::types::Int<3>, SCALE>(raw.resize_to::<crate::int::types::Int<3>>()).policy_acosh_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d76", feature = "wide"))]
-        4 => crate::D::<crate::int::types::Int<4>, SCALE>(raw.resize_to::<crate::int::types::Int<4>>()).policy_acosh_with(wd, mode).0.resize_to::<Int<N>>(),
+        4 => crate::D::<crate::int::types::Int<4>, SCALE>(raw.resize_to::<crate::int::types::Int<4>>()).policy_acosh_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d115", feature = "wide"))]
-        6 => crate::D::<crate::int::types::Int<6>, SCALE>(raw.resize_to::<crate::int::types::Int<6>>()).policy_acosh_with(wd, mode).0.resize_to::<Int<N>>(),
+        6 => crate::D::<crate::int::types::Int<6>, SCALE>(raw.resize_to::<crate::int::types::Int<6>>()).policy_acosh_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d153", feature = "wide"))]
-        8 => crate::D::<crate::int::types::Int<8>, SCALE>(raw.resize_to::<crate::int::types::Int<8>>()).policy_acosh_with(wd, mode).0.resize_to::<Int<N>>(),
+        8 => crate::D::<crate::int::types::Int<8>, SCALE>(raw.resize_to::<crate::int::types::Int<8>>()).policy_acosh_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d230", feature = "wide"))]
-        12 => crate::D::<crate::int::types::Int<12>, SCALE>(raw.resize_to::<crate::int::types::Int<12>>()).policy_acosh_with(wd, mode).0.resize_to::<Int<N>>(),
+        12 => crate::D::<crate::int::types::Int<12>, SCALE>(raw.resize_to::<crate::int::types::Int<12>>()).policy_acosh_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d307", feature = "wide", feature = "x-wide"))]
-        16 => crate::D::<crate::int::types::Int<16>, SCALE>(raw.resize_to::<crate::int::types::Int<16>>()).policy_acosh_with(wd, mode).0.resize_to::<Int<N>>(),
+        16 => crate::D::<crate::int::types::Int<16>, SCALE>(raw.resize_to::<crate::int::types::Int<16>>()).policy_acosh_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d462", feature = "x-wide"))]
-        24 => crate::D::<crate::int::types::Int<24>, SCALE>(raw.resize_to::<crate::int::types::Int<24>>()).policy_acosh_with(wd, mode).0.resize_to::<Int<N>>(),
+        24 => crate::D::<crate::int::types::Int<24>, SCALE>(raw.resize_to::<crate::int::types::Int<24>>()).policy_acosh_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d616", feature = "x-wide"))]
-        32 => crate::D::<crate::int::types::Int<32>, SCALE>(raw.resize_to::<crate::int::types::Int<32>>()).policy_acosh_with(wd, mode).0.resize_to::<Int<N>>(),
+        32 => crate::D::<crate::int::types::Int<32>, SCALE>(raw.resize_to::<crate::int::types::Int<32>>()).policy_acosh_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d924", feature = "xx-wide"))]
-        48 => crate::D::<crate::int::types::Int<48>, SCALE>(raw.resize_to::<crate::int::types::Int<48>>()).policy_acosh_with(wd, mode).0.resize_to::<Int<N>>(),
+        48 => crate::D::<crate::int::types::Int<48>, SCALE>(raw.resize_to::<crate::int::types::Int<48>>()).policy_acosh_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d1232", feature = "xx-wide"))]
-        64 => crate::D::<crate::int::types::Int<64>, SCALE>(raw.resize_to::<crate::int::types::Int<64>>()).policy_acosh_with(wd, mode).0.resize_to::<Int<N>>(),
-        _ => crate::D::<crate::int::types::Int<2>, SCALE>(raw.resize_to::<crate::int::types::Int<2>>()).policy_acosh_with(wd, mode).0.resize_to::<Int<N>>(),
+        64 => crate::D::<crate::int::types::Int<64>, SCALE>(raw.resize_to::<crate::int::types::Int<64>>()).policy_acosh_with(working_digits, mode).0.resize_to::<Int<N>>(),
+        _ => crate::D::<crate::int::types::Int<2>, SCALE>(raw.resize_to::<crate::int::types::Int<2>>()).policy_acosh_with(working_digits, mode).0.resize_to::<Int<N>>(),
     }
 }
 
@@ -2962,31 +2963,31 @@ pub(crate) fn atanh_dispatch<const N: usize, const SCALE: u32>(raw: Int<N>, mode
 
 #[inline]
 #[must_use]
-pub(crate) fn atanh_dispatch_with<const N: usize, const SCALE: u32>(raw: Int<N>, wd: u32, mode: RoundingMode) -> Int<N> {
+pub(crate) fn atanh_dispatch_with<const N: usize, const SCALE: u32>(raw: Int<N>, working_digits: u32, mode: RoundingMode) -> Int<N> {
     match N {
-        1 => crate::D::<crate::int::types::Int<1>, SCALE>(raw.resize_to::<crate::int::types::Int<1>>()).policy_atanh_with(wd, mode).0.resize_to::<Int<N>>(),
-        2 => crate::D::<crate::int::types::Int<2>, SCALE>(raw.resize_to::<crate::int::types::Int<2>>()).policy_atanh_with(wd, mode).0.resize_to::<Int<N>>(),
+        1 => crate::D::<crate::int::types::Int<1>, SCALE>(raw.resize_to::<crate::int::types::Int<1>>()).policy_atanh_with(working_digits, mode).0.resize_to::<Int<N>>(),
+        2 => crate::D::<crate::int::types::Int<2>, SCALE>(raw.resize_to::<crate::int::types::Int<2>>()).policy_atanh_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d57", feature = "wide"))]
-        3 => crate::D::<crate::int::types::Int<3>, SCALE>(raw.resize_to::<crate::int::types::Int<3>>()).policy_atanh_with(wd, mode).0.resize_to::<Int<N>>(),
+        3 => crate::D::<crate::int::types::Int<3>, SCALE>(raw.resize_to::<crate::int::types::Int<3>>()).policy_atanh_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d76", feature = "wide"))]
-        4 => crate::D::<crate::int::types::Int<4>, SCALE>(raw.resize_to::<crate::int::types::Int<4>>()).policy_atanh_with(wd, mode).0.resize_to::<Int<N>>(),
+        4 => crate::D::<crate::int::types::Int<4>, SCALE>(raw.resize_to::<crate::int::types::Int<4>>()).policy_atanh_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d115", feature = "wide"))]
-        6 => crate::D::<crate::int::types::Int<6>, SCALE>(raw.resize_to::<crate::int::types::Int<6>>()).policy_atanh_with(wd, mode).0.resize_to::<Int<N>>(),
+        6 => crate::D::<crate::int::types::Int<6>, SCALE>(raw.resize_to::<crate::int::types::Int<6>>()).policy_atanh_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d153", feature = "wide"))]
-        8 => crate::D::<crate::int::types::Int<8>, SCALE>(raw.resize_to::<crate::int::types::Int<8>>()).policy_atanh_with(wd, mode).0.resize_to::<Int<N>>(),
+        8 => crate::D::<crate::int::types::Int<8>, SCALE>(raw.resize_to::<crate::int::types::Int<8>>()).policy_atanh_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d230", feature = "wide"))]
-        12 => crate::D::<crate::int::types::Int<12>, SCALE>(raw.resize_to::<crate::int::types::Int<12>>()).policy_atanh_with(wd, mode).0.resize_to::<Int<N>>(),
+        12 => crate::D::<crate::int::types::Int<12>, SCALE>(raw.resize_to::<crate::int::types::Int<12>>()).policy_atanh_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d307", feature = "wide", feature = "x-wide"))]
-        16 => crate::D::<crate::int::types::Int<16>, SCALE>(raw.resize_to::<crate::int::types::Int<16>>()).policy_atanh_with(wd, mode).0.resize_to::<Int<N>>(),
+        16 => crate::D::<crate::int::types::Int<16>, SCALE>(raw.resize_to::<crate::int::types::Int<16>>()).policy_atanh_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d462", feature = "x-wide"))]
-        24 => crate::D::<crate::int::types::Int<24>, SCALE>(raw.resize_to::<crate::int::types::Int<24>>()).policy_atanh_with(wd, mode).0.resize_to::<Int<N>>(),
+        24 => crate::D::<crate::int::types::Int<24>, SCALE>(raw.resize_to::<crate::int::types::Int<24>>()).policy_atanh_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d616", feature = "x-wide"))]
-        32 => crate::D::<crate::int::types::Int<32>, SCALE>(raw.resize_to::<crate::int::types::Int<32>>()).policy_atanh_with(wd, mode).0.resize_to::<Int<N>>(),
+        32 => crate::D::<crate::int::types::Int<32>, SCALE>(raw.resize_to::<crate::int::types::Int<32>>()).policy_atanh_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d924", feature = "xx-wide"))]
-        48 => crate::D::<crate::int::types::Int<48>, SCALE>(raw.resize_to::<crate::int::types::Int<48>>()).policy_atanh_with(wd, mode).0.resize_to::<Int<N>>(),
+        48 => crate::D::<crate::int::types::Int<48>, SCALE>(raw.resize_to::<crate::int::types::Int<48>>()).policy_atanh_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d1232", feature = "xx-wide"))]
-        64 => crate::D::<crate::int::types::Int<64>, SCALE>(raw.resize_to::<crate::int::types::Int<64>>()).policy_atanh_with(wd, mode).0.resize_to::<Int<N>>(),
-        _ => crate::D::<crate::int::types::Int<2>, SCALE>(raw.resize_to::<crate::int::types::Int<2>>()).policy_atanh_with(wd, mode).0.resize_to::<Int<N>>(),
+        64 => crate::D::<crate::int::types::Int<64>, SCALE>(raw.resize_to::<crate::int::types::Int<64>>()).policy_atanh_with(working_digits, mode).0.resize_to::<Int<N>>(),
+        _ => crate::D::<crate::int::types::Int<2>, SCALE>(raw.resize_to::<crate::int::types::Int<2>>()).policy_atanh_with(working_digits, mode).0.resize_to::<Int<N>>(),
     }
 }
 
@@ -3022,31 +3023,31 @@ pub(crate) fn to_degrees_dispatch<const N: usize, const SCALE: u32>(raw: Int<N>,
 
 #[inline]
 #[must_use]
-pub(crate) fn to_degrees_dispatch_with<const N: usize, const SCALE: u32>(raw: Int<N>, wd: u32, mode: RoundingMode) -> Int<N> {
+pub(crate) fn to_degrees_dispatch_with<const N: usize, const SCALE: u32>(raw: Int<N>, working_digits: u32, mode: RoundingMode) -> Int<N> {
     match N {
-        1 => crate::D::<crate::int::types::Int<1>, SCALE>(raw.resize_to::<crate::int::types::Int<1>>()).policy_to_degrees_with(wd, mode).0.resize_to::<Int<N>>(),
-        2 => crate::D::<crate::int::types::Int<2>, SCALE>(raw.resize_to::<crate::int::types::Int<2>>()).policy_to_degrees_with(wd, mode).0.resize_to::<Int<N>>(),
+        1 => crate::D::<crate::int::types::Int<1>, SCALE>(raw.resize_to::<crate::int::types::Int<1>>()).policy_to_degrees_with(working_digits, mode).0.resize_to::<Int<N>>(),
+        2 => crate::D::<crate::int::types::Int<2>, SCALE>(raw.resize_to::<crate::int::types::Int<2>>()).policy_to_degrees_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d57", feature = "wide"))]
-        3 => crate::D::<crate::int::types::Int<3>, SCALE>(raw.resize_to::<crate::int::types::Int<3>>()).policy_to_degrees_with(wd, mode).0.resize_to::<Int<N>>(),
+        3 => crate::D::<crate::int::types::Int<3>, SCALE>(raw.resize_to::<crate::int::types::Int<3>>()).policy_to_degrees_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d76", feature = "wide"))]
-        4 => crate::D::<crate::int::types::Int<4>, SCALE>(raw.resize_to::<crate::int::types::Int<4>>()).policy_to_degrees_with(wd, mode).0.resize_to::<Int<N>>(),
+        4 => crate::D::<crate::int::types::Int<4>, SCALE>(raw.resize_to::<crate::int::types::Int<4>>()).policy_to_degrees_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d115", feature = "wide"))]
-        6 => crate::D::<crate::int::types::Int<6>, SCALE>(raw.resize_to::<crate::int::types::Int<6>>()).policy_to_degrees_with(wd, mode).0.resize_to::<Int<N>>(),
+        6 => crate::D::<crate::int::types::Int<6>, SCALE>(raw.resize_to::<crate::int::types::Int<6>>()).policy_to_degrees_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d153", feature = "wide"))]
-        8 => crate::D::<crate::int::types::Int<8>, SCALE>(raw.resize_to::<crate::int::types::Int<8>>()).policy_to_degrees_with(wd, mode).0.resize_to::<Int<N>>(),
+        8 => crate::D::<crate::int::types::Int<8>, SCALE>(raw.resize_to::<crate::int::types::Int<8>>()).policy_to_degrees_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d230", feature = "wide"))]
-        12 => crate::D::<crate::int::types::Int<12>, SCALE>(raw.resize_to::<crate::int::types::Int<12>>()).policy_to_degrees_with(wd, mode).0.resize_to::<Int<N>>(),
+        12 => crate::D::<crate::int::types::Int<12>, SCALE>(raw.resize_to::<crate::int::types::Int<12>>()).policy_to_degrees_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d307", feature = "wide", feature = "x-wide"))]
-        16 => crate::D::<crate::int::types::Int<16>, SCALE>(raw.resize_to::<crate::int::types::Int<16>>()).policy_to_degrees_with(wd, mode).0.resize_to::<Int<N>>(),
+        16 => crate::D::<crate::int::types::Int<16>, SCALE>(raw.resize_to::<crate::int::types::Int<16>>()).policy_to_degrees_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d462", feature = "x-wide"))]
-        24 => crate::D::<crate::int::types::Int<24>, SCALE>(raw.resize_to::<crate::int::types::Int<24>>()).policy_to_degrees_with(wd, mode).0.resize_to::<Int<N>>(),
+        24 => crate::D::<crate::int::types::Int<24>, SCALE>(raw.resize_to::<crate::int::types::Int<24>>()).policy_to_degrees_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d616", feature = "x-wide"))]
-        32 => crate::D::<crate::int::types::Int<32>, SCALE>(raw.resize_to::<crate::int::types::Int<32>>()).policy_to_degrees_with(wd, mode).0.resize_to::<Int<N>>(),
+        32 => crate::D::<crate::int::types::Int<32>, SCALE>(raw.resize_to::<crate::int::types::Int<32>>()).policy_to_degrees_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d924", feature = "xx-wide"))]
-        48 => crate::D::<crate::int::types::Int<48>, SCALE>(raw.resize_to::<crate::int::types::Int<48>>()).policy_to_degrees_with(wd, mode).0.resize_to::<Int<N>>(),
+        48 => crate::D::<crate::int::types::Int<48>, SCALE>(raw.resize_to::<crate::int::types::Int<48>>()).policy_to_degrees_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d1232", feature = "xx-wide"))]
-        64 => crate::D::<crate::int::types::Int<64>, SCALE>(raw.resize_to::<crate::int::types::Int<64>>()).policy_to_degrees_with(wd, mode).0.resize_to::<Int<N>>(),
-        _ => crate::D::<crate::int::types::Int<2>, SCALE>(raw.resize_to::<crate::int::types::Int<2>>()).policy_to_degrees_with(wd, mode).0.resize_to::<Int<N>>(),
+        64 => crate::D::<crate::int::types::Int<64>, SCALE>(raw.resize_to::<crate::int::types::Int<64>>()).policy_to_degrees_with(working_digits, mode).0.resize_to::<Int<N>>(),
+        _ => crate::D::<crate::int::types::Int<2>, SCALE>(raw.resize_to::<crate::int::types::Int<2>>()).policy_to_degrees_with(working_digits, mode).0.resize_to::<Int<N>>(),
     }
 }
 
@@ -3082,31 +3083,31 @@ pub(crate) fn to_radians_dispatch<const N: usize, const SCALE: u32>(raw: Int<N>,
 
 #[inline]
 #[must_use]
-pub(crate) fn to_radians_dispatch_with<const N: usize, const SCALE: u32>(raw: Int<N>, wd: u32, mode: RoundingMode) -> Int<N> {
+pub(crate) fn to_radians_dispatch_with<const N: usize, const SCALE: u32>(raw: Int<N>, working_digits: u32, mode: RoundingMode) -> Int<N> {
     match N {
-        1 => crate::D::<crate::int::types::Int<1>, SCALE>(raw.resize_to::<crate::int::types::Int<1>>()).policy_to_radians_with(wd, mode).0.resize_to::<Int<N>>(),
-        2 => crate::D::<crate::int::types::Int<2>, SCALE>(raw.resize_to::<crate::int::types::Int<2>>()).policy_to_radians_with(wd, mode).0.resize_to::<Int<N>>(),
+        1 => crate::D::<crate::int::types::Int<1>, SCALE>(raw.resize_to::<crate::int::types::Int<1>>()).policy_to_radians_with(working_digits, mode).0.resize_to::<Int<N>>(),
+        2 => crate::D::<crate::int::types::Int<2>, SCALE>(raw.resize_to::<crate::int::types::Int<2>>()).policy_to_radians_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d57", feature = "wide"))]
-        3 => crate::D::<crate::int::types::Int<3>, SCALE>(raw.resize_to::<crate::int::types::Int<3>>()).policy_to_radians_with(wd, mode).0.resize_to::<Int<N>>(),
+        3 => crate::D::<crate::int::types::Int<3>, SCALE>(raw.resize_to::<crate::int::types::Int<3>>()).policy_to_radians_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d76", feature = "wide"))]
-        4 => crate::D::<crate::int::types::Int<4>, SCALE>(raw.resize_to::<crate::int::types::Int<4>>()).policy_to_radians_with(wd, mode).0.resize_to::<Int<N>>(),
+        4 => crate::D::<crate::int::types::Int<4>, SCALE>(raw.resize_to::<crate::int::types::Int<4>>()).policy_to_radians_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d115", feature = "wide"))]
-        6 => crate::D::<crate::int::types::Int<6>, SCALE>(raw.resize_to::<crate::int::types::Int<6>>()).policy_to_radians_with(wd, mode).0.resize_to::<Int<N>>(),
+        6 => crate::D::<crate::int::types::Int<6>, SCALE>(raw.resize_to::<crate::int::types::Int<6>>()).policy_to_radians_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d153", feature = "wide"))]
-        8 => crate::D::<crate::int::types::Int<8>, SCALE>(raw.resize_to::<crate::int::types::Int<8>>()).policy_to_radians_with(wd, mode).0.resize_to::<Int<N>>(),
+        8 => crate::D::<crate::int::types::Int<8>, SCALE>(raw.resize_to::<crate::int::types::Int<8>>()).policy_to_radians_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d230", feature = "wide"))]
-        12 => crate::D::<crate::int::types::Int<12>, SCALE>(raw.resize_to::<crate::int::types::Int<12>>()).policy_to_radians_with(wd, mode).0.resize_to::<Int<N>>(),
+        12 => crate::D::<crate::int::types::Int<12>, SCALE>(raw.resize_to::<crate::int::types::Int<12>>()).policy_to_radians_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d307", feature = "wide", feature = "x-wide"))]
-        16 => crate::D::<crate::int::types::Int<16>, SCALE>(raw.resize_to::<crate::int::types::Int<16>>()).policy_to_radians_with(wd, mode).0.resize_to::<Int<N>>(),
+        16 => crate::D::<crate::int::types::Int<16>, SCALE>(raw.resize_to::<crate::int::types::Int<16>>()).policy_to_radians_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d462", feature = "x-wide"))]
-        24 => crate::D::<crate::int::types::Int<24>, SCALE>(raw.resize_to::<crate::int::types::Int<24>>()).policy_to_radians_with(wd, mode).0.resize_to::<Int<N>>(),
+        24 => crate::D::<crate::int::types::Int<24>, SCALE>(raw.resize_to::<crate::int::types::Int<24>>()).policy_to_radians_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d616", feature = "x-wide"))]
-        32 => crate::D::<crate::int::types::Int<32>, SCALE>(raw.resize_to::<crate::int::types::Int<32>>()).policy_to_radians_with(wd, mode).0.resize_to::<Int<N>>(),
+        32 => crate::D::<crate::int::types::Int<32>, SCALE>(raw.resize_to::<crate::int::types::Int<32>>()).policy_to_radians_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d924", feature = "xx-wide"))]
-        48 => crate::D::<crate::int::types::Int<48>, SCALE>(raw.resize_to::<crate::int::types::Int<48>>()).policy_to_radians_with(wd, mode).0.resize_to::<Int<N>>(),
+        48 => crate::D::<crate::int::types::Int<48>, SCALE>(raw.resize_to::<crate::int::types::Int<48>>()).policy_to_radians_with(working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d1232", feature = "xx-wide"))]
-        64 => crate::D::<crate::int::types::Int<64>, SCALE>(raw.resize_to::<crate::int::types::Int<64>>()).policy_to_radians_with(wd, mode).0.resize_to::<Int<N>>(),
-        _ => crate::D::<crate::int::types::Int<2>, SCALE>(raw.resize_to::<crate::int::types::Int<2>>()).policy_to_radians_with(wd, mode).0.resize_to::<Int<N>>(),
+        64 => crate::D::<crate::int::types::Int<64>, SCALE>(raw.resize_to::<crate::int::types::Int<64>>()).policy_to_radians_with(working_digits, mode).0.resize_to::<Int<N>>(),
+        _ => crate::D::<crate::int::types::Int<2>, SCALE>(raw.resize_to::<crate::int::types::Int<2>>()).policy_to_radians_with(working_digits, mode).0.resize_to::<Int<N>>(),
     }
 }
 
@@ -3142,31 +3143,31 @@ pub(crate) fn atan2_dispatch<const N: usize, const SCALE: u32>(raw: Int<N>, othe
 
 #[inline]
 #[must_use]
-pub(crate) fn atan2_dispatch_with<const N: usize, const SCALE: u32>(raw: Int<N>, other: Int<N>, wd: u32, mode: RoundingMode) -> Int<N> {
+pub(crate) fn atan2_dispatch_with<const N: usize, const SCALE: u32>(raw: Int<N>, other: Int<N>, working_digits: u32, mode: RoundingMode) -> Int<N> {
     match N {
-        1 => crate::D::<crate::int::types::Int<1>, SCALE>(raw.resize_to::<crate::int::types::Int<1>>()).policy_atan2_with(crate::D::<crate::int::types::Int<1>, SCALE>(other.resize_to::<crate::int::types::Int<1>>()), wd, mode).0.resize_to::<Int<N>>(),
-        2 => crate::D::<crate::int::types::Int<2>, SCALE>(raw.resize_to::<crate::int::types::Int<2>>()).policy_atan2_with(crate::D::<crate::int::types::Int<2>, SCALE>(other.resize_to::<crate::int::types::Int<2>>()), wd, mode).0.resize_to::<Int<N>>(),
+        1 => crate::D::<crate::int::types::Int<1>, SCALE>(raw.resize_to::<crate::int::types::Int<1>>()).policy_atan2_with(crate::D::<crate::int::types::Int<1>, SCALE>(other.resize_to::<crate::int::types::Int<1>>()), working_digits, mode).0.resize_to::<Int<N>>(),
+        2 => crate::D::<crate::int::types::Int<2>, SCALE>(raw.resize_to::<crate::int::types::Int<2>>()).policy_atan2_with(crate::D::<crate::int::types::Int<2>, SCALE>(other.resize_to::<crate::int::types::Int<2>>()), working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d57", feature = "wide"))]
-        3 => crate::D::<crate::int::types::Int<3>, SCALE>(raw.resize_to::<crate::int::types::Int<3>>()).policy_atan2_with(crate::D::<crate::int::types::Int<3>, SCALE>(other.resize_to::<crate::int::types::Int<3>>()), wd, mode).0.resize_to::<Int<N>>(),
+        3 => crate::D::<crate::int::types::Int<3>, SCALE>(raw.resize_to::<crate::int::types::Int<3>>()).policy_atan2_with(crate::D::<crate::int::types::Int<3>, SCALE>(other.resize_to::<crate::int::types::Int<3>>()), working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d76", feature = "wide"))]
-        4 => crate::D::<crate::int::types::Int<4>, SCALE>(raw.resize_to::<crate::int::types::Int<4>>()).policy_atan2_with(crate::D::<crate::int::types::Int<4>, SCALE>(other.resize_to::<crate::int::types::Int<4>>()), wd, mode).0.resize_to::<Int<N>>(),
+        4 => crate::D::<crate::int::types::Int<4>, SCALE>(raw.resize_to::<crate::int::types::Int<4>>()).policy_atan2_with(crate::D::<crate::int::types::Int<4>, SCALE>(other.resize_to::<crate::int::types::Int<4>>()), working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d115", feature = "wide"))]
-        6 => crate::D::<crate::int::types::Int<6>, SCALE>(raw.resize_to::<crate::int::types::Int<6>>()).policy_atan2_with(crate::D::<crate::int::types::Int<6>, SCALE>(other.resize_to::<crate::int::types::Int<6>>()), wd, mode).0.resize_to::<Int<N>>(),
+        6 => crate::D::<crate::int::types::Int<6>, SCALE>(raw.resize_to::<crate::int::types::Int<6>>()).policy_atan2_with(crate::D::<crate::int::types::Int<6>, SCALE>(other.resize_to::<crate::int::types::Int<6>>()), working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d153", feature = "wide"))]
-        8 => crate::D::<crate::int::types::Int<8>, SCALE>(raw.resize_to::<crate::int::types::Int<8>>()).policy_atan2_with(crate::D::<crate::int::types::Int<8>, SCALE>(other.resize_to::<crate::int::types::Int<8>>()), wd, mode).0.resize_to::<Int<N>>(),
+        8 => crate::D::<crate::int::types::Int<8>, SCALE>(raw.resize_to::<crate::int::types::Int<8>>()).policy_atan2_with(crate::D::<crate::int::types::Int<8>, SCALE>(other.resize_to::<crate::int::types::Int<8>>()), working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d230", feature = "wide"))]
-        12 => crate::D::<crate::int::types::Int<12>, SCALE>(raw.resize_to::<crate::int::types::Int<12>>()).policy_atan2_with(crate::D::<crate::int::types::Int<12>, SCALE>(other.resize_to::<crate::int::types::Int<12>>()), wd, mode).0.resize_to::<Int<N>>(),
+        12 => crate::D::<crate::int::types::Int<12>, SCALE>(raw.resize_to::<crate::int::types::Int<12>>()).policy_atan2_with(crate::D::<crate::int::types::Int<12>, SCALE>(other.resize_to::<crate::int::types::Int<12>>()), working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d307", feature = "wide", feature = "x-wide"))]
-        16 => crate::D::<crate::int::types::Int<16>, SCALE>(raw.resize_to::<crate::int::types::Int<16>>()).policy_atan2_with(crate::D::<crate::int::types::Int<16>, SCALE>(other.resize_to::<crate::int::types::Int<16>>()), wd, mode).0.resize_to::<Int<N>>(),
+        16 => crate::D::<crate::int::types::Int<16>, SCALE>(raw.resize_to::<crate::int::types::Int<16>>()).policy_atan2_with(crate::D::<crate::int::types::Int<16>, SCALE>(other.resize_to::<crate::int::types::Int<16>>()), working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d462", feature = "x-wide"))]
-        24 => crate::D::<crate::int::types::Int<24>, SCALE>(raw.resize_to::<crate::int::types::Int<24>>()).policy_atan2_with(crate::D::<crate::int::types::Int<24>, SCALE>(other.resize_to::<crate::int::types::Int<24>>()), wd, mode).0.resize_to::<Int<N>>(),
+        24 => crate::D::<crate::int::types::Int<24>, SCALE>(raw.resize_to::<crate::int::types::Int<24>>()).policy_atan2_with(crate::D::<crate::int::types::Int<24>, SCALE>(other.resize_to::<crate::int::types::Int<24>>()), working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d616", feature = "x-wide"))]
-        32 => crate::D::<crate::int::types::Int<32>, SCALE>(raw.resize_to::<crate::int::types::Int<32>>()).policy_atan2_with(crate::D::<crate::int::types::Int<32>, SCALE>(other.resize_to::<crate::int::types::Int<32>>()), wd, mode).0.resize_to::<Int<N>>(),
+        32 => crate::D::<crate::int::types::Int<32>, SCALE>(raw.resize_to::<crate::int::types::Int<32>>()).policy_atan2_with(crate::D::<crate::int::types::Int<32>, SCALE>(other.resize_to::<crate::int::types::Int<32>>()), working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d924", feature = "xx-wide"))]
-        48 => crate::D::<crate::int::types::Int<48>, SCALE>(raw.resize_to::<crate::int::types::Int<48>>()).policy_atan2_with(crate::D::<crate::int::types::Int<48>, SCALE>(other.resize_to::<crate::int::types::Int<48>>()), wd, mode).0.resize_to::<Int<N>>(),
+        48 => crate::D::<crate::int::types::Int<48>, SCALE>(raw.resize_to::<crate::int::types::Int<48>>()).policy_atan2_with(crate::D::<crate::int::types::Int<48>, SCALE>(other.resize_to::<crate::int::types::Int<48>>()), working_digits, mode).0.resize_to::<Int<N>>(),
         #[cfg(any(feature = "d1232", feature = "xx-wide"))]
-        64 => crate::D::<crate::int::types::Int<64>, SCALE>(raw.resize_to::<crate::int::types::Int<64>>()).policy_atan2_with(crate::D::<crate::int::types::Int<64>, SCALE>(other.resize_to::<crate::int::types::Int<64>>()), wd, mode).0.resize_to::<Int<N>>(),
-        _ => crate::D::<crate::int::types::Int<2>, SCALE>(raw.resize_to::<crate::int::types::Int<2>>()).policy_atan2_with(crate::D::<crate::int::types::Int<2>, SCALE>(other.resize_to::<crate::int::types::Int<2>>()), wd, mode).0.resize_to::<Int<N>>(),
+        64 => crate::D::<crate::int::types::Int<64>, SCALE>(raw.resize_to::<crate::int::types::Int<64>>()).policy_atan2_with(crate::D::<crate::int::types::Int<64>, SCALE>(other.resize_to::<crate::int::types::Int<64>>()), working_digits, mode).0.resize_to::<Int<N>>(),
+        _ => crate::D::<crate::int::types::Int<2>, SCALE>(raw.resize_to::<crate::int::types::Int<2>>()).policy_atan2_with(crate::D::<crate::int::types::Int<2>, SCALE>(other.resize_to::<crate::int::types::Int<2>>()), working_digits, mode).0.resize_to::<Int<N>>(),
     }
 }
 
@@ -3318,23 +3319,23 @@ mod forward_rung_tests {
         type Core = crate::types::widths::wide_trig_d307::Core;
         const G: u32 =
             <Core as crate::algos::support::wide_trig_core::WideTrigCore>::GUARD;
-        for v in ["1", "-1", "2", "3141", "-1570"] {
-            let x: crate::D307<0> = v.parse().unwrap();
+        for input in ["1", "-1", "2", "3141", "-1570"] {
+            let value: crate::D307<0> = input.parse().unwrap();
             for mode in ALL_MODES {
                 assert_eq!(
-                    super::forward_rung::sin_strict::<Core, 0, G>(x.to_bits(), mode),
-                    crate::algos::support::wide_trig_core::sin_series::<Core, 0>(x.to_bits(), mode),
-                    "sin({v}) mode {mode:?}"
+                    super::forward_rung::sin_strict::<Core, 0, G>(value.to_bits(), mode),
+                    crate::algos::support::wide_trig_core::sin_series::<Core, 0>(value.to_bits(), mode),
+                    "sin({input}) mode {mode:?}"
                 );
                 assert_eq!(
-                    super::forward_rung::tan_strict::<Core, 0, G, true, true>(x.to_bits(), mode),
-                    crate::algos::support::wide_trig_core::tan_series::<Core, 0>(x.to_bits(), mode),
-                    "tan({v}) mode {mode:?}"
+                    super::forward_rung::tan_strict::<Core, 0, G, true, true>(value.to_bits(), mode),
+                    crate::algos::support::wide_trig_core::tan_series::<Core, 0>(value.to_bits(), mode),
+                    "tan({input}) mode {mode:?}"
                 );
                 assert_eq!(
-                    super::forward_rung::atan_strict::<Core, 0, G, true>(x.to_bits(), mode),
-                    crate::algos::support::wide_trig_core::atan_series::<Core, 0>(x.to_bits(), mode),
-                    "atan({v}) mode {mode:?}"
+                    super::forward_rung::atan_strict::<Core, 0, G, true>(value.to_bits(), mode),
+                    crate::algos::support::wide_trig_core::atan_series::<Core, 0>(value.to_bits(), mode),
+                    "atan({input}) mode {mode:?}"
                 );
             }
         }
@@ -3347,13 +3348,13 @@ mod forward_rung_tests {
     #[cfg(feature = "d307")]
     fn d307_band_atan_rung_matches_tier_narrow() {
         type Core = crate::types::widths::wide_trig_d307::Core;
-        for v in ["1", "-1", "2", "3141"] {
-            let x: crate::D307<150> = v.parse().unwrap();
+        for input in ["1", "-1", "2", "3141"] {
+            let value: crate::D307<150> = input.parse().unwrap();
             for mode in ALL_MODES {
                 assert_eq!(
-                    super::forward_rung::atan_strict::<Core, 150, 10, false>(x.to_bits(), mode),
-                    crate::algos::support::wide_trig_core::atan_narrow::<Core, 150, 10>(x.to_bits(), mode),
-                    "atan({v}) band mode {mode:?}"
+                    super::forward_rung::atan_strict::<Core, 150, 10, false>(value.to_bits(), mode),
+                    crate::algos::support::wide_trig_core::atan_narrow::<Core, 150, 10>(value.to_bits(), mode),
+                    "atan({input}) band mode {mode:?}"
                 );
             }
         }
@@ -3367,16 +3368,16 @@ mod forward_rung_tests {
         type Core = crate::types::widths::wide_trig_d307::Core;
         const G: u32 =
             <Core as crate::algos::support::wide_trig_core::WideTrigCore>::GUARD;
-        let x: crate::D307<0> = "1000000000".parse().unwrap();
+        let value: crate::D307<0> = "1000000000".parse().unwrap();
         for mode in ALL_MODES {
             assert_eq!(
-                super::forward_rung::sin_strict::<Core, 0, G>(x.to_bits(), mode),
-                crate::algos::support::wide_trig_core::sin_series::<Core, 0>(x.to_bits(), mode),
+                super::forward_rung::sin_strict::<Core, 0, G>(value.to_bits(), mode),
+                crate::algos::support::wide_trig_core::sin_series::<Core, 0>(value.to_bits(), mode),
                 "sin(1e9) mode {mode:?}"
             );
             assert_eq!(
-                super::forward_rung::atan_strict::<Core, 0, G, true>(x.to_bits(), mode),
-                crate::algos::support::wide_trig_core::atan_series::<Core, 0>(x.to_bits(), mode),
+                super::forward_rung::atan_strict::<Core, 0, G, true>(value.to_bits(), mode),
+                crate::algos::support::wide_trig_core::atan_series::<Core, 0>(value.to_bits(), mode),
                 "atan(1e9) mode {mode:?}"
             );
         }
@@ -3401,12 +3402,12 @@ mod forward_rung_tests {
         const G: u32 =
             <Core as crate::algos::support::wide_trig_core::WideTrigCore>::GUARD;
         // The bench input set at SCALE 153: raw = {0.3, 1.0, 1.5, 3141}·10^36.
-        let p36 = crate::int::types::Int::<16>::from_i128(10i128.pow(36));
+        let ten_pow_36 = crate::int::types::Int::<16>::from_i128(10i128.pow(36));
         let raws = [
             crate::int::types::Int::<16>::from_i128(3 * 10i128.pow(35)),
-            p36,
+            ten_pow_36,
             crate::int::types::Int::<16>::from_i128(15 * 10i128.pow(35)),
-            crate::int::types::Int::<16>::from_i128(3141) * p36,
+            crate::int::types::Int::<16>::from_i128(3141) * ten_pow_36,
         ];
         for raw in raws {
             for mode in ALL_MODES {
@@ -3475,10 +3476,10 @@ mod forward_rung_tests {
         type Core = crate::types::widths::wide_trig_d1232::Core;
         const G: u32 =
             <Core as crate::algos::support::wide_trig_core::WideTrigCore>::GUARD;
-        let p36 = crate::int::types::Int::<64>::from_i128(10i128.pow(36));
+        let ten_pow_36 = crate::int::types::Int::<64>::from_i128(10i128.pow(36));
         let raws = [
             crate::int::types::Int::<64>::from_i128(3 * 10i128.pow(35)),
-            p36,
+            ten_pow_36,
             crate::int::types::Int::<64>::from_i128(15 * 10i128.pow(35)),
         ];
         for raw in raws {
@@ -3523,15 +3524,22 @@ mod forward_rung_tests {
         ($Core:ty, $N:literal, $SCALE:literal, $with_big:expr) => {{
             type C = $Core;
             const G: u32 = <C as crate::algos::support::wide_trig_core::WideTrigCore>::GUARD;
-            let p = crate::int::types::Int::<$N>::from_i128(10i128).pow(($SCALE as u32).min(36));
+            let scale_factor =
+                crate::int::types::Int::<$N>::from_i128(10i128).pow(($SCALE as u32).min(36));
             let ten = crate::int::types::Int::<$N>::from_i128(10);
-            let i = |n: i128| crate::int::types::Int::<$N>::from_i128(n);
-            // Forward trig: {0.3, 1.0, 1.5, 3141}·p (+ 1e9·p at s0).
-            let mut fwd = vec![p * i(3) / ten, p, p + (p >> 1), p * i(3141)];
+            let int = |value: i128| crate::int::types::Int::<$N>::from_i128(value);
+            // Forward trig: {0.3, 1.0, 1.5, 3141}·scale_factor
+            // (+ 1e9·scale_factor at s0).
+            let mut forward_raws = vec![
+                scale_factor * int(3) / ten,
+                scale_factor,
+                scale_factor + (scale_factor >> 1),
+                scale_factor * int(3141)
+            ];
             if $with_big {
-                fwd.push(p * i(1_000_000_000));
+                forward_raws.push(scale_factor * int(1_000_000_000));
             }
-            for raw in fwd {
+            for raw in forward_raws {
                 for mode in ALL_MODES {
                     assert_eq!(
                         super::forward_rung::sin_strict::<C, $SCALE, G>(raw, mode),
@@ -3555,8 +3563,12 @@ mod forward_rung_tests {
                     );
                 }
             }
-            // asin: the unit-domain set {0.3, 0.9, 1.0}·p.
-            for raw in [p * i(3) / ten, p * i(9) / ten, p] {
+            // asin: the unit-domain set {0.3, 0.9, 1.0}·scale_factor.
+            for raw in [
+                scale_factor * int(3) / ten,
+                scale_factor * int(9) / ten,
+                scale_factor
+            ] {
                 for mode in ALL_MODES {
                     assert_eq!(
                         super::inverse_rung::asin_strict::<C, $SCALE>(raw, mode),
@@ -3565,11 +3577,17 @@ mod forward_rung_tests {
                     );
                 }
             }
-            // sinh / exp / asinh: the EXP_ARG_BUDGET set {0.3, 1, 1.5, 9.5}·p
-            // (+ the 50·p out-of-budget probe at s0).
-            let mut small = vec![p * i(3) / ten, p, p + (p >> 1), p * i(9) + (p >> 1)];
+            // sinh / exp / asinh: the EXP_ARG_BUDGET set
+            // {0.3, 1, 1.5, 9.5}·scale_factor (+ the 50·scale_factor
+            // out-of-budget probe at s0).
+            let mut small = vec![
+                scale_factor * int(3) / ten,
+                scale_factor,
+                scale_factor + (scale_factor >> 1),
+                scale_factor * int(9) + (scale_factor >> 1)
+            ];
             if $with_big {
-                small.push(p * i(50));
+                small.push(scale_factor * int(50));
             }
             for raw in small {
                 for mode in ALL_MODES {
@@ -3641,7 +3659,7 @@ mod forward_rung_tests {
         use crate::int::types::Int;
         let raw = Int::<24>::from_i128(10).pow(293);
         let one = Int::<24>::from_i128(1);
-        let x = crate::D::<Int<24>, 461>(raw);
+        let deep_value = crate::D::<Int<24>, 461>(raw);
         for mode in ALL_MODES {
             let nearest = crate::support::rounding::is_nearest_mode(mode);
             // sinh / atanh: expanding odd (true value just ABOVE raw).
@@ -3662,27 +3680,28 @@ mod forward_rung_tests {
                     _ => raw - one,
                 }
             };
-            assert_eq!(x.sinh_strict_with(mode).0, expand, "sinh mode {mode:?}");
+            assert_eq!(deep_value.sinh_strict_with(mode).0, expand, "sinh mode {mode:?}");
             assert_eq!(super::sinh_dispatch::<24, 461>(raw, mode), expand, "sinh dispatch {mode:?}");
-            assert_eq!(x.tanh_strict_with(mode).0, compress, "tanh mode {mode:?}");
+            assert_eq!(deep_value.tanh_strict_with(mode).0, compress, "tanh mode {mode:?}");
             assert_eq!(super::tanh_dispatch::<24, 461>(raw, mode), compress, "tanh dispatch {mode:?}");
-            assert_eq!(x.asinh_strict_with(mode).0, compress, "asinh mode {mode:?}");
+            assert_eq!(deep_value.asinh_strict_with(mode).0, compress, "asinh mode {mode:?}");
             assert_eq!(super::asinh_dispatch::<24, 461>(raw, mode), compress, "asinh dispatch {mode:?}");
-            assert_eq!(x.atanh_strict_with(mode).0, expand, "atanh mode {mode:?}");
+            assert_eq!(deep_value.atanh_strict_with(mode).0, expand, "atanh mode {mode:?}");
             assert_eq!(super::atanh_dispatch::<24, 461>(raw, mode), expand, "atanh dispatch {mode:?}");
         }
         // Default == _with(DEFAULT) for the whole family, deep + ordinary.
         let half = Int::<24>::from_i128(5) * Int::<24>::from_i128(10).pow(460);
-        for v in [raw, half] {
-            let y = crate::D::<Int<24>, 461>(v);
-            let m = crate::support::rounding::DEFAULT_ROUNDING_MODE;
-            assert_eq!(y.sinh_strict(), y.sinh_strict_with(m), "sinh default");
-            assert_eq!(y.cosh_strict(), y.cosh_strict_with(m), "cosh default");
-            assert_eq!(y.tanh_strict(), y.tanh_strict_with(m), "tanh default");
-            assert_eq!(y.asinh_strict(), y.asinh_strict_with(m), "asinh default");
-            assert_eq!(y.atanh_strict(), y.atanh_strict_with(m), "atanh default");
-            let z = crate::D::<Int<24>, 461>(v + Int::<24>::from_i128(10).pow(461)); // >= 1 for acosh
-            assert_eq!(z.acosh_strict(), z.acosh_strict_with(m), "acosh default");
+        for raw_case in [raw, half] {
+            let case_value = crate::D::<Int<24>, 461>(raw_case);
+            let default_mode = crate::support::rounding::DEFAULT_ROUNDING_MODE;
+            assert_eq!(case_value.sinh_strict(), case_value.sinh_strict_with(default_mode), "sinh default");
+            assert_eq!(case_value.cosh_strict(), case_value.cosh_strict_with(default_mode), "cosh default");
+            assert_eq!(case_value.tanh_strict(), case_value.tanh_strict_with(default_mode), "tanh default");
+            assert_eq!(case_value.asinh_strict(), case_value.asinh_strict_with(default_mode), "asinh default");
+            assert_eq!(case_value.atanh_strict(), case_value.atanh_strict_with(default_mode), "atanh default");
+            let acosh_value =
+                crate::D::<Int<24>, 461>(raw_case + Int::<24>::from_i128(10).pow(461)); // >= 1 for acosh
+            assert_eq!(acosh_value.acosh_strict(), acosh_value.acosh_strict_with(default_mode), "acosh default");
         }
     }
 
@@ -3695,18 +3714,18 @@ mod forward_rung_tests {
     #[cfg(feature = "d307")]
     fn d307_inverse_rung_matches_tier_kernels() {
         type Core = crate::types::widths::wide_trig_d307::Core;
-        for v in ["0", "0.25", "0.6", "0.9", "1", "-0.6", "-1"] {
-            let x: crate::D307<19> = v.parse().unwrap();
+        for input in ["0", "0.25", "0.6", "0.9", "1", "-0.6", "-1"] {
+            let value: crate::D307<19> = input.parse().unwrap();
             for mode in ALL_MODES {
                 assert_eq!(
-                    super::inverse_rung::asin_strict::<Core, 19>(x.to_bits(), mode),
-                    crate::algos::trig::inverse_schoolbook::asin_schoolbook::<Core, 19>(x.to_bits(), mode),
-                    "asin({v}) mode {mode:?}"
+                    super::inverse_rung::asin_strict::<Core, 19>(value.to_bits(), mode),
+                    crate::algos::trig::inverse_schoolbook::asin_schoolbook::<Core, 19>(value.to_bits(), mode),
+                    "asin({input}) mode {mode:?}"
                 );
                 assert_eq!(
-                    super::inverse_rung::acos_strict::<Core, 19>(x.to_bits(), mode),
-                    crate::algos::trig::inverse_schoolbook::acos_schoolbook::<Core, 19>(x.to_bits(), mode),
-                    "acos({v}) mode {mode:?}"
+                    super::inverse_rung::acos_strict::<Core, 19>(value.to_bits(), mode),
+                    crate::algos::trig::inverse_schoolbook::acos_schoolbook::<Core, 19>(value.to_bits(), mode),
+                    "acos({input}) mode {mode:?}"
                 );
             }
         }
@@ -3721,12 +3740,12 @@ mod forward_rung_tests {
             ("0", "1"),
             ("1000000000", "1"),
         ] {
-            let yd: crate::D307<19> = y.parse().unwrap();
-            let xd: crate::D307<19> = x.parse().unwrap();
+            let y_value: crate::D307<19> = y.parse().unwrap();
+            let x_value: crate::D307<19> = x.parse().unwrap();
             for mode in ALL_MODES {
                 assert_eq!(
-                    super::inverse_rung::atan2_strict::<Core, 19>(yd.to_bits(), xd.to_bits(), mode),
-                    crate::algos::trig::inverse_schoolbook::atan2_schoolbook::<Core, 19>(yd.to_bits(), xd.to_bits(), mode),
+                    super::inverse_rung::atan2_strict::<Core, 19>(y_value.to_bits(), x_value.to_bits(), mode),
+                    crate::algos::trig::inverse_schoolbook::atan2_schoolbook::<Core, 19>(y_value.to_bits(), x_value.to_bits(), mode),
                     "atan2({y}, {x}) mode {mode:?}"
                 );
             }
@@ -3742,23 +3761,23 @@ mod forward_rung_tests {
     #[cfg(feature = "d307")]
     fn d307_hyper_rung_matches_tier_kernels() {
         type Core = crate::types::widths::wide_trig_d307::Core;
-        for v in ["0", "0.3", "1", "1.5", "9.9", "-1", "-9.9", "50"] {
-            let x: crate::D307<19> = v.parse().unwrap();
+        for input in ["0", "0.3", "1", "1.5", "9.9", "-1", "-9.9", "50"] {
+            let value: crate::D307<19> = input.parse().unwrap();
             for mode in ALL_MODES {
                 assert_eq!(
-                    super::hyper_rung::sinh_strict::<Core, 19>(x.to_bits(), mode),
-                    crate::algos::trig::hyper_schoolbook::sinh_schoolbook::<Core, 19>(x.to_bits(), mode),
-                    "sinh({v}) mode {mode:?}"
+                    super::hyper_rung::sinh_strict::<Core, 19>(value.to_bits(), mode),
+                    crate::algos::trig::hyper_schoolbook::sinh_schoolbook::<Core, 19>(value.to_bits(), mode),
+                    "sinh({input}) mode {mode:?}"
                 );
                 assert_eq!(
-                    super::hyper_rung::cosh_strict::<Core, 19>(x.to_bits(), mode),
-                    crate::algos::trig::hyper_schoolbook::cosh_schoolbook::<Core, 19>(x.to_bits(), mode),
-                    "cosh({v}) mode {mode:?}"
+                    super::hyper_rung::cosh_strict::<Core, 19>(value.to_bits(), mode),
+                    crate::algos::trig::hyper_schoolbook::cosh_schoolbook::<Core, 19>(value.to_bits(), mode),
+                    "cosh({input}) mode {mode:?}"
                 );
                 assert_eq!(
-                    super::hyper_rung::tanh_strict::<Core, 19>(x.to_bits(), mode),
-                    crate::algos::trig::hyper_schoolbook::tanh_schoolbook::<Core, 19>(x.to_bits(), mode),
-                    "tanh({v}) mode {mode:?}"
+                    super::hyper_rung::tanh_strict::<Core, 19>(value.to_bits(), mode),
+                    crate::algos::trig::hyper_schoolbook::tanh_schoolbook::<Core, 19>(value.to_bits(), mode),
+                    "tanh({input}) mode {mode:?}"
                 );
             }
         }
@@ -3773,33 +3792,33 @@ mod forward_rung_tests {
     #[cfg(feature = "d307")]
     fn d307_extra_rung_matches_tier_kernels() {
         type Core = crate::types::widths::wide_trig_d307::Core;
-        for v in ["0", "0.5", "1", "2", "1000000000", "-0.5", "-2"] {
-            let x: crate::D307<19> = v.parse().unwrap();
+        for input in ["0", "0.5", "1", "2", "1000000000", "-0.5", "-2"] {
+            let value: crate::D307<19> = input.parse().unwrap();
             for mode in ALL_MODES {
                 assert_eq!(
-                    super::extra_rung::asinh_strict::<Core, 19>(x.to_bits(), mode),
-                    crate::algos::trig::hyper_schoolbook::asinh_schoolbook::<Core, 19>(x.to_bits(), mode),
-                    "asinh({v}) mode {mode:?}"
+                    super::extra_rung::asinh_strict::<Core, 19>(value.to_bits(), mode),
+                    crate::algos::trig::hyper_schoolbook::asinh_schoolbook::<Core, 19>(value.to_bits(), mode),
+                    "asinh({input}) mode {mode:?}"
                 );
             }
         }
-        for v in ["1", "1.0000000000000000001", "1.5", "2", "1000", "1000000000"] {
-            let x: crate::D307<19> = v.parse().unwrap();
+        for input in ["1", "1.0000000000000000001", "1.5", "2", "1000", "1000000000"] {
+            let value: crate::D307<19> = input.parse().unwrap();
             for mode in ALL_MODES {
                 assert_eq!(
-                    super::extra_rung::acosh_strict::<Core, 19>(x.to_bits(), mode),
-                    crate::algos::trig::hyper_schoolbook::acosh_schoolbook::<Core, 19>(x.to_bits(), mode),
-                    "acosh({v}) mode {mode:?}"
+                    super::extra_rung::acosh_strict::<Core, 19>(value.to_bits(), mode),
+                    crate::algos::trig::hyper_schoolbook::acosh_schoolbook::<Core, 19>(value.to_bits(), mode),
+                    "acosh({input}) mode {mode:?}"
                 );
             }
         }
-        for v in ["0", "0.5", "0.9999999999999999999", "-0.9999999999999999999", "-0.5"] {
-            let x: crate::D307<19> = v.parse().unwrap();
+        for input in ["0", "0.5", "0.9999999999999999999", "-0.9999999999999999999", "-0.5"] {
+            let value: crate::D307<19> = input.parse().unwrap();
             for mode in ALL_MODES {
                 assert_eq!(
-                    super::extra_rung::atanh_strict::<Core, 19>(x.to_bits(), mode),
-                    crate::algos::trig::hyper_schoolbook::atanh_schoolbook::<Core, 19>(x.to_bits(), mode),
-                    "atanh({v}) mode {mode:?}"
+                    super::extra_rung::atanh_strict::<Core, 19>(value.to_bits(), mode),
+                    crate::algos::trig::hyper_schoolbook::atanh_schoolbook::<Core, 19>(value.to_bits(), mode),
+                    "atanh({input}) mode {mode:?}"
                 );
             }
         }

--- a/src/policy/work_rung.rs
+++ b/src/policy/work_rung.rs
@@ -63,16 +63,16 @@ pub(in crate::policy) const AVAIL_RUNGS: [usize; 13] =
 
 /// Smallest ladder width (limbs) in `[lo, hi]` whose digit budget
 /// (`limbs · 8`, = `BITS/8` — the shared Ziv escalation's own capacity
-/// rule) strictly clears `need` decimal digits. If no ladder member in
-/// range clears it (the tier's max-scale extreme), `hi` is the answer —
-/// reproducing the tier's full `$Work`, so those cells stay
+/// rule) strictly clears `needed_digits` decimal digits. If no ladder
+/// member in range clears it (the tier's max-scale extreme), `hi` is the
+/// answer — reproducing the tier's full `$Work`, so those cells stay
 /// bit-identical to the pre-rung routing.
-pub(in crate::policy) const fn smallest_rung(need: u32, lo: usize, hi: usize) -> usize {
+pub(in crate::policy) const fn smallest_rung(needed_digits: u32, lo: usize, hi: usize) -> usize {
     let mut i = 0;
     while i < AVAIL_RUNGS.len() {
-        let w = AVAIL_RUNGS[i];
-        if w >= lo && w <= hi && (w as u32) * 8 > need {
-            return w;
+        let limbs = AVAIL_RUNGS[i];
+        if limbs >= lo && limbs <= hi && (limbs as u32) * 8 > needed_digits {
+            return limbs;
         }
         i += 1;
     }
@@ -188,8 +188,8 @@ pub(in crate::policy) const fn near_special_rung<C: WideTrigCore, const SCALE: u
 pub(in crate::policy) fn in_budget<St: BigInt, const SCALE: u32, const BUDGET: u32>(
     raw: &St,
 ) -> bool {
-    let bl = crate::algos::exp::exp_generic::bit_length::<St>(*raw) as u64;
-    bl * 100_000 <= ((SCALE + BUDGET) as u64) * 332_192
+    let raw_bit_length = crate::algos::exp::exp_generic::bit_length::<St>(*raw) as u64;
+    raw_bit_length * 100_000 <= ((SCALE + BUDGET) as u64) * 332_192
 }
 
 /// The const-folded work-rung match: one macro emits the 13-arm ladder

--- a/src/support/display.rs
+++ b/src/support/display.rs
@@ -127,8 +127,8 @@ where
     /// let sub = D38s12::from_bits(decimal_scaled::Int::<2>::try_from(1_500_000_000_i128).unwrap());
     /// assert_eq!(format!("{sub:e}"), "1.5e-3");
     /// ```
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        format_exp::<N>(self.0, SCALE, false, f)
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        format_exp::<N>(self.0, SCALE, false, formatter)
     }
 }
 
@@ -152,8 +152,8 @@ where
     /// let v = D38s12::from_bits(decimal_scaled::Int::<2>::try_from(1_500_000_000_000_i128).unwrap());
     /// assert_eq!(format!("{v:E}"), "1.5E0");
     /// ```
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        format_exp::<N>(self.0, SCALE, true, f)
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        format_exp::<N>(self.0, SCALE, true, formatter)
     }
 }
 
@@ -173,31 +173,31 @@ where
 fn format_exp<const N: usize>(
     value: Int<N>,
     scale: u32,
-    upper: bool,
-    f: &mut fmt::Formatter<'_>,
+    uppercase: bool,
+    formatter: &mut fmt::Formatter<'_>,
 ) -> fmt::Result
 where
     Limbs<N>: ComputeLimbs,
 {
-    let exp_char = if upper { 'E' } else { 'e' };
+    let exp_char = if uppercase { 'E' } else { 'e' };
     if value.is_zero() {
-        return write!(f, "0{exp_char}0");
+        return write!(formatter, "0{exp_char}0");
     }
     let negative = value.is_negative();
 
     // Decimal digits of the magnitude, MSB-first with no leading zeros,
     // written into the per-`N` formatting buffer (the identical extraction
     // path the integer `Display` impls take — pure stack, no heap).
-    let mag = *value.unsigned_abs().as_limbs();
+    let magnitude = *value.unsigned_abs().as_limbs();
     let mut buf = Limbs::<N>::digit_formatting_limbs_u8();
-    let digits = fmt_into::<N>(&mag, 10, true, buf.as_mut()).as_bytes();
-    let len = digits.len();
+    let digits = fmt_into::<N>(&magnitude, 10, true, buf.as_mut()).as_bytes();
+    let digit_count = digits.len();
 
     // The decimal exponent for the leading digit is `(len - 1) - scale`.
-    let exp: i32 = (len as i32 - 1) - scale as i32;
+    let exp: i32 = (digit_count as i32 - 1) - scale as i32;
 
     // Strip trailing zeros from the mantissa digit string.
-    let mut frac_end = len;
+    let mut frac_end = digit_count;
     while frac_end > 1 && digits[frac_end - 1] == b'0' {
         frac_end -= 1;
     }
@@ -205,15 +205,15 @@ where
     let mantissa_frac = &digits[1..frac_end];
 
     if negative {
-        f.write_str("-")?;
+        formatter.write_str("-")?;
     }
     if mantissa_frac.is_empty() {
         // Single-digit mantissa: emit without a decimal point.
-        write!(f, "{mantissa_int}{exp_char}{exp}")
+        write!(formatter, "{mantissa_int}{exp_char}{exp}")
     } else {
         // mantissa_frac contains only ASCII digit bytes; from_utf8 cannot fail.
         let frac_str = core::str::from_utf8(mantissa_frac).map_err(|_| fmt::Error)?;
-        write!(f, "{mantissa_int}.{frac_str}{exp_char}{exp}")
+        write!(formatter, "{mantissa_int}.{frac_str}{exp_char}{exp}")
     }
 }
 
@@ -249,13 +249,13 @@ pub(crate) struct ParseComponents<'a> {
 ///
 /// Strict: integer-only string slicing; no arithmetic.
 pub(crate) fn parse_components<const SCALE: u32>(
-    s: &str,
+    input: &str,
 ) -> Result<ParseComponents<'_>, ParseError> {
-    if s.is_empty() {
+    if input.is_empty() {
         return Err(ParseError::Empty);
     }
 
-    let bytes = s.as_bytes();
+    let bytes = input.as_bytes();
     let mut idx = 0usize;
 
     // Consume an optional leading sign byte.
@@ -279,10 +279,10 @@ pub(crate) fn parse_components<const SCALE: u32>(
     // notation and invalid characters immediately.
     let mut dot_pos: Option<usize> = None;
     {
-        let mut i = idx;
-        while i < bytes.len() {
-            let c = bytes[i];
-            match c {
+        let mut scan_pos = idx;
+        while scan_pos < bytes.len() {
+            let byte = bytes[scan_pos];
+            match byte {
                 b'0'..=b'9' => {}
                 b'.' => {
                     if dot_pos.is_some() {
@@ -290,19 +290,19 @@ pub(crate) fn parse_components<const SCALE: u32>(
                         // missing-digit case.
                         return Err(ParseError::InvalidChar);
                     }
-                    dot_pos = Some(i);
+                    dot_pos = Some(scan_pos);
                 }
                 b'e' | b'E' => {
                     return Err(ParseError::ScientificNotation);
                 }
                 _ => return Err(ParseError::InvalidChar),
             }
-            i += 1;
+            scan_pos += 1;
         }
     }
 
     let (int_str, mut frac_str) = match dot_pos {
-        Some(p) => (&bytes[idx..p], &bytes[p + 1..]),
+        Some(dot_index) => (&bytes[idx..dot_index], &bytes[dot_index + 1..]),
         None => (&bytes[idx..], &[][..]),
     };
 

--- a/src/support/error.rs
+++ b/src/support/error.rs
@@ -32,10 +32,10 @@ pub enum ConvertError {
 }
 
 impl core::fmt::Display for ConvertError {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            Self::Overflow => f.write_str("decimal conversion overflow"),
-            Self::NotFinite => f.write_str("decimal conversion from non-finite float"),
+            Self::Overflow => formatter.write_str("decimal conversion overflow"),
+            Self::NotFinite => formatter.write_str("decimal conversion from non-finite float"),
         }
     }
 }
@@ -72,8 +72,8 @@ pub enum ParseError {
 }
 
 impl core::fmt::Display for ParseError {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        let msg = match self {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let message = match self {
             Self::Empty => "empty input",
             Self::SignOnly => "sign with no digits",
             Self::LeadingZero => "redundant leading zero in integer part",
@@ -83,7 +83,7 @@ impl core::fmt::Display for ParseError {
             Self::OutOfRange => "value out of representable range",
             Self::MissingDigits => "decimal point with no adjacent digits",
         };
-        f.write_str(msg)
+        formatter.write_str(message)
     }
 }
 

--- a/src/support/int_fmt.rs
+++ b/src/support/int_fmt.rs
@@ -15,13 +15,13 @@ use crate::int::types::compute_limbs::{ComputeLimbs, Limbs};
 /// `limbs /= radix` in place, returning the remainder. `radix` must be a
 /// u64 (so the per-limb divide stays inside `u128 / u64`).
 fn div_small_radix(limbs: &mut [u64], radix: u64) -> u64 {
-    let mut rem: u64 = 0;
+    let mut remainder: u64 = 0;
     for limb in limbs.iter_mut().rev() {
-        let acc = ((rem as u128) << 64) | (*limb as u128);
-        *limb = (acc / (radix as u128)) as u64;
-        rem = (acc % (radix as u128)) as u64;
+        let accumulator = ((remainder as u128) << 64) | (*limb as u128);
+        *limb = (accumulator / (radix as u128)) as u64;
+        remainder = (accumulator % (radix as u128)) as u64;
     }
-    rem
+    remainder
 }
 
 /// `10^19` — the largest power of ten that fits in a `u64`
@@ -42,7 +42,7 @@ const POW10_19_DIGITS: usize = 19;
 pub(crate) fn fmt_into<'a, const N: usize>(
     limbs: &[u64],
     radix: u64,
-    lower: bool,
+    lowercase: bool,
     buf: &'a mut [u8],
 ) -> &'a str
 where
@@ -58,46 +58,46 @@ where
     let mut work_buf = Limbs::<N>::single_u64();
     let work = work_buf.as_mut();
     work[..limbs.len()].copy_from_slice(limbs);
-    let wl = limbs.len();
+    let limb_count = limbs.len();
     let mut pos = buf.len();
 
     if radix == 10 {
         // Peel one 19-digit base-10^19 chunk per full-width divide.
         loop {
-            let chunk = div_small_radix(&mut work[..wl], POW10_19);
-            if is_zero(&work[..wl]) {
+            let chunk = div_small_radix(&mut work[..limb_count], POW10_19);
+            if is_zero(&work[..limb_count]) {
                 // Most-significant chunk: emit without leading-zero pad.
-                let mut v = chunk;
+                let mut remaining = chunk;
                 loop {
                     pos -= 1;
-                    buf[pos] = b'0' + (v % 10) as u8;
-                    v /= 10;
-                    if v == 0 {
+                    buf[pos] = b'0' + (remaining % 10) as u8;
+                    remaining /= 10;
+                    if remaining == 0 {
                         break;
                     }
                 }
                 break;
             }
             // Interior chunk: always exactly 19 zero-padded digits.
-            let mut v = chunk;
+            let mut remaining = chunk;
             for _ in 0..POW10_19_DIGITS {
                 pos -= 1;
-                buf[pos] = b'0' + (v % 10) as u8;
-                v /= 10;
+                buf[pos] = b'0' + (remaining % 10) as u8;
+                remaining /= 10;
             }
         }
         return core::str::from_utf8(&buf[pos..]).unwrap();
     }
 
-    let digits: &[u8] = if lower {
+    let digits: &[u8] = if lowercase {
         b"0123456789abcdef"
     } else {
         b"0123456789ABCDEF"
     };
-    while !is_zero(&work[..wl]) {
-        let r = div_small_radix(&mut work[..wl], radix);
+    while !is_zero(&work[..limb_count]) {
+        let digit = div_small_radix(&mut work[..limb_count], radix);
         pos -= 1;
-        buf[pos] = digits[r as usize];
+        buf[pos] = digits[digit as usize];
     }
     core::str::from_utf8(&buf[pos..]).unwrap()
 }

--- a/src/support/rounding.rs
+++ b/src/support/rounding.rs
@@ -123,11 +123,12 @@ pub const DEFAULT_ROUNDING_MODE: RoundingMode = RoundingMode::HalfToEven;
 /// The three inputs collapse the per-step numerics that every mode
 /// cares about into mode-independent booleans / orderings:
 ///
-/// - `cmp_r` — three-way comparison of `|r|` against `|m| − |r|`. This
+/// - `remainder_cmp` — three-way comparison of `|r|` against `|m| − |r|`.
+///   This
 ///   is exactly the round-up condition (`|r| > |m| − |r|` ⇔ `2·|r| > |m|`)
 ///   without the doubling-overflow risk. `Equal` flags the half-way tie,
 ///   which only occurs when the divisor is even.
-/// - `q_is_odd` — parity of the truncated quotient. Drives the
+/// - `quotient_is_odd` — parity of the truncated quotient. Drives the
 ///   half-to-even tie break.
 /// - `result_positive` — sign of the true result (`sign(n) == sign(m)`).
 ///   Drives `Floor` / `Ceiling`.
@@ -141,19 +142,19 @@ pub const DEFAULT_ROUNDING_MODE: RoundingMode = RoundingMode::HalfToEven;
 #[inline(always)]
 pub(crate) fn should_bump(
     mode: RoundingMode,
-    cmp_r: ::core::cmp::Ordering,
-    q_is_odd: bool,
+    remainder_cmp: ::core::cmp::Ordering,
+    quotient_is_odd: bool,
     result_positive: bool,
 ) -> bool {
     use ::core::cmp::Ordering;
     match mode {
-        RoundingMode::HalfToEven => match cmp_r {
+        RoundingMode::HalfToEven => match remainder_cmp {
             Ordering::Less => false,
             Ordering::Greater => true,
-            Ordering::Equal => q_is_odd,
+            Ordering::Equal => quotient_is_odd,
         },
-        RoundingMode::HalfAwayFromZero => !matches!(cmp_r, Ordering::Less),
-        RoundingMode::HalfTowardZero => matches!(cmp_r, Ordering::Greater),
+        RoundingMode::HalfAwayFromZero => !matches!(remainder_cmp, Ordering::Less),
+        RoundingMode::HalfTowardZero => matches!(remainder_cmp, Ordering::Greater),
         RoundingMode::Trunc => false,
         RoundingMode::Floor => !result_positive,
         RoundingMode::Ceiling => result_positive,
@@ -211,11 +212,11 @@ where
     if is_nearest_mode(mode) {
         return raw;
     }
-    let positive = raw > zero;
+    let is_positive = raw > zero;
     match mode {
         // Toward zero: drop the sub-ULP magnitude, landing on |raw| − 1.
         RoundingMode::Trunc => {
-            if positive {
+            if is_positive {
                 raw - one
             } else {
                 raw + one
@@ -223,7 +224,7 @@ where
         }
         // Toward −∞.
         RoundingMode::Floor => {
-            if positive {
+            if is_positive {
                 raw - one
             } else {
                 raw
@@ -231,7 +232,7 @@ where
         }
         // Toward +∞.
         RoundingMode::Ceiling => {
-            if positive {
+            if is_positive {
                 raw
             } else {
                 raw + one
@@ -264,14 +265,14 @@ where
     if is_nearest_mode(mode) {
         return raw;
     }
-    let positive = raw > zero;
+    let is_positive = raw > zero;
     match mode {
         // Toward zero: the excess is sub-ULP, so the magnitude stays at
         // `|raw|` — i.e. `raw` unchanged.
         RoundingMode::Trunc => raw,
         // Toward −∞.
         RoundingMode::Floor => {
-            if positive {
+            if is_positive {
                 raw
             } else {
                 raw - one
@@ -279,7 +280,7 @@ where
         }
         // Toward +∞.
         RoundingMode::Ceiling => {
-            if positive {
+            if is_positive {
                 raw + one
             } else {
                 raw
@@ -306,14 +307,14 @@ pub(crate) fn apply_rounding(raw: i128, divisor: i128, mode: RoundingMode) -> i1
         return quotient;
     }
 
-    let abs_rem = remainder.unsigned_abs();
-    let abs_div = divisor.unsigned_abs();
-    let comp = abs_div - abs_rem;
-    let cmp_r = abs_rem.cmp(&comp);
-    let q_is_odd = (quotient & 1) != 0;
+    let abs_remainder = remainder.unsigned_abs();
+    let abs_divisor = divisor.unsigned_abs();
+    let complement = abs_divisor - abs_remainder;
+    let remainder_cmp = abs_remainder.cmp(&complement);
+    let quotient_is_odd = (quotient & 1) != 0;
     let result_positive = (raw < 0) == (divisor < 0);
 
-    if should_bump(mode, cmp_r, q_is_odd, result_positive) {
+    if should_bump(mode, remainder_cmp, quotient_is_odd, result_positive) {
         if result_positive {
             quotient + 1
         } else {
@@ -340,19 +341,19 @@ const F64_INTEGER_THRESHOLD: f64 = 9_007_199_254_740_992.0_f64;
 /// is recovered via an `i128` round-trip, which is exact in that range.
 /// The negative-zero sign is preserved to match [`f64::trunc`] bit-for-bit.
 #[inline]
-pub(crate) fn trunc_f64(x: f64) -> f64 {
-    if x.is_nan() {
-        return x;
+pub(crate) fn trunc_f64(value: f64) -> f64 {
+    if value.is_nan() {
+        return value;
     }
-    let magnitude = if x < 0.0 { -x } else { x };
+    let magnitude = if value < 0.0 { -value } else { value };
     if magnitude >= F64_INTEGER_THRESHOLD {
         // NaN is already returned above, so `>=` is the exact complement of
         // `< THRESHOLD` here: already-integral / too-large magnitudes pass
         // through unchanged.
-        return x;
+        return value;
     }
-    let truncated = x as i128 as f64;
-    if truncated == 0.0 && x.is_sign_negative() {
+    let truncated = value as i128 as f64;
+    if truncated == 0.0 && value.is_sign_negative() {
         -0.0
     } else {
         truncated
@@ -363,9 +364,9 @@ pub(crate) fn trunc_f64(x: f64) -> f64 {
 /// [`f64::floor`]: drop to the truncated value, then step down by one
 /// when truncation rounded a negative value up toward zero.
 #[inline]
-pub(crate) fn floor_f64(x: f64) -> f64 {
-    let truncated = trunc_f64(x);
-    if truncated > x {
+pub(crate) fn floor_f64(value: f64) -> f64 {
+    let truncated = trunc_f64(value);
+    if truncated > value {
         truncated - 1.0
     } else {
         truncated
@@ -375,9 +376,9 @@ pub(crate) fn floor_f64(x: f64) -> f64 {
 /// Round an `f64` toward positive infinity, libm-free. Equivalent to
 /// [`f64::ceil`]: the mirror of [`floor_f64`].
 #[inline]
-pub(crate) fn ceil_f64(x: f64) -> f64 {
-    let truncated = trunc_f64(x);
-    if truncated < x {
+pub(crate) fn ceil_f64(value: f64) -> f64 {
+    let truncated = trunc_f64(value);
+    if truncated < value {
         truncated + 1.0
     } else {
         truncated
@@ -388,9 +389,9 @@ pub(crate) fn ceil_f64(x: f64) -> f64 {
 /// Equivalent to [`f64::round`]: a fractional part with magnitude `>= 0.5`
 /// steps the truncated value one away from zero.
 #[inline]
-pub(crate) fn round_half_away_f64(x: f64) -> f64 {
-    let truncated = trunc_f64(x);
-    let fraction = x - truncated;
+pub(crate) fn round_half_away_f64(value: f64) -> f64 {
+    let truncated = trunc_f64(value);
+    let fraction = value - truncated;
     if fraction >= 0.5 {
         truncated + 1.0
     } else if fraction <= -0.5 {
@@ -405,9 +406,9 @@ pub(crate) fn round_half_away_f64(x: f64) -> f64 {
 /// past `0.5` in magnitude steps one away from zero; an exact half steps
 /// only when the truncated value is odd, landing on the even neighbour.
 #[inline]
-pub(crate) fn round_half_even_f64(x: f64) -> f64 {
-    let truncated = trunc_f64(x);
-    let fraction = x - truncated;
+pub(crate) fn round_half_even_f64(value: f64) -> f64 {
+    let truncated = trunc_f64(value);
+    let fraction = value - truncated;
     if fraction > 0.5 {
         truncated + 1.0
     } else if fraction < -0.5 {
@@ -434,11 +435,11 @@ pub(crate) fn round_half_even_f64(x: f64) -> f64 {
 /// (`(x - 0.5).ceil()` for `x >= 0`, `(x + 0.5).floor()` otherwise)
 /// using the libm-free [`ceil_f64`] / [`floor_f64`].
 #[inline]
-pub(crate) fn round_half_toward_zero_f64(x: f64) -> f64 {
-    if x >= 0.0 {
-        ceil_f64(x - 0.5)
+pub(crate) fn round_half_toward_zero_f64(value: f64) -> f64 {
+    if value >= 0.0 {
+        ceil_f64(value - 0.5)
     } else {
-        floor_f64(x + 0.5)
+        floor_f64(value + 0.5)
     }
 }
 
@@ -469,99 +470,99 @@ mod tests {
     /// Zero remainder is exact for every mode.
     #[test]
     fn zero_remainder_is_quotient_for_all_modes() {
-        for m in modes() {
-            assert_eq!(apply_rounding(20, 10, m), 2, "{m:?}");
-            assert_eq!(apply_rounding(-20, 10, m), -2, "{m:?}");
-            assert_eq!(apply_rounding(0, 10, m), 0, "{m:?}");
+        for mode in modes() {
+            assert_eq!(apply_rounding(20, 10, mode), 2, "{mode:?}");
+            assert_eq!(apply_rounding(-20, 10, mode), -2, "{mode:?}");
+            assert_eq!(apply_rounding(0, 10, mode), 0, "{mode:?}");
         }
     }
 
     /// Half-to-even: ties go to even neighbour.
     #[test]
     fn half_to_even_ties() {
-        let m = RoundingMode::HalfToEven;
-        assert_eq!(apply_rounding(5, 10, m), 0); // 0.5 -> 0 (even)
-        assert_eq!(apply_rounding(15, 10, m), 2); // 1.5 -> 2
-        assert_eq!(apply_rounding(25, 10, m), 2); // 2.5 -> 2 (even)
-        assert_eq!(apply_rounding(35, 10, m), 4); // 3.5 -> 4
-        assert_eq!(apply_rounding(-5, 10, m), 0); // -0.5 -> 0
-        assert_eq!(apply_rounding(-15, 10, m), -2); // -1.5 -> -2
-        assert_eq!(apply_rounding(-25, 10, m), -2); // -2.5 -> -2
-        assert_eq!(apply_rounding(-35, 10, m), -4); // -3.5 -> -4
+        let mode = RoundingMode::HalfToEven;
+        assert_eq!(apply_rounding(5, 10, mode), 0); // 0.5 -> 0 (even)
+        assert_eq!(apply_rounding(15, 10, mode), 2); // 1.5 -> 2
+        assert_eq!(apply_rounding(25, 10, mode), 2); // 2.5 -> 2 (even)
+        assert_eq!(apply_rounding(35, 10, mode), 4); // 3.5 -> 4
+        assert_eq!(apply_rounding(-5, 10, mode), 0); // -0.5 -> 0
+        assert_eq!(apply_rounding(-15, 10, mode), -2); // -1.5 -> -2
+        assert_eq!(apply_rounding(-25, 10, mode), -2); // -2.5 -> -2
+        assert_eq!(apply_rounding(-35, 10, mode), -4); // -3.5 -> -4
     }
 
     /// Half-away-from-zero: ties go away from zero.
     #[test]
     fn half_away_from_zero_ties() {
-        let m = RoundingMode::HalfAwayFromZero;
-        assert_eq!(apply_rounding(5, 10, m), 1);
-        assert_eq!(apply_rounding(15, 10, m), 2);
-        assert_eq!(apply_rounding(25, 10, m), 3);
-        assert_eq!(apply_rounding(-5, 10, m), -1);
-        assert_eq!(apply_rounding(-15, 10, m), -2);
-        assert_eq!(apply_rounding(-25, 10, m), -3);
+        let mode = RoundingMode::HalfAwayFromZero;
+        assert_eq!(apply_rounding(5, 10, mode), 1);
+        assert_eq!(apply_rounding(15, 10, mode), 2);
+        assert_eq!(apply_rounding(25, 10, mode), 3);
+        assert_eq!(apply_rounding(-5, 10, mode), -1);
+        assert_eq!(apply_rounding(-15, 10, mode), -2);
+        assert_eq!(apply_rounding(-25, 10, mode), -3);
     }
 
     /// Half-toward-zero: ties go toward zero.
     #[test]
     fn half_toward_zero_ties() {
-        let m = RoundingMode::HalfTowardZero;
-        assert_eq!(apply_rounding(5, 10, m), 0);
-        assert_eq!(apply_rounding(15, 10, m), 1);
-        assert_eq!(apply_rounding(25, 10, m), 2);
-        assert_eq!(apply_rounding(-5, 10, m), 0);
-        assert_eq!(apply_rounding(-15, 10, m), -1);
-        assert_eq!(apply_rounding(-25, 10, m), -2);
+        let mode = RoundingMode::HalfTowardZero;
+        assert_eq!(apply_rounding(5, 10, mode), 0);
+        assert_eq!(apply_rounding(15, 10, mode), 1);
+        assert_eq!(apply_rounding(25, 10, mode), 2);
+        assert_eq!(apply_rounding(-5, 10, mode), 0);
+        assert_eq!(apply_rounding(-15, 10, mode), -1);
+        assert_eq!(apply_rounding(-25, 10, mode), -2);
     }
 
     /// Trunc: always toward zero, regardless of magnitude.
     #[test]
     fn trunc_always_toward_zero() {
-        let m = RoundingMode::Trunc;
-        assert_eq!(apply_rounding(7, 10, m), 0);
-        assert_eq!(apply_rounding(9, 10, m), 0);
-        assert_eq!(apply_rounding(19, 10, m), 1);
-        assert_eq!(apply_rounding(-7, 10, m), 0);
-        assert_eq!(apply_rounding(-19, 10, m), -1);
+        let mode = RoundingMode::Trunc;
+        assert_eq!(apply_rounding(7, 10, mode), 0);
+        assert_eq!(apply_rounding(9, 10, mode), 0);
+        assert_eq!(apply_rounding(19, 10, mode), 1);
+        assert_eq!(apply_rounding(-7, 10, mode), 0);
+        assert_eq!(apply_rounding(-19, 10, mode), -1);
     }
 
     /// Floor: always toward negative infinity.
     #[test]
     fn floor_toward_negative_infinity() {
-        let m = RoundingMode::Floor;
-        assert_eq!(apply_rounding(1, 10, m), 0);
-        assert_eq!(apply_rounding(7, 10, m), 0);
-        assert_eq!(apply_rounding(9, 10, m), 0);
-        assert_eq!(apply_rounding(-1, 10, m), -1);
-        assert_eq!(apply_rounding(-7, 10, m), -1);
-        assert_eq!(apply_rounding(-19, 10, m), -2);
+        let mode = RoundingMode::Floor;
+        assert_eq!(apply_rounding(1, 10, mode), 0);
+        assert_eq!(apply_rounding(7, 10, mode), 0);
+        assert_eq!(apply_rounding(9, 10, mode), 0);
+        assert_eq!(apply_rounding(-1, 10, mode), -1);
+        assert_eq!(apply_rounding(-7, 10, mode), -1);
+        assert_eq!(apply_rounding(-19, 10, mode), -2);
     }
 
     /// Ceiling: always toward positive infinity.
     #[test]
     fn ceiling_toward_positive_infinity() {
-        let m = RoundingMode::Ceiling;
-        assert_eq!(apply_rounding(1, 10, m), 1);
-        assert_eq!(apply_rounding(7, 10, m), 1);
-        assert_eq!(apply_rounding(19, 10, m), 2);
-        assert_eq!(apply_rounding(-1, 10, m), 0);
-        assert_eq!(apply_rounding(-7, 10, m), 0);
-        assert_eq!(apply_rounding(-19, 10, m), -1);
+        let mode = RoundingMode::Ceiling;
+        assert_eq!(apply_rounding(1, 10, mode), 1);
+        assert_eq!(apply_rounding(7, 10, mode), 1);
+        assert_eq!(apply_rounding(19, 10, mode), 2);
+        assert_eq!(apply_rounding(-1, 10, mode), 0);
+        assert_eq!(apply_rounding(-7, 10, mode), 0);
+        assert_eq!(apply_rounding(-19, 10, mode), -1);
     }
 
     /// Non-half values go to the nearest neighbour for every "half"
     /// mode and ignore the half-tie rule.
     #[test]
     fn non_half_goes_to_nearest() {
-        for m in [
+        for mode in [
             RoundingMode::HalfToEven,
             RoundingMode::HalfAwayFromZero,
             RoundingMode::HalfTowardZero,
         ] {
-            assert_eq!(apply_rounding(4, 10, m), 0, "{m:?} 0.4");
-            assert_eq!(apply_rounding(6, 10, m), 1, "{m:?} 0.6");
-            assert_eq!(apply_rounding(-4, 10, m), 0, "{m:?} -0.4");
-            assert_eq!(apply_rounding(-6, 10, m), -1, "{m:?} -0.6");
+            assert_eq!(apply_rounding(4, 10, mode), 0, "{mode:?} 0.4");
+            assert_eq!(apply_rounding(6, 10, mode), 1, "{mode:?} 0.6");
+            assert_eq!(apply_rounding(-4, 10, mode), 0, "{mode:?} -0.4");
+            assert_eq!(apply_rounding(-6, 10, mode), -1, "{mode:?} -0.6");
         }
     }
 }

--- a/src/support/serde_helpers.rs
+++ b/src/support/serde_helpers.rs
@@ -134,7 +134,7 @@ impl<'de, const SCALE: u32> Deserialize<'de> for crate::D<crate::int::types::Int
 pub mod decimal_serde {
     use super::{Deserialize, Deserializer, PhantomData, Serialize, Serializer, Visitor};
 
-    /// Serialise `v` using the `D38` wire format.
+    /// Serialise `value` using the `D38` wire format.
     ///
     /// Intended for use under `#[serde(serialize_with = "...")]` or
     /// `#[serde(with = "...")]`.
@@ -144,10 +144,10 @@ pub mod decimal_serde {
     /// Strict: all arithmetic is integer-only; result is bit-exact.
     #[inline]
     pub fn serialize<const SCALE: u32, S: Serializer>(
-        v: &crate::D<crate::int::types::Int<2>, SCALE>,
-        s: S,
+        value: &crate::D<crate::int::types::Int<2>, SCALE>,
+        serializer: S,
     ) -> Result<S::Ok, S::Error> {
-        v.serialize(s)
+        value.serialize(serializer)
     }
 
     /// Deserialise a `D38` using the wire format.
@@ -160,9 +160,9 @@ pub mod decimal_serde {
     /// Strict: all arithmetic is integer-only; result is bit-exact.
     #[inline]
     pub fn deserialize<'de, const SCALE: u32, D: Deserializer<'de>>(
-        d: D,
+        deserializer: D,
     ) -> Result<crate::D<crate::int::types::Int<2>, SCALE>, D::Error> {
-        crate::D::<crate::int::types::Int<2>, SCALE>::deserialize(d)
+        crate::D::<crate::int::types::Int<2>, SCALE>::deserialize(deserializer)
     }
 
     /// Visitor that backs [`deserialize`]. Public so external helper
@@ -183,8 +183,8 @@ pub mod decimal_serde {
     impl<'de, const SCALE: u32> Visitor<'de> for DecimalVisitor<SCALE> {
         type Value = crate::D<crate::int::types::Int<2>, SCALE>;
 
-        fn expecting(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-            f.write_str(
+        fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+            formatter.write_str(
                 "a base-10 i128 integer string, 16 little-endian bytes, \
                  or a native integer",
             )
@@ -192,7 +192,7 @@ pub mod decimal_serde {
 
         // ── String wire form (human-readable) ─────────────────────────
 
-        fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<Self::Value, E> {
+        fn visit_str<E: serde::de::Error>(self, text: &str) -> Result<Self::Value, E> {
             // The wire format is a strict base-10 i128 integer literal
             // matching `-?[0-9]+`. No whitespace, no leading `+`, no
             // decimal point, no scientific notation, no underscores.
@@ -202,7 +202,7 @@ pub mod decimal_serde {
             // A leading `+` is rejected explicitly to keep one canonical
             // wire form per value, matching JavaScript BigInt.toString()
             // output which is never `+`-prefixed.
-            let bytes = v.as_bytes();
+            let bytes = text.as_bytes();
             if bytes.is_empty() {
                 return Err(serde::de::Error::custom(
                     "decimal-scaled: empty string is not a valid i128 wire",
@@ -213,46 +213,46 @@ pub mod decimal_serde {
                     "decimal-scaled: leading `+` is not part of the canonical wire format",
                 ));
             }
-            v.parse::<i128>().map(|n| crate::D::<crate::int::types::Int<2>, SCALE>::from_bits(crate::int::types::Int::<2>::from_i128(n))).map_err(|_| {
+            text.parse::<i128>().map(|parsed| crate::D::<crate::int::types::Int<2>, SCALE>::from_bits(crate::int::types::Int::<2>::from_i128(parsed))).map_err(|_| {
                 serde::de::Error::custom("decimal-scaled: expected a base-10 i128 integer string")
             })
         }
 
-        fn visit_borrowed_str<E: serde::de::Error>(self, v: &'de str) -> Result<Self::Value, E> {
-            self.visit_str(v)
+        fn visit_borrowed_str<E: serde::de::Error>(self, text: &'de str) -> Result<Self::Value, E> {
+            self.visit_str(text)
         }
 
         #[cfg(feature = "alloc")]
         fn visit_string<E: serde::de::Error>(
             self,
-            v: alloc::string::String,
+            text: alloc::string::String,
         ) -> Result<Self::Value, E> {
-            self.visit_str(&v)
+            self.visit_str(&text)
         }
 
         // ── Bytes wire form (binary) ───────────────────────────────────
 
-        fn visit_bytes<E: serde::de::Error>(self, v: &[u8]) -> Result<Self::Value, E> {
+        fn visit_bytes<E: serde::de::Error>(self, bytes: &[u8]) -> Result<Self::Value, E> {
             // Require exactly 16 bytes: the little-endian i128 layout.
-            let arr: [u8; 16] = v.try_into().map_err(|_| {
+            let le_bytes: [u8; 16] = bytes.try_into().map_err(|_| {
                 serde::de::Error::invalid_length(
-                    v.len(),
+                    bytes.len(),
                     &"exactly 16 little-endian bytes for an i128",
                 )
             })?;
-            Ok(crate::D::<crate::int::types::Int<2>, SCALE>::from_bits(crate::int::types::Int::<2>::from_i128(i128::from_le_bytes(arr))))
+            Ok(crate::D::<crate::int::types::Int<2>, SCALE>::from_bits(crate::int::types::Int::<2>::from_i128(i128::from_le_bytes(le_bytes))))
         }
 
-        fn visit_borrowed_bytes<E: serde::de::Error>(self, v: &'de [u8]) -> Result<Self::Value, E> {
-            self.visit_bytes(v)
+        fn visit_borrowed_bytes<E: serde::de::Error>(self, bytes: &'de [u8]) -> Result<Self::Value, E> {
+            self.visit_bytes(bytes)
         }
 
         #[cfg(feature = "alloc")]
         fn visit_byte_buf<E: serde::de::Error>(
             self,
-            v: alloc::vec::Vec<u8>,
+            bytes: alloc::vec::Vec<u8>,
         ) -> Result<Self::Value, E> {
-            self.visit_bytes(&v)
+            self.visit_bytes(&bytes)
         }
 
         // ── Native-integer wire forms ──────────────────────────────────
@@ -263,46 +263,46 @@ pub mod decimal_serde {
         // interpreted as the scaled i128 storage, matching the binary
         // serialise path.
 
-        fn visit_i8<E: serde::de::Error>(self, v: i8) -> Result<Self::Value, E> {
-            Ok(crate::D::<crate::int::types::Int<2>, SCALE>::from_bits(crate::int::types::Int::<2>::from_i128(i128::from(v))))
+        fn visit_i8<E: serde::de::Error>(self, value: i8) -> Result<Self::Value, E> {
+            Ok(crate::D::<crate::int::types::Int<2>, SCALE>::from_bits(crate::int::types::Int::<2>::from_i128(i128::from(value))))
         }
 
-        fn visit_i16<E: serde::de::Error>(self, v: i16) -> Result<Self::Value, E> {
-            Ok(crate::D::<crate::int::types::Int<2>, SCALE>::from_bits(crate::int::types::Int::<2>::from_i128(i128::from(v))))
+        fn visit_i16<E: serde::de::Error>(self, value: i16) -> Result<Self::Value, E> {
+            Ok(crate::D::<crate::int::types::Int<2>, SCALE>::from_bits(crate::int::types::Int::<2>::from_i128(i128::from(value))))
         }
 
-        fn visit_i32<E: serde::de::Error>(self, v: i32) -> Result<Self::Value, E> {
-            Ok(crate::D::<crate::int::types::Int<2>, SCALE>::from_bits(crate::int::types::Int::<2>::from_i128(i128::from(v))))
+        fn visit_i32<E: serde::de::Error>(self, value: i32) -> Result<Self::Value, E> {
+            Ok(crate::D::<crate::int::types::Int<2>, SCALE>::from_bits(crate::int::types::Int::<2>::from_i128(i128::from(value))))
         }
 
-        fn visit_i64<E: serde::de::Error>(self, v: i64) -> Result<Self::Value, E> {
-            Ok(crate::D::<crate::int::types::Int<2>, SCALE>::from_bits(crate::int::types::Int::<2>::from_i128(i128::from(v))))
+        fn visit_i64<E: serde::de::Error>(self, value: i64) -> Result<Self::Value, E> {
+            Ok(crate::D::<crate::int::types::Int<2>, SCALE>::from_bits(crate::int::types::Int::<2>::from_i128(i128::from(value))))
         }
 
-        fn visit_i128<E: serde::de::Error>(self, v: i128) -> Result<Self::Value, E> {
-            Ok(crate::D::<crate::int::types::Int<2>, SCALE>::from_bits(crate::int::types::Int::<2>::from_i128(v)))
+        fn visit_i128<E: serde::de::Error>(self, value: i128) -> Result<Self::Value, E> {
+            Ok(crate::D::<crate::int::types::Int<2>, SCALE>::from_bits(crate::int::types::Int::<2>::from_i128(value)))
         }
 
-        fn visit_u8<E: serde::de::Error>(self, v: u8) -> Result<Self::Value, E> {
-            Ok(crate::D::<crate::int::types::Int<2>, SCALE>::from_bits(crate::int::types::Int::<2>::from_i128(i128::from(v))))
+        fn visit_u8<E: serde::de::Error>(self, value: u8) -> Result<Self::Value, E> {
+            Ok(crate::D::<crate::int::types::Int<2>, SCALE>::from_bits(crate::int::types::Int::<2>::from_i128(i128::from(value))))
         }
 
-        fn visit_u16<E: serde::de::Error>(self, v: u16) -> Result<Self::Value, E> {
-            Ok(crate::D::<crate::int::types::Int<2>, SCALE>::from_bits(crate::int::types::Int::<2>::from_i128(i128::from(v))))
+        fn visit_u16<E: serde::de::Error>(self, value: u16) -> Result<Self::Value, E> {
+            Ok(crate::D::<crate::int::types::Int<2>, SCALE>::from_bits(crate::int::types::Int::<2>::from_i128(i128::from(value))))
         }
 
-        fn visit_u32<E: serde::de::Error>(self, v: u32) -> Result<Self::Value, E> {
-            Ok(crate::D::<crate::int::types::Int<2>, SCALE>::from_bits(crate::int::types::Int::<2>::from_i128(i128::from(v))))
+        fn visit_u32<E: serde::de::Error>(self, value: u32) -> Result<Self::Value, E> {
+            Ok(crate::D::<crate::int::types::Int<2>, SCALE>::from_bits(crate::int::types::Int::<2>::from_i128(i128::from(value))))
         }
 
-        fn visit_u64<E: serde::de::Error>(self, v: u64) -> Result<Self::Value, E> {
-            Ok(crate::D::<crate::int::types::Int<2>, SCALE>::from_bits(crate::int::types::Int::<2>::from_i128(i128::from(v))))
+        fn visit_u64<E: serde::de::Error>(self, value: u64) -> Result<Self::Value, E> {
+            Ok(crate::D::<crate::int::types::Int<2>, SCALE>::from_bits(crate::int::types::Int::<2>::from_i128(i128::from(value))))
         }
 
-        fn visit_u128<E: serde::de::Error>(self, v: u128) -> Result<Self::Value, E> {
+        fn visit_u128<E: serde::de::Error>(self, value: u128) -> Result<Self::Value, E> {
             // u128 values above i128::MAX cannot be represented; reject
             // explicitly rather than wrapping silently.
-            i128::try_from(v).map(|n| crate::D::<crate::int::types::Int<2>, SCALE>::from_bits(crate::int::types::Int::<2>::from_i128(n))).map_err(|_| {
+            i128::try_from(value).map(|narrowed| crate::D::<crate::int::types::Int<2>, SCALE>::from_bits(crate::int::types::Int::<2>::from_i128(narrowed))).map_err(|_| {
                 serde::de::Error::custom("decimal-scaled: u128 value exceeds i128 storage range")
             })
         }
@@ -333,9 +333,9 @@ mod tests {
     /// `"0"` deserialises to `ZERO` via the canonical-string path.
     #[test]
     fn deserialize_canonical_zero_string() {
-        let de: StrDeserializer<DeError> = "0".into_deserializer();
-        let v: D38s12 = D38s12::deserialize(de).unwrap();
-        assert_eq!(v, D38s12::ZERO);
+        let deserializer: StrDeserializer<DeError> = "0".into_deserializer();
+        let value: D38s12 = D38s12::deserialize(deserializer).unwrap();
+        assert_eq!(value, D38s12::ZERO);
     }
 
     /// The visitor accepts the scaled integer representation of `ONE`
@@ -343,8 +343,8 @@ mod tests {
     #[test]
     fn visitor_accepts_scaled_one_str() {
         let visitor = decimal_serde::DecimalVisitor::<12>(PhantomData);
-        let v: D38s12 = <_ as Visitor>::visit_str::<DeError>(visitor, "1000000000000").unwrap();
-        assert_eq!(v, D38s12::ONE);
+        let value: D38s12 = <_ as Visitor>::visit_str::<DeError>(visitor, "1000000000000").unwrap();
+        assert_eq!(value, D38s12::ONE);
     }
 
     /// The visitor rejects a decimal-point string. `"1.5"` is the
@@ -352,8 +352,8 @@ mod tests {
     #[test]
     fn visitor_rejects_decimal_point_str() {
         let visitor = decimal_serde::DecimalVisitor::<12>(PhantomData);
-        let res: Result<D38s12, _> = <_ as Visitor>::visit_str::<DeError>(visitor, "1.5");
-        assert!(res.is_err(), "expected reject; got Ok({:?})", res);
+        let parsed: Result<D38s12, _> = <_ as Visitor>::visit_str::<DeError>(visitor, "1.5");
+        assert!(parsed.is_err(), "expected reject; got Ok({:?})", parsed);
     }
 
     // ── Native-integer wire form round-trips ──────────────────────────
@@ -363,16 +363,16 @@ mod tests {
     #[test]
     fn visitor_accepts_i64_as_storage() {
         let visitor = decimal_serde::DecimalVisitor::<12>(PhantomData);
-        let v: D38s12 = <_ as Visitor>::visit_i64::<DeError>(visitor, -5).unwrap();
-        assert_eq!(v.to_bits(), -5);
+        let value: D38s12 = <_ as Visitor>::visit_i64::<DeError>(visitor, -5).unwrap();
+        assert_eq!(value.to_bits(), -5);
     }
 
     /// `visit_u64` with `u64::MAX` widens cleanly into `i128` storage.
     #[test]
     fn visitor_accepts_u64_max() {
         let visitor = decimal_serde::DecimalVisitor::<12>(PhantomData);
-        let v: D38s12 = <_ as Visitor>::visit_u64::<DeError>(visitor, u64::MAX).unwrap();
-        assert_eq!(v.to_bits(), u64::MAX as i128);
+        let value: D38s12 = <_ as Visitor>::visit_u64::<DeError>(visitor, u64::MAX).unwrap();
+        assert_eq!(value.to_bits(), u64::MAX as i128);
     }
 
     /// `visit_u128` past `i128::MAX` yields an explicit out-of-range
@@ -380,9 +380,13 @@ mod tests {
     #[test]
     fn visitor_rejects_u128_above_i128_max() {
         let visitor = decimal_serde::DecimalVisitor::<12>(PhantomData);
-        let res: Result<D38s12, _> =
+        let parsed: Result<D38s12, _> =
             <_ as Visitor>::visit_u128::<DeError>(visitor, (i128::MAX as u128) + 1);
-        assert!(res.is_err(), "expected overflow reject; got Ok({:?})", res);
+        assert!(
+            parsed.is_err(),
+            "expected overflow reject; got Ok({:?})",
+            parsed
+        );
     }
 
     // ── JSON round-trips ──────────────────────────────────────────────
@@ -420,11 +424,11 @@ mod tests {
     /// `-5 * 10^12 = -5_000_000_000_000`.
     #[test]
     fn json_negative_round_trips() {
-        let v = D38s12::try_from(-5_i32).unwrap();
-        let json = serde_json::to_string(&v).unwrap();
+        let value = D38s12::try_from(-5_i32).unwrap();
+        let json = serde_json::to_string(&value).unwrap();
         assert_eq!(json, "\"-5000000000000\"");
         let back: D38s12 = serde_json::from_str(&json).unwrap();
-        assert_eq!(back, v);
+        assert_eq!(back, value);
         assert_eq!(back.to_bits(), -5_000_000_000_000_i128);
     }
 
@@ -450,8 +454,8 @@ mod tests {
     #[test]
     fn json_string_matches_i128_to_string() {
         let raw: i128 = -123_456_789_012_345_678_901_234_567_890_i128;
-        let v = D38s12::from_bits(crate::int::types::Int::<2>::from_i128(raw));
-        let json = serde_json::to_string(&v).unwrap();
+        let value = D38s12::from_bits(crate::int::types::Int::<2>::from_i128(raw));
+        let json = serde_json::to_string(&value).unwrap();
         assert_eq!(json, format!("\"{}\"", raw));
     }
 
@@ -459,40 +463,40 @@ mod tests {
 
     #[test]
     fn json_rejects_decimal_point_string() {
-        let res: Result<D38s12, _> = serde_json::from_str("\"1.5\"");
-        assert!(res.is_err(), "expected reject; got Ok({:?})", res);
+        let parsed: Result<D38s12, _> = serde_json::from_str("\"1.5\"");
+        assert!(parsed.is_err(), "expected reject; got Ok({:?})", parsed);
     }
 
     #[test]
     fn json_rejects_scientific_notation_string() {
-        let res: Result<D38s12, _> = serde_json::from_str("\"1e6\"");
-        assert!(res.is_err(), "expected reject; got Ok({:?})", res);
+        let parsed: Result<D38s12, _> = serde_json::from_str("\"1e6\"");
+        assert!(parsed.is_err(), "expected reject; got Ok({:?})", parsed);
     }
 
     #[test]
     fn json_rejects_not_a_number_string() {
-        let res: Result<D38s12, _> = serde_json::from_str("\"not-a-number\"");
-        assert!(res.is_err(), "expected reject; got Ok({:?})", res);
+        let parsed: Result<D38s12, _> = serde_json::from_str("\"not-a-number\"");
+        assert!(parsed.is_err(), "expected reject; got Ok({:?})", parsed);
     }
 
     #[test]
     fn json_rejects_empty_string() {
-        let res: Result<D38s12, _> = serde_json::from_str("\"\"");
-        assert!(res.is_err(), "expected reject; got Ok({:?})", res);
+        let parsed: Result<D38s12, _> = serde_json::from_str("\"\"");
+        assert!(parsed.is_err(), "expected reject; got Ok({:?})", parsed);
     }
 
     #[test]
     fn json_rejects_leading_whitespace_string() {
         // `i128::from_str` does not trim whitespace; the wire format
         // requires a strict integer literal.
-        let res: Result<D38s12, _> = serde_json::from_str("\"  42\"");
-        assert!(res.is_err(), "expected reject; got Ok({:?})", res);
+        let parsed: Result<D38s12, _> = serde_json::from_str("\"  42\"");
+        assert!(parsed.is_err(), "expected reject; got Ok({:?})", parsed);
     }
 
     #[test]
     fn json_rejects_plus_prefix() {
-        let res: Result<D38s12, _> = serde_json::from_str("\"+42\"");
-        assert!(res.is_err(), "expected reject; got Ok({:?})", res);
+        let parsed: Result<D38s12, _> = serde_json::from_str("\"+42\"");
+        assert!(parsed.is_err(), "expected reject; got Ok({:?})", parsed);
     }
 
     /// A bare JSON integer (not a string) is accepted via `visit_i64`.
@@ -511,7 +515,7 @@ mod tests {
         // Verify the raw 16 LE bytes appear somewhere in the postcard
         // output (postcard may prepend a varint length prefix).
         let raw = D38s12::ONE.to_bits().as_i128().to_le_bytes();
-        assert!(bytes.windows(16).any(|w| w == raw));
+        assert!(bytes.windows(16).any(|window| window == raw));
         let back: D38s12 = postcard::from_bytes(&bytes).unwrap();
         assert_eq!(back, D38s12::ONE);
     }
@@ -525,10 +529,10 @@ mod tests {
 
     #[test]
     fn postcard_negative_round_trips() {
-        let v = D38s12::try_from(-5_i32).unwrap();
-        let bytes: alloc::vec::Vec<u8> = postcard::to_allocvec(&v).unwrap();
+        let value = D38s12::try_from(-5_i32).unwrap();
+        let bytes: alloc::vec::Vec<u8> = postcard::to_allocvec(&value).unwrap();
         let back: D38s12 = postcard::from_bytes(&bytes).unwrap();
-        assert_eq!(back, v);
+        assert_eq!(back, value);
     }
 
     #[test]
@@ -550,10 +554,10 @@ mod tests {
     /// the MSB.
     #[test]
     fn postcard_byte_order_matches_le() {
-        let v = D38s12::from_bits(crate::int::types::Int::<2>::from_i128(0x0123_4567_89AB_CDEF_FEDC_BA98_7654_3210_i128));
-        let bytes: alloc::vec::Vec<u8> = postcard::to_allocvec(&v).unwrap();
-        let raw = v.to_bits().as_i128().to_le_bytes();
-        let found = bytes.windows(16).position(|w| w == raw);
+        let value = D38s12::from_bits(crate::int::types::Int::<2>::from_i128(0x0123_4567_89AB_CDEF_FEDC_BA98_7654_3210_i128));
+        let bytes: alloc::vec::Vec<u8> = postcard::to_allocvec(&value).unwrap();
+        let raw = value.to_bits().as_i128().to_le_bytes();
+        let found = bytes.windows(16).position(|window| window == raw);
         assert!(
             found.is_some(),
             "expected raw LE bytes embedded; got {:?}",
@@ -569,12 +573,12 @@ mod tests {
     /// to `to_le_bytes`, matches the binary wire representation directly.
     #[test]
     fn cross_format_json_string_matches_le_bytes() {
-        let v = D38s12::try_from(42_i32).unwrap();
-        let json = serde_json::to_string(&v).unwrap();
+        let value = D38s12::try_from(42_i32).unwrap();
+        let json = serde_json::to_string(&value).unwrap();
         let inner = json.trim_matches('"');
         let parsed: i128 = inner.parse().unwrap();
         let json_bytes = parsed.to_le_bytes();
-        let direct_bytes = v.to_bits().as_i128().to_le_bytes();
+        let direct_bytes = value.to_bits().as_i128().to_le_bytes();
         assert_eq!(json_bytes, direct_bytes);
     }
 
@@ -584,10 +588,10 @@ mod tests {
     #[test]
     fn cross_scale_wire_is_storage_only() {
         let raw: i128 = 1_500_000_000_000;
-        let v12 = crate::D::<crate::int::types::Int<2>, 12>::from_bits(crate::int::types::Int::<2>::from_i128(raw));
-        let v6 = crate::D::<crate::int::types::Int<2>, 6>::from_bits(crate::int::types::Int::<2>::from_i128(raw));
-        assert_eq!(serde_json::to_string(&v12).unwrap(), "\"1500000000000\"");
-        assert_eq!(serde_json::to_string(&v6).unwrap(), "\"1500000000000\"");
+        let at_scale_12 = crate::D::<crate::int::types::Int<2>, 12>::from_bits(crate::int::types::Int::<2>::from_i128(raw));
+        let at_scale_6 = crate::D::<crate::int::types::Int<2>, 6>::from_bits(crate::int::types::Int::<2>::from_i128(raw));
+        assert_eq!(serde_json::to_string(&at_scale_12).unwrap(), "\"1500000000000\"");
+        assert_eq!(serde_json::to_string(&at_scale_6).unwrap(), "\"1500000000000\"");
     }
 
     // ── decimal_serde free-function helpers ───────────────────────────
@@ -602,13 +606,13 @@ mod tests {
             length: crate::D<crate::int::types::Int<2>, 12>,
         }
 
-        let h = Holder {
+        let holder = Holder {
             length: D38s12::try_from(7_i32).unwrap(),
         };
-        let json = serde_json::to_string(&h).unwrap();
+        let json = serde_json::to_string(&holder).unwrap();
         assert_eq!(json, r#"{"length":"7000000000000"}"#);
         let back: Holder = serde_json::from_str(&json).unwrap();
-        assert_eq!(back, h);
+        assert_eq!(back, holder);
     }
 }
 
@@ -632,15 +636,15 @@ macro_rules! decl_wide_serde {
             /// readable formats, or as `$bytes_len` little-endian
             /// bytes for binary formats.
             #[inline]
-            fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
-                if s.is_human_readable() {
+            fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+                if serializer.is_human_readable() {
                     #[cfg(feature = "alloc")]
                     {
-                        s.serialize_str(&self.0.to_string())
+                        serializer.serialize_str(&self.0.to_string())
                     }
                     #[cfg(not(feature = "alloc"))]
                     {
-                        let _ = s;
+                        let _ = serializer;
                         Err(serde::ser::Error::custom(
                             "decimal-scaled: human-readable serialisation requires `alloc`",
                         ))
@@ -655,27 +659,27 @@ macro_rules! decl_wide_serde {
                     for (i, limb) in limbs.iter().enumerate() {
                         bytes[i * 8..(i + 1) * 8].copy_from_slice(&limb.to_le_bytes());
                     }
-                    s.serialize_bytes(&bytes)
+                    serializer.serialize_bytes(&bytes)
                 }
             }
         }
 
         impl<'de, const SCALE: u32> Deserialize<'de> for $crate::types::widths::$Type<SCALE> {
             #[inline]
-            fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+            fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
                 struct V<const S: u32>;
                 impl<'de, const S: u32> Visitor<'de> for V<S> {
                     type Value = $crate::types::widths::$Type<S>;
-                    fn expecting(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                        f.write_str(concat!(
+                    fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                        formatter.write_str(concat!(
                             "a base-10 integer string or ",
                             stringify!($bytes_len),
                             " little-endian bytes for ",
                             stringify!($Type),
                         ))
                     }
-                    fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<Self::Value, E> {
-                        let parsed = <$Storage>::from_str_radix(v, 10).map_err(|_| {
+                    fn visit_str<E: serde::de::Error>(self, text: &str) -> Result<Self::Value, E> {
+                        let parsed = <$Storage>::from_str_radix(text, 10).map_err(|_| {
                             serde::de::Error::custom(concat!(
                                 stringify!($Type),
                                 ": invalid base-10 integer string",
@@ -685,26 +689,26 @@ macro_rules! decl_wide_serde {
                     }
                     fn visit_borrowed_str<E: serde::de::Error>(
                         self,
-                        v: &'de str,
+                        text: &'de str,
                     ) -> Result<Self::Value, E> {
-                        self.visit_str(v)
+                        self.visit_str(text)
                     }
                     #[cfg(feature = "alloc")]
                     fn visit_string<E: serde::de::Error>(
                         self,
-                        v: alloc::string::String,
+                        text: alloc::string::String,
                     ) -> Result<Self::Value, E> {
-                        self.visit_str(&v)
+                        self.visit_str(&text)
                     }
-                    fn visit_bytes<E: serde::de::Error>(self, v: &[u8]) -> Result<Self::Value, E> {
-                        if v.len() != $bytes_len {
+                    fn visit_bytes<E: serde::de::Error>(self, bytes: &[u8]) -> Result<Self::Value, E> {
+                        if bytes.len() != $bytes_len {
                             return Err(serde::de::Error::invalid_length($bytes_len, &self));
                         }
                         // 8 bytes per u64 limb; bytes_len/8 limbs total.
                         let mut limbs = [0u64; $bytes_len / 8];
                         for (i, limb) in limbs.iter_mut().enumerate() {
                             let mut buf = [0u8; 8];
-                            buf.copy_from_slice(&v[i * 8..(i + 1) * 8]);
+                            buf.copy_from_slice(&bytes[i * 8..(i + 1) * 8]);
                             *limb = u64::from_le_bytes(buf);
                         }
                         Ok(<$crate::types::widths::$Type<S>>::from_bits(
@@ -713,15 +717,15 @@ macro_rules! decl_wide_serde {
                     }
                     fn visit_borrowed_bytes<E: serde::de::Error>(
                         self,
-                        v: &'de [u8],
+                        bytes: &'de [u8],
                     ) -> Result<Self::Value, E> {
-                        self.visit_bytes(v)
+                        self.visit_bytes(bytes)
                     }
                 }
-                if d.is_human_readable() {
-                    d.deserialize_str(V::<SCALE>)
+                if deserializer.is_human_readable() {
+                    deserializer.deserialize_str(V::<SCALE>)
                 } else {
-                    d.deserialize_bytes(V::<SCALE>)
+                    deserializer.deserialize_bytes(V::<SCALE>)
                 }
             }
         }
@@ -754,26 +758,26 @@ mod wide_serde_tests {
 
     #[test]
     fn d76_human_readable_round_trip() {
-        let v = crate::D::<crate::int::types::Int<4>, 12>::try_from(1_234_567_i128).unwrap();
-        let json = serde_json::to_string(&v).unwrap();
+        let value = crate::D::<crate::int::types::Int<4>, 12>::try_from(1_234_567_i128).unwrap();
+        let json = serde_json::to_string(&value).unwrap();
         let back: crate::D<crate::int::types::Int<4>, 12> = serde_json::from_str(&json).unwrap();
-        assert_eq!(back, v);
+        assert_eq!(back, value);
     }
 
     #[test]
     fn d76_negative_human_readable_round_trip() {
-        let v = -crate::D::<crate::int::types::Int<4>, 12>::try_from(987_654_321_i128).unwrap();
-        let json = serde_json::to_string(&v).unwrap();
+        let value = -crate::D::<crate::int::types::Int<4>, 12>::try_from(987_654_321_i128).unwrap();
+        let json = serde_json::to_string(&value).unwrap();
         let back: crate::D<crate::int::types::Int<4>, 12> = serde_json::from_str(&json).unwrap();
-        assert_eq!(back, v);
+        assert_eq!(back, value);
     }
 
     #[test]
     fn d76_binary_round_trip() {
         // postcard is a binary, non-self-describing format.
-        let v = crate::D::<crate::int::types::Int<4>, 12>::try_from(42_i128).unwrap();
-        let bytes = postcard::to_allocvec(&v).unwrap();
+        let value = crate::D::<crate::int::types::Int<4>, 12>::try_from(42_i128).unwrap();
+        let bytes = postcard::to_allocvec(&value).unwrap();
         let back: crate::D<crate::int::types::Int<4>, 12> = postcard::from_bytes(&bytes).unwrap();
-        assert_eq!(back, v);
+        assert_eq!(back, value);
     }
 }

--- a/src/types/log_exp.rs
+++ b/src/types/log_exp.rs
@@ -589,11 +589,11 @@ mod strict_tests {
     #[test]
     fn ln_strict_is_correctly_rounded_vs_f64() {
         fn check(raw: i128) {
-            let x = crate::D::<crate::int::types::Int<2>, 9>::from_bits(crate::int::types::Int::<2>::from_i128(raw));
-            let strict = x.ln_strict().to_bits().as_i128();
+            let value = crate::D::<crate::int::types::Int<2>, 9>::from_bits(crate::int::types::Int::<2>::from_i128(raw));
+            let strict = value.ln_strict().to_bits().as_i128();
             let reference = {
-                let v = raw as f64 / 1e9;
-                (v.ln() * 1e9).round() as i128
+                let as_float = raw as f64 / 1e9;
+                (as_float.ln() * 1e9).round() as i128
             };
             assert!(
                 (strict - reference).abs() <= 1,
@@ -621,8 +621,8 @@ mod strict_tests {
     #[test]
     fn strict_log_exp_family_matches_f64() {
         fn check_exp(raw: i128) {
-            let x = crate::D::<crate::int::types::Int<2>, 9>::from_bits(crate::int::types::Int::<2>::from_i128(raw));
-            let strict = x.exp_strict().to_bits().as_i128();
+            let value = crate::D::<crate::int::types::Int<2>, 9>::from_bits(crate::int::types::Int::<2>::from_i128(raw));
+            let strict = value.exp_strict().to_bits().as_i128();
             let reference = ((raw as f64 / 1e9).exp() * 1e9).round() as i128;
             assert!(
                 (strict - reference).abs() <= 1,
@@ -630,8 +630,8 @@ mod strict_tests {
             );
         }
         fn check_log2(raw: i128) {
-            let x = crate::D::<crate::int::types::Int<2>, 9>::from_bits(crate::int::types::Int::<2>::from_i128(raw));
-            let strict = x.log2_strict().to_bits().as_i128();
+            let value = crate::D::<crate::int::types::Int<2>, 9>::from_bits(crate::int::types::Int::<2>::from_i128(raw));
+            let strict = value.log2_strict().to_bits().as_i128();
             let reference = ((raw as f64 / 1e9).log2() * 1e9).round() as i128;
             assert!(
                 (strict - reference).abs() <= 1,
@@ -639,8 +639,8 @@ mod strict_tests {
             );
         }
         fn check_log10(raw: i128) {
-            let x = crate::D::<crate::int::types::Int<2>, 9>::from_bits(crate::int::types::Int::<2>::from_i128(raw));
-            let strict = x.log10_strict().to_bits().as_i128();
+            let value = crate::D::<crate::int::types::Int<2>, 9>::from_bits(crate::int::types::Int::<2>::from_i128(raw));
+            let strict = value.log10_strict().to_bits().as_i128();
             let reference = ((raw as f64 / 1e9).log10() * 1e9).round() as i128;
             assert!(
                 (strict - reference).abs() <= 1,
@@ -679,8 +679,8 @@ mod strict_tests {
     #[test]
     fn strict_exp2_at_integers() {
         for k in 0_i128..=12 {
-            let x = crate::D::<crate::int::types::Int<2>, 12>::from_bits(crate::int::types::Int::<2>::from_i128(k * 10i128.pow(12)));
-            let got = x.exp2_strict().to_bits().as_i128();
+            let value = crate::D::<crate::int::types::Int<2>, 12>::from_bits(crate::int::types::Int::<2>::from_i128(k * 10i128.pow(12)));
+            let got = value.exp2_strict().to_bits().as_i128();
             let expected = (1i128 << k) * 10i128.pow(12);
             assert_eq!(got, expected, "2^{k}");
         }
@@ -691,12 +691,12 @@ mod strict_tests {
     fn ln_strict_of_powers_of_two() {
         let ln2_s18: i128 = 693_147_180_559_945_309;
         for k in 1_i128..=20 {
-            let x = crate::D::<crate::int::types::Int<2>, 18>::from_bits(crate::int::types::Int::<2>::from_i128((1i128 << k) * 10i128.pow(18)));
-            let got = x.ln_strict().to_bits().as_i128();
+            let value = crate::D::<crate::int::types::Int<2>, 18>::from_bits(crate::int::types::Int::<2>::from_i128((1i128 << k) * 10i128.pow(18)));
+            let got = value.ln_strict().to_bits().as_i128();
             let expected = k * ln2_s18;
-            let tol = k / 2 + 2;
+            let tolerance = k / 2 + 2;
             assert!(
-                (got - expected).abs() <= tol,
+                (got - expected).abs() <= tolerance,
                 "ln(2^{k}) = {got}, expected ≈ {expected}"
             );
         }
@@ -741,16 +741,16 @@ mod strict_tests {
     /// ln of a value > 1 is positive.
     #[test]
     fn ln_above_one_is_positive() {
-        let v = D38s12::from_bits(crate::int::types::Int::<2>::from_i128(1_500_000_000_000));
-        let result = v.ln();
+        let value = D38s12::from_bits(crate::int::types::Int::<2>::from_i128(1_500_000_000_000));
+        let result = value.ln();
         assert!(result.to_bits().as_i128() > 0);
     }
 
     /// ln of a value in (0, 1) is negative.
     #[test]
     fn ln_below_one_is_negative() {
-        let v = D38s12::from_bits(crate::int::types::Int::<2>::from_i128(500_000_000_000));
-        let result = v.ln();
+        let value = D38s12::from_bits(crate::int::types::Int::<2>::from_i128(500_000_000_000));
+        let result = value.ln();
         assert!(result.to_bits().as_i128() < 0);
         assert!(
             within(result, -693_147_180_560, STRICT_TOLERANCE_LSB),
@@ -768,8 +768,8 @@ mod strict_tests {
     #[test]
     #[should_panic(expected = "argument must be positive")]
     fn ln_of_negative_panics() {
-        let neg = D38s12::from_bits(crate::int::types::Int::<2>::from_i128(-1_000_000_000_000));
-        let _ = neg.ln();
+        let negative_value = D38s12::from_bits(crate::int::types::Int::<2>::from_i128(-1_000_000_000_000));
+        let _ = negative_value.ln();
     }
 
     // log2 / log10 / log derive from ln; tolerance grows because the
@@ -852,9 +852,9 @@ mod strict_tests {
     #[test]
     #[should_panic(expected = "base must not equal 1")]
     fn log_base_one_panics() {
-        let x = D38s12::from_bits(crate::int::types::Int::<2>::from_i128(5_000_000_000_000));
+        let value = D38s12::from_bits(crate::int::types::Int::<2>::from_i128(5_000_000_000_000));
         let one = D38s12::ONE;
-        let _ = x.log(one);
+        let _ = value.log(one);
     }
 
     // exp / exp2 tolerance accounts for Taylor truncation, 2^k bit-shift

--- a/src/types/log_exp_fast.rs
+++ b/src/types/log_exp_fast.rs
@@ -260,9 +260,9 @@ mod tests {
     /// Each f64 step adds up to ~1 LSB; 4 LSB absorbs two quantisation steps.
     const FOUR_LSB: i128 = 4;
 
-    fn within_lsb(actual: D38s12, expected: D38s12, lsb: i128) -> bool {
+    fn within_lsb(actual: D38s12, expected: D38s12, tolerance_lsb: i128) -> bool {
         let diff = (actual.to_bits() - expected.to_bits()).abs();
-        diff <= lsb
+        diff <= tolerance_lsb
     }
 
     // Bit-exact identity tests
@@ -382,13 +382,13 @@ mod tests {
             45_678_912_345_679_i128, // ~45.678912
             78_901_234_567_890_i128, // ~78.901234
         ] {
-            let x = D38s12::from_bits(crate::int::types::Int::<2>::from_i128(raw));
-            let recovered = x.ln().exp();
+            let value = D38s12::from_bits(crate::int::types::Int::<2>::from_i128(raw));
+            let recovered = value.ln().exp();
             assert!(
-                within_lsb(recovered, x, ROUND_TRIP_TOLERANCE_LSB),
+                within_lsb(recovered, value, ROUND_TRIP_TOLERANCE_LSB),
                 "exp(ln(x)) != x for raw={raw}: got bits {} (delta {})",
                 recovered.to_bits(),
-                (recovered.to_bits() - x.to_bits()).abs(),
+                (recovered.to_bits() - value.to_bits()).abs(),
             );
         }
     }
@@ -398,13 +398,13 @@ mod tests {
     /// `e ~= 2.718`, so the error stays inside `LOG_EXP_TOLERANCE_LSB`.
     #[test]
     fn exp_of_ln_e_round_trip() {
-        let e = D38s12::e();
-        let recovered = e.ln().exp();
+        let euler = D38s12::e();
+        let recovered = euler.ln().exp();
         assert!(
-            within_lsb(recovered, e, LOG_EXP_TOLERANCE_LSB),
+            within_lsb(recovered, euler, LOG_EXP_TOLERANCE_LSB),
             "exp(ln(e)) != e: got bits {} (delta {})",
             recovered.to_bits(),
-            (recovered.to_bits() - e.to_bits()).abs(),
+            (recovered.to_bits() - euler.to_bits()).abs(),
         );
     }
 
@@ -422,13 +422,13 @@ mod tests {
             1_234_567_890_123_i128,  // ~1.234567
             7_890_123_456_789_i128,  // ~7.890123
         ] {
-            let x = D38s12::from_bits(crate::int::types::Int::<2>::from_i128(raw));
-            let recovered = x.exp().ln();
+            let value = D38s12::from_bits(crate::int::types::Int::<2>::from_i128(raw));
+            let recovered = value.exp().ln();
             assert!(
-                within_lsb(recovered, x, FOUR_LSB),
+                within_lsb(recovered, value, FOUR_LSB),
                 "ln(exp(x)) != x for raw={raw}: got bits {} (delta {})",
                 recovered.to_bits(),
-                (recovered.to_bits() - x.to_bits()).abs(),
+                (recovered.to_bits() - value.to_bits()).abs(),
             );
         }
     }
@@ -438,16 +438,16 @@ mod tests {
     /// `log(self, e) ~= ln(self)` -- base-aware form is consistent with `ln`.
     #[test]
     fn log_base_e_matches_ln() {
-        let e = D38s12::e();
+        let euler = D38s12::e();
         for raw in [
             500_000_000_000_i128,   // 0.5
             1_234_567_890_123_i128, // ~1.234567
             4_567_891_234_567_i128, // ~4.567891
             7_890_123_456_789_i128, // ~7.890123
         ] {
-            let x = D38s12::from_bits(crate::int::types::Int::<2>::from_i128(raw));
-            let via_log = x.log(e);
-            let via_ln = x.ln();
+            let value = D38s12::from_bits(crate::int::types::Int::<2>::from_i128(raw));
+            let via_log = value.log(euler);
+            let via_ln = value.ln();
             assert!(
                 within_lsb(via_log, via_ln, FOUR_LSB),
                 "log(x, e) != ln(x) for raw={raw}: log bits {}, ln bits {}",
@@ -467,9 +467,9 @@ mod tests {
             4_567_891_234_567_i128, // ~4.567891
             7_890_123_456_789_i128, // ~7.890123
         ] {
-            let x = D38s12::from_bits(crate::int::types::Int::<2>::from_i128(raw));
-            let via_log = x.log(two);
-            let via_log2 = x.log2();
+            let value = D38s12::from_bits(crate::int::types::Int::<2>::from_i128(raw));
+            let via_log = value.log(two);
+            let via_log2 = value.log2();
             assert!(
                 within_lsb(via_log, via_log2, FOUR_LSB),
                 "log(x, 2) != log2(x) for raw={raw}: log bits {}, log2 bits {}",
@@ -489,9 +489,9 @@ mod tests {
             4_567_891_234_567_i128, // ~4.567891
             7_890_123_456_789_i128, // ~7.890123
         ] {
-            let x = D38s12::from_bits(crate::int::types::Int::<2>::from_i128(raw));
-            let via_log = x.log(ten);
-            let via_log10 = x.log10();
+            let value = D38s12::from_bits(crate::int::types::Int::<2>::from_i128(raw));
+            let via_log = value.log(ten);
+            let via_log10 = value.log10();
             assert!(
                 within_lsb(via_log, via_log10, FOUR_LSB),
                 "log(x, 10) != log10(x) for raw={raw}: log bits {}, log10 bits {}",

--- a/src/types/powers.rs
+++ b/src/types/powers.rs
@@ -70,10 +70,10 @@
 //!
 //! # Square-and-multiply algorithm
 //!
-//! Starting from `acc = ONE`, the algorithm walks the bits of `exp` from
-//! low to high. On each iteration:
+//! Starting from `accumulator = ONE`, the algorithm walks the bits of
+//! `exp` from low to high. On each iteration:
 //!
-//! 1. If the current bit of `exp` is set, multiply `acc *= base`.
+//! 1. If the current bit of `exp` is set, multiply `accumulator *= base`.
 //! 2. Square `base *= base`.
 //!
 //! This costs `O(log exp)` multiplications rather than `O(exp)`. The
@@ -125,19 +125,19 @@ impl<const SCALE: u32> crate::D<crate::int::types::Int<2>, SCALE> {
     #[inline]
     #[must_use]
     pub fn pow(self, exp: u32) -> Self {
-        let mut acc = Self::ONE;
+        let mut accumulator = Self::ONE;
         let mut base = self;
-        let mut e = exp;
-        while e > 0 {
-            if e & 1 == 1 {
-                acc *= base;
+        let mut remaining_exponent = exp;
+        while remaining_exponent > 0 {
+            if remaining_exponent & 1 == 1 {
+                accumulator *= base;
             }
-            e >>= 1;
-            if e > 0 {
+            remaining_exponent >>= 1;
+            if remaining_exponent > 0 {
                 base *= base;
             }
         }
-        acc
+        accumulator
     }
 
     /// Raises `self` to the signed integer power `exp`.
@@ -428,19 +428,19 @@ impl<const SCALE: u32> crate::D<crate::int::types::Int<2>, SCALE> {
     #[inline]
     #[must_use]
     pub fn checked_pow(self, exp: u32) -> Option<Self> {
-        let mut acc = Self::ONE;
+        let mut accumulator = Self::ONE;
         let mut base = self;
-        let mut e = exp;
-        while e > 0 {
-            if e & 1 == 1 {
-                acc = acc.checked_mul(base)?;
+        let mut remaining_exponent = exp;
+        while remaining_exponent > 0 {
+            if remaining_exponent & 1 == 1 {
+                accumulator = accumulator.checked_mul(base)?;
             }
-            e >>= 1;
-            if e > 0 {
+            remaining_exponent >>= 1;
+            if remaining_exponent > 0 {
                 base = base.checked_mul(base)?;
             }
         }
-        Some(acc)
+        Some(accumulator)
     }
 
     /// Returns `self^exp`, wrapping two's-complement on overflow at
@@ -468,19 +468,19 @@ impl<const SCALE: u32> crate::D<crate::int::types::Int<2>, SCALE> {
     #[inline]
     #[must_use]
     pub fn wrapping_pow(self, exp: u32) -> Self {
-        let mut acc = Self::ONE;
+        let mut accumulator = Self::ONE;
         let mut base = self;
-        let mut e = exp;
-        while e > 0 {
-            if e & 1 == 1 {
-                acc = acc.wrapping_mul(base);
+        let mut remaining_exponent = exp;
+        while remaining_exponent > 0 {
+            if remaining_exponent & 1 == 1 {
+                accumulator = accumulator.wrapping_mul(base);
             }
-            e >>= 1;
-            if e > 0 {
+            remaining_exponent >>= 1;
+            if remaining_exponent > 0 {
                 base = base.wrapping_mul(base);
             }
         }
-        acc
+        accumulator
     }
 
     /// Returns `self^exp`, clamping to `D38::MAX` or `D38::MIN` on
@@ -511,15 +511,15 @@ impl<const SCALE: u32> crate::D<crate::int::types::Int<2>, SCALE> {
         if exp == 0 {
             return Self::ONE;
         }
-        let mut acc = Self::ONE;
+        let mut accumulator = Self::ONE;
         let mut base = self;
-        let mut e = exp;
+        let mut remaining_exponent = exp;
         // The final result is negative iff the base is negative and exp is odd.
         let result_negative_if_overflow = self.is_negative() && (exp & 1) == 1;
-        while e > 0 {
-            if e & 1 == 1 {
-                match acc.checked_mul(base) {
-                    Some(q) => acc = q,
+        while remaining_exponent > 0 {
+            if remaining_exponent & 1 == 1 {
+                match accumulator.checked_mul(base) {
+                    Some(product) => accumulator = product,
                     None => {
                         return if result_negative_if_overflow {
                             Self::MIN
@@ -529,10 +529,10 @@ impl<const SCALE: u32> crate::D<crate::int::types::Int<2>, SCALE> {
                     }
                 }
             }
-            e >>= 1;
-            if e > 0 {
+            remaining_exponent >>= 1;
+            if remaining_exponent > 0 {
                 match base.checked_mul(base) {
-                    Some(q) => base = q,
+                    Some(squared) => base = squared,
                     None => {
                         // base*base is non-negative (squared); clamp by the
                         // sign of the would-be final result.
@@ -545,7 +545,7 @@ impl<const SCALE: u32> crate::D<crate::int::types::Int<2>, SCALE> {
                 }
             }
         }
-        acc
+        accumulator
     }
 
     /// Returns `(self^exp, overflowed)`.
@@ -571,24 +571,24 @@ impl<const SCALE: u32> crate::D<crate::int::types::Int<2>, SCALE> {
     #[inline]
     #[must_use]
     pub fn overflowing_pow(self, exp: u32) -> (Self, bool) {
-        let mut acc = Self::ONE;
+        let mut accumulator = Self::ONE;
         let mut base = self;
-        let mut e = exp;
+        let mut remaining_exponent = exp;
         let mut overflowed = false;
-        while e > 0 {
-            if e & 1 == 1 {
-                let (q, o) = acc.overflowing_mul(base);
-                acc = q;
-                overflowed |= o;
+        while remaining_exponent > 0 {
+            if remaining_exponent & 1 == 1 {
+                let (product, step_overflowed) = accumulator.overflowing_mul(base);
+                accumulator = product;
+                overflowed |= step_overflowed;
             }
-            e >>= 1;
-            if e > 0 {
-                let (q, o) = base.overflowing_mul(base);
-                base = q;
-                overflowed |= o;
+            remaining_exponent >>= 1;
+            if remaining_exponent > 0 {
+                let (squared, step_overflowed) = base.overflowing_mul(base);
+                base = squared;
+                overflowed |= step_overflowed;
             }
         }
-        (acc, overflowed)
+        (accumulator, overflowed)
     }
 }
 
@@ -606,12 +606,12 @@ mod tests {
         // So a correctly-rounded q satisfies q^2 - q < N ≤ q^2 + q  (q>0),
         // or N == 0 when q == 0.
         fn check<const S: u32>(raw: i128) {
-            let x = crate::D::<crate::int::types::Int<2>, S>::from_bits(crate::int::types::Int::<2>::from_i128(raw));
-            let q = x.sqrt_strict().to_bits().as_i128();
+            let value = crate::D::<crate::int::types::Int<2>, S>::from_bits(crate::int::types::Int::<2>::from_i128(raw));
+            let q = value.sqrt_strict().to_bits().as_i128();
             assert!(q >= 0, "sqrt result must be non-negative");
             // N = raw · 10^S as 256-bit; q is small enough that q^2 fits 256-bit.
-            let mult = 10u128.pow(S);
-            let (n_hi, n_lo) = crate::algos::support::mg_divide::mul_u128_to_u256(raw as u128, mult);
+            let multiplier = 10u128.pow(S);
+            let (n_hi, n_lo) = crate::algos::support::mg_divide::mul_u128_to_u256(raw as u128, multiplier);
             let (qsq_hi, qsq_lo) = crate::algos::support::mg_divide::mul_u128_to_u256(q as u128, q as u128);
             // lower: N > q^2 - q ⇔   N + q > q^2   (q ≥ 0)
             // upper: N ≤ q^2 + q
@@ -671,8 +671,8 @@ mod tests {
         // hold the 384-bit cubes (i256 is already a dev-dependency).
         use i256::U256;
         fn check<const S: u32>(raw: i128) {
-            let x = crate::D::<crate::int::types::Int<2>, S>::from_bits(crate::int::types::Int::<2>::from_i128(raw));
-            let q = x.cbrt_strict().to_bits().as_i128();
+            let value = crate::D::<crate::int::types::Int<2>, S>::from_bits(crate::int::types::Int::<2>::from_i128(raw));
+            let q = value.cbrt_strict().to_bits().as_i128();
             // Sign must match the input.
             assert_eq!(q.signum(), raw.signum(), "cbrt sign mismatch");
             let qa = q.unsigned_abs();
@@ -682,8 +682,8 @@ mod tests {
             // scales exercised here to keep the check in U256 range.
             // (The 384-bit path itself is exercised across all scales by
             // the round-trip tests; this exact check covers S ≤ 25.)
-            let m = U256::from(10u8).pow(2 * S);
-            let n = U256::from(ra) * m;
+            let scale_factor = U256::from(10u8).pow(2 * S);
+            let n = U256::from(ra) * scale_factor;
             let eight_n = n << 3;
             let two_q = U256::from(qa) * U256::from(2u8);
             let upper = {

--- a/src/types/powers_fast.rs
+++ b/src/types/powers_fast.rs
@@ -136,9 +136,13 @@ impl<const SCALE: u32> crate::D<crate::int::types::Int<2>, SCALE> {
     #[inline]
     #[must_use]
     pub fn hypot_fast(self, other: Self) -> Self {
-        let a = self.abs();
-        let b = other.abs();
-        let (large, small) = if a >= b { (a, b) } else { (b, a) };
+        let abs_self = self.abs();
+        let abs_other = other.abs();
+        let (large, small) = if abs_self >= abs_other {
+            (abs_self, abs_other)
+        } else {
+            (abs_other, abs_self)
+        };
         if large == Self::ZERO {
             // Both inputs are zero; large is the max of two non-negatives,
             // so this branch is only reached when both are zero.

--- a/src/types/traits/arithmetic.rs
+++ b/src/types/traits/arithmetic.rs
@@ -104,7 +104,7 @@ pub trait DecimalArithmetic:
     fn div_ceil(self, rhs: Self) -> Self;
     fn abs_diff(self, rhs: Self) -> Self;
     fn midpoint(self, rhs: Self) -> Self;
-    fn mul_add(self, a: Self, b: Self) -> Self;
+    fn mul_add(self, multiplier: Self, addend: Self) -> Self;
 
     // ── Integer-exponent powers ──────────────────────────────────────
 


### PR DESCRIPTION
Applies the project naming convention to the whole tree: parameters of
functions, methods and constructors get real, descriptive names, and locals get
them where a real name exists.

190 files across seven commits, one per area, each independently verified.

## The vocabulary is the tree's own

Nothing here is invented. Every long name was already in use somewhere in the
repo; the sweep makes it consistent. `working_digits` was already the name of
that parameter in the algorithm layer (870 uses) while the policy layer one
level up called it `wd` — those two layers now agree. The same holds for
`working_scale`, `working_value`, `guard_digits`, `table_size` and `radicand`,
each taken from prose the files already contained.

Three idioms that were half-and-half across the tree are now unified:
`ex`/`enx` → `exp_x`/`exp_neg_x`, `thresh`/`thresh_exp` → `threshold`/
`threshold_exponent`, `thr_x` → `saturation_bound`.

## Single letters are kept where a derivation defines them

A letter that a file's own doc block defines is part of that derivation, and
renaming it breaks the correspondence between the prose and the code it
explains. So these stay:

- Knuth Algorithm D's `u`/`v`/`q_hat`/`r_hat`, Möller–Granlund's `d`/`dinv`/
  `n2,n1,n0`, Burnikel–Ziegler's `a`/`b`/`q`/`r`/`s`/`d`/`rr`, Karatsuba's
  `z0`/`z1`/`z2`, Zimmermann RR-3805's `sqrtrem` notation, Knuth TAOCP 4.3.2
  Ex. 17 in `isqrt_schoolbook`
- `x`/`y`/`x0` in every Newton loop, whose AM-GM proof is written `(x + n/x)/2`
- `k` in `v = k·ln2 + s` and `x = 2^k·m`; `u` in `log1p_fixed_inner`, whose
  tail-sign proof is written in terms of `u`
- the dense limb-scratch notation in the schoolbook inner loops

`mul_toom3.rs` keeps its operand names `a`/`b` while `mul_karatsuba.rs` takes
`lhs`/`rhs`, and the difference is deliberate: toom3 has an `# Algorithm`
section deriving the method in exactly those symbols, karatsuba has no such
block.

The sharpest non-rename: `isqrt_newton`'s Heron step keeps `q`, because `q`
holds `n/x` and is then `add_assign`ed with `x` — `quotient` would be actively
false two lines later.

## The part that is worth more than the renaming

A short name is a small problem. A name that is WRONG is a real one, and the
sweep surfaced a number of them:

| was | meant | now |
|---|---|---|
| `r256` | a **128**-bit `(r1·B + r0)` pair | `remainder_pair` |
| `w` | a *window word* — in a tree where `w` means working scale 249 times | `window_word` |
| `hi` | a *length*, beside a `hi` that is a limb *value* in the same file | `low_len` / `high_len` |
| `a2`/`b2` | "zero-padded copy" in a test and "the high third" in the kernel — **same file** | `a_padded` / `b_padded` |
| `s` | a *limb*, in a file whose doc defines `s` as the **root** | `limb` |
| `n` | the *radicand* in one function and the *dividend* in another — same file | `radicand` / `dividend` |
| `la`/`lb` | limb *slices* in one file, limb *lengths* in another | `a_limbs` / `a_len` |
| `i` | a *length* returned from `sig_len` | `len` |

The near-min Ziv walker — the code three correctness fixes landed in this week —
now states its signal plainly: `position.abs_diff(pending_position) <= 1`,
where it previously read `p.abs_diff(pp) <= 1`.

## Verification

"Pure rename" is a claim that can be checked rather than trusted, so it was.
Every file was compared against its parent commit on four streams — numeric
literals, string literals (with `{capture}` names normalised out), the code
punctuation skeleton, and item names (`fn`/`const`/`static`/`type`/`struct`/
`enum`/`trait`/`mod`). Any movement in those is not a rename. Negative controls
confirm the checker still fails on a one-character edit to a string's visible
text.

That check has one structural blind spot, and it is worth stating: renaming a
binding but missing one *use* leaves all four streams identical, because
identifiers are precisely what they exclude. Only the compiler catches that —
and it did, once, in a `#[cfg(feature = "d76")]` test block that the default
build never compiles. Hence four compile configurations, not one.

- `cargo check` default `--all-targets`
- `cargo check --features wide,x-wide,xx-wide,macros --all-targets`
- `cargo check --no-default-features --lib`
- `cargo check --features wide,... --lib`

Both test suites return the counts they returned before the sweep began —
418 / 33 / 14 / 3 / 10 / 59 default, 557 / 37 / 14 / 3 / 10 / 60 wide. No test
gained, lost or changed.

Format-string captures were renamed with their bindings, leaving every character
outside the braces untouched, so rendered messages are byte-identical.

## Known exclusion

The four Tang tables under `src/algos/support/` are generator output and are not
touched. Their accessors keep single-letter parameters, because the rename has
to go into `scripts/gen_*_table.py` and be followed by a regeneration.

That is blocked on a pre-existing, unrelated defect: `gen_ln_tang_table.py`
emits a two-parameter `ln_table_entry_baked`, while the committed table and all
four call sites use three (`pow10_w` supplied by the caller). Regenerating today
would break the build and silently revert that optimisation. The other three
generators reproduce their tables byte-for-byte, and no baked value has drifted
in any of them — all 14,462 ln literals are identical. Tracked separately.
