### PR TITLE
chore(deps): update g_math requirement from 0.4 to 0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -217,7 +217,7 @@ fixed = "1"
 # g_math: another fixed-point arithmetic crate that claims "0 ULP
 # transcendentals". Used as a benchmark baseline + accuracy comparison
 # (see benches/g_math_comparison.rs).
-g_math = "0.4"
+g_math = "0.5"
 # Library-comparison comparators for the §5 chapter in docs/benchmarks.md.
 # All bench-only; never compiled into a normal build.
 fastnum = { version = "0.7", default-features = false, features = ["std"] }

--- a/golden-competitors/Cargo.toml
+++ b/golden-competitors/Cargo.toml
@@ -26,7 +26,7 @@ bigdecimal = "0.4"
 dashu-float = "0.6"
 fastnum = { version = "0.7", default-features = false, features = ["std"] }
 decimal-rs = "0.2"
-g_math = { version = "0.4", features = ["balanced"] }
+g_math = { version = "0.5", features = ["balanced"] }
 
 [features]
 # Width-tier passthroughs onto the decimal-scaled subject (mirroring


### PR DESCRIPTION
Supersedes #80.

Two lines — the version in the root `Cargo.toml` (bench/comparison baseline) and in `golden-competitors/Cargo.toml`, with `features = ["balanced"]` preserved.

## Why this replaces #80 rather than fixing it

Dependabot raised #80 against `main`. Retargeting it to `release/0.5.1` meant its branch had already absorbed the codeql workflow changes when it was updated against main, and those same changes then reached `release/0.5.1` via #107. With the identical content arriving from both sides, `gh pr update-branch` refused: *"Cannot update PR branch due to conflicts"*.

Untangling a dependabot branch's workflow history for a two-line bump is not worth it, so the change is remade cleanly on top of `release/0.5.1`.

Deliberately **not** carried across from #80: the codeql workflow changes (already present via #107 — re-applying them is what caused the conflict) and an unrelated UTF-8 BOM strip on the root `Cargo.toml`.

## Notes

`Cargo.lock` is untracked and gitignored here, so there is nothing to regenerate — resolution happens on CI.

g_math is a comparison subject backing the §5 library-comparison figures. Those are regenerated from a fresh Actions run as part of the release, and the comparison always measures the latest release of each peer, so no separate rescore is needed.