### PR TITLE
ci(golden): taper the stripe ladder for the eight-mode surface

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -13,7 +13,7 @@
 
 ## Automatic gates (CI — must be green)
 
-- [ ] 📐 Precision (0.5 ULP gate) — `ci.yml` `golden (gate)` at 0 bad / 0 panic, all 6 modes, every band-edge `(width, scale)` cell; `tests (gate)` green (incl. proptest ULP fuzz)
+- [ ] 📐 Precision (0.5 ULP gate) — `golden-comprehensive.yml` at 0 bad / 0 panic, all 8 modes, every band-edge `(width, scale)` cell; `ci.yml` `tests (gate)` green (incl. proptest ULP fuzz)
 - [ ] cargo-audit — clean
 
 ## Manual checks (verified before merge)

--- a/.github/workflows/golden-comprehensive.yml
+++ b/.github/workflows/golden-comprehensive.yml
@@ -1,6 +1,6 @@
 name: "🌕 golden comprehensive"
 
-# The full six-mode golden surface — every row, every cell, all six
+# The full eight-mode golden surface — every row, every cell, all eight
 # rounding modes — on every push, in its OWN workflow so it never shares
 # a run's runner allocation with the ci.yml gates. This is the crate's
 # CORRECTNESS GATE: it took over from the deleted 0.5 ULP precision gate,
@@ -18,7 +18,7 @@ name: "🌕 golden comprehensive"
 # WITHIN a shard the rows still stripe (GOLDEN_STRIPE=k/n) so the heavy
 # wide tiers stay inside the job timeout. The splice stitches
 # shard × stripe mini reports back together. Coverage is UNCHANGED —
-# full rows, all six modes.
+# full rows, all eight modes.
 
 on:
   push:
@@ -59,12 +59,19 @@ jobs:
                     ("d924", "924"), ("d1232", "1232")]
           # Stripe count PER WIDTH TIER (owner 2026-06-13): the wide tiers
           # dominate the per-stripe wall time, so they fan out into more,
-          # thinner stripes to stay inside the job timeout; every other
-          # shard takes the default of 4. Each matrix entry carries its own
-          # `total`, so the stripe job gets GOLDEN_STRIPE=k/n with THAT
+          # thinner stripes to stay inside the job timeout. The ladder
+          # TAPERS with tier width — widest tier, most stripes — and d230
+          # and below take the default of 4. Each matrix entry carries its
+          # own `total`, so the stripe job gets GOLDEN_STRIPE=k/n with THAT
           # shard's own n (k = 0..n-1 — the harness's disjoint row partition,
           # line % n == k, self-consistent for any n).
-          STRIPES = {"d1232": 10, "d924": 8, "d616": 6}
+          # Re-sized 2026-09-02 for the eight-mode surface: the two GDA modes
+          # took the sweep from 72,119,970 checks to 96,159,960. That is
+          # EXACTLY a third more, not approximately — 72,119,970 / 6 =
+          # 12,019,995 per mode, x 8 = 96,159,960 — so every stripe carries a
+          # third more work. The ladder scales the fan-out with tier cost
+          # rather than letting the widest stripes absorb it.
+          STRIPES = {"d1232": 16, "d924": 12, "d616": 10, "d462": 8, "d307": 6}
           print(json.dumps([{"shard": s, "widths": w, "stripe": k,
                              "total": STRIPES.get(s, 4)}
                             for (s, w) in shards
@@ -162,7 +169,7 @@ jobs:
         with:
           name: golden-exe-${{ matrix.shard }}
 
-      - name: Run stripe (all six modes, the shard's full rows)
+      - name: Run stripe (all eight modes, the shard's full rows)
         env:
           GOLDEN_STRIPE: "${{ matrix.stripe }}/${{ matrix.total }}"
           GOLDEN_WIDTHS: "${{ matrix.widths }}"
@@ -235,7 +242,7 @@ jobs:
             fi
           done
           {
-            echo "## golden comprehensive — combined (all six modes, full surface, width-sharded)"
+            echo "## golden comprehensive — combined (all eight modes, full surface, width-sharded)"
             echo '```'
             cat combined/summaries.txt
             echo '```'

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -60,8 +60,8 @@ the rest are **manual** and must be verified by hand before merge.
   informational — see Manual.)
 - **golden comprehensive** — `golden-comprehensive.yml`; the crate's
   **correctness gate** (it replaced the deleted 0.5 ULP precision gate).
-  The full six-mode golden surface — every band-edge `(width, scale)`
-  cell, every row, all six rounding modes — width-sharded × row-striped,
+  The full eight-mode golden surface — every band-edge `(width, scale)`
+  cell, every row, all eight rounding modes — width-sharded × row-striped,
   0 bad / 0 panic. The precision guarantee is *enforced here, not
   assumed*: a kernel that rounds wrong turns this red.
 - **docs-drift** — `docs-drift.yml`; `render_docs.py --check` on every
@@ -135,7 +135,7 @@ git checkout -b release/<MAJOR.MINOR.PATCH>   # e.g. release/0.4.4
   manual checklist above).
 - The golden gate green: `golden_default` and `golden_all_modes`
   (`decimal-scale-test`) at **0 bad / 0 panic** over every band-edge
-  `(width, scale)` cell, all six rounding modes — run on CI by
+  `(width, scale)` cell, all eight rounding modes — run on CI by
   `golden-comprehensive.yml` (the correctness gate that replaced the
   retired 0.5 ULP precision suite).
 - **Regenerate the single-sourced docs and commit on the release branch
@@ -152,33 +152,48 @@ git checkout -b release/<MAJOR.MINOR.PATCH>   # e.g. release/0.4.4
 Stale numbers misrepresent the release. Every data-driven page is
 regenerated from a **fresh GitHub-Actions run** (never a local sweep —
 local machines cannot produce stable numbers). The pipeline is now
-**self-rendering**: pushing the release branch triggers each data
-workflow, and each one re-runs its bench/gate, self-commits its results
-TSV under `results/`, runs `scripts/render_docs.py`, and commits the
-refreshed page back to the branch in ONE `github-actions[bot]` commit
-(no manual download / ingest / chart step). A `GITHUB_TOKEN` self-commit
-does not re-trigger workflows, so there is no loop.
+**self-rendering**: each data workflow re-runs its bench/gate,
+self-commits its results TSV under `results/`, runs
+`scripts/render_docs.py`, and commits the refreshed page back to the
+branch in ONE `github-actions[bot]` commit (no manual download / ingest /
+chart step). A `GITHUB_TOKEN` self-commit does not re-trigger workflows,
+so there is no loop.
 
-Pushing to `release/*` triggers these, each in its own serial queue
-(`cancel-in-progress: false` — a queued run waits its turn; it is never
-cancelled):
+**On a release branch only ONE of the four starts itself.** Pushing to
+`release/*` runs `golden-comprehensive.yml`; the three timing and
+comparison workflows are `workflow_dispatch`-only there and have to be
+started by hand. That is deliberate, and each one says so in its own
+`on:` comment: they self-commit, and on a release branch with an open PR
+that self-commit would move the PR head onto a commit the REQUIRED gates
+never ran on, so the PR could never go green.
 
-| Workflow | Re-runs | Self-renders |
-|----------|---------|--------------|
-| `golden-comprehensive.yml` | the six-mode golden surface | `golden.md`, `precision.md` (`results/golden/`) |
-| `lib-perf.yml` | peer-crate timing over the golden set | `comparisons.md` + category pages (`results/lib_cmp/`) |
-| `history.yml` | per-version timing across releases | `history.md` (`results/history/`) |
-| `bench-branch-compare.yml` | branch-vs-latest-tag timing (advisory perf signal) | `performance.md` (`results/timing/`) |
+| Workflow | Re-runs | Self-renders | On `release/*` |
+|----------|---------|--------------|----------------|
+| `golden-comprehensive.yml` | the eight-mode golden surface | `golden.md`, `precision.md` (`results/golden/`) | on push |
+| `lib-perf.yml` | peer-crate timing over the golden set | `comparisons.md` + category pages (`results/lib_cmp/`) | dispatch only |
+| `history.yml` | per-version timing across releases | `history.md` (`results/history/`) | dispatch only |
+| `bench-branch-compare.yml` | branch-vs-latest-tag timing (advisory perf signal) | `performance.md` (`results/timing/`) | dispatch only |
 
-So "refresh benchmarks" is: **push the release branch, wait for these
-workflows to land their self-commits, then `git pull`.** Poll with
-`gh run list --branch release/<version>`. The wide tiers are slow; the
-narrow / peer runs finish sooner. If a self-commit is missing (a run
-failed mid-way), re-run just that workflow — never hand-edit the page:
+So "refresh benchmarks" is: push the release branch, then start the other
+three by hand —
 
 ```sh
-gh workflow run <workflow>.yml --ref release/<version>
+gh workflow run lib-perf.yml             --ref release/<version>
+gh workflow run history.yml              --ref release/<version>
+gh workflow run bench-branch-compare.yml --ref release/<version>
 ```
+
+— then wait for all four to land their self-commits and `git pull`. Poll
+with `gh run list --branch release/<version>`. Each queues serially
+(`cancel-in-progress: false` — a queued run waits its turn; it is never
+cancelled). The wide tiers are slow; the narrow / peer runs finish
+sooner. If a self-commit is missing because a run failed mid-way, re-run
+that workflow the same way — never hand-edit the page.
+
+> **This failure mode is silent.** Pushing alone raises no error and
+> refreshes no timing data: three of the four never start, and the pages
+> keep the previous release's numbers. Confirm with `gh run list` rather
+> than assuming the push was enough.
 
 The non-data GENERATED regions (the install snippet pinned to the new
 `major.minor`, the width-tier table) are NOT refreshed by a workflow —


### PR DESCRIPTION
The two GDA rounding modes took the golden sweep from 72,119,970 checks to 96,159,960 — exactly a third more work in every stripe (72,119,970 ÷ 6 × 8). The wide tiers already dominated wall time, so the fan-out now tapers with tier width instead of leaving the widest stripes to absorb the increase and drift toward the job timeout.

| tier | before | after |
|---|---|---|
| d1232 | 10 | **16** |
| d924 | 8 | **12** |
| d616 | 6 | **10** |
| d462 | 4 (default) | **8** |
| d307 | 4 (default) | **6** |
| d230 and below | 4 | 4 |

`d462` and `d307` are new keys rather than edits — they were falling through to the default, so they would otherwise have taken the full increase on four stripes each. The shard list and the `STRIPES.get(s, 4)` default are untouched.

## RELEASING.md — a silent failure in the release process

Two corrections, and the second matters more than the mode counts.

Section 3 claimed that pushing to `release/*` triggers all four data workflows, and told the releaser to "push the release branch, wait for these workflows to land their self-commits, then `git pull`". **That is true for one of the four.** Verified against the live branch: after two pushes to `release/0.5.1`, ten runs each of `golden comprehensive` and `ci`, and zero of the other three.

`lib-perf`, `history` and `bench-branch-compare` are `workflow_dispatch`-only on a release branch, and each says so in its own header — `bench-branch-compare` gives the reason: on a release branch with an open PR the self-commit would move the PR head onto a commit the required gates never ran on.

So a releaser following the doc would push, see no error, and conclude the benchmarks had refreshed when nothing ran. The section now leads with which one starts itself, carries the three `gh workflow run` lines as the normal path rather than a remedy, and says plainly that the failure mode is silent. The same false claim appeared in prose above the table and is corrected too.

## Stale mode counts

Eight in total, none catchable by `docs-drift` since all are prose: three in `RELEASING.md`, four in `golden-comprehensive.yml` (including the combined-report heading echoed into every run's job summary), and one in the release PR template.

That last one was stale twice over — it pointed at `ci.yml`'s `golden (gate)`, but the golden surface no longer runs in `ci.yml` at all (`ci.yml:99` says so). A releaser following that checklist was being sent to a job that does not exist.