### PR TITLE
ci(golden): balance the stripe ladder from measured durations

### DIFF
--- a/.github/workflows/golden-comprehensive.yml
+++ b/.github/workflows/golden-comprehensive.yml
@@ -57,11 +57,13 @@ jobs:
                     ("d115", "115"), ("d153", "153"), ("d230", "230"),
                     ("d307", "307"), ("d462", "462"), ("d616", "616"),
                     ("d924", "924"), ("d1232", "1232")]
-          # Stripe count PER WIDTH TIER (owner 2026-06-13): the wide tiers
+          # Stripe count PER WIDTH TIER (owner 2026-06-13): the heavy tiers
           # dominate the per-stripe wall time, so they fan out into more,
-          # thinner stripes to stay inside the job timeout. The ladder
-          # TAPERS with tier width — widest tier, most stripes — and d230
-          # and below take the default of 4. Each matrix entry carries its
+          # thinner stripes to stay inside the job timeout. The fan-out
+          # follows MEASURED per-tier cost, not tier width — see the sizing
+          # note below, where d616/d462/d307 go DOWN because width alone had
+          # over-provisioned them. Anything not named takes the default of 2.
+          # Each matrix entry carries its
           # own `total`, so the stripe job gets GOLDEN_STRIPE=k/n with THAT
           # shard's own n (k = 0..n-1 — the harness's disjoint row partition,
           # line % n == k, self-consistent for any n).
@@ -71,14 +73,37 @@ jobs:
           # 12,019,995 per mode, x 8 = 96,159,960 — so every stripe carries a
           # third more work. The ladder scales the fan-out with tier cost
           # rather than letting the widest stripes absorb it.
-          # Raised again 2026-09-02 at the top three tiers (16/12/10 ->
-          # 20/16/12) after watching the first eight-mode run: those are the
-          # tiers whose stripes still set the critical path, so shortening
-          # them shortens the whole workflow. d462 and d307 keep the sizes
-          # they were just given; d230 and below stay at the default 4, where
-          # the per-stripe cost is not what holds the run up. 86 stripe jobs
-          # in total (24 at the default + 6 + 8 + 12 + 16 + 20).
-          STRIPES = {"d1232": 20, "d924": 16, "d616": 12, "d462": 8, "d307": 6}
+          # BALANCED 2026-09-02 from measured per-stripe durations rather than
+          # by hand. Run 33577670109 (86 stripes, all green) gave, per tier,
+          # mean stripe seconds and tier totals:
+          #
+          #   d1232 375s/7508s   d924 226s/3624s   d616 140s/1682s
+          #   d307   86s/517s    d462  70s/564s    d230  50s/203s
+          #   narrow 38s/153s    d115  31s/127s    d153  28s/115s
+          #   d57    25s/101s    d76   25s/102s
+          #
+          # Two things stood out. d1232 alone is HALF the total work and its
+          # stripes ran 15x longer than d76's, so it set the critical path
+          # single-handedly. And the low tiers were OVER-provisioned: d57/d76
+          # at 25s are essentially pure job overhead, since the smallest
+          # observed mean bounds the per-job fixed cost at ~25s.
+          #
+          # Sizing: subtract that 25s overhead to get each tier's net work,
+          # then n = ceil(net / (target - overhead)) for a target of 200s —
+          # the middle of the 2-4 minute band the owner wants a stripe to sit
+          # in. Tiers whose ENTIRE work is under 2 minutes cannot reach the
+          # band and take a floor of 2, which costs almost nothing and stops
+          # any tier being a single point of failure.
+          #
+          # Result: 85 jobs (vs 86) and a critical path of ~200s (vs 417s) —
+          # the same runner budget for half the wall time, because the fan-out
+          # now follows measured cost instead of tier width. Note d616, d462
+          # and d307 go DOWN; width alone was the wrong proxy.
+          #
+          # To re-balance after a surface change, re-run the same measurement
+          # (per-tier mean and total stripe seconds) and redo the arithmetic —
+          # do not extrapolate this table.
+          STRIPES = {"d1232": 40, "d924": 19, "d616": 8, "d462": 3, "d307": 3}
           # `stripe` is the harness's partition selector and MUST stay
           # 0-based: the row filter is `line % total == stripe`, so a
           # 1-based value would never match on the last stripe — that job
@@ -88,9 +113,9 @@ jobs:
           # two into one field.
           print(json.dumps([{"shard": s, "widths": w, "stripe": k,
                              "label": k + 1,
-                             "total": STRIPES.get(s, 4)}
+                             "total": STRIPES.get(s, 2)}
                             for (s, w) in shards
-                            for k in range(STRIPES.get(s, 4))]))
+                            for k in range(STRIPES.get(s, 2))]))
           EOF
           )" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
Sizes the golden stripe fan-out from **measured per-stripe durations** instead of
from tier width.

## What the measurement showed

Run 33577670109 (86 stripes, all green, the first full eight-mode run) gave these
per-tier mean stripe seconds and tier totals:

| tier | mean | total | | tier | mean | total |
|---|---|---|---|---|---|---|
| d1232 | 375s | 7508s | | d230 | 50s | 203s |
| d924 | 226s | 3624s | | narrow | 38s | 153s |
| d616 | 140s | 1682s | | d115 | 31s | 127s |
| d307 | 86s | 517s | | d153 | 28s | 115s |
| d462 | 70s | 564s | | d57 / d76 | 25s | ~101s |

Two things stand out. **d1232 alone is half the total work**, with stripes 15x
longer than d76's — it set the critical path single-handedly. And the low tiers
were *over*-provisioned: d57 and d76 at 25s are essentially pure job overhead,
since the smallest observed mean bounds the per-job fixed cost at about 25s.

## The sizing

Subtract that 25s overhead to get each tier's net work, then
`n = ceil(net / (target - overhead))` for a 200s target — the middle of the
2-4 minute band a stripe should sit in. Tiers whose entire workload is under two
minutes cannot reach the band and take a floor of 2, which costs almost nothing
and stops any tier being a single point of failure.

```
STRIPES = {"d1232": 40, "d924": 19, "d616": 8, "d462": 3, "d307": 3}   # default 2
```

| tier | before | after | stripe before | stripe after |
|---|---|---|---|---|
| d1232 | 20 | **40** | 375s | 200s |
| d924 | 16 | **19** | 226s | 194s |
| d616 | 12 | **8** | 140s | 198s |
| d462 | 8 | **3** | 70s | 145s |
| d307 | 6 | **3** | 86s | 147s |
| six others | 4 | **2** | 25-50s | 25-75s |

**85 jobs (down from 86), critical path 375s mean / 417s worst stripe -> 200s.**
The same runner budget for half the wall time. Note d616, d462 and d307 go
*down*: width alone was the wrong proxy for cost.

## Correctness

The row filter is `line % total == stripe`, so the partition has to stay complete
and 0-based or rows are silently dropped rather than failed. Checked for both
ladders: every shard's stripes form exactly `0..n-1`, no gaps, no duplicates,
with `label = stripe + 1` keeping the job titles 1-based. Total graded rows are
unchanged — this redistributes the same work, it does not reduce it.

The sizing note is recorded beside the table with an explicit instruction to
re-measure rather than extrapolate after a surface change, since that is exactly
how the width-based ladder went wrong.
